### PR TITLE
chore: add gwq worktree support for parallel coding sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .env
 .env.local
 .env.*.local
+.env.worktree
 
 # OS files
 .DS_Store

--- a/.gwq.toml
+++ b/.gwq.toml
@@ -1,0 +1,5 @@
+[worktree]
+basedir = "~/worktrees"
+
+[naming]
+template = "{{.Host}}/{{.Owner}}/{{.Repository}}/{{.Branch}}"

--- a/.sandbox/Dockerfile
+++ b/.sandbox/Dockerfile
@@ -11,4 +11,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Install gwq for git worktree management
+ARG GWQ_VERSION=v0.6.0
+RUN ARCH="$(dpkg --print-architecture)" && \
+    if [ "$ARCH" = "amd64" ]; then GWQ_ARCH="amd64"; \
+    elif [ "$ARCH" = "arm64" ]; then GWQ_ARCH="arm64"; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
+    curl -fsSL "https://github.com/d-kuro/gwq/releases/download/${GWQ_VERSION}/gwq_linux_${GWQ_ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin gwq && \
+    chmod +x /usr/local/bin gwq
+
 USER agent

--- a/client/webpack.config.cjs
+++ b/client/webpack.config.cjs
@@ -87,13 +87,13 @@ module.exports = (env, argv) => {
         : []),
     ],
     devServer: {
-      port: 5173,
+      port: parseInt(process.env.CLIENT_DEV_PORT || '5173', 10),
       hot: true,
       historyApiFallback: true,
       proxy: [
         {
           context: ['/api'],
-          target: 'http://localhost:3000',
+          target: `http://localhost:${process.env.PORT || '3000'}`,
           changeOrigin: true,
         },
       ],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default tseslint.config(
         module: 'readonly',
         __dirname: 'readonly',
         __filename: 'readonly',
+        process: 'readonly',
       },
     },
     rules: {

--- a/scripts/install-gwq.sh
+++ b/scripts/install-gwq.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fallback installer for gwq in existing sandboxes where the Dockerfile
+# wasn't rebuilt or the download was blocked at build time.
+# Downloads gwq to ~/.local/bin/ and adds it to PATH via the persistent env file.
+set -euo pipefail
+
+GWQ_VERSION="${GWQ_VERSION:-v0.6.0}"
+INSTALL_DIR="${HOME}/.local/bin"
+PERSISTENT_ENV="/etc/sandbox-persistent.sh"
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  GWQ_ARCH="amd64" ;;
+  aarch64) GWQ_ARCH="arm64" ;;
+  *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Check if already installed
+if command -v gwq &>/dev/null; then
+  echo "gwq is already installed: $(gwq --version)"
+  exit 0
+fi
+
+echo "Installing gwq ${GWQ_VERSION} (${GWQ_ARCH}) to ${INSTALL_DIR}..."
+mkdir -p "$INSTALL_DIR"
+
+curl -fsSL "https://github.com/d-kuro/gwq/releases/download/${GWQ_VERSION}/gwq_linux_${GWQ_ARCH}.tar.gz" \
+  | tar -xz -C "$INSTALL_DIR" gwq
+
+chmod +x "${INSTALL_DIR}/gwq"
+
+# Add to PATH via persistent env file if not already there
+if [ -f "$PERSISTENT_ENV" ]; then
+  if ! grep -q '\.local/bin' "$PERSISTENT_ENV" 2>/dev/null; then
+    echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\"" >> "$PERSISTENT_ENV"
+    echo "Added ~/.local/bin to PATH in ${PERSISTENT_ENV}"
+  fi
+else
+  echo "Warning: ${PERSISTENT_ENV} not found. Add ~/.local/bin to your PATH manually." >&2
+fi
+
+# Make available in current session
+export PATH="${INSTALL_DIR}:${PATH}"
+echo "gwq installed successfully: $(gwq --version)"

--- a/scripts/sandbox-start.sh
+++ b/scripts/sandbox-start.sh
@@ -12,7 +12,7 @@ echo "Building sandbox template image ..."
 docker build -t "$IMAGE_NAME" -f "$PROJECT_DIR/.sandbox/Dockerfile" "$PROJECT_DIR/.sandbox"
 
 echo "Launching sandbox ..."
