### PR TITLE
ci: add merge-back automation after stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,3 +159,49 @@ jobs:
         if: always()
         with:
           sarif_file: scout-results.sarif
+
+  # ---------------------------------------------------------------------------
+  # Job 4: Merge main back into beta after stable release
+  # ---------------------------------------------------------------------------
+  merge-back:
+    name: Merge Back to Beta
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: >-
+      needs.release.outputs.new-release-published == 'true' &&
+      needs.release.outputs.is-prerelease == 'false'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create merge-back PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.release.outputs.new-release-version }}"
+
+          # Skip if beta already has the release tag
+          if git merge-base --is-ancestor "v${VERSION}" origin/beta 2>/dev/null; then
+            echo "v${VERSION} is already an ancestor of beta"
+            exit 0
+          fi
+
+          # Skip if a merge-back PR already exists
+          EXISTING=$(gh pr list --base beta --head main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Merge-back PR #${EXISTING} already exists"
+            exit 0
+          fi
+
+          gh pr create \
+            --base beta \
+            --head main \
+            --title "chore: merge main (v${VERSION}) back into beta" \
+            --body "Syncs the v${VERSION} release tag from main into beta so semantic-release correctly bumps to the next version."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,7 @@ All agents must clearly identify themselves in commits and GitHub interactions:
   12. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`
   13. **Documentation**: Launch `docs-writer` to update `README.md` with newly shipped features. Commit to `beta`.
   14. **Epic promotion**: After all stories in an epic are complete (merged to `beta`), UAT is approved, and documentation is updated, create a PR from `beta` to `main` using a **merge commit** (not squash): `gh pr create --base main --head beta --title "..." --body "..."` then `gh pr merge --merge <pr-url>`. Merge commits preserve individual commits for semantic-release analysis.
+  15. **Merge-back**: After the stable release is published on `main`, merge `main` back into `beta` so the release tag is reachable from beta's history. This is automated by the `merge-back` job in `release.yml`, which creates a PR from `main` into `beta`. If the automated PR fails (e.g., merge conflicts), manually resolve: create a branch from `beta`, merge `origin/main`, push, and PR to `beta`. **Without this step, semantic-release on beta cannot see the stable tag and keeps incrementing the old pre-release version.**
 
 Note: Dependabot auto-merge (`.github/workflows/dependabot-auto-merge.yml`) targets `beta` — it handles automated dependency updates, not agent work.
 
@@ -263,6 +264,8 @@ Cornerstone uses a two-tier release model:
 
 - **Feature PR -> `beta`**: Squash merge (clean history)
 - **`beta` -> `main`** (epic promotion): Merge commit (preserves individual commits so semantic-release can analyze them)
+
+**Merge-back after promotion:** After each epic promotion (`beta` -> `main`), `main` must be merged back into `beta`. This ensures the stable release tag (e.g., `v1.7.0`) is reachable from beta's git history. Without this, semantic-release on beta continues incrementing the old pre-release series. The `release.yml` workflow automates this via a `merge-back` job.
 
 **Hotfixes:** If a critical fix must go directly to `main`, immediately cherry-pick the fix back to `beta` to keep branches in sync.
 


### PR DESCRIPTION
## Summary

- Adds a `merge-back` job (Job 4) to `release.yml` that automatically creates a PR from `main` → `beta` after stable releases
- Adds step 15 (Merge-back) to the CLAUDE.md workflow documentation
- Adds merge-back explanation to the Release Model section

**Context:** After epic promotion (beta → main → v1.7.0), semantic-release on beta kept producing `v1.7.0-beta.X` instead of `v1.8.0-beta.1`. The root cause: the `v1.7.0` tag sits on main's merge commit, which is not an ancestor of beta. The merge-back job ensures the stable release tag becomes reachable from beta's history.

**Companion PR:** #99 (already merged) performed the immediate fix by merging main back into beta for v1.7.0.

## Test plan

- [ ] Verify `release.yml` merge-back job only triggers on stable releases (`is-prerelease == 'false'`)
- [ ] Verify idempotency guards: skips if tag already reachable or PR already exists
- [ ] Verify CLAUDE.md step 15 documents the merge-back process
- [ ] Verify Release Model section explains the merge-back requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)