### PR TITLE
feat(work-items): redesign dependency management UX with direction toggle

### DIFF
--- a/client/src/components/WorkItemPicker/WorkItemPicker.tsx
+++ b/client/src/components/WorkItemPicker/WorkItemPicker.tsx
@@ -7,6 +7,7 @@ import styles from './WorkItemPicker.module.css';
 interface WorkItemPickerProps {
   value: string;
   onChange: (id: string) => void;
+  onSelectItem?: (item: { id: string; title: string }) => void;
   excludeIds: string[];
   disabled?: boolean;
   placeholder?: string;
@@ -15,6 +16,7 @@ interface WorkItemPickerProps {
 export function WorkItemPicker({
   value,
   onChange,
+  onSelectItem,
   excludeIds,
   disabled = false,
   placeholder = 'Search work items...',
@@ -104,6 +106,7 @@ export function WorkItemPicker({
   const handleSelect = (item: WorkItemSummary) => {
     setSelectedItem(item);
     onChange(item.id);
+    onSelectItem?.({ id: item.id, title: item.title });
     setIsOpen(false);
     setSearchTerm('');
     setResults([]);

--- a/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.module.css
+++ b/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.module.css
@@ -182,6 +182,195 @@
   cursor: not-allowed;
 }
 
+/* Dependencies section */
+.dependenciesSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+}
+
+.addDependencyRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Direction toggle segmented button group */
+.directionToggle {
+  display: flex;
+  border-radius: 0.375rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border-strong);
+}
+
+.directionButton {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+  border-radius: 0;
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+}
+
+.directionButton:not(:last-child) {
+  border-right: 1px solid var(--color-border-strong);
+}
+
+.directionButton:hover:not(:disabled):not(.directionButtonActive) {
+  background: var(--color-bg-tertiary);
+}
+
+.directionButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  z-index: 1;
+  position: relative;
+}
+
+.directionButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.directionButtonActive {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.directionButtonActive:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.depTypeGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.depTypeSelect {
+  /* uses .select base styles */
+}
+
+.dependencyHelpText {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0.375rem 0 0 0;
+  font-style: italic;
+}
+
+.addDepButton {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.addDepButton:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.addDepButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Pending dependency chips */
+.pendingDependenciesList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pendingDependencyChip {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+}
+
+.directionPill {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.directionPillDependsOn {
+  background: var(--color-status-in-progress-bg);
+  color: var(--color-status-in-progress-text);
+}
+
+.directionPillBlocks {
+  background: var(--color-status-blocked-bg);
+  color: var(--color-status-blocked-text);
+}
+
+.chipTitle {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chipType {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  padding: 0.125rem 0.375rem;
+  background: var(--color-border);
+  border-radius: 0.25rem;
+}
+
+.chipRemove {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  font-size: 1.125rem;
+  line-height: 1;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  transition: all 0.15s;
+}
+
+.chipRemove:hover:not(:disabled) {
+  color: var(--color-danger);
+  background: var(--color-overlay-delete);
+}
+
+.chipRemove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Mobile responsiveness */
 @media (max-width: 767px) {
   .container {

--- a/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.test.tsx
+++ b/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.test.tsx
@@ -9,16 +9,20 @@ import type { TagResponse, UserResponse } from '@cornerstone/shared';
 import type * as WorkItemsApiTypes from '../../lib/workItemsApi.js';
 import type * as TagsApiTypes from '../../lib/tagsApi.js';
 import type * as UsersApiTypes from '../../lib/usersApi.js';
+import type * as DependenciesApiTypes from '../../lib/dependenciesApi.js';
 import type * as WorkItemCreatePageTypes from './WorkItemCreatePage.js';
 
 const mockCreateWorkItem = jest.fn<typeof WorkItemsApiTypes.createWorkItem>();
+const mockListWorkItems = jest.fn<typeof WorkItemsApiTypes.listWorkItems>();
 const mockFetchTags = jest.fn<typeof TagsApiTypes.fetchTags>();
 const mockCreateTag = jest.fn<typeof TagsApiTypes.createTag>();
 const mockListUsers = jest.fn<typeof UsersApiTypes.listUsers>();
+const mockCreateDependency = jest.fn<typeof DependenciesApiTypes.createDependency>();
 
 // Mock only API modules — do NOT mock react-router-dom (causes OOM)
 jest.unstable_mockModule('../../lib/workItemsApi.js', () => ({
   createWorkItem: mockCreateWorkItem,
+  listWorkItems: mockListWorkItems,
 }));
 
 jest.unstable_mockModule('../../lib/tagsApi.js', () => ({
@@ -28,6 +32,10 @@ jest.unstable_mockModule('../../lib/tagsApi.js', () => ({
 
 jest.unstable_mockModule('../../lib/usersApi.js', () => ({
   listUsers: mockListUsers,
+}));
+
+jest.unstable_mockModule('../../lib/dependenciesApi.js', () => ({
+  createDependency: mockCreateDependency,
 }));
 
 // Helper to capture current location
@@ -66,6 +74,8 @@ describe('WorkItemCreatePage', () => {
 
   beforeEach(async () => {
     mockCreateWorkItem.mockReset();
+    mockListWorkItems.mockReset();
+    mockCreateDependency.mockReset();
     mockFetchTags.mockReset();
     mockCreateTag.mockReset();
     mockListUsers.mockReset();

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
@@ -510,6 +510,65 @@
   box-shadow: var(--shadow-focus-subtle);
 }
 
+/* Direction toggle segmented button group */
+.directionToggle {
+  display: flex;
+  border-radius: 0.375rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border-strong);
+}
+
+.directionButton {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+  border-radius: 0;
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+}
+
+.directionButton:not(:last-child) {
+  border-right: 1px solid var(--color-border-strong);
+}
+
+.directionButton:hover:not(:disabled):not(.directionButtonActive) {
+  background: var(--color-bg-tertiary);
+}
+
+.directionButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  z-index: 1;
+  position: relative;
+}
+
+.directionButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.directionButtonActive {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.directionButtonActive:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+/* Dependency type help text */
+.dependencyHelpText {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0.375rem 0 0 0;
+  font-style: italic;
+}
+
 /* Buttons */
 .addButton,
 .saveButton,

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
@@ -328,10 +328,10 @@ describe('WorkItemDetailPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByText('No predecessors')).toBeInTheDocument();
+        expect(screen.getByText('No dependencies')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('No successors')).toBeInTheDocument();
+      expect(screen.getByText('No items blocked')).toBeInTheDocument();
     });
 
     it('renders existing predecessors', async () => {
@@ -364,8 +364,8 @@ describe('WorkItemDetailPage', () => {
         expect(screen.getByText('Foundation work')).toBeInTheDocument();
       });
 
-      // Query within predecessors list to avoid matching the form dropdown
-      const predecessorsList = screen.getByText('Predecessors (Blocking This)').closest('div');
+      // Query within "Depends On" list to avoid matching the form dropdown
+      const predecessorsList = screen.getByText('Depends On').closest('div');
       expect(predecessorsList).toHaveTextContent('Finish-to-Start');
     });
   });


### PR DESCRIPTION
## Summary

- **WorkItemDetailPage**: Renamed "Predecessors (Blocking This)" → "Depends On" and "Successors (Blocked By This)" → "Blocks"; added segmented direction toggle to the Add Dependency form; added delete buttons to successor items; added direction-aware confirmation modal text; added dependency type description help text; excluded successors from picker's exclude list
- **WorkItemCreatePage**: Added full Dependencies section with direction toggle, WorkItemPicker, type dropdown with help text, pending dependency chips (removable), and sequential post-creation dependency creation
- **WorkItemPicker**: Added optional `onSelectItem` prop that returns `{ id, title }` alongside the existing `onChange(id)` — non-breaking addition

No backend changes. Direction is handled by swapping predecessor/successor IDs in existing API calls (`createDependency(successorId, { predecessorId })` for "depends on" and `createDependency(pickedItemId, { predecessorId: currentItemId })` for "blocks").

## Changed Files

- `client/src/components/WorkItemPicker/WorkItemPicker.tsx` — optional `onSelectItem` prop
- `client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx` — full redesign
- `client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css` — direction toggle + help text styles
- `client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx` — trivial label text fixes
- `client/src/pages/WorkItemCreatePage/WorkItemCreatePage.tsx` — new Dependencies section
- `client/src/pages/WorkItemCreatePage/WorkItemCreatePage.module.css` — new styles for chips, toggle, pills
- `client/src/pages/WorkItemCreatePage/WorkItemCreatePage.test.tsx` — added missing mocks for new imports

## Test plan

- [ ] All 371 client-side Jest tests pass (`npm test -- --testPathPatterns="client/src"`)
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run format:check` passes
- [ ] `npm run typecheck` passes
- [ ] On WorkItemDetailPage: direction toggle switches between "depends on" and "blocks", correct API call is made for each
- [ ] On WorkItemDetailPage: successors now have a × delete button; confirmation modal shows direction-aware text
- [ ] On WorkItemDetailPage: dependency type dropdown shows description help text
- [ ] On WorkItemCreatePage: dependencies section shows toggle + picker + type dropdown + chip list
- [ ] On WorkItemCreatePage: pending chips show colored direction pill and can be removed
- [ ] Keyboard: Tab navigates toggle buttons, Enter/Space activates them

🤖 Generated with [Claude Code](https://claude.com/claude-code)