### PR TITLE
feat(theme): dark mode with user preference toggle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AppShell } from './components/AppShell/AppShell';
 import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthGuard } from './components/AuthGuard/AuthGuard';
 
 const SetupPage = lazy(() => import('./pages/SetupPage/SetupPage'));
@@ -22,45 +23,47 @@ const NotFoundPage = lazy(() => import('./pages/NotFoundPage/NotFoundPage'));
 export function App() {
   return (
     <BrowserRouter>
-      <AuthProvider>
-        <Routes>
-          {/* Auth routes (no AppShell wrapper) */}
-          <Route
-            path="setup"
-            element={
-              <Suspense fallback={<div>Loading...</div>}>
-                <SetupPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="login"
-            element={
-              <Suspense fallback={<div>Loading...</div>}>
-                <LoginPage />
-              </Suspense>
-            }
-          />
+      <ThemeProvider>
+        <AuthProvider>
+          <Routes>
+            {/* Auth routes (no AppShell wrapper) */}
+            <Route
+              path="setup"
+              element={
+                <Suspense fallback={<div>Loading...</div>}>
+                  <SetupPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="login"
+              element={
+                <Suspense fallback={<div>Loading...</div>}>
+                  <LoginPage />
+                </Suspense>
+              }
+            />
 
-          {/* Protected app routes (with AuthGuard and AppShell wrapper) */}
-          <Route element={<AuthGuard />}>
-            <Route element={<AppShell />}>
-              <Route index element={<DashboardPage />} />
-              <Route path="work-items" element={<WorkItemsPage />} />
-              <Route path="work-items/new" element={<WorkItemCreatePage />} />
-              <Route path="work-items/:id" element={<WorkItemDetailPage />} />
-              <Route path="budget" element={<BudgetPage />} />
-              <Route path="timeline" element={<TimelinePage />} />
-              <Route path="household-items" element={<HouseholdItemsPage />} />
-              <Route path="documents" element={<DocumentsPage />} />
-              <Route path="tags" element={<TagManagementPage />} />
-              <Route path="profile" element={<ProfilePage />} />
-              <Route path="admin/users" element={<UserManagementPage />} />
-              <Route path="*" element={<NotFoundPage />} />
+            {/* Protected app routes (with AuthGuard and AppShell wrapper) */}
+            <Route element={<AuthGuard />}>
+              <Route element={<AppShell />}>
+                <Route index element={<DashboardPage />} />
+                <Route path="work-items" element={<WorkItemsPage />} />
+                <Route path="work-items/new" element={<WorkItemCreatePage />} />
+                <Route path="work-items/:id" element={<WorkItemDetailPage />} />
+                <Route path="budget" element={<BudgetPage />} />
+                <Route path="timeline" element={<TimelinePage />} />
+                <Route path="household-items" element={<HouseholdItemsPage />} />
+                <Route path="documents" element={<DocumentsPage />} />
+                <Route path="tags" element={<TagManagementPage />} />
+                <Route path="profile" element={<ProfilePage />} />
+                <Route path="admin/users" element={<UserManagementPage />} />
+                <Route path="*" element={<NotFoundPage />} />
+              </Route>
             </Route>
-          </Route>
-        </Routes>
-      </AuthProvider>
+          </Routes>
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   );
 }

--- a/client/src/components/AppShell/AppShell.test.tsx
+++ b/client/src/components/AppShell/AppShell.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import type React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { lazy } from 'react';
@@ -28,6 +29,16 @@ jest.unstable_mockModule('../../contexts/AuthContext.js', () => ({
     refreshAuth: jest.fn(),
     logout: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
   }),
+}));
+
+// Mock ThemeContext so ThemeToggle (inside Sidebar) can call useTheme()
+jest.unstable_mockModule('../../contexts/ThemeContext.js', () => ({
+  useTheme: () => ({
+    theme: 'system',
+    resolvedTheme: 'light',
+    setTheme: jest.fn(),
+  }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 describe('AppShell', () => {
@@ -147,7 +158,7 @@ describe('AppShell', () => {
     );
 
     // Overlay should not exist in DOM when sidebar is closed
-    const overlay = document.querySelector('[aria-hidden="true"]');
+    const overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).not.toBeInTheDocument();
   });
 
@@ -165,7 +176,7 @@ describe('AppShell', () => {
     await user.click(menuButton);
 
     // Overlay should now exist in DOM
-    const overlay = document.querySelector('[aria-hidden="true"]');
+    const overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).toBeInTheDocument();
   });
 
@@ -184,14 +195,14 @@ describe('AppShell', () => {
     await user.click(menuButton);
 
     // Verify overlay exists
-    let overlay = document.querySelector('[aria-hidden="true"]');
+    let overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).toBeInTheDocument();
 
     // Click overlay to close
     await user.click(overlay as HTMLElement);
 
     // Overlay should be removed
-    overlay = document.querySelector('[aria-hidden="true"]');
+    overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).not.toBeInTheDocument();
   });
 
@@ -210,14 +221,14 @@ describe('AppShell', () => {
     await user.click(menuButton);
 
     // Verify overlay exists
-    let overlay = document.querySelector('[aria-hidden="true"]');
+    let overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).toBeInTheDocument();
 
     // Press Escape
     await user.keyboard('{Escape}');
 
     // Overlay should be removed
-    overlay = document.querySelector('[aria-hidden="true"]');
+    overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).not.toBeInTheDocument();
   });
 
