### PR TITLE
chore: EPIC-02 refinement — address non-blocking review comments

### DIFF
--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
-  const sidebarClassName = `${styles.sidebar} ${isOpen ? styles.open : ''}`;
+  const sidebarClassName = [styles.sidebar, isOpen && styles.open].filter(Boolean).join(' ');
 
   return (
     <aside className={sidebarClassName}>

--- a/client/webpack.config.cjs
+++ b/client/webpack.config.cjs
@@ -59,19 +59,17 @@ module.exports = (env, argv) => {
         },
       ],
     },
-    optimization: {
-      splitChunks: {
-        chunks: 'all',
-      },
-      ...(isProduction
-        ? {
-            minimizer: [
-              '...',
-              new CssMinimizerPlugin(),
-            ],
-          }
-        : {}),
-    },
+    optimization: isProduction
+      ? {
+          splitChunks: {
+            chunks: 'all',
+          },
+          minimizer: [
+            '...',
+            new CssMinimizerPlugin(),
+          ],
+        }
+      : {},
     plugins: [
       new HtmlWebpackPlugin({
         template: './index.html',


### PR DESCRIPTION
## Summary

Addresses non-blocking observations collected from all EPIC-02 PR reviews (#45, #47, #48, #49) as part of the epic refinement phase.

### Code fixes

- **Fix trailing space in Sidebar className** (PR #48, architect observation): The template literal `${styles.sidebar} ${isOpen ? styles.open : ''}` produced a trailing space when `isOpen` was false. Switched to `[styles.sidebar, isOpen && styles.open].filter(Boolean).join(' ')`.

- **Wrap `splitChunks` in `isProduction` conditional** (PR #49, architect observation): `splitChunks: { chunks: 'all' }` was previously applied in both dev and production modes. While harmless, it's cleaner to only apply it in production alongside the other optimization settings.

### Process observations (documented, no code changes)

- CLAUDE.md refinement phase was bundled with Story #33 feature PR (scope creep noted by PO)
- Test authorship in Story #33 by frontend-developer instead of QA agent (process note by PO)
- Unicode hamburger icon could become SVG in future (architect forward-looking note, PR #45)
- `request()` not exported for potential future PATCH support (PO observation, PR #47)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — all clean
- [x] `npm run typecheck` — all packages clean
- [x] `npm test` — 163 tests pass (18 suites)
- [x] `npm run build` — succeeds
- [x] `npm audit` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)