-docker sandbox run --load-local-template -t "$IMAGE_NAME" claude "$PROJECT_DIR"
+docker sandbox run -t "$IMAGE_NAME" claude "$PROJECT_DIR"
 
 # After creating a new sandbox, we need to run the following to authenticate:
 # docker sandbox exec -it claude-cornerstone gh auth login

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Create a new git worktree for parallel coding sessions.
+#
+# Usage: worktree-create.sh <branch-name> [slot]
+#
+# - <branch-name>: The branch to check out in the new worktree (created from beta if new)
+# - [slot]: Port slot 1-3 (auto-detected if omitted)
+#
+# Each slot maps to a unique pair of server/client ports:
+#   Slot 0: PORT=3000, CLIENT_DEV_PORT=5173 (main worktree, default)
+#   Slot 1: PORT=3001, CLIENT_DEV_PORT=5174
+#   Slot 2: PORT=3002, CLIENT_DEV_PORT=5175
+#   Slot 3: PORT=3003, CLIENT_DEV_PORT=5176
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAIN_WORKTREE="$(dirname "$SCRIPT_DIR")"
+
+BRANCH="${1:?Usage: worktree-create.sh <branch-name> [slot]}"
+SLOT="${2:-}"
+
+# Require gwq
+if ! command -v gwq &>/dev/null; then
+  echo "Error: gwq is not installed. Run: scripts/install-gwq.sh" >&2
+  exit 1
+fi
+
+# Auto-detect next free slot (1-3) by checking which .env.worktree files exist
+if [ -z "$SLOT" ]; then
+  WORKTREE_DIRS=$(git -C "$MAIN_WORKTREE" worktree list --porcelain | grep '^worktree ' | awk '{print $2}')
+  USED_SLOTS=()
+  for dir in $WORKTREE_DIRS; do
+    if [ -f "$dir/.env.worktree" ]; then
+      s=$(grep '^PORT=' "$dir/.env.worktree" 2>/dev/null | head -1 | sed 's/PORT=300//')
+      if [ -n "$s" ] && [ "$s" -ge 1 ] && [ "$s" -le 3 ]; then
+        USED_SLOTS+=("$s")
+      fi
+    fi
+  done
+  for candidate in 1 2 3; do
+    found=0
+    for used in "${USED_SLOTS[@]+"${USED_SLOTS[@]}"}"; do
+      if [ "$candidate" = "$used" ]; then found=1; break; fi
+    done
+    if [ "$found" = "0" ]; then
+      SLOT="$candidate"
+      break
+    fi
+  done
+  if [ -z "$SLOT" ]; then
+    echo "Error: All slots (1-3) are in use. Remove a worktree first." >&2
+    exit 1
+  fi
+  echo "Auto-selected slot ${SLOT}"
+fi
+
+if [ "$SLOT" -lt 1 ] || [ "$SLOT" -gt 3 ]; then
+  echo "Error: Slot must be 1-3 (slot 0 is the main worktree)" >&2
+  exit 1
+fi
+
+SERVER_PORT=$((3000 + SLOT))
+CLIENT_PORT=$((5173 + SLOT))
+
+# Create worktree via gwq (creates branch from current HEAD if it doesn't exist)
+echo "Creating worktree for branch '${BRANCH}' (slot ${SLOT}: ports ${SERVER_PORT}/${CLIENT_PORT})..."
+
+# If the branch doesn't exist, create it from beta
+if ! git -C "$MAIN_WORKTREE" rev-parse --verify "$BRANCH" &>/dev/null; then
+  echo "Branch '${BRANCH}' does not exist, creating from beta..."
+  git -C "$MAIN_WORKTREE" branch "$BRANCH" beta
+fi
+
+cd "$MAIN_WORKTREE"
+gwq add "$BRANCH"
+
+# Find the worktree path
+WORKTREE_PATH=$(git -C "$MAIN_WORKTREE" worktree list --porcelain | grep -A0 "^worktree " | awk '{print $2}' | while read -r dir; do
+  if git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null | grep -qx "$BRANCH"; then
+    echo "$dir"
+    break
+  fi
+done)
+
+if [ -z "$WORKTREE_PATH" ]; then
+  echo "Error: Could not find worktree path after creation" >&2
+  exit 1
+fi
+
+echo "Worktree created at: ${WORKTREE_PATH}"
+
+# Write .env.worktree
+cat > "${WORKTREE_PATH}/.env.worktree" <<EOF
+PORT=${SERVER_PORT}
+CLIENT_DEV_PORT=${CLIENT_PORT}
+DATABASE_URL=./data/cornerstone.db
+NODE_ENV=development
+SECURE_COOKIES=false
+EOF
+echo "Created .env.worktree (PORT=${SERVER_PORT}, CLIENT_DEV_PORT=${CLIENT_PORT})"
+
+# Symlink agent memory from main worktree so learnings are shared
+AGENT_MEMORY_SRC="${MAIN_WORKTREE}/.claude/agent-memory"
+AGENT_MEMORY_DST="${WORKTREE_PATH}/.claude/agent-memory"
+if [ -d "$AGENT_MEMORY_SRC" ]; then
+  mkdir -p "${WORKTREE_PATH}/.claude"
+  if [ ! -L "$AGENT_MEMORY_DST" ]; then
+    ln -s "$AGENT_MEMORY_SRC" "$AGENT_MEMORY_DST"
+    echo "Symlinked .claude/agent-memory/ from main worktree"
+  fi
+fi
+
+# Bootstrap: install dependencies and build shared
+echo "Bootstrapping worktree (npm install + build shared)..."
+cd "$WORKTREE_PATH"
+npm install
+npm rebuild better-sqlite3 2>/dev/null || true
+npm run build -w shared
+
+echo ""
+echo "Worktree ready at: ${WORKTREE_PATH}"
+echo "To start development:"
+echo "  cd ${WORKTREE_PATH}"
+echo "  source .env.worktree && npm run dev"

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Remove a git worktree created by worktree-create.sh.
+#
+# Usage: worktree-remove.sh <branch-name> [--delete-branch]
+#
+# - <branch-name>: The branch whose worktree should be removed
+# - --delete-branch: Also delete the local branch after removing the worktree
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAIN_WORKTREE="$(dirname "$SCRIPT_DIR")"
+
+BRANCH="${1:?Usage: worktree-remove.sh <branch-name> [--delete-branch]}"
+DELETE_BRANCH=false
+if [ "${2:-}" = "--delete-branch" ]; then
+  DELETE_BRANCH=true
+fi
+
+# Find the worktree path for this branch
+WORKTREE_PATH=$(git -C "$MAIN_WORKTREE" worktree list --porcelain | grep -A0 "^worktree " | awk '{print $2}' | while read -r dir; do
+  if [ "$dir" = "$MAIN_WORKTREE" ]; then continue; fi
+  if git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null | grep -qx "$BRANCH"; then
+    echo "$dir"
+    break
+  fi
+done)
+
+if [ -z "$WORKTREE_PATH" ]; then
+  echo "Error: No worktree found for branch '${BRANCH}'" >&2
+  echo "Active worktrees:"
+  git -C "$MAIN_WORKTREE" worktree list
+  exit 1
+fi
+
+echo "Removing worktree at: ${WORKTREE_PATH}"
+git -C "$MAIN_WORKTREE" worktree remove "$WORKTREE_PATH" --force
+
+if [ "$DELETE_BRANCH" = true ]; then
+  echo "Deleting local branch '${BRANCH}'..."
+  git -C "$MAIN_WORKTREE" branch -d "$BRANCH" 2>/dev/null || \
+    git -C "$MAIN_WORKTREE" branch -D "$BRANCH"
+fi
+
+echo ""
+echo "Remaining worktrees:"
+git -C "$MAIN_WORKTREE" worktree list


