### PR TITLE
fix(work-items): fix actions menu clipping and edit button 404

### DIFF
--- a/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
@@ -145,7 +145,6 @@
   background-color: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  overflow: hidden;
   box-shadow: var(--shadow-md);
 }
 

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -585,7 +585,7 @@ export function WorkItemsPage() {
                             <button
                               type="button"
                               className={styles.menuItem}
-                              onClick={() => navigate(`/work-items/${item.id}/edit`)}
+                              onClick={() => navigate(`/work-items/${item.id}`)}
                             >
                               Edit
                             </button>
@@ -627,7 +627,7 @@ export function WorkItemsPage() {
                           <button
                             type="button"
                             className={styles.menuItem}
-                            onClick={() => navigate(`/work-items/${item.id}/edit`)}
+                            onClick={() => navigate(`/work-items/${item.id}`)}
                           >
                             Edit
                           </button>


### PR DESCRIPTION
## Summary
- Remove `overflow: hidden` from `.tableContainer` so the actions dropdown menu is no longer clipped at the container boundary
- Change edit button navigation from `/work-items/:id/edit` to `/work-items/:id` since the detail page already serves as the edit view (fixes 404)

## Test plan
- [ ] Open Work Items list page
- [ ] Click the actions menu (three-dot button) on a work item — dropdown should render fully visible, not clipped
- [ ] Click "Edit" in the actions menu — should navigate to the work item detail page (not a 404)
- [ ] Verify on both table view (desktop) and card view (mobile)
- [ ] All 1142 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)