@@ -258,7 +269,7 @@ describe('AppShell', () => {
 
     // Open
     await user.click(menuButton);
-    let overlay = document.querySelector('[aria-hidden="true"]');
+    let overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).toBeInTheDocument();
 
     // Header button should now say "Close menu"
@@ -267,7 +278,7 @@ describe('AppShell', () => {
 
     // Close
     await user.click(menuButton);
-    overlay = document.querySelector('[aria-hidden="true"]');
+    overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).not.toBeInTheDocument();
 
     // Button should now say "Open menu" again
@@ -275,7 +286,7 @@ describe('AppShell', () => {
 
     // Open again
     await user.click(menuButton);
-    overlay = document.querySelector('[aria-hidden="true"]');
+    overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).toBeInTheDocument();
   });
 
@@ -328,7 +339,7 @@ describe('AppShell', () => {
     expect(sidebar.className).not.toMatch(/open/);
 
     // Overlay should be removed
-    const overlay = document.querySelector('[aria-hidden="true"]');
+    const overlay = document.querySelector('[data-testid="sidebar-overlay"]');
     expect(overlay).not.toBeInTheDocument();
   });
 

--- a/client/src/components/AppShell/AppShell.tsx
+++ b/client/src/components/AppShell/AppShell.tsx
@@ -32,7 +32,12 @@ export function AppShell() {
     <div className={styles.appShell}>
       <Sidebar isOpen={isSidebarOpen} onClose={handleCloseSidebar} />
       {isSidebarOpen && (
-        <div className={styles.overlay} onClick={handleCloseSidebar} aria-hidden="true" />
+        <div
+          className={styles.overlay}
+          onClick={handleCloseSidebar}
+          aria-hidden="true"
+          data-testid="sidebar-overlay"
+        />
       )}
       <div className={styles.mainContent}>
         <Header onToggleSidebar={handleToggleSidebar} isSidebarOpen={isSidebarOpen} />

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -80,6 +80,11 @@
   outline-offset: -2px;
 }
 
+.themeSection {
+  /* Wrapper keeps the toggle flush with sidebar nav style */
+  padding: var(--spacing-1) 0;
+}
+
 .sidebarHeader {
   display: none;
 }

--- a/client/src/components/Sidebar/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/Sidebar.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import type React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../test/testUtils.js';
@@ -28,6 +29,18 @@ jest.unstable_mockModule('../../contexts/AuthContext.js', () => ({
     refreshAuth: jest.fn(),
     logout: mockLogout,
   }),
+}));
+
+// Mock ThemeContext so Sidebar tests don't need a ThemeProvider
+const mockSetTheme = jest.fn<(theme: string) => void>();
+
+jest.unstable_mockModule('../../contexts/ThemeContext.js', () => ({
+  useTheme: () => ({
+    theme: 'system',
+    resolvedTheme: 'light',
+    setTheme: mockSetTheme,
+  }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 describe('Sidebar', () => {
@@ -344,9 +357,9 @@ describe('Sidebar', () => {
 
     // Still 9 navigation links
     expect(links).toHaveLength(9);
-    // 2 buttons: close button + logout button
-    expect(buttons).toHaveLength(2);
+    // 3 buttons: close button + theme toggle + logout button
+    expect(buttons).toHaveLength(3);
     expect(buttons[0]).toHaveAttribute('aria-label', 'Close menu');
-    expect(buttons[1]).toHaveTextContent(/logout/i);
+    expect(buttons[2]).toHaveTextContent(/logout/i);
   });
 });

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext.js';
 import { Logo } from '../Logo/Logo.js';
+import { ThemeToggle } from '../ThemeToggle/ThemeToggle.js';
 import styles from './Sidebar.module.css';
 
 interface SidebarProps {
@@ -96,6 +97,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             User Management
           </NavLink>
         )}
+        <div className={styles.navSeparator} />
+        <div className={styles.themeSection}>
+          <ThemeToggle />
+        </div>
         <div className={styles.navSeparator} />
         <button
           type="button"

--- a/client/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/client/src/components/ThemeToggle/ThemeToggle.module.css
@@ -1,0 +1,43 @@
+.themeToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  width: 100%;
+  padding: var(--spacing-3) var(--spacing-6);
+  background: transparent;
+  border: none;
+  color: var(--color-sidebar-text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color var(--transition-medium);
+  border-radius: 0;
+}
+
+.themeToggle:hover {
+  background-color: var(--color-sidebar-hover);
+}
+
+.themeToggle:focus-visible {
+  outline: 2px solid var(--color-sidebar-focus-ring);
+  outline-offset: -2px;
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.label {
+  font-size: var(--font-size-sm);
+}
+
+/* Mobile / tablet touch target */
+@media (max-width: 1024px) {
+  .themeToggle {
+    min-height: 44px;
+  }
+}

--- a/client/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,113 @@
+import { useTheme, type ThemePreference } from '../../contexts/ThemeContext.js';
+import styles from './ThemeToggle.module.css';
+
+/** Inline SVG icons — no external dependency, use currentColor */
+
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function MonitorIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
+const THEME_CYCLE: ThemePreference[] = ['light', 'dark', 'system'];
+
+const THEME_LABELS: Record<ThemePreference, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+};
+
+const NEXT_THEME: Record<ThemePreference, ThemePreference> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+};
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const handleClick = () => {
+    setTheme(NEXT_THEME[theme]);
+  };
+
+  const nextTheme = NEXT_THEME[theme];
+  const nextLabel = THEME_LABELS[nextTheme];
+
+  return (
+    <button
+      type="button"
+      className={styles.themeToggle}
+      onClick={handleClick}
+      aria-label={`Switch to ${nextLabel} mode`}
+      title={`Current: ${THEME_LABELS[theme]} — click to switch to ${nextLabel}`}
+    >
+      <span className={styles.icon}>
+        {theme === 'light' && <SunIcon />}
+        {theme === 'dark' && <MoonIcon />}
+        {theme === 'system' && <MonitorIcon />}
+      </span>
+      <span className={styles.label}>{THEME_LABELS[theme]}</span>
+    </button>
+  );
+}
+
+// Export the cycle array for use in tests
+export { THEME_CYCLE };

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+export interface ThemeContextValue {
+  /** The user's explicit preference: 'light', 'dark', or 'system' */
+  theme: ThemePreference;
+  /** The actual applied theme after resolving 'system' against OS preference */
+  resolvedTheme: ResolvedTheme;
+  /** Update the user's theme preference */
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'theme';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  if (preference === 'system') return getSystemTheme();
+  return preference;
+}
+
+function readStoredPreference(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  } catch {
+    // localStorage may be unavailable (e.g., private browsing with strict settings)
+  }
+  return 'system';
+}
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemePreference>(readStoredPreference);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(readStoredPreference()),
+  );
+
+  // Apply the resolved theme to <html data-theme="...">
+  useEffect(() => {
+    document.documentElement.dataset.theme = resolvedTheme;
+  }, [resolvedTheme]);
+
+  // Listen for OS-level dark mode changes when preference is 'system'
+  useEffect(() => {
+    if (theme !== 'system') return;
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setResolvedTheme(e.matches ? 'dark' : 'light');
+    };
+
+    mq.addEventListener('change', handleChange);
+    return () => mq.removeEventListener('change', handleChange);
+  }, [theme]);
+
+  const setTheme = useCallback((preference: ThemePreference) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, preference);
+    } catch {
+      // Ignore storage errors
+    }
+    setThemeState(preference);
+    setResolvedTheme(resolveTheme(preference));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -273,22 +273,118 @@
 }
 
 /* ============================================================
- * LAYER 3 — DARK MODE STUBS
- * Overrides are implemented in Story 12.4
+ * LAYER 3 — DARK MODE OVERRIDES
+ * Scoped to [data-theme="dark"] on <html> — set by ThemeContext.
+ * Only semantic tokens need overriding; palette tokens remain unchanged.
  * ============================================================ */
 
