### PR TITLE
fix(docker): copy server/node_modules to production stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,10 @@ COPY shared/package.json shared/
 COPY server/package.json server/
 COPY client/package.json client/
 
-# Copy production node_modules from builder (npm hoists to root, no workspace node_modules)
+# Copy production node_modules from builder (npm hoists most deps to root,
+# but some may remain in workspace-specific node_modules due to version constraints)
 COPY --from=builder /app/node_modules/ node_modules/
+COPY --from=builder /app/server/node_modules/ server/node_modules/
 
 # Copy built artifacts from builder
 COPY --from=builder /app/shared/dist/ shared/dist/


### PR DESCRIPTION
## Summary

Fixes runtime crash in Docker container where `drizzle-orm` couldn't be found.

**Root cause:** `drizzle-orm` is installed in `server/node_modules/` (not hoisted to root) due to npm workspace constraints. The Dockerfile only copied root `node_modules/` to the production stage, missing the workspace-specific dependencies.

**Fix:** Add `COPY --from=builder /app/server/node_modules/ server/node_modules/` to copy workspace-specific dependencies.

## Test plan

- [x] Build Docker image
- [x] Run container — verify no `ERR_MODULE_NOT_FOUND` at startup
- [x] Verify app serves correctly at port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)