### PR TITLE
fix(client): toggle hamburger icon based on sidebar state

### DIFF
--- a/client/src/components/AppShell/AppShell.test.tsx
+++ b/client/src/components/AppShell/AppShell.test.tsx
@@ -103,7 +103,7 @@ describe('AppShell', () => {
       </Routes>,
     );
 
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
     expect(menuButton).toBeInTheDocument();
   });
 
@@ -131,7 +131,7 @@ describe('AppShell', () => {
       </Routes>,
     );
 
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
     await user.click(menuButton);
 
     // Overlay should now exist in DOM
@@ -150,7 +150,7 @@ describe('AppShell', () => {
     );
 
     // Open sidebar
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
     await user.click(menuButton);
 
     // Verify overlay exists
@@ -176,7 +176,7 @@ describe('AppShell', () => {
     );
 
     // Open sidebar
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
     await user.click(menuButton);
 
     // Verify overlay exists
@@ -207,7 +207,7 @@ describe('AppShell', () => {
     expect(sidebar.className).not.toMatch(/open/);
 
     // Toggle sidebar open
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
     await user.click(menuButton);
 
     // Sidebar should now have 'open' class
@@ -224,21 +224,71 @@ describe('AppShell', () => {
       </Routes>,
     );
 
-    const menuButton = screen.getByRole('button', { name: /toggle navigation menu/i });
+    let menuButton = screen.getByRole('button', { name: /open menu/i });
 
     // Open
     await user.click(menuButton);
     let overlay = document.querySelector('[aria-hidden="true"]');
     expect(overlay).toBeInTheDocument();
 
+    // Button should now say "Close menu"
+    menuButton = screen.getByRole('button', { name: /close menu/i });
+
     // Close
     await user.click(menuButton);
     overlay = document.querySelector('[aria-hidden="true"]');
     expect(overlay).not.toBeInTheDocument();
 
+    // Button should now say "Open menu" again
+    menuButton = screen.getByRole('button', { name: /open menu/i });
+
     // Open again
     await user.click(menuButton);
     overlay = document.querySelector('[aria-hidden="true"]');
     expect(overlay).toBeInTheDocument();
+  });
+
+  it('menu button icon changes from ☰ to ✕ when sidebar opens', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <Routes>
+        <Route element={<AppShell />} path="*">
+          <Route index element={<div>Test Content</div>} />
+        </Route>
+      </Routes>,
+    );
+
+    // Initially button shows hamburger icon
+    let menuButton = screen.getByRole('button', { name: /open menu/i });
+    expect(menuButton).toHaveTextContent('☰');
+
+    // Click to open
+    await user.click(menuButton);
+
+    // Button should now show close icon
+    menuButton = screen.getByRole('button', { name: /close menu/i });
+    expect(menuButton).toHaveTextContent('✕');
+  });
+
+  it('menu button aria-label changes from "Open menu" to "Close menu" when sidebar opens', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <Routes>
+        <Route element={<AppShell />} path="*">
+          <Route index element={<div>Test Content</div>} />
+        </Route>
+      </Routes>,
+    );
+
+    // Initially button has "Open menu" label
+    let menuButton = screen.getByRole('button', { name: /open menu/i });
+    expect(menuButton).toHaveAttribute('aria-label', 'Open menu');
+
+    // Click to open
+    await user.click(menuButton);
+
+    // Button should now have "Close menu" label
+    menuButton = screen.getByRole('button', { name: /close menu/i });
+    expect(menuButton).toHaveAttribute('aria-label', 'Close menu');
   });
 });

--- a/client/src/components/AppShell/AppShell.tsx
+++ b/client/src/components/AppShell/AppShell.tsx
@@ -35,7 +35,7 @@ export function AppShell() {
         <div className={styles.overlay} onClick={handleCloseSidebar} aria-hidden="true" />
       )}
       <div className={styles.mainContent}>
-        <Header onToggleSidebar={handleToggleSidebar} />
+        <Header onToggleSidebar={handleToggleSidebar} isSidebarOpen={isSidebarOpen} />
         <main className={styles.pageContent}>
           <Suspense fallback={<div className={styles.loading}>Loading...</div>}>
             <Outlet />

--- a/client/src/components/Header/Header.test.tsx
+++ b/client/src/components/Header/Header.test.tsx
@@ -4,11 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { Header } from './Header';
 
 describe('Header', () => {
-  it('renders menu toggle button with correct aria-label', () => {
+  it('renders menu toggle button with "Open menu" aria-label when sidebar is closed', () => {
     const mockToggle = jest.fn();
-    render(<Header onToggleSidebar={mockToggle} />);
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
 
-    const button = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const button = screen.getByRole('button', { name: /open menu/i });
     expect(button).toBeInTheDocument();
   });
 
@@ -16,9 +16,9 @@ describe('Header', () => {
     const mockToggle = jest.fn();
     const user = userEvent.setup();
 
-    render(<Header onToggleSidebar={mockToggle} />);
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
 
-    const button = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const button = screen.getByRole('button', { name: /open menu/i });
     await user.click(button);
 
     expect(mockToggle).toHaveBeenCalledTimes(1);
@@ -28,9 +28,9 @@ describe('Header', () => {
     const mockToggle = jest.fn();
     const user = userEvent.setup();
 
-    render(<Header onToggleSidebar={mockToggle} />);
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
 
-    const button = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const button = screen.getByRole('button', { name: /open menu/i });
     await user.click(button);
     await user.click(button);
     await user.click(button);
@@ -40,7 +40,7 @@ describe('Header', () => {
 
   it('renders title area with correct data-testid', () => {
     const mockToggle = jest.fn();
-    render(<Header onToggleSidebar={mockToggle} />);
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
 
     const titleArea = screen.getByTestId('page-title');
     expect(titleArea).toBeInTheDocument();
@@ -48,9 +48,41 @@ describe('Header', () => {
 
   it('menu button has type="button" to prevent form submission', () => {
     const mockToggle = jest.fn();
-    render(<Header onToggleSidebar={mockToggle} />);
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
 
-    const button = screen.getByRole('button', { name: /toggle navigation menu/i });
+    const button = screen.getByRole('button', { name: /open menu/i });
     expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('shows ☰ icon when sidebar is closed', () => {
+    const mockToggle = jest.fn();
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
+
+    const button = screen.getByRole('button', { name: /open menu/i });
+    expect(button).toHaveTextContent('☰');
+  });
+
+  it('shows ✕ icon when sidebar is open', () => {
+    const mockToggle = jest.fn();
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={true} />);
+
+    const button = screen.getByRole('button', { name: /close menu/i });
+    expect(button).toHaveTextContent('✕');
+  });
+
+  it('has "Open menu" aria-label when sidebar is closed', () => {
+    const mockToggle = jest.fn();
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={false} />);
+
+    const button = screen.getByRole('button', { name: /open menu/i });
+    expect(button).toHaveAttribute('aria-label', 'Open menu');
+  });
+
+  it('has "Close menu" aria-label when sidebar is open', () => {
+    const mockToggle = jest.fn();
+    render(<Header onToggleSidebar={mockToggle} isSidebarOpen={true} />);
+
+    const button = screen.getByRole('button', { name: /close menu/i });
+    expect(button).toHaveAttribute('aria-label', 'Close menu');
   });
 });

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -2,18 +2,19 @@ import styles from './Header.module.css';
 
 interface HeaderProps {
   onToggleSidebar: () => void;
+  isSidebarOpen: boolean;
 }
 
-export function Header({ onToggleSidebar }: HeaderProps) {
+export function Header({ onToggleSidebar, isSidebarOpen }: HeaderProps) {
   return (
     <header className={styles.header}>
       <button
         type="button"
         className={styles.menuButton}
         onClick={onToggleSidebar}
-        aria-label="Toggle navigation menu"
+        aria-label={isSidebarOpen ? 'Close menu' : 'Open menu'}
       >
-        ☰
+        {isSidebarOpen ? '✕' : '☰'}
       </button>
       <div className={styles.titleArea} data-testid="page-title"></div>
     </header>


### PR DESCRIPTION
## Summary

- Pass `isSidebarOpen` prop from `AppShell` to `Header` component
- Toggle button icon between ☰ (closed) and ✕ (open)
- Update `aria-label` dynamically: "Open menu" / "Close menu"
- Fixes failing UAT scenarios 18, 20, 21 from EPIC-02 validation

## Root Cause

The `Header` component only received `onToggleSidebar` callback but not the `isSidebarOpen` state. Without knowing the sidebar state, the button couldn't change its icon.

## Files Changed

| File | Change |
|------|--------|
| `Header.tsx` | Added `isSidebarOpen` prop, conditional icon + aria-label |
| `AppShell.tsx` | Passes `isSidebarOpen={isSidebarOpen}` to Header |
| `Header.test.tsx` | 9 tests (5 updated + 4 new for icon/aria-label states) |
| `AppShell.test.tsx` | 13 tests (9 updated + 2 new for icon/aria-label toggle) |

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — all clean
- [x] `npm run typecheck` — all 3 workspaces clean
- [x] `npm test` — 169 tests pass (18 suites)
- [x] `npm run build` — all packages succeed
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual: resize to mobile (<768px), click ☰ → should show ✕, click ✕ → should show ☰
- [ ] Manual: resize to tablet (768-1024px), verify same toggle behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)