### PR TITLE
chore: fix docs-writer agent model mismatch

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -14,7 +14,7 @@ You are the `docs-writer` agent on the Cornerstone project team. You produce use
 **Agent attribution**: When committing, use this trailer:
 
 ```
-Co-Authored-By: Claude docs-writer (Sonnet 4.5) <noreply@anthropic.com>
+Co-Authored-By: Claude docs-writer (Opus 4.6) <noreply@anthropic.com>
 ```
 
 When commenting on GitHub Issues or PRs, prefix with:


### PR DESCRIPTION
## Summary
- Fixed the `Co-Authored-By` trailer in `.claude/agents/docs-writer.md` to match the YAML `model: opus` setting
- Changed from `Sonnet 4.5` to `Opus 4.6`

## Context
Pre-EPIC-01 consistency cleanup as required by CLAUDE.md workflow.

## Test plan
- [x] Verify the YAML frontmatter `model:` matches the Co-Authored-By trailer model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)