### PR TITLE
fix(sidebar): hide User Management nav link for non-admin users

### DIFF
--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -8,7 +8,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
   const sidebarClassName = [styles.sidebar, isOpen && styles.open].filter(Boolean).join(' ');
 
   return (
@@ -75,13 +75,15 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         >
           Profile
         </NavLink>
-        <NavLink
-          to="/admin/users"
-          className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
-          onClick={onClose}
-        >
-          User Management
-        </NavLink>
+        {user?.role === 'admin' && (
+          <NavLink
+            to="/admin/users"
+            className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
+            onClick={onClose}
+          >
+            User Management
+          </NavLink>
+        )}
         <div className={styles.navSeparator} />
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Hide the "User Management" nav link in the Sidebar for non-admin users
- Only renders when `user?.role === 'admin'` — prevents members from seeing a link that returns 403
- Server-side `requireRole('admin')` middleware remains as defense-in-depth

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — clean
- [x] `npm test` (Sidebar tests) — all 29 pass (mock user is admin, so link count unchanged)
- [ ] Manual: log in as member user, verify "User Management" link is not visible
- [ ] Manual: log in as admin user, verify "User Management" link is visible and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)