-/* [data-theme="dark"] {
-  --color-bg-primary: var(--color-gray-900);
-  --color-bg-secondary: var(--color-gray-800);
-  --color-bg-tertiary: var(--color-gray-700);
-  --color-bg-hover: var(--color-gray-800);
+[data-theme='dark'] {
+  /* --- Backgrounds --- */
+  --color-bg-primary: #1a1a2e;
+  --color-bg-secondary: #16213e;
+  --color-bg-tertiary: #1e293b;
+  --color-bg-inverse: var(--color-gray-100);
+  --color-bg-hover: #1e293b;
 
-  --color-text-primary: var(--color-white);
-  --color-text-secondary: var(--color-gray-200);
-  --color-text-body: var(--color-gray-300);
-  --color-text-muted: var(--color-gray-400);
-  --color-text-subtle: var(--color-gray-400);
+  /* --- Text --- */
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #cbd5e1;
+  --color-text-body: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-text-subtle: #94a3b8;
+  --color-text-inverse: var(--color-gray-900);
+  --color-text-placeholder: #475569;
+  --color-text-disabled: #475569;
 
-  --color-border: var(--color-gray-700);
-  --color-border-strong: var(--color-gray-600);
-} */
+  /* --- Borders --- */
+  --color-border: #334155;
+  --color-border-strong: #475569;
+  --color-border-focus: #60a5fa;
+
+  /* --- Primary action --- */
+  --color-primary: #60a5fa;
+  --color-primary-hover: #3b82f6;
+  --color-primary-active: #2563eb;
+  --color-primary-text: var(--color-gray-900);
+  --color-primary-bg: rgba(59, 130, 246, 0.15);
+  --color-primary-bg-hover: rgba(59, 130, 246, 0.25);
+  --color-primary-badge-text: #93c5fd;
+
+  /* --- Danger / Error --- */
+  --color-danger: #f87171;
+  --color-danger-hover: #ef4444;
+  --color-danger-active: #dc2626;
+  --color-danger-text: var(--color-gray-900);
+  --color-danger-bg: rgba(239, 68, 68, 0.1);
+  --color-danger-bg-strong: rgba(239, 68, 68, 0.2);
+  --color-danger-border: rgba(239, 68, 68, 0.3);
+  --color-danger-text-on-light: #fca5a5;
+  --color-danger-input-border: #ef4444;
+
+  /* --- Success --- */
+  --color-success: #34d399;
+  --color-success-hover: #10b981;
+  --color-success-bg: rgba(16, 185, 129, 0.1);
+  --color-success-border: rgba(16, 185, 129, 0.3);
+  --color-success-text-on-light: #6ee7b7;
+  --color-success-badge-bg: rgba(16, 185, 129, 0.15);
+  --color-success-badge-bg-alt: rgba(16, 185, 129, 0.2);
+  --color-success-badge-text: #a7f3d0;
+
+  /* --- Sidebar --- */
+  --color-sidebar-bg: #0f172a;
+  --color-sidebar-text: #e2e8f0;
+  --color-sidebar-hover: #1e293b;
+  --color-sidebar-active: #3b82f6;
+  --color-sidebar-focus-ring: #60a5fa;
+  --color-sidebar-separator: #334155;
+
+  /* --- Focus rings --- */
+  --color-focus-ring: rgba(96, 165, 250, 0.4);
+  --color-focus-ring-subtle: rgba(96, 165, 250, 0.15);
+  --color-focus-ring-danger: rgba(239, 68, 68, 0.15);
+  --color-focus-ring-primary-alt: rgba(96, 165, 250, 0.15);
+
+  /* --- Overlay / backdrop --- */
+  --color-overlay: rgba(0, 0, 0, 0.7);
+  --color-overlay-light: rgba(0, 0, 0, 0.3);
+  --color-overlay-medium: rgba(0, 0, 0, 0.4);
+  --color-overlay-danger: rgba(239, 68, 68, 0.15);
+  --color-overlay-delete: rgba(239, 68, 68, 0.15);
+
+  /* --- Status badges --- */
+  --color-status-not-started-bg: #334155;
+  --color-status-not-started-text: #94a3b8;
+  --color-status-in-progress-bg: rgba(59, 130, 246, 0.2);
+  --color-status-in-progress-text: #93c5fd;
+  --color-status-completed-bg: rgba(16, 185, 129, 0.15);
+  --color-status-completed-text: #a7f3d0;
+  --color-status-blocked-bg: rgba(239, 68, 68, 0.15);
+  --color-status-blocked-text: #fca5a5;
+
+  /* --- Role badges --- */
+  --color-role-admin-bg: rgba(59, 130, 246, 0.2);
+  --color-role-admin-text: #93c5fd;
+  --color-role-member-bg: #334155;
+  --color-role-member-text: #94a3b8;
+
+  /* --- User status badges --- */
+  --color-user-active-bg: rgba(16, 185, 129, 0.15);
+  --color-user-active-text: #6ee7b7;
+  --color-user-inactive-bg: rgba(239, 68, 68, 0.15);
+  --color-user-inactive-text: #fca5a5;
+
+  /* --- Shadows (deeper/darker in dark mode) --- */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.3), 0 4px 6px rgba(0, 0, 0, 0.2);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.4);
+  --shadow-xl-strong: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  --shadow-2xl: 0 20px 25px rgba(0, 0, 0, 0.5);
+  --shadow-inset-deep: 0 10px 25px rgba(0, 0, 0, 0.4);
+  --shadow-kbd: 0 1px 0 rgba(255, 255, 255, 0.1);
+  --shadow-focus: 0 0 0 3px rgba(96, 165, 250, 0.4);
+  --shadow-focus-subtle: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  --shadow-focus-primary-alt: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  --shadow-focus-danger: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}

