### PR TITLE
fix(e2e): scope logout button locator to sidebar instead of nav

### DIFF
--- a/e2e/pages/AppShellPage.ts
+++ b/e2e/pages/AppShellPage.ts
@@ -69,7 +69,7 @@ export class AppShellPage {
   }
 
   async logout(): Promise<void> {
-    const logoutButton = this.nav.getByRole('button', { name: 'Logout' });
+    const logoutButton = this.sidebar.getByRole('button', { name: 'Logout' });
     await logoutButton.click();
   }
 

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -120,7 +120,7 @@ test.describe('Sidebar Navigation', () => {
     }
 
     // Then: Logout button should be visible in the sidebar
-    const logoutButton = appShell.nav.getByRole('button', { name: 'Logout' });
+    const logoutButton = appShell.sidebar.getByRole('button', { name: 'Logout' });
     await expect(logoutButton).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- PR #127 moved the Logout `<button>` from inside `<nav>` to a sidebar footer `<div>` (still within `<aside>`)
- Updated `AppShellPage.logout()` to scope the locator to `this.sidebar` instead of `this.nav`
- Updated `sidebar-navigation.spec.ts` "Logout button is present" test to use `appShell.sidebar` instead of `appShell.nav`
- Fixes 56 E2E test failures across all viewports (14 unique tests x 4-6 viewports, plus cascade failures from change-password test)

## Test plan

- [ ] CI E2E tests pass (all 421 tests: 402 pass + 19 viewport-specific skips)
- [ ] Specifically verify: `login-logout.spec.ts`, `sidebar-navigation.spec.ts`, `change-password.spec.ts`, `proxy-setup.spec.ts`, `migrations.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)