### PR DESCRIPTION
## Summary

- Install [gwq](https://github.com/d-kuro/gwq) in the sandbox Dockerfile for git worktree management, with a fallback `scripts/install-gwq.sh` for existing sandboxes
- Add `scripts/worktree-create.sh` and `scripts/worktree-remove.sh` for worktree lifecycle with automatic port slot allocation (slots 1-3), agent-memory symlink, and npm bootstrap
- Make dev server ports configurable via `CLIENT_DEV_PORT` and `PORT` env vars in `client/webpack.config.cjs` (backward-compatible defaults)
- Add `.gwq.toml` project config, `.env.worktree` to `.gitignore`, `process` to ESLint CJS globals
- Document the "Parallel Coding Sessions" workflow in `CLAUDE.md` with port allocation table and usage examples

## Test plan

- [ ] Verify `gwq --version` works in a freshly built sandbox
- [ ] Run `scripts/worktree-create.sh feat/test-worktree 1` — confirm directory, `.env.worktree`, agent-memory symlink, and `node_modules/` exist
- [ ] In main worktree, `npm run dev` binds to 3000/5173; in new worktree, `source .env.worktree && npm run dev` binds to 3001/5174
- [ ] Run `scripts/worktree-remove.sh feat/test-worktree` — confirm directory removed
- [ ] Quality gates pass: `npm run lint && npm run format:check && npm run typecheck && npm test && npm run build && npm audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)