--- a/client/src/test/setupTests.ts
+++ b/client/src/test/setupTests.ts
@@ -11,3 +11,22 @@ Object.defineProperties(globalThis, {
   TextEncoder: { value: TextEncoder },
   TextDecoder: { value: TextDecoder },
 });
+
+// Polyfill window.matchMedia for jsdom (not implemented in jsdom by default).
+// ThemeContext uses this to detect the OS dark-mode preference.
+// We default to light mode (matches: false) so tests run with the light theme.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}


### PR DESCRIPTION
## Summary

- Complete `[data-theme="dark"]` overrides in `tokens.css` for all semantic token categories: backgrounds, text, borders, primary/danger/success actions, sidebar, focus rings, overlays, status/role/user-status badges, and shadows
- New `ThemeContext` (`ThemeProvider` + `useTheme`) that reads/writes `localStorage`, resolves `'system'` via `window.matchMedia`, and reactively updates on OS preference changes — sets `document.documentElement.dataset.theme` on every change
- New `ThemeToggle` component in the sidebar: cycles Light → Dark → System with inline SVG sun/moon/monitor icons (no icon library dependency), keyboard accessible, uses token-only CSS
- `ThemeProvider` wraps `AuthProvider` in `App.tsx` (inside `BrowserRouter`, outside `AuthProvider`) so dark mode applies globally including auth pages
- Test infrastructure: `window.matchMedia` polyfill added to `setupTests.ts`; `AppShell` overlay gets `data-testid="sidebar-overlay"` so tests are not confused by SVG `aria-hidden="true"` icons; `Sidebar` and `AppShell` tests updated to mock `ThemeContext`

