### PR TITLE
chore(work-items): EPIC-03 refinement — address non-blocking PR review feedback

### DIFF
--- a/client/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
+++ b/client/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
@@ -25,14 +25,16 @@ export function KeyboardShortcutsHelp({ shortcuts, onClose }: KeyboardShortcutsH
             </tr>
           </thead>
           <tbody>
-            {shortcuts.map((shortcut) => (
-              <tr key={shortcut.key}>
-                <td className={styles.keyCell}>
-                  <kbd className={styles.kbd}>{shortcut.key}</kbd>
-                </td>
-                <td className={styles.descriptionCell}>{shortcut.description}</td>
-              </tr>
-            ))}
+            {shortcuts
+              .filter((shortcut) => shortcut.description)
+              .map((shortcut) => (
+                <tr key={shortcut.key}>
+                  <td className={styles.keyCell}>
+                    <kbd className={styles.kbd}>{shortcut.key}</kbd>
+                  </td>
+                  <td className={styles.descriptionCell}>{shortcut.description}</td>
+                </tr>
+              ))}
           </tbody>
         </table>
       </div>

--- a/client/src/components/TagPicker/TagPicker.module.css
+++ b/client/src/components/TagPicker/TagPicker.module.css
@@ -88,6 +88,15 @@
   border-top: 1px solid #e5e7eb;
 }
 
