### PR TITLE
fix(server): add trustProxy support for reverse proxy deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ HOST=0.0.0.0
 LOG_LEVEL=info
 NODE_ENV=production
 
+# Set to true when running behind a reverse proxy (e.g., nginx)
+# TRUST_PROXY=false
+
 # ─── Database ──────────────────────────────────────────
 DATABASE_URL=/app/data/cornerstone.db
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -22,6 +22,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     logger: {
       level: process.env.LOG_LEVEL || 'info',
     },
+    trustProxy: process.env.TRUST_PROXY === 'true',
   });
 
   // Configuration (must be first)

--- a/server/src/plugins/config.test.ts
+++ b/server/src/plugins/config.test.ts
@@ -19,6 +19,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         nodeEnv: 'production',
         sessionDuration: 604800,
         secureCookies: true,
+        trustProxy: false,
         oidcIssuer: undefined,
         oidcClientId: undefined,
         oidcClientSecret: undefined,
@@ -44,6 +45,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         nodeEnv: 'production',
         sessionDuration: 604800,
         secureCookies: true,
+        trustProxy: false,
         oidcIssuer: undefined,
         oidcClientId: undefined,
         oidcClientSecret: undefined,
@@ -71,6 +73,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         nodeEnv: 'development',
         sessionDuration: 604800,
         secureCookies: true,
+        trustProxy: false,
         oidcIssuer: undefined,
         oidcClientId: undefined,
         oidcClientSecret: undefined,
@@ -93,6 +96,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         nodeEnv: 'production',
         sessionDuration: 604800,
         secureCookies: true,
+        trustProxy: false,
         oidcIssuer: undefined,
         oidcClientId: undefined,
         oidcClientSecret: undefined,
@@ -187,6 +191,34 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
       });
 
       expect(config.oidcEnabled).toBe(false);
+    });
+  });
+
+  describe('TRUST_PROXY Configuration', () => {
+    it('defaults to false when not set', () => {
+      const config = loadConfig({});
+      expect(config.trustProxy).toBe(false);
+    });
+
+    it('parses TRUST_PROXY=true', () => {
+      const config = loadConfig({ TRUST_PROXY: 'true' });
+      expect(config.trustProxy).toBe(true);
+    });
+
+    it('parses TRUST_PROXY=false', () => {
+      const config = loadConfig({ TRUST_PROXY: 'false' });
+      expect(config.trustProxy).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      const config = loadConfig({ TRUST_PROXY: 'TRUE' });
+      expect(config.trustProxy).toBe(true);
+    });
+
+    it('rejects invalid value', () => {
+      expect(() => loadConfig({ TRUST_PROXY: 'yes' })).toThrow(
+        "TRUST_PROXY must be 'true' or 'false', got: yes",
+      );
     });
   });
 

--- a/server/src/plugins/config.ts
+++ b/server/src/plugins/config.ts
@@ -9,6 +9,7 @@ export interface AppConfig {
   nodeEnv: string;
   sessionDuration: number; // seconds
   secureCookies: boolean;
+  trustProxy: boolean;
   oidcIssuer?: string;
   oidcClientId?: string;
   oidcClientSecret?: string;
@@ -89,6 +90,18 @@ export function loadConfig(env: Record<string, string | undefined>): AppConfig {
     secureCookies = true; // Default fallback
   }
 
+  // Parse TRUST_PROXY (boolean, default false)
+  const trustProxyStr = (getValue('TRUST_PROXY') ?? 'false').toLowerCase();
+  let trustProxy: boolean;
+  if (trustProxyStr === 'true') {
+    trustProxy = true;
+  } else if (trustProxyStr === 'false') {
+    trustProxy = false;
+  } else {
+    errors.push(`TRUST_PROXY must be 'true' or 'false', got: ${getValue('TRUST_PROXY')}`);
+    trustProxy = false; // Default fallback
+  }
+
   // OIDC configuration (all optional)
   const oidcIssuer = getValue('OIDC_ISSUER');
   const oidcClientId = getValue('OIDC_CLIENT_ID');
@@ -111,6 +124,7 @@ export function loadConfig(env: Record<string, string | undefined>): AppConfig {
     nodeEnv,
     sessionDuration,
     secureCookies,
+    trustProxy,
     oidcIssuer,
     oidcClientId,
     oidcClientSecret,
@@ -134,6 +148,7 @@ export default fp(
         nodeEnv: config.nodeEnv,
         sessionDuration: config.sessionDuration,
         secureCookies: config.secureCookies,
+        trustProxy: config.trustProxy,
         oidcEnabled: config.oidcEnabled,
         oidcIssuer: config.oidcIssuer,
       },


### PR DESCRIPTION
## Summary

- Adds `TRUST_PROXY` env var (default `false`) to enable Fastify's `trustProxy` when running behind a reverse proxy (e.g., nginx for SSL termination)
- Without this, Fastify misinterprets proxied connections, causing 502 errors on `POST /api/auth/setup` due to premature upstream connection closure
- Includes config validation, logging, `.env.example` documentation, and 5 new unit tests

## Changes

- `server/src/app.ts` — pass `trustProxy` to Fastify constructor from `TRUST_PROXY` env var
- `server/src/plugins/config.ts` — add `trustProxy` to `AppConfig` interface, parsing, validation, and log output
- `.env.example` — document `TRUST_PROXY` option under Server section
- `server/src/plugins/config.test.ts` — add `trustProxy: false` to all default assertions + 5 new TRUST_PROXY tests

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — all 3 workspaces clean
- [x] `npm test` — 613 tests pass (34 suites)
- [x] `npm run build` — succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual: rebuild Docker image, run behind nginx-proxy with `TRUST_PROXY=true`, verify `POST /api/auth/setup` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)