## Files Changed

- `client/src/styles/tokens.css` — Layer 3 dark mode overrides (was a commented stub)
- `client/src/contexts/ThemeContext.tsx` — new file
- `client/src/components/ThemeToggle/ThemeToggle.tsx` — new file
- `client/src/components/ThemeToggle/ThemeToggle.module.css` — new file
- `client/src/App.tsx` — wrap with ThemeProvider
- `client/src/components/Sidebar/Sidebar.tsx` — add ThemeToggle
- `client/src/components/Sidebar/Sidebar.module.css` — add themeSection wrapper style
- `client/src/components/AppShell/AppShell.tsx` — add data-testid to overlay
- `client/src/test/setupTests.ts` — add window.matchMedia polyfill
- `client/src/components/Sidebar/Sidebar.test.tsx` — mock ThemeContext, update button count
- `client/src/components/AppShell/AppShell.test.tsx` — mock ThemeContext, update overlay selector

## Quality Gates

- `npm run lint` — 0 errors
- `npm run format:check` — all clean
- `npm run typecheck` — all 3 workspaces clean
- `npm test` — 1072/1072 tests pass (53 suites)
- `npm audit` — 17 pre-existing vulns (semantic-release/eslint chain, not fixable without breaking changes), 0 new

## Test Plan

- [ ] Toggle cycles: Light → Dark → System → Light
- [ ] Dark mode visuals: dark backgrounds, light text, readable badges across all pages
- [ ] System mode: respects OS dark/light preference; updates reactively on OS change
- [ ] Preference persists across page reload (stored in localStorage)
- [ ] Login and setup pages also apply the theme (ThemeProvider is outside AuthProvider)
- [ ] Token verification: `grep -rn '#[0-9a-fA-F]' client/src --include="*.module.css"` returns zero results

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)