+.createError {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  color: #991b1b;
+}
+
 .createHeader {
   font-size: 0.875rem;
   color: #374151;

--- a/client/src/components/TagPicker/TagPicker.tsx
+++ b/client/src/components/TagPicker/TagPicker.tsx
@@ -9,6 +9,7 @@ interface TagPickerProps {
   onSelectionChange: (tagIds: string[]) => void;
   onCreateTag?: (name: string, color: string | null) => Promise<TagResponse>;
   disabled?: boolean;
+  onError?: (message: string) => void;
 }
 
 export function TagPicker({
@@ -17,11 +18,13 @@ export function TagPicker({
   onSelectionChange,
   onCreateTag,
   disabled = false,
+  onError,
 }: TagPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [newTagColor, setNewTagColor] = useState<string>('#3b82f6');
+  const [createError, setCreateError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -71,6 +74,7 @@ export function TagPicker({
     if (!onCreateTag || !canCreateNew) return;
 
     setIsCreating(true);
+    setCreateError(null);
 
     try {
       const newTag = await onCreateTag(searchTerm.trim(), newTagColor);
@@ -78,9 +82,12 @@ export function TagPicker({
       setSearchTerm('');
       setNewTagColor('#3b82f6'); // Reset to default
       inputRef.current?.focus();
-    } catch (error) {
-      // Error handling should be done by parent component
-      console.error('Failed to create tag:', error);
+    } catch {
+      const errorMessage = 'Failed to create tag. Please try again.';
+      setCreateError(errorMessage);
+      if (onError) {
+        onError(errorMessage);
+      }
     } finally {
       setIsCreating(false);
     }
@@ -128,6 +135,11 @@ export function TagPicker({
 
           {canCreateNew && (
             <form className={styles.createForm} onSubmit={handleCreateTag}>
+              {createError && (
+                <div className={styles.createError} role="alert">
+                  {createError}
+                </div>
+              )}
               <div className={styles.createHeader}>
                 Create new tag: <strong>{searchTerm.trim()}</strong>
               </div>

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -16,6 +16,11 @@ export interface KeyboardShortcut {
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]): KeyboardShortcut[] {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
+      // Ignore shortcuts when modifier keys are held
+      if (event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+
       // Ignore shortcuts when focus is on input elements
       const target = event.target as HTMLElement;
       const isInputField =

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
@@ -16,6 +16,35 @@
   color: #dc2626;
 }
 
+.errorBanner {
+  position: relative;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  color: #991b1b;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.closeError {
+  background: transparent;
+  border: none;
+  color: #991b1b;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  transition: background 0.15s;
+}
+
+.closeError:hover {
+  background: rgba(153, 27, 27, 0.1);
+}
+
 /* Header */
 .header {
   margin-bottom: 2rem;

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -72,6 +72,11 @@ export default function WorkItemDetailPage() {
 
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
 
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [deletingNoteId, setDeletingNoteId] = useState<string | null>(null);
+  const [deletingSubtaskId, setDeletingSubtaskId] = useState<string | null>(null);
+  const [deletingDependencyId, setDeletingDependencyId] = useState<string | null>(null);
+
   // Load all data on mount
   useEffect(() => {
     if (!id) return;
@@ -168,12 +173,13 @@ export default function WorkItemDetailPage() {
 
   const saveTitle = async () => {
     if (!id || !editedTitle.trim()) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { title: editedTitle.trim() });
       setIsEditingTitle(false);
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update title');
+      setInlineError('Failed to update title');
       console.error('Failed to update title:', err);
     }
   };
@@ -192,12 +198,13 @@ export default function WorkItemDetailPage() {
 
   const saveDescription = async () => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { description: editedDescription.trim() || null });
       setIsEditingDescription(false);
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update description');
+      setInlineError('Failed to update description');
       console.error('Failed to update description:', err);
     }
   };
@@ -210,11 +217,12 @@ export default function WorkItemDetailPage() {
   // Status change
   const handleStatusChange = async (newStatus: WorkItemStatus) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { status: newStatus });
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update status');
+      setInlineError('Failed to update status');
       console.error('Failed to update status:', err);
     }
   };
@@ -222,11 +230,12 @@ export default function WorkItemDetailPage() {
   // Assigned user change
   const handleAssignedUserChange = async (userId: string) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { assignedUserId: userId || null });
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update assigned user');
+      setInlineError('Failed to update assigned user');
       console.error('Failed to update assigned user:', err);
     }
   };
@@ -234,11 +243,12 @@ export default function WorkItemDetailPage() {
   // Date changes
   const handleDateChange = async (field: 'startDate' | 'endDate', value: string) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { [field]: value || null });
       await reloadWorkItem();
     } catch (err) {
-      alert(`Failed to update ${field}`);
+      setInlineError(`Failed to update ${field}`);
       console.error(`Failed to update ${field}:`, err);
     }
   };
@@ -249,11 +259,12 @@ export default function WorkItemDetailPage() {
     const duration = value ? Number(value) : null;
     if (duration !== null && (isNaN(duration) || duration < 0)) return;
 
+    setInlineError(null);
     try {
       await updateWorkItem(id, { durationDays: duration });
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update duration');
+      setInlineError('Failed to update duration');
       console.error('Failed to update duration:', err);
     }
   };
@@ -261,11 +272,12 @@ export default function WorkItemDetailPage() {
   // Constraint changes
   const handleConstraintChange = async (field: 'startAfter' | 'startBefore', value: string) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { [field]: value || null });
       await reloadWorkItem();
     } catch (err) {
-      alert(`Failed to update ${field}`);
+      setInlineError(`Failed to update ${field}`);
       console.error(`Failed to update ${field}:`, err);
     }
   };
@@ -273,11 +285,12 @@ export default function WorkItemDetailPage() {
   // Tags change
   const handleTagsChange = async (tagIds: string[]) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateWorkItem(id, { tagIds });
       await reloadWorkItem();
     } catch (err) {
-      alert('Failed to update tags');
+      setInlineError('Failed to update tags');
       console.error('Failed to update tags:', err);
     }
   };
@@ -288,12 +301,13 @@ export default function WorkItemDetailPage() {
     if (!id || !newNoteContent.trim()) return;
 
     setIsAddingNote(true);
+    setInlineError(null);
     try {
       await createNote(id, { content: newNoteContent.trim() });
       setNewNoteContent('');
       await reloadNotes();
     } catch (err) {
-      alert('Failed to add note');
+      setInlineError('Failed to add note');
       console.error('Failed to add note:', err);
     } finally {
       setIsAddingNote(false);
@@ -307,13 +321,14 @@ export default function WorkItemDetailPage() {
 
   const saveNoteEdit = async (noteId: string) => {
     if (!id || !editedNoteContent.trim()) return;
+    setInlineError(null);
     try {
       await updateNote(id, noteId, { content: editedNoteContent.trim() });
       setEditingNoteId(null);
       setEditedNoteContent('');
       await reloadNotes();
     } catch (err) {
-      alert('Failed to update note');
+      setInlineError('Failed to update note');
       console.error('Failed to update note:', err);
     }
   };
@@ -324,12 +339,19 @@ export default function WorkItemDetailPage() {
   };
 
   const handleDeleteNote = async (noteId: string) => {
-    if (!id || !confirm('Delete this note?')) return;
+    if (!id) return;
+    setDeletingNoteId(noteId);
+  };
+
+  const confirmDeleteNote = async () => {
+    if (!id || !deletingNoteId) return;
+    setInlineError(null);
     try {
-      await deleteNote(id, noteId);
+      await deleteNote(id, deletingNoteId);
+      setDeletingNoteId(null);
       await reloadNotes();
     } catch (err) {
-      alert('Failed to delete note');
+      setInlineError('Failed to delete note');
       console.error('Failed to delete note:', err);
     }
   };
@@ -340,12 +362,13 @@ export default function WorkItemDetailPage() {
     if (!id || !newSubtaskTitle.trim()) return;
 
     setIsAddingSubtask(true);
+    setInlineError(null);
     try {
       await createSubtask(id, { title: newSubtaskTitle.trim() });
       setNewSubtaskTitle('');
       await reloadSubtasks();
     } catch (err) {
-      alert('Failed to add subtask');
+      setInlineError('Failed to add subtask');
       console.error('Failed to add subtask:', err);
     } finally {
       setIsAddingSubtask(false);
@@ -354,11 +377,12 @@ export default function WorkItemDetailPage() {
 
   const handleToggleSubtask = async (subtaskId: string, isCompleted: boolean) => {
     if (!id) return;
+    setInlineError(null);
     try {
       await updateSubtask(id, subtaskId, { isCompleted });
       await reloadSubtasks();
     } catch (err) {
-      alert('Failed to update subtask');
+      setInlineError('Failed to update subtask');
       console.error('Failed to update subtask:', err);
     }
   };
@@ -370,13 +394,14 @@ export default function WorkItemDetailPage() {
 
   const saveSubtaskEdit = async (subtaskId: string) => {
     if (!id || !editedSubtaskTitle.trim()) return;
+    setInlineError(null);
     try {
       await updateSubtask(id, subtaskId, { title: editedSubtaskTitle.trim() });
       setEditingSubtaskId(null);
       setEditedSubtaskTitle('');
       await reloadSubtasks();
     } catch (err) {
-      alert('Failed to update subtask');
+      setInlineError('Failed to update subtask');
       console.error('Failed to update subtask:', err);
     }
   };
@@ -387,12 +412,19 @@ export default function WorkItemDetailPage() {
   };
 
   const handleDeleteSubtask = async (subtaskId: string) => {
-    if (!id || !confirm('Delete this subtask?')) return;
+    if (!id) return;
+    setDeletingSubtaskId(subtaskId);
+  };
+
+  const confirmDeleteSubtask = async () => {
+    if (!id || !deletingSubtaskId) return;
+    setInlineError(null);
     try {
-      await deleteSubtask(id, subtaskId);
+      await deleteSubtask(id, deletingSubtaskId);
+      setDeletingSubtaskId(null);
       await reloadSubtasks();
     } catch (err) {
-      alert('Failed to delete subtask');
+      setInlineError('Failed to delete subtask');
       console.error('Failed to delete subtask:', err);
     }
   };
@@ -406,11 +438,12 @@ export default function WorkItemDetailPage() {
     const [moved] = reordered.splice(index, 1);
     reordered.splice(newIndex, 0, moved);
 
+    setInlineError(null);
     try {
       await reorderSubtasks(id, { subtaskIds: reordered.map((s) => s.id) });
       await reloadSubtasks();
     } catch (err) {
-      alert('Failed to reorder subtasks');
+      setInlineError('Failed to reorder subtasks');
       console.error('Failed to reorder subtasks:', err);
     }
   };
@@ -421,6 +454,7 @@ export default function WorkItemDetailPage() {
     if (!id || !newDependencyPredecessorId) return;
 
     setIsAddingDependency(true);
+    setInlineError(null);
     try {
       await createDependency(id, {
         predecessorId: newDependencyPredecessorId,
@@ -430,7 +464,7 @@ export default function WorkItemDetailPage() {
       setNewDependencyType('finish_to_start');
       await reloadDependencies();
     } catch (err) {
-      alert('Failed to add dependency');
+      setInlineError('Failed to add dependency');
       console.error('Failed to add dependency:', err);
     } finally {
       setIsAddingDependency(false);
@@ -438,12 +472,19 @@ export default function WorkItemDetailPage() {
   };
 
   const handleDeleteDependency = async (predecessorId: string) => {
-    if (!id || !confirm('Remove this dependency?')) return;
+    if (!id) return;
+    setDeletingDependencyId(predecessorId);
+  };
+
+  const confirmDeleteDependency = async () => {
+    if (!id || !deletingDependencyId) return;
+    setInlineError(null);
     try {
-      await deleteDependency(id, predecessorId);
+      await deleteDependency(id, deletingDependencyId);
+      setDeletingDependencyId(null);
       await reloadDependencies();
     } catch (err) {
-      alert('Failed to remove dependency');
+      setInlineError('Failed to remove dependency');
       console.error('Failed to remove dependency:', err);
     }
   };
@@ -452,11 +493,12 @@ export default function WorkItemDetailPage() {
   const handleDeleteWorkItem = async () => {
     if (!id) return;
     setIsDeleting(true);
+    setInlineError(null);
     try {
       await deleteWorkItem(id);
       navigate('/work-items');
     } catch (err) {
-      alert('Failed to delete work item');
+      setInlineError('Failed to delete work item');
       console.error('Failed to delete work item:', err);
       setIsDeleting(false);
     }
@@ -481,7 +523,7 @@ export default function WorkItemDetailPage() {
             setShowDeleteConfirm(true);
           }
         },
-        description: 'Delete work item',
+        description: 'Delete work item (Delete / Backspace)',
       },
       {
         key: 'Backspace',
@@ -490,7 +532,7 @@ export default function WorkItemDetailPage() {
             setShowDeleteConfirm(true);
           }
         },
-        description: 'Delete work item',
+        description: '', // Empty description to hide in help overlay
       },
       {
         key: 'Escape',
@@ -566,6 +608,21 @@ export default function WorkItemDetailPage() {
 
   return (
     <div className={styles.container}>
+      {/* Inline error banner */}
+      {inlineError && (
+        <div className={styles.errorBanner} role="alert">
+          {inlineError}
+          <button
+            type="button"
+            className={styles.closeError}
+            onClick={() => setInlineError(null)}
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {/* Header */}
       <div className={styles.header}>
         <button type="button" className={styles.backButton} onClick={() => navigate('/work-items')}>
@@ -749,6 +806,7 @@ export default function WorkItemDetailPage() {
               selectedTagIds={workItem.tags.map((t) => t.id)}
               onSelectionChange={handleTagsChange}
               onCreateTag={handleCreateTag}
+              onError={(message) => setInlineError(message)}
             />
           </section>
         </div>
@@ -1087,6 +1145,93 @@ export default function WorkItemDetailPage() {
       {/* Keyboard shortcuts help */}
       {showShortcutsHelp && (
         <KeyboardShortcutsHelp shortcuts={shortcuts} onClose={() => setShowShortcutsHelp(false)} />
+      )}
+
+      {/* Note deletion confirmation modal */}
+      {deletingNoteId && (
+        <div className={styles.modal}>
+          <div className={styles.modalBackdrop} onClick={() => setDeletingNoteId(null)} />
+          <div className={styles.modalContent}>
+            <h2 className={styles.modalTitle}>Delete Note?</h2>
+            <p className={styles.modalText}>
+              Are you sure you want to delete this note? This action cannot be undone.
+            </p>
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancelButton}
+                onClick={() => setDeletingNoteId(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.modalDeleteButton}
+                onClick={confirmDeleteNote}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Subtask deletion confirmation modal */}
+      {deletingSubtaskId && (
+        <div className={styles.modal}>
+          <div className={styles.modalBackdrop} onClick={() => setDeletingSubtaskId(null)} />
+          <div className={styles.modalContent}>
+            <h2 className={styles.modalTitle}>Delete Subtask?</h2>
+            <p className={styles.modalText}>
+              Are you sure you want to delete this subtask? This action cannot be undone.
+            </p>
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancelButton}
+                onClick={() => setDeletingSubtaskId(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.modalDeleteButton}
+                onClick={confirmDeleteSubtask}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Dependency deletion confirmation modal */}
+      {deletingDependencyId && (
+        <div className={styles.modal}>
+          <div className={styles.modalBackdrop} onClick={() => setDeletingDependencyId(null)} />
+          <div className={styles.modalContent}>
+            <h2 className={styles.modalTitle}>Remove Dependency?</h2>
+            <p className={styles.modalText}>
+              Are you sure you want to remove this dependency? This action cannot be undone.
+            </p>
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancelButton}
+                onClick={() => setDeletingDependencyId(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.modalDeleteButton}
+                onClick={confirmDeleteDependency}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/server/src/routes/dependencies.test.ts
+++ b/server/src/routes/dependencies.test.ts
@@ -296,7 +296,7 @@ describe('Dependency Routes', () => {
       expect(body.error.code).toBe('CONFLICT');
       expect(body.error.message).toContain('Circular dependency detected');
       expect(body.error.details?.code).toBe('CIRCULAR_DEPENDENCY');
-      expect(body.error.details?.cyclePath).toBeDefined();
+      expect(body.error.details?.cycle).toBeDefined();
     });
 
     it('should return 400 when dependencyType is invalid', async () => {

--- a/server/src/services/dependencyService.test.ts
+++ b/server/src/services/dependencyService.test.ts
@@ -210,7 +210,7 @@ describe('Dependency Service', () => {
         expect(error).toBeInstanceOf(ConflictError);
         if (error instanceof ConflictError) {
           expect(error.details?.code).toBe('CIRCULAR_DEPENDENCY');
-          expect(error.details?.cyclePath).toBeDefined();
+          expect(error.details?.cycle).toBeDefined();
         }
       }
     });

--- a/server/src/services/noteService.ts
+++ b/server/src/services/noteService.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { eq, desc } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import { workItemNotes, workItems, users } from '../db/schema.js';
+import { workItemNotes, users } from '../db/schema.js';
 import type {
   NoteResponse,
   NoteUserSummary,
@@ -10,6 +10,7 @@ import type {
   UpdateNoteRequest,
 } from '@cornerstone/shared';
 import { NotFoundError, ForbiddenError, ValidationError } from '../errors/AppError.js';
+import { ensureWorkItemExists } from './workItemService.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
@@ -38,17 +39,6 @@ function toNoteResponse(
     createdAt: note.createdAt,
     updatedAt: note.updatedAt,
   };
-}
-
-/**
- * Verify a work item exists.
- * @throws NotFoundError if work item does not exist
- */
-function ensureWorkItemExists(db: DbType, workItemId: string): void {
-  const workItem = db.select().from(workItems).where(eq(workItems.id, workItemId)).get();
-  if (!workItem) {
-    throw new NotFoundError('Work item not found');
-  }
 }
 
 /**

--- a/server/src/services/subtaskService.ts
+++ b/server/src/services/subtaskService.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { eq, asc, sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import { workItemSubtasks, workItems } from '../db/schema.js';
+import { workItemSubtasks } from '../db/schema.js';
 import type {
   SubtaskResponse,
   CreateSubtaskRequest,
@@ -10,6 +10,7 @@ import type {
   ReorderSubtasksRequest,
 } from '@cornerstone/shared';
 import { NotFoundError, ValidationError } from '../errors/AppError.js';
+import { ensureWorkItemExists } from './workItemService.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
@@ -25,17 +26,6 @@ function toSubtaskResponse(subtask: typeof workItemSubtasks.$inferSelect): Subta
     createdAt: subtask.createdAt,
     updatedAt: subtask.updatedAt,
   };
-}
-
-/**
- * Verify a work item exists.
- * @throws NotFoundError if work item does not exist
- */
-function ensureWorkItemExists(db: DbType, workItemId: string): void {
-  const workItem = db.select().from(workItems).where(eq(workItems.id, workItemId)).get();
-  if (!workItem) {
-    throw new NotFoundError('Work item not found');
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses non-blocking review observations collected from EPIC-03 PRs (#97-#106).

### Backend fixes
- Escape SQL LIKE wildcards (`%`, `_`) in search queries
- Extract shared `ensureWorkItemExists()` helper
- Add DFS iteration limits (10K max) to cycle detection
- Move self-reference check before DB queries
- Rename `cyclePath` → `cycle` for API contract compliance

### Frontend fixes
- Fix action menu click-outside detection (shared ref issue)
- Replace `alert()`/`confirm()` with custom modals
- Add modifier key guard (Ctrl/Alt/Meta) to keyboard shortcuts
- Initialize selectedIndex to -1 (no default selection)
- Combine duplicate Delete/Backspace help entries
- Remove `console.error` in TagPicker, use error state
- Differentiate empty state vs no-results on list page

## Test plan

- [x] All existing tests pass (1072 tests)
- [x] Lint, typecheck, format all clean
- [x] No new functionality — refinement only

🤖 Generated with [Claude Code](https://claude.com/claude-code)