### PR TITLE
docs(schema): EPIC-03 work items schema, API contract, and ADR-012

### DIFF
--- a/server/src/db/migrations/0002_create_work_items.sql
+++ b/server/src/db/migrations/0002_create_work_items.sql
@@ -1,0 +1,85 @@
+-- EPIC-03: Work Items Core CRUD & Properties
+-- Creates the work items, tags, notes, subtasks, and dependencies tables.
+
+CREATE TABLE work_items (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'not_started' CHECK(status IN ('not_started', 'in_progress', 'completed', 'blocked')),
+  start_date TEXT,
+  end_date TEXT,
+  duration_days INTEGER,
+  start_after TEXT,
+  start_before TEXT,
+  assigned_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_by TEXT NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_work_items_status ON work_items (status);
+CREATE INDEX idx_work_items_assigned_user_id ON work_items (assigned_user_id);
+CREATE INDEX idx_work_items_created_at ON work_items (created_at);
+
+CREATE TABLE tags (
+  id TEXT PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  color TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE work_item_tags (
+  work_item_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  tag_id TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (work_item_id, tag_id)
+);
+
+CREATE INDEX idx_work_item_tags_tag_id ON work_item_tags (tag_id);
+
+CREATE TABLE work_item_notes (
+  id TEXT PRIMARY KEY,
+  work_item_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  created_by TEXT NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_work_item_notes_work_item_id ON work_item_notes (work_item_id);
+
+CREATE TABLE work_item_subtasks (
+  id TEXT PRIMARY KEY,
+  work_item_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  is_completed INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_work_item_subtasks_work_item_id ON work_item_subtasks (work_item_id);
+
+CREATE TABLE work_item_dependencies (
+  predecessor_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  successor_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  dependency_type TEXT NOT NULL DEFAULT 'finish_to_start' CHECK(dependency_type IN ('finish_to_start', 'start_to_start', 'finish_to_finish', 'start_to_finish')),
+  PRIMARY KEY (predecessor_id, successor_id),
+  CHECK (predecessor_id != successor_id)
+);
+
+CREATE INDEX idx_work_item_dependencies_successor_id ON work_item_dependencies (successor_id);
+
+-- Rollback:
+-- DROP INDEX IF EXISTS idx_work_item_dependencies_successor_id;
+-- DROP TABLE IF EXISTS work_item_dependencies;
+-- DROP INDEX IF EXISTS idx_work_item_subtasks_work_item_id;
+-- DROP TABLE IF EXISTS work_item_subtasks;
+-- DROP INDEX IF EXISTS idx_work_item_notes_work_item_id;
+-- DROP TABLE IF EXISTS work_item_notes;
+-- DROP INDEX IF EXISTS idx_work_item_tags_tag_id;
+-- DROP TABLE IF EXISTS work_item_tags;
+-- DROP TABLE IF EXISTS tags;
+-- DROP INDEX IF EXISTS idx_work_items_created_at;
+-- DROP INDEX IF EXISTS idx_work_items_assigned_user_id;
+-- DROP INDEX IF EXISTS idx_work_items_status;
+-- DROP TABLE IF EXISTS work_items;


### PR DESCRIPTION
## Summary

Designs the complete database schema, API contract, shared type specifications, and pagination conventions for EPIC-03 (Work Items Core CRUD & Properties). This is the architecture-only deliverable that all 8 implementation stories (#87-#94) build against.

### Artifacts Produced

**Source tree:**
- `server/src/db/migrations/0002_create_work_items.sql` -- 6 new tables with indexes and constraints

**GitHub Wiki (already pushed):**
- **Schema page** -- Full documentation for all EPIC-03 tables: `work_items`, `tags`, `work_item_tags`, `work_item_notes`, `work_item_subtasks`, `work_item_dependencies`
- **API Contract page** -- 19 endpoint specifications covering:
  - Work Items CRUD (5 endpoints)
  - Tags CRUD (4 endpoints)
  - Notes CRUD (4 endpoints)
  - Subtasks CRUD + reorder (5 endpoints)
  - Dependencies CRUD (3 endpoints -- note: the note had a typo; there are actually 3)
- **Architecture page** -- Pagination, filtering, and sorting conventions
- **ADR-012** -- Pagination, Filtering, and Sorting Conventions (offset-based)
- **ADR Index** -- Updated with ADR-012

### Key Design Decisions

1. **No `priority` column**: Requirements specify Tags for custom organization. Users can create priority tags ("High Priority", "Critical") rather than being forced into a fixed enum.
2. **4 status values**: `not_started`, `in_progress`, `completed`, `blocked`. "Cancelled" omitted (delete achieves this). "On hold" mapped to "blocked" (better fit for construction).
3. **Composite PKs for junction/dependency tables**: No surrogate IDs on `work_item_tags` or `work_item_dependencies`.
4. **Notes NOT embedded in detail response**: Fetched separately to allow future pagination.
5. **Offset-based pagination** (ADR-012): Simple, sufficient for <1000 items.
6. **`created_by` on work_items**: Tracks who created each item. Uses SET NULL on delete to preserve work items when users are removed.
7. **Dependencies use `predecessor_id`/`successor_id` as composite PK**: Delete endpoint uses `/:id/dependencies/:predecessorId`.
8. **New error codes**: `CIRCULAR_DEPENDENCY` and `DUPLICATE_DEPENDENCY` added to the ErrorCode union.

### Stories Supported

All 8 EPIC-03 stories can now be implemented against these contracts:
- #87: Schema is fully defined in the migration file
- #88: Work items CRUD API contract is specified
- #89: Tags API contract is specified (plus UI requirements from acceptance criteria)
- #90: Notes and subtasks API contract is specified
- #91-#92: API response shapes support list and detail views
- #93: Dependencies API contract with circular detection is specified
- #94: No API changes needed (frontend-only keyboard shortcuts)

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npm test` -- 614 tests pass
- [x] Migration SQL syntax verified against existing migration patterns
- [x] Wiki pages are internally consistent (Schema matches API Contract matches migration SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)