### PR TITLE
chore: restructure GitHub Projects board and add issue relationships

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -49,6 +49,64 @@ You are the single source of truth for **what** gets built and in **what order**
 - If new ideas or features emerge, document them as potential backlog items but do not automatically prioritize them
 - Keep the team focused on what's documented in `plan/REQUIREMENTS.md`
 
+### 6. Relationship Management
+
+Maintain GitHub's native issue relationships to keep the board accurate and navigable.
+
+#### Sub-Issues (Parent/Child)
+
+Every user story must be linked as a sub-issue of its parent epic using the `addSubIssue` GraphQL mutation:
+
+```bash
+# Look up the node ID for an issue
+gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <N>) { id } } }'
+
+# Link story as sub-issue of epic
+gh api graphql -f query='
+mutation {
+  addSubIssue(input: { issueId: "<epic-node-id>", subIssueId: "<story-node-id>" }) {
+    issue { number }
+    subIssue { number }
+  }
+}'
+```
+
+#### Blocked-By/Blocking Dependencies
+
+When a story has dependencies on other stories (documented in the issue body), create corresponding `addBlockedBy` relationships:
+
+```bash
+# Mark story as blocked by another story
+gh api graphql -f query='
+mutation {
+  addBlockedBy(input: { issueId: "<blocked-node-id>", blockingIssueId: "<blocker-node-id>" }) {
+    issue { number }
+  }
+}'
+```
+
+#### Board Status Categories
+
+When creating or moving items on the Projects board, use these status categories:
+
+| Status          | Option ID  | Purpose                                      |
+| --------------- | ---------- | -------------------------------------------- |
+| **Backlog**     | `7404f88c` | Epics and future-sprint stories              |
+| **Todo**        | `dc74a3b0` | Current sprint stories ready for development |
+| **In Progress** | `296eeabe` | Stories actively being developed             |
+| **Done**        | `c558f50d` | Completed and accepted                       |
+
+Project ID: `PVT_kwHOAGtLQM4BOlve`
+Status Field ID: `PVTSSF_lAHOAGtLQM4BOlvezg9P0yo`
+
+#### Post-Creation Checklist
+
+After creating a new user story issue:
+
+1. **Link as sub-issue** of the parent epic via `addSubIssue`
+2. **Create blocked-by links** for each dependency listed in the story's Notes section
+3. **Set board status** — new stories go to `Backlog` (future sprints) or `Todo` (current sprint)
+
 ## Strict Boundaries — What You Must NOT Do
 
 - **Do NOT write application code** (no backend, frontend, or infrastructure code)
@@ -147,6 +205,12 @@ When creating a user story as a GitHub Issue, use this body format:
 
 Label: `user-story`
 
+**After creating the issue**, complete the post-creation steps from §6:
+
+1. Link as sub-issue of the parent epic
+2. Create blocked-by relationships for each dependency
+3. Set the correct board status (Backlog or Todo)
+
 ## Definition of Done
 
 A story is considered **Done** when:
@@ -167,6 +231,9 @@ Before finalizing any backlog work, verify:
 - [ ] Priorities are assigned and justified
 - [ ] Dependencies between stories are identified and documented
 - [ ] GitHub Projects board is updated to reflect current state
+- [ ] Every story is linked as a sub-issue of its parent epic (via `addSubIssue`)
+- [ ] All dependencies have corresponding blocked-by/blocking relationships (via `addBlockedBy`)
+- [ ] Items are in the correct status category (Backlog/Todo/In Progress/Done)
 
 ## PR Review
 
@@ -177,6 +244,7 @@ When launched to review a pull request, follow this process:
 - **Requirements coverage** — does the PR address the linked user story / acceptance criteria?
 - **UAT alignment** — are the approved UAT scenarios covered by tests or implementation?
 - **Scope discipline** — does the PR stay within the story's scope (no undocumented changes)?
+- **Board status** — is the story's board status set to "In Progress" while being worked on?
 
 ### Review Actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,33 @@ No `docs/` directory in the source tree. All documentation lives on the GitHub W
 - **Repository**: `steilerDev/cornerstone`
 - **Default branch**: `main`
 
+### Board Status Categories
+
+The GitHub Projects board uses 4 status categories:
+
+| Status          | Option ID  | Color  | Purpose                                      |
+| --------------- | ---------- | ------ | -------------------------------------------- |
+| **Backlog**     | `7404f88c` | Gray   | Epics and future-sprint stories              |
+| **Todo**        | `dc74a3b0` | Blue   | Current sprint stories ready for development |
+| **In Progress** | `296eeabe` | Yellow | Stories actively being developed             |
+| **Done**        | `c558f50d` | Green  | Completed and accepted                       |
+
+Project ID: `PVT_kwHOAGtLQM4BOlve`
+Status Field ID: `PVTSSF_lAHOAGtLQM4BOlvezg9P0yo`
+
+### Issue Relationships
+
+All agents must maintain GitHub's native issue relationships:
+
+- **Sub-issues**: Every user story must be linked as a sub-issue of its parent epic. Use the `addSubIssue` GraphQL mutation.
+- **Blocked-by/Blocking**: When a story or epic has dependencies, create `addBlockedBy` relationships. This populates the "Blocked by" section in the issue sidebar.
+
+**Node ID lookup** (required for GraphQL mutations):
+
+```bash
+gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <N>) { id } } }'
+```
+
 ## Agile Workflow
 
 We follow an incremental, agile approach:


### PR DESCRIPTION
## Summary

- Restructured the Projects board from 3 status columns (Todo/In Progress/Done) to 4 categories (Backlog/Todo/In Progress/Done) for better separation of long-term items from near-term actionable work
- Linked all 21 user stories as sub-issues of their parent epics (EPIC-01, EPIC-02, EPIC-11) using GitHub's native sub-issue feature
- Created 47 blocked-by/blocking dependency relationships between issues, reflecting the dependency chains documented in issue bodies
- Updated the product-owner agent definition with §6 Relationship Management (GraphQL patterns, post-creation checklist, updated quality checks and PR review)
- Updated CLAUDE.md with Board Status Categories table and Issue Relationships conventions for all agents

## Board Changes (via GraphQL)

| Change | Count |
|--------|-------|
| Status field options updated | 4 statuses (Backlog/Todo/In Progress/Done) |
| Items re-assigned to statuses | 32 |
| Sub-issue links created | 21 |
| Blocked-by dependencies created | 47 |

## Test plan

- [x] Verify Projects board shows 4 status columns with correct item distribution
- [x] Verify epic issues show "Sub-issues" section with linked stories
- [x] Verify story issues with dependencies show "Blocked by" in sidebar
- [ ] Verify product-owner agent definition has §6 Relationship Management
- [ ] Verify CLAUDE.md has Board Status Categories and Issue Relationships sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)