### PR TITLE
ci(release): stamp version via Docker build arg instead of git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           context: .
           push: true
+          build-args: APP_VERSION=${{ needs.release.outputs.new-release-version }}
           tags: ${{ steps.meta-beta.outputs.tags || steps.meta-stable.outputs.tags || 'cornerstone:ci-test' }}
           labels: ${{ steps.meta-beta.outputs.labels || steps.meta-stable.outputs.labels }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,13 +35,6 @@
       }
     ],
     ["@semantic-release/npm", { "npmPublish": false }],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
-      }
-    ],
     "@semantic-release/github"
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ COPY client/package.json client/
 # ensuring compatibility with the Alpine musl libc in the production image
 RUN npm ci --build-from-source
 
+# Stamp the release version into package.json (set at build time by CI;
+# defaults to 0.0.0-dev for local builds). This keeps the version visible
+# in the running container without committing it back to the repo.
+ARG APP_VERSION=0.0.0-dev
+RUN npm pkg set "version=${APP_VERSION}"
+
 # Copy source code
 COPY tsconfig.base.json ./
 COPY shared/ shared/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       ],
       "devDependencies": {
         "@eslint/js": "9.39.2",
-        "@semantic-release/git": "10.0.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -3304,83 +3303,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
-    "@semantic-release/git": "10.0.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git` plugin which tried to push version bump commits directly to the protected `beta` branch (fails with `GH006: Protected branch update failed`)
- Add `APP_VERSION` Docker build arg to stamp the release version into `package.json` during the Docker build instead
- Pass the release version from the semantic-release job to the Docker build in `release.yml`

## How it works
1. `@semantic-release/npm` still writes the version to `package.json` in the CI workspace (for the tag/release)
2. `@semantic-release/github` creates the GitHub release and tag
3. The Docker job receives the version via `build-args: APP_VERSION=X.Y.Z` and runs `npm pkg set version=X.Y.Z` in the builder stage
4. The running container has the correct version in `package.json` without any commits pushed back to the branch

Local Docker builds default to `0.0.0-dev`.

## Test plan
- [ ] CI passes (lint, typecheck, tests, Docker build)
- [ ] Next push to beta triggers a successful semantic-release with tag + GitHub release
- [ ] Docker image contains the correct version in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)