### PR TITLE
fix(theme): fix dark mode input styling and sidebar layout

### DIFF
--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -32,6 +32,8 @@
   display: flex;
   flex-direction: column;
   padding: 1rem 0;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .navLink {
@@ -55,8 +57,36 @@
 }
 
 .navSeparator {
-  margin-top: auto;
   border-top: 1px solid var(--color-sidebar-separator);
+  margin: var(--spacing-2) 0;
+}
+
+.sidebarFooter {
+  margin-top: auto;
+  padding: var(--spacing-3) 0;
+  border-top: 1px solid var(--color-sidebar-separator);
+  flex-shrink: 0;
+}
+
+.projectInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2) var(--spacing-6);
+  font-size: var(--font-size-xs);
+  color: var(--color-sidebar-text);
+  opacity: 0.5;
+}
+
+.githubLink {
+  color: inherit;
+  text-decoration: none;
+}
+
+.githubLink:hover {
+  text-decoration: underline;
+  opacity: 0.8;
 }
 
 .logoutButton {
@@ -78,11 +108,6 @@
 .logoutButton:focus-visible {
   outline: 2px solid var(--color-sidebar-focus-ring);
   outline-offset: -2px;
-}
-
-.themeSection {
-  /* Wrapper keeps the toggle flush with sidebar nav style */
-  padding: var(--spacing-1) 0;
 }
 
 .sidebarHeader {

--- a/client/src/components/Sidebar/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/Sidebar.test.tsx
@@ -64,11 +64,12 @@ describe('Sidebar', () => {
     onClose: mockOnClose,
   });
 
-  it('renders all 9 navigation links', () => {
+  it('renders all 9 navigation links plus 1 GitHub footer link', () => {
     renderWithRouter(<SidebarModule.Sidebar {...getDefaultProps()} />);
 
     const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(9);
+    // 9 nav links + 1 GitHub link in the footer
+    expect(links).toHaveLength(10);
   });
 
   it('renders navigation with correct aria-label', () => {
@@ -355,8 +356,8 @@ describe('Sidebar', () => {
     const links = screen.getAllByRole('link');
     const buttons = screen.getAllByRole('button');
 
-    // Still 9 navigation links
-    expect(links).toHaveLength(9);
+    // 9 nav links + 1 GitHub link in the footer
+    expect(links).toHaveLength(10);
     // 3 buttons: close button + theme toggle + logout button
     expect(buttons).toHaveLength(3);
     expect(buttons[0]).toHaveAttribute('aria-label', 'Close menu');

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -97,11 +97,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             User Management
           </NavLink>
         )}
-        <div className={styles.navSeparator} />
-        <div className={styles.themeSection}>
-          <ThemeToggle />
-        </div>
-        <div className={styles.navSeparator} />
+      </nav>
+      <div className={styles.sidebarFooter}>
+        <ThemeToggle />
         <button
           type="button"
           className={styles.logoutButton}
@@ -111,7 +109,18 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         >
           Logout
         </button>
-      </nav>
+        <div className={styles.projectInfo}>
+          <span>Cornerstone v{__APP_VERSION__}</span>
+          <a
+            href="https://github.com/steilerDev/cornerstone"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.githubLink}
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
     </aside>
   );
 }

--- a/client/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/client/src/components/ThemeToggle/ThemeToggle.module.css
@@ -3,20 +3,21 @@
   align-items: center;
   gap: var(--spacing-2);
   width: 100%;
-  padding: var(--spacing-3) var(--spacing-6);
+  padding: var(--spacing-2) var(--spacing-6);
   background: transparent;
   border: none;
   color: var(--color-sidebar-text);
-  font: inherit;
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   cursor: pointer;
   text-align: left;
   transition: background-color var(--transition-medium);
   border-radius: 0;
+  opacity: 0.7;
 }
 
 .themeToggle:hover {
   background-color: var(--color-sidebar-hover);
+  opacity: 1;
 }
 
 .themeToggle:focus-visible {
@@ -28,16 +29,22 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  opacity: 0.85;
 }
 
 .label {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
 }
 
 /* Mobile / tablet touch target */
 @media (max-width: 1024px) {
   .themeToggle {
     min-height: 44px;
+    font-size: var(--font-size-sm);
+    padding: var(--spacing-2) var(--spacing-6);
+    opacity: 0.8;
+  }
+
+  .label {
+    font-size: var(--font-size-sm);
   }
 }

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -50,9 +50,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     resolveTheme(initialPreference),
   );
 
-  // Apply the resolved theme to <html data-theme="...">
+  // Apply the resolved theme to <html data-theme="..."> and set color-scheme
+  // so the browser renders native widgets (date inputs, selects, scrollbars)
+  // in the appropriate color scheme.
   useEffect(() => {
     document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.style.colorScheme = resolvedTheme;
   }, [resolvedTheme]);
 
   // Listen for OS-level dark mode changes when preference is 'system'

--- a/client/src/pages/ProfilePage/ProfilePage.module.css
+++ b/client/src/pages/ProfilePage/ProfilePage.module.css
@@ -135,6 +135,7 @@
   border-radius: 0.375rem;
   font-size: 0.875rem;
   color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;

--- a/client/src/pages/TagManagementPage/TagManagementPage.module.css
+++ b/client/src/pages/TagManagementPage/TagManagementPage.module.css
@@ -111,6 +111,7 @@
   border-radius: 0.375rem;
   font-size: 0.875rem;
   color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
@@ -115,6 +115,7 @@
   border-radius: 0.375rem;
   font-family: inherit;
   width: 100%;
+  background-color: var(--color-bg-primary);
 }
 
 .titleInput:focus {
@@ -214,6 +215,7 @@
   font-family: inherit;
   resize: vertical;
   min-height: 150px;
+  background-color: var(--color-bg-primary);
 }
 
 .descriptionTextarea:focus {
@@ -274,6 +276,7 @@
   font-size: 0.875rem;
   font-family: inherit;
   resize: vertical;
+  background-color: var(--color-bg-primary);
 }
 
 .noteTextarea:focus {
@@ -347,6 +350,7 @@
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-family: inherit;
+  background-color: var(--color-bg-primary);
 }
 
 .subtaskInput:focus {

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
@@ -91,6 +91,7 @@
   border: 1px solid var(--color-border-strong);
   border-radius: 0.5rem;
   font-size: 0.875rem;
+  background-color: var(--color-bg-primary);
   transition: border-color 0.2s;
 }
 

--- a/client/src/pages/shared/AuthPage.module.css
+++ b/client/src/pages/shared/AuthPage.module.css
@@ -77,6 +77,7 @@
   border-radius: 0.375rem;
   font-size: 0.875rem;
   color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -24,6 +24,15 @@ body {
   color: var(--color-text-primary);
 }
 
+input,
+textarea,
+select,
+button {
+  font: inherit;
+  color: inherit;
+  background-color: transparent;
+}
+
 #root {
   min-height: 100vh;
 }

--- a/client/src/types/globals.d.ts
+++ b/client/src/types/globals.d.ts
@@ -1,0 +1,2 @@
+/** Injected at build time by webpack DefinePlugin from the root package.json version. */
+declare const __APP_VERSION__: string;

--- a/client/webpack.config.cjs
+++ b/client/webpack.config.cjs
@@ -3,6 +3,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const { DefinePlugin } = require('webpack');
+const rootPkg = require('../package.json');
 
 module.exports = (env, argv) => {
   const isProduction = argv.mode === 'production';
@@ -76,6 +78,9 @@ module.exports = (env, argv) => {
         }
       : {},
     plugins: [
+      new DefinePlugin({
+        __APP_VERSION__: JSON.stringify(rootPkg.version),
+      }),
       new HtmlWebpackPlugin({
         template: './index.html',
       }),

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -68,6 +68,10 @@ const config: Config = {
       testMatch: ['<rootDir>/client/src/**/*.test.{ts,tsx}'],
       setupFilesAfterEnv: ['<rootDir>/client/src/test/setupTests.ts'],
       transformIgnorePatterns: ['node_modules/(?!@testing-library)'],
+      // Define webpack globals so tests don't need the webpack build pipeline
+      globals: {
+        __APP_VERSION__: '0.0.0-test',
+      },
       transform: {
         '^.+\\.tsx?$': [
           'ts-jest',


### PR DESCRIPTION
## Summary

- **Dark mode form inputs**: Added global form element reset (`font: inherit; color: inherit; background-color: transparent`) and set `color-scheme` on `<html>` so native widgets (date pickers, selects, scrollbars) render in dark mode. Added explicit `background-color: var(--color-bg-primary)` to all input CSS modules that were missing it.
- **Sidebar restructure**: Moved ThemeToggle and logout button out of `<nav>` into a new `sidebarFooter` section pushed to the bottom via `margin-top: auto`. Added project info (version + GitHub link) at the bottom.
- **ThemeToggle styling**: Restyled with smaller font (`--font-size-xs`), muted opacity (0.7 → 1 on hover), and compact padding to differentiate from nav links.
- **Version injection**: Added webpack `DefinePlugin` to inject `__APP_VERSION__` from root `package.json` at build time, with TypeScript declaration and Jest global fallback.

## Test plan

- [ ] Toggle dark mode → all form inputs (search, date, text, select, email, password) have dark backgrounds and light text
- [ ] Date picker widget renders in dark theme
- [ ] Login/setup page inputs are dark-themed
- [ ] ThemeToggle is visually distinct from nav links, positioned at sidebar bottom
- [ ] Version string and GitHub link appear in sidebar footer
- [ ] All CI quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)