### PR TITLE
ci: add agent attribution, branching workflow, and Dependabot auto-merge

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -136,6 +136,27 @@ Before considering any task complete, verify:
 - Log errors with sufficient context for debugging
 - Use consistent error response shapes as defined in the API contract
 
+## Attribution
+
+- **Agent name**: `backend-developer`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude backend-developer (Sonnet 4.5) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[backend-developer]**` on the first line
+
+## Git Workflow
+
+**Never commit directly to `main`.** All changes go through feature branches and pull requests.
+
+1. Create a feature branch: `git checkout -b <type>/<issue-number>-<short-description> main`
+2. Implement changes and run quality gates (`lint`, `typecheck`, `test`, `format:check`, `build`)
+3. Commit with conventional commit message and your Co-Authored-By trailer
+4. Push: `git push -u origin <branch-name>`
+5. Create a PR: `gh pr create --title "..." --body "..."`
+6. Wait for CI: `gh pr checks <pr-number> --watch`
+7. **Auto-merge rules**:
+   - `fix`, `chore`, `test`, `docs`, `ci`, `build` — enable auto-merge: `gh pr merge --auto --squash <pr-url>`
+   - `feat`, `refactor`, or commits with `!` / `BREAKING CHANGE` — leave PR open for human review
+8. After merge, clean up: `git checkout main && git pull && git branch -d <branch-name>`
+
 ## Update Your Agent Memory
 
 As you work on the Cornerstone backend, update your agent memory with discoveries about:

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -132,6 +132,27 @@ Before considering any task complete:
 - If acceptance criteria are ambiguous, state your interpretation and proceed, flagging the assumption
 - If you encounter a bug in the backend API response, document it clearly with the expected vs actual behavior
 
+## Attribution
+
+- **Agent name**: `frontend-developer`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude frontend-developer (Sonnet 4.5) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[frontend-developer]**` on the first line
+
+## Git Workflow
+
+**Never commit directly to `main`.** All changes go through feature branches and pull requests.
+
+1. Create a feature branch: `git checkout -b <type>/<issue-number>-<short-description> main`
+2. Implement changes and run quality gates (`lint`, `typecheck`, `test`, `format:check`, `build`)
+3. Commit with conventional commit message and your Co-Authored-By trailer
+4. Push: `git push -u origin <branch-name>`
+5. Create a PR: `gh pr create --title "..." --body "..."`
+6. Wait for CI: `gh pr checks <pr-number> --watch`
+7. **Auto-merge rules**:
+   - `fix`, `chore`, `test`, `docs`, `ci`, `build` — enable auto-merge: `gh pr merge --auto --squash <pr-url>`
+   - `feat`, `refactor`, or commits with `!` / `BREAKING CHANGE` — leave PR open for human review
+8. After merge, clean up: `git checkout main && git pull && git branch -d <branch-name>`
+
 ## Update Your Agent Memory
 
 As you work on the frontend codebase, update your agent memory with discoveries about:

--- a/.claude/agents/product-architect.md
+++ b/.claude/agents/product-architect.md
@@ -166,6 +166,27 @@ Use `gh` CLI to fetch Wiki pages (`gh api repos/steilerDev/cornerstone/wiki/page
 - [ ] Naming conventions are consistent (snake_case in DB, camelCase in TypeScript)
 - [ ] No business logic was implemented — only interfaces and contracts
 
+## Attribution
+
+- **Agent name**: `product-architect`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude product-architect (Opus 4.6) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[product-architect]**` on the first line
+
+## Git Workflow
+
+**Never commit directly to `main`.** All changes go through feature branches and pull requests.
+
+1. Create a feature branch: `git checkout -b <type>/<issue-number>-<short-description> main`
+2. Implement changes and run quality gates (`lint`, `typecheck`, `test`, `format:check`, `build`)
+3. Commit with conventional commit message and your Co-Authored-By trailer
+4. Push: `git push -u origin <branch-name>`
+5. Create a PR: `gh pr create --title "..." --body "..."`
+6. Wait for CI: `gh pr checks <pr-number> --watch`
+7. **Auto-merge rules**:
+   - `fix`, `chore`, `test`, `docs`, `ci`, `build` — enable auto-merge: `gh pr merge --auto --squash <pr-url>`
+   - `feat`, `refactor`, or commits with `!` / `BREAKING CHANGE` — leave PR open for human review
+8. After merge, clean up: `git checkout main && git pull && git branch -d <branch-name>`
+
 ## Update Your Agent Memory
 
 As you work on the Cornerstone project, update your agent memory with architectural discoveries and decisions. This builds institutional knowledge across conversations. Write concise notes about what you found and where.

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -168,6 +168,13 @@ Before finalizing any backlog work, verify:
 - [ ] Dependencies between stories are identified and documented
 - [ ] GitHub Projects board is updated to reflect current state
 
+## Attribution
+
+- **Agent name**: `product-owner`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude product-owner (Opus 4.6) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[product-owner]**` on the first line
+- You do not typically commit code, but if you do, follow the branching strategy in `CLAUDE.md` (feature branches + PRs, never push directly to `main`)
+
 **Update your agent memory** as you discover product requirements patterns, backlog organization decisions, prioritization rationale, dependency chains between features, stakeholder preferences, and recurring scope clarifications. This builds up institutional knowledge across conversations. Write concise notes about what you found and where.
 
 Examples of what to record:

--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -230,6 +230,13 @@ Before considering your work complete, verify:
 
 ---
 
+## Attribution
+
+- **Agent name**: `qa-integration-tester`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude qa-integration-tester (Sonnet 4.5) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[qa-integration-tester]**` on the first line
+- You do not typically commit application code, but if you commit test files, follow the branching strategy in `CLAUDE.md` (feature branches + PRs, never push directly to `main`)
+
 ## Update Your Agent Memory
 
 As you discover important information while testing, update your agent memory to build institutional knowledge across conversations. Write concise notes about what you found and where.

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -171,6 +171,13 @@ What could happen if this is not fixed.
 - Be thorough but avoid false positives — verify findings before reporting
 - When uncertain about a finding, mark it as requiring further investigation rather than guessing
 
+## Attribution
+
+- **Agent name**: `security-engineer`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude security-engineer (Sonnet 4.5) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[security-engineer]**` on the first line
+- You do not typically commit code, but if you do, follow the branching strategy in `CLAUDE.md` (feature branches + PRs, never push directly to `main`)
+
 ## Update Your Agent Memory
 
 As you discover security patterns, vulnerabilities, and architectural decisions in this codebase, update your agent memory. This builds institutional knowledge across conversations. Write concise notes about what you found and where.

--- a/.claude/agents/uat-validator.md
+++ b/.claude/agents/uat-validator.md
@@ -191,6 +191,13 @@ Type 'APPROVED' to confirm or describe any issues found.
 - **Is the acceptance criterion ambiguous?** → Stop, ask the product owner for clarification, then ask the user
 - **Did an automated test fail?** → Investigate root cause, report with reproduction steps, do not mark as passed
 
+## Attribution
+
+- **Agent name**: `uat-validator`
+- **Co-Authored-By trailer**: `Co-Authored-By: Claude uat-validator (Sonnet 4.5) <noreply@anthropic.com>`
+- **GitHub comments**: Always prefix with `**[uat-validator]**` on the first line
+- You do not typically commit code, but if you commit test files, follow the branching strategy in `CLAUDE.md` (feature branches + PRs, never push directly to `main`)
+
 ## Update your agent memory
 
 As you work across sprints, update your agent memory with:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,48 @@ All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 - **Breaking changes**: Use `!` suffix or `BREAKING CHANGE:` footer
 - Every completed task gets its own commit with a meaningful description
 - **Link commits to issues**: When a commit resolves work tracked in a GitHub Issue, include `Fixes #<issue-number>` in the commit message body (one per line for multiple issues). This automatically closes the related issue(s) when merged to `main`.
-- **Always commit and push after verification passes.** When a work session completes and all quality gates (`lint`, `typecheck`, `test`, `format:check`, `build`, `npm audit`) pass, create a commit and push it to the remote before ending the session. Do not leave verified work uncommitted or unpushed.
+- **Always commit, push to a feature branch, and create a PR after verification passes.** When a work session completes and all quality gates (`lint`, `typecheck`, `test`, `format:check`, `build`, `npm audit`) pass, commit, push to the feature branch, and create a PR before ending the session. Do not leave verified work uncommitted or unpushed. Never push directly to `main`.
+
+### Agent Attribution
+
+All agents must clearly identify themselves in commits and GitHub interactions:
+
+- **Commits**: Include the agent name in the `Co-Authored-By` trailer:
+
+  ```
+  Co-Authored-By: Claude <agent-name> (<model>) <noreply@anthropic.com>
+  ```
+
+  Replace `<agent-name>` with one of: `backend-developer`, `frontend-developer`, `product-architect`, `product-owner`, `qa-integration-tester`, `security-engineer`, `uat-validator`, or `orchestrator` (when the orchestrating Claude commits directly). Replace `<model>` with the agent's actual model (e.g., `Opus 4.6`, `Sonnet 4.5`). Each agent's definition file specifies the exact trailer to use.
+
+- **GitHub comments** (on issues, PRs, or discussions): Prefix the first line with the agent name in bold brackets:
+
+  ```
+  **[backend-developer]** This endpoint has been implemented...
+  ```
+
+- When the orchestrator commits work produced by a specific agent, it must use that agent's name in the `Co-Authored-By` trailer, not its own.
+
+### Branching Strategy
+
+**Never commit directly to `main`.** All changes go through feature branches and pull requests.
+
+- **Branch naming**: `<type>/<issue-number>-<short-description>`
+
+  - Examples: `feat/42-work-item-crud`, `fix/55-budget-calc`, `ci/18-dependabot-auto-merge`
+  - Use the conventional commit type as the prefix
+  - Include the GitHub Issue number when one exists
+
+- **Workflow**:
+  1. Create a feature branch: `git checkout -b <branch-name> main`
+  2. Implement changes, run quality gates, commit
+  3. Push the branch: `git push -u origin <branch-name>`
+  4. Create a PR: `gh pr create --title "..." --body "..."`
+  5. Wait for CI: `gh pr checks <pr-number> --watch`
+  6. **Auto-merge rules** (based on conventional commit type):
+     - `fix`, `chore`, `test`, `docs`, `ci`, `build` — enable auto-merge: `gh pr merge --auto --squash <pr-url>`
+     - `feat`, `refactor`, or commits with `!` / `BREAKING CHANGE` — leave PR open for human review
+  7. After merge, clean up: `git checkout main && git pull && git branch -d <branch-name>`
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

- **Agent attribution**: All commits now require `Co-Authored-By` trailers with agent name and model. GitHub comments must be prefixed with `**[agent-name]**`. Each agent definition file includes the exact trailer to use.
- **Feature branch workflow**: Agents must never push directly to `main`. All changes go through feature branches (`<type>/<issue>-<desc>`) with PRs. Auto-merge rules: `fix`/`chore`/`test`/`docs`/`ci`/`build` PRs auto-merge; `feat`/`refactor`/breaking changes require human review.
- **Dependabot auto-merge**: New workflow auto-approves and squash-merges patch/minor Dependabot PRs. Major version bumps are left for manual review.

### Files changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Added attribution rules and branching strategy sections |
| `.claude/agents/*.md` (7 files) | Added attribution + git workflow sections per agent |
| `.github/workflows/dependabot-auto-merge.yml` | New workflow for Dependabot auto-merge |

### Prerequisites (already configured by repo owner)

- Dependabot secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
- Auto-merge enabled in repo settings
- Branch protection with required status checks on `main`

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 37 tests pass
- [x] `npm run build` — succeeds
- [ ] CI passes on this PR (first PR using the new branching workflow)
- [ ] Verify Dependabot workflow YAML is valid after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)