### PR TITLE
ci: trigger semantic-release for all conventional commit types

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,39 @@
 {
   "branches": ["main", { "name": "beta", "prerelease": true }],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "docs", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "ci", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "chore", "section": "Chores" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "test", "section": "Tests" },
+            { "type": "build", "section": "Build System" },
+            { "type": "ci", "section": "Continuous Integration" }
+          ]
+        }
+      }
+    ],
     ["@semantic-release/npm", { "npmPublish": false }],
     "@semantic-release/github"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/user-event": "14.6.1",
         "@types/jest": "30.0.0",
         "concurrently": "9.2.1",
+        "conventional-changelog-conventionalcommits": "^9.1.0",
         "eslint": "9.39.2",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-react": "7.37.5",
@@ -7213,6 +7214,19 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
       "integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
+      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "30.0.0",
     "concurrently": "9.2.1",
+    "conventional-changelog-conventionalcommits": "9.1.0",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-react": "7.37.5",


### PR DESCRIPTION
## Summary

- Add custom `releaseRules` to `@semantic-release/commit-analyzer` so `docs`, `refactor`, `chore`, `test`, `build`, and `ci` commit types all trigger a `patch` release (previously only `feat`, `fix`, and `perf` did)
- Switch `@semantic-release/release-notes-generator` to the `conventionalcommits` preset with explicit type→section mappings so all commit types appear in release notes
- Add `conventional-changelog-conventionalcommits@9.1.0` dev dependency (required by the preset)

## Context

After v1.7.0-beta.12, three commits landed on `beta` but no release was created because their types (`build`, `chore`, `test`) were not recognized as release triggers by the default analyzer rules.

## Test plan

- [ ] `npm audit` shows 0 vulnerabilities
- [ ] CI passes (Quality Gates + Docker)
- [ ] After merge to `beta`, semantic-release creates v1.7.0-beta.13 with properly sectioned release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)