### PR TITLE
fix(docker): copy SQL migration files to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,9 @@ COPY --from=builder /app/shared/dist/ shared/dist/
 COPY --from=builder /app/server/dist/ server/dist/
 COPY --from=builder /app/client/dist/ client/dist/
 
+# Copy SQL migration files (tsc does not copy non-TS assets)
+COPY --from=builder /app/server/src/db/migrations/ server/dist/db/migrations/
+
 # Expose server port
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary

Fixes the Docker container failing to initialize the database on first launch, preventing admin setup.

**Root cause:** TypeScript compiler (`tsc`) does not copy `.sql` files from `server/src/db/migrations/` to `server/dist/db/migrations/`. The migration runner reads SQL files from the `dist/` directory at runtime, but that directory was empty in the Docker image. Without migrations, the database has no tables, so `POST /api/auth/setup` fails.

**Fix:** Added `COPY --from=builder /app/server/src/db/migrations/ server/dist/db/migrations/` to copy the SQL migration files into the expected runtime location.

Combined with PR #65 (server/node_modules) and PR #66 (auth guard), this completes the Docker runtime fixes for EPIC-01.

## Test plan

- [x] Build Docker image
- [x] Run with empty data volume — database initializes with migration
- [x] Navigate to `/setup` — form renders, admin account creation works
- [x] Login with new credentials — redirects to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)