### PR TITLE
fix(client): add close button inside sidebar for mobile/tablet

### DIFF
--- a/client/src/components/AppShell/AppShell.test.tsx
+++ b/client/src/components/AppShell/AppShell.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
@@ -231,8 +231,9 @@ describe('AppShell', () => {
     let overlay = document.querySelector('[aria-hidden="true"]');
     expect(overlay).toBeInTheDocument();
 
-    // Button should now say "Close menu"
-    menuButton = screen.getByRole('button', { name: /close menu/i });
+    // Header button should now say "Close menu"
+    const header = screen.getByRole('banner');
+    menuButton = within(header).getByRole('button', { name: /close menu/i });
 
     // Close
     await user.click(menuButton);
@@ -265,9 +266,40 @@ describe('AppShell', () => {
     // Click to open
     await user.click(menuButton);
 
-    // Button should now show close icon
-    menuButton = screen.getByRole('button', { name: /close menu/i });
+    // Header button should now show close icon
+    const header = screen.getByRole('banner');
+    menuButton = within(header).getByRole('button', { name: /close menu/i });
     expect(menuButton).toHaveTextContent('✕');
+  });
+
+  it('clicking close button inside sidebar closes the sidebar', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <Routes>
+        <Route element={<AppShell />} path="*">
+          <Route index element={<div>Test Content</div>} />
+        </Route>
+      </Routes>,
+    );
+
+    // Open sidebar
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
+    await user.click(menuButton);
+
+    // Sidebar should be open
+    const sidebar = screen.getByRole('complementary');
+    expect(sidebar.className).toMatch(/open/);
+
+    // Click the close button inside the sidebar
+    const closeButton = within(sidebar).getByRole('button', { name: /close menu/i });
+    await user.click(closeButton);
+
+    // Sidebar should be closed
+    expect(sidebar.className).not.toMatch(/open/);
+
+    // Overlay should be removed
+    const overlay = document.querySelector('[aria-hidden="true"]');
+    expect(overlay).not.toBeInTheDocument();
   });
 
   it('menu button aria-label changes from "Open menu" to "Close menu" when sidebar opens', async () => {
@@ -287,8 +319,9 @@ describe('AppShell', () => {
     // Click to open
     await user.click(menuButton);
 
-    // Button should now have "Close menu" label
-    menuButton = screen.getByRole('button', { name: /close menu/i });
+    // Header button should now have "Close menu" label
+    const header = screen.getByRole('banner');
+    menuButton = within(header).getByRole('button', { name: /close menu/i });
     expect(menuButton).toHaveAttribute('aria-label', 'Close menu');
   });
 });

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -32,6 +32,10 @@
   background-color: #3b82f6;
 }
 
+.sidebarHeader {
+  display: none;
+}
+
 /* Mobile and tablet: fixed position, hidden by default */
 @media (max-width: 1024px) {
   .sidebar {
@@ -43,10 +47,46 @@
     z-index: 100;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
+    will-change: transform;
   }
 
   .sidebar.open {
     transform: translateX(0);
+  }
+
+  .sidebarHeader {
+    display: flex;
+    justify-content: flex-start;
+    padding: 0.5rem;
+  }
+
+  .closeButton {
+    min-width: 44px;
+    min-height: 44px;
+    border: none;
+    background: transparent;
+    color: #f9fafb;
+    font-size: 1.5rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+    opacity: 0;
+    transition: opacity 0.1s ease 0.2s;
+  }
+
+  .closeButton:hover {
+    background-color: #374151;
+  }
+
+  .closeButton:focus-visible {
+    outline: 2px solid #60a5fa;
+    outline-offset: 2px;
+  }
+
+  .sidebar.open .closeButton {
+    opacity: 1;
   }
 
   .navLink {

--- a/client/src/components/Sidebar/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/Sidebar.test.tsx
@@ -111,6 +111,23 @@ describe('Sidebar', () => {
     expect(activeLinks[0]).toHaveTextContent(/budget/i);
   });
 
+  it('renders a close button with correct aria-label', () => {
+    renderWithRouter(<Sidebar {...defaultProps} isOpen={true} />);
+
+    const closeButton = screen.getByRole('button', { name: /close menu/i });
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('clicking close button calls onClose', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Sidebar {...defaultProps} isOpen={true} />);
+
+    const closeButton = screen.getByRole('button', { name: /close menu/i });
+    await user.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
   it('sidebar has .open class when isOpen is true', () => {
     renderWithRouter(<Sidebar {...defaultProps} isOpen={true} />);
 

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,16 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
   return (
     <aside className={sidebarClassName}>
+      <div className={styles.sidebarHeader}>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="Close menu"
+        >
+          ✕
+        </button>
+      </div>
       <nav className={styles.nav} aria-label="Main navigation">
         <NavLink
           to="/"


### PR DESCRIPTION
## Summary

- Adds a dedicated ✕ close button inside the sidebar component, visible only on mobile/tablet (`≤1024px`)
- Fixes the issue where the Header's close icon was hidden behind the sidebar overlay due to z-index stacking
- Updates AppShell tests to use `within()` scoping to disambiguate between Header and Sidebar close buttons
- Adds 2 new Sidebar unit tests and 1 new AppShell integration test for the close button

## Root Cause

On mobile/tablet, the sidebar has `position: fixed; z-index: 100` which covers the Header's hamburger/close button. The standard mobile drawer pattern places the close button *inside* the drawer itself.

## Test plan

- [ ] `npm run lint` — no errors
- [ ] `npm run format:check` — all clean
- [ ] `npm run typecheck` — no type errors
- [ ] `npm test` — all 172 tests pass (3 new tests added)
- [ ] `npm run build` — succeeds
- [ ] Manual: resize to mobile (<768px), tap ☰ → sidebar slides in with ✕ button at top-right → tap ✕ → sidebar closes
- [ ] Manual: resize to desktop (>1024px) → no close button visible in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)