### PR TITLE
ci(docker): add multi-arch builds, provenance, and SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,16 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.new-release-version }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -123,6 +127,11 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: APP_VERSION=${{ needs.release.outputs.new-release-version }}
           tags: ${{ steps.meta-beta.outputs.tags || steps.meta-stable.outputs.tags || 'cornerstone:ci-test' }}
           labels: ${{ steps.meta-beta.outputs.labels || steps.meta-stable.outputs.labels }}


### PR DESCRIPTION
## Summary

- Build Docker images for **linux/amd64 + linux/arm64** via QEMU emulation, so ARM users (Apple Silicon, Raspberry Pi, ARM cloud) can run the published image natively
- Attach **SLSA provenance** (`mode=max`) and **SBOM** attestations to every published image for supply chain transparency
- Add **GitHub Actions build cache** (`type=gha`) to speed up repeated builds (arm64 under QEMU is slow without caching)
- Add `id-token: write` permission to enable signed Sigstore provenance

## Changes

Only `.github/workflows/release.yml` (Docker job) is modified:
1. Added `id-token: write` permission
2. Added QEMU setup step before Buildx
3. Added `platforms`, `provenance`, `sbom`, `cache-from`, `cache-to` to `build-push-action`

CI workflow (`ci.yml`) is unchanged — it stays amd64-only for speed.

## Risk: DHI base image arm64 support

The `dhi.io/node:24-alpine3.23` base images must publish arm64 manifests. If they don't, the arm64 build leg will fail. The first CI run will confirm — fallback is switching to official `node:24-alpine` images.

## Verification

After the first release:
```bash
docker manifest inspect steilerdev/cornerstone:<version>
docker buildx imagetools inspect steilerdev/cornerstone:<version> --format '{{ json .Provenance }}'
docker buildx imagetools inspect steilerdev/cornerstone:<version> --format '{{ json .SBOM }}'
```

## Test plan
- [ ] CI quality gates pass (no code changes, only workflow YAML)
- [ ] First beta release after merge produces a multi-arch manifest with amd64 + arm64 entries
- [ ] Provenance and SBOM attestations are attached to the published image
- [ ] arm64 image runs correctly on Apple Silicon (`docker run --rm steilerdev/cornerstone:<version>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)