### PR TITLE
fix: add /api/health/ready to public routes for Docker healthcheck

### DIFF
--- a/server/src/plugins/auth.ts
+++ b/server/src/plugins/auth.ts
@@ -17,6 +17,7 @@ const PUBLIC_ROUTES = new Set([
   '/api/auth/oidc/login',
   '/api/auth/oidc/callback',
   '/api/health',
+  '/api/health/ready',
 ]);
 
 // Type augmentation: makes request.user available throughout the app


### PR DESCRIPTION
## Summary

- The Dockerfile healthcheck uses `/api/health/ready`, but this endpoint was missing from the `PUBLIC_ROUTES` set in the auth plugin, causing the auth middleware to reject the unauthenticated probe with a 401
- Added `/api/health/ready` to `PUBLIC_ROUTES` so container orchestrators and load balancers can reach the readiness endpoint without authentication

## Test plan

- [x] `npm test` — 614 tests pass across 34 suites
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)