### PR TITLE
feat(budget): budget sub-navigation, formatting consistency, and polish (Story #149)

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -118,7 +118,8 @@ describe('App', () => {
     render(<App />);
 
     // Wait for lazy-loaded BudgetCategories component to resolve
-    const heading = await screen.findByRole('heading', { name: /budget categories/i, level: 1 });
+    // h1 now says "Budget" (shared across all budget pages); h2 says "Categories"
+    const heading = await screen.findByRole('heading', { name: /^budget$/i, level: 1 });
     expect(heading).toBeInTheDocument();
   });
 

--- a/client/src/components/AppShell/AppShell.test.tsx
+++ b/client/src/components/AppShell/AppShell.test.tsx
@@ -129,8 +129,7 @@ describe('AppShell', () => {
     // All navigation links should be present
     expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /work items/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /budget categories/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /budget sources/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^budget$/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /timeline/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /household items/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /documents/i })).toBeInTheDocument();

--- a/client/src/components/BudgetSubNav/BudgetSubNav.module.css
+++ b/client/src/components/BudgetSubNav/BudgetSubNav.module.css
@@ -1,0 +1,78 @@
+/* ============================================================
+ * BudgetSubNav — horizontal tab navigation for the Budget section
+ * ============================================================ */
+
+.subNav {
+  width: 100%;
+}
+
+/* Scrollable tab row — scrolls horizontally when tabs overflow on mobile */
+.tabList {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+  border-bottom: 2px solid var(--color-border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  /* Hide scrollbar on browsers that support it — tabs still scroll on touch */
+  scrollbar-width: none; /* Firefox */
+}
+
+.tabList::-webkit-scrollbar {
+  display: none; /* Chrome / Safari */
+}
+
+/* Individual tab link */
+.tab {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-2-5) var(--spacing-4);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  /* Pull the tab border down so it overlaps the container border */
+  margin-bottom: -2px;
+  transition:
+    color var(--transition-normal),
+    border-color var(--transition-normal),
+    background-color var(--transition-normal);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.tab:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
+}
+
+.tab:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus-subtle);
+  border-radius: var(--radius-sm);
+}
+
+/* Active tab */
+.tabActive {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.tabActive:hover {
+  color: var(--color-primary-hover);
+  background-color: var(--color-bg-secondary);
+  border-bottom-color: var(--color-primary-hover);
+}
+
+/* ============================================================
+ * RESPONSIVE — Mobile (max 767px): reduce padding for smaller screens
+ * ============================================================ */
+
+@media (max-width: 767px) {
+  .tab {
+    padding: var(--spacing-2) var(--spacing-3);
+    font-size: var(--font-size-xs);
+  }
+}

--- a/client/src/components/BudgetSubNav/BudgetSubNav.tsx
+++ b/client/src/components/BudgetSubNav/BudgetSubNav.tsx
@@ -1,0 +1,39 @@
+import { NavLink } from 'react-router-dom';
+import styles from './BudgetSubNav.module.css';
+
+const BUDGET_TABS = [
+  { label: 'Overview', to: '/budget/overview' },
+  { label: 'Categories', to: '/budget/categories' },
+  { label: 'Vendors', to: '/budget/vendors' },
+  { label: 'Sources', to: '/budget/sources' },
+  { label: 'Subsidies', to: '/budget/subsidies' },
+] as const;
+
+/**
+ * BudgetSubNav — horizontal tab-style navigation for the Budget section.
+ *
+ * Renders a scrollable row of tab links for all budget sub-pages.
+ * The currently active tab is highlighted using the primary design token.
+ * On mobile the row scrolls horizontally so all tabs remain reachable.
+ */
+export function BudgetSubNav() {
+  return (
+    <nav className={styles.subNav} aria-label="Budget section navigation">
+      <div className={styles.tabList} role="list">
+        {BUDGET_TABS.map((tab) => (
+          <NavLink
+            key={tab.to}
+            to={tab.to}
+            end
+            className={({ isActive }) => `${styles.tab} ${isActive ? styles.tabActive : ''}`}
+            role="listitem"
+          >
+            {tab.label}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+export default BudgetSubNav;

--- a/client/src/components/Sidebar/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/Sidebar.test.tsx
@@ -64,12 +64,12 @@ describe('Sidebar', () => {
     onClose: mockOnClose,
   });
 
-  it('renders all 13 navigation links plus 1 GitHub footer link', () => {
+  it('renders all 9 navigation links plus 1 GitHub footer link', () => {
     renderWithRouter(<SidebarModule.Sidebar {...getDefaultProps()} />);
 
     const links = screen.getAllByRole('link');
-    // 13 nav links + 1 GitHub link in the footer
-    expect(links).toHaveLength(14);
+    // 9 nav links + 1 GitHub link in the footer
+    expect(links).toHaveLength(10);
   });
 
   it('renders navigation with correct aria-label', () => {
@@ -87,10 +87,7 @@ describe('Sidebar', () => {
       'href',
       '/work-items',
     );
-    expect(screen.getByRole('link', { name: /budget categories/i })).toHaveAttribute(
-      'href',
-      '/budget/categories',
-    );
+    expect(screen.getByRole('link', { name: /^budget$/i })).toHaveAttribute('href', '/budget');
     expect(screen.getByRole('link', { name: /timeline/i })).toHaveAttribute('href', '/timeline');
     expect(screen.getByRole('link', { name: /household items/i })).toHaveAttribute(
       'href',
@@ -130,12 +127,12 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /dashboard/i })).not.toHaveClass('active');
   });
 
-  it('budget categories link is active at /budget/categories', () => {
+  it('budget link is active at /budget', () => {
     renderWithRouter(<SidebarModule.Sidebar {...getDefaultProps()} />, {
-      initialEntries: ['/budget/categories'],
+      initialEntries: ['/budget'],
     });
 
-    const budgetLink = screen.getByRole('link', { name: /budget categories/i });
+    const budgetLink = screen.getByRole('link', { name: /^budget$/i });
     expect(budgetLink).toHaveClass('active');
   });
 
@@ -168,14 +165,14 @@ describe('Sidebar', () => {
 
   it('only one link is active at a time', () => {
     renderWithRouter(<SidebarModule.Sidebar {...getDefaultProps()} />, {
-      initialEntries: ['/budget/categories'],
+      initialEntries: ['/budget'],
     });
 
     const activeLinks = screen
       .getAllByRole('link')
       .filter((link) => link.classList.contains('active'));
     expect(activeLinks).toHaveLength(1);
-    expect(activeLinks[0]).toHaveTextContent(/budget categories/i);
+    expect(activeLinks[0]).toHaveTextContent(/^budget$/i);
   });
 
   it('renders a close button with correct aria-label', () => {
@@ -229,11 +226,11 @@ describe('Sidebar', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it('clicking a nav link calls onClose (budget categories)', async () => {
+  it('clicking a nav link calls onClose (budget)', async () => {
     const user = userEvent.setup();
     renderWithRouter(<SidebarModule.Sidebar {...getDefaultProps()} />);
 
-    const budgetLink = screen.getByRole('link', { name: /budget categories/i });
+    const budgetLink = screen.getByRole('link', { name: /^budget$/i });
     await user.click(budgetLink);
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
@@ -359,8 +356,8 @@ describe('Sidebar', () => {
     const links = screen.getAllByRole('link');
     const buttons = screen.getAllByRole('button');
 
-    // 13 nav links + 1 GitHub link in the footer
-    expect(links).toHaveLength(14);
+    // 9 nav links + 1 GitHub link in the footer
+    expect(links).toHaveLength(10);
     // 3 buttons: close button + theme toggle + logout button
     expect(buttons).toHaveLength(3);
     expect(buttons[0]).toHaveAttribute('aria-label', 'Close menu');

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -46,39 +46,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           Work Items
         </NavLink>
         <NavLink
-          to="/budget/overview"
+          to="/budget"
           className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
           onClick={onClose}
         >
-          Budget Overview
-        </NavLink>
-        <NavLink
-          to="/budget/categories"
-          className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
-          onClick={onClose}
-        >
-          Budget Categories
-        </NavLink>
-        <NavLink
-          to="/budget/vendors"
-          className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
-          onClick={onClose}
-        >
-          Vendors
-        </NavLink>
-        <NavLink
-          to="/budget/sources"
-          className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
-          onClick={onClose}
-        >
-          Budget Sources
-        </NavLink>
-        <NavLink
-          to="/budget/subsidies"
-          className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
-          onClick={onClose}
-        >
-          Subsidies
+          Budget
         </NavLink>
         <NavLink
           to="/timeline"

--- a/client/src/lib/formatters.ts
+++ b/client/src/lib/formatters.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared formatting utilities for the Cornerstone frontend.
+ *
+ * All budget-related pages use these helpers to ensure consistent presentation
+ * of currency, percentages, and dates throughout the application.
+ */
+
+/**
+ * Format a number as a currency string in EUR.
+ *
+ * Uses `Intl.NumberFormat` so the output respects locale conventions for
+ * thousands separators and decimal points while always showing 2 fraction
+ * digits and the € symbol.
+ *
+ * Negative values are rendered correctly (e.g. −€1,234.56).
+ *
+ * @param amount - The numeric amount to format (may be negative).
+ * @returns A locale-formatted currency string, e.g. "€1,234.56".
+ */
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+/**
+ * Format a number as a percentage string with 2 decimal places.
+ *
+ * @param rate - The raw percentage value (e.g. 3.5 → "3.50%").
+ * @returns A formatted percentage string.
+ */
+export function formatPercent(rate: number): string {
+  return `${rate.toFixed(2)}%`;
+}

--- a/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.module.css
+++ b/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.module.css
@@ -26,6 +26,22 @@
   margin: 0;
 }
 
+/* ---- Section header (below sub-nav) ---- */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
 /* ---- Banners ---- */
 
 .successBanner {
@@ -561,8 +577,9 @@
     padding: var(--spacing-4);
   }
 
-  /* Stack page header vertically */
-  .pageHeader {
+  /* Stack page header and section header vertically on mobile */
+  .pageHeader,
+  .sectionHeader {
     flex-direction: column;
     align-items: stretch;
   }

--- a/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.test.tsx
+++ b/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.test.tsx
@@ -101,14 +101,15 @@ describe('BudgetCategoriesPage', () => {
   // ─── Page structure ─────────────────────────────────────────────────────────
 
   describe('page structure', () => {
-    it('renders the page heading "Budget Categories"', async () => {
+    it('renders the page heading "Budget" and section heading "Categories"', async () => {
       mockFetchBudgetCategories.mockResolvedValueOnce(emptyResponse);
 
       renderPage();
 
       await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
         expect(
-          screen.getByRole('heading', { name: /budget categories/i, level: 1 }),
+          screen.getByRole('heading', { name: /^categories$/i, level: 2 }),
         ).toBeInTheDocument();
       });
     });

--- a/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.tsx
+++ b/client/src/pages/BudgetCategoriesPage/BudgetCategoriesPage.tsx
@@ -7,6 +7,7 @@ import {
   deleteBudgetCategory,
 } from '../../lib/budgetCategoriesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './BudgetCategoriesPage.module.css';
 
 const DEFAULT_COLOR = '#3b82f6';
@@ -220,7 +221,13 @@ export function BudgetCategoriesPage() {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading}>Loading budget categories...</div>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.loading}>Loading budget categories...</div>
+        </div>
       </div>
     );
   }
@@ -228,12 +235,18 @@ export function BudgetCategoriesPage() {
   if (error && categories.length === 0) {
     return (
       <div className={styles.container}>
-        <div className={styles.errorCard} role="alert">
-          <h2 className={styles.errorTitle}>Error</h2>
-          <p>{error}</p>
-          <button type="button" className={styles.button} onClick={() => void loadCategories()}>
-            Retry
-          </button>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.errorCard} role="alert">
+            <h2 className={styles.errorTitle}>Error</h2>
+            <p>{error}</p>
+            <button type="button" className={styles.button} onClick={() => void loadCategories()}>
+              Retry
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -244,7 +257,15 @@ export function BudgetCategoriesPage() {
       <div className={styles.content}>
         {/* Page header */}
         <div className={styles.pageHeader}>
-          <h1 className={styles.pageTitle}>Budget Categories</h1>
+          <h1 className={styles.pageTitle}>Budget</h1>
+        </div>
+
+        {/* Budget sub-navigation */}
+        <BudgetSubNav />
+
+        {/* Section header with action button */}
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Categories</h2>
           <button
             type="button"
             className={styles.button}

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
@@ -208,7 +208,7 @@ describe('BudgetOverviewPage', () => {
       await user.click(screen.getByRole('button', { name: /retry/i }));
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: /budget overview/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
       });
 
       // fetchBudgetOverview should have been called twice (initial + retry)
@@ -243,15 +243,13 @@ describe('BudgetOverviewPage', () => {
   // ─── Page header ──────────────────────────────────────────────────────────
 
   describe('page header', () => {
-    it('renders "Budget Overview" heading when data is loaded', async () => {
+    it('renders "Budget" heading when data is loaded', async () => {
       mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
 
       renderPage();
 
       await waitFor(() => {
-        expect(
-          screen.getByRole('heading', { name: /budget overview/i, level: 1 }),
-        ).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
       });
     });
   });

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
@@ -2,18 +2,9 @@ import { useState, useEffect } from 'react';
 import type { BudgetOverview } from '@cornerstone/shared';
 import { fetchBudgetOverview } from '../../lib/budgetOverviewApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { formatCurrency } from '../../lib/formatters.js';
+import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './BudgetOverviewPage.module.css';
-
-// ---- Formatting helpers ----
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'EUR',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
-}
 
 // ---- Sub-components ----
 
@@ -93,8 +84,14 @@ export function BudgetOverviewPage() {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading} role="status" aria-label="Loading budget overview">
-          Loading budget overview...
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.loading} role="status" aria-label="Loading budget overview">
+            Loading budget overview...
+          </div>
         </div>
       </div>
     );
@@ -104,12 +101,22 @@ export function BudgetOverviewPage() {
   if (error) {
     return (
       <div className={styles.container}>
-        <div className={styles.errorCard} role="alert">
-          <h2 className={styles.errorTitle}>Error</h2>
-          <p>{error}</p>
-          <button type="button" className={styles.retryButton} onClick={() => void loadOverview()}>
-            Retry
-          </button>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.errorCard} role="alert">
+            <h2 className={styles.errorTitle}>Error</h2>
+            <p>{error}</p>
+            <button
+              type="button"
+              className={styles.retryButton}
+              onClick={() => void loadOverview()}
+            >
+              Retry
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -132,8 +139,11 @@ export function BudgetOverviewPage() {
       <div className={styles.content}>
         {/* Page header */}
         <div className={styles.pageHeader}>
-          <h1 className={styles.pageTitle}>Budget Overview</h1>
+          <h1 className={styles.pageTitle}>Budget</h1>
         </div>
+
+        {/* Budget sub-navigation */}
+        <BudgetSubNav />
 
         {/* Empty state */}
         {!hasData && (

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -26,6 +26,22 @@
   margin: 0;
 }
 
+/* ---- Section header (below sub-nav) ---- */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
 /* ---- Banners ---- */
 
 .successBanner {
@@ -673,8 +689,9 @@
     padding: var(--spacing-4);
   }
 
-  /* Stack page header vertically */
-  .pageHeader {
+  /* Stack page header and section header vertically on mobile */
+  .pageHeader,
+  .sectionHeader {
     flex-direction: column;
     align-items: stretch;
   }

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -117,15 +117,14 @@ describe('BudgetSourcesPage', () => {
   // ─── Page structure ──────────────────────────────────────────────────────────
 
   describe('page structure', () => {
-    it('renders the page heading "Budget Sources"', async () => {
+    it('renders the page heading "Budget" and section heading "Sources"', async () => {
       mockFetchBudgetSources.mockResolvedValueOnce(emptyResponse);
 
       renderPage();
 
       await waitFor(() => {
-        expect(
-          screen.getByRole('heading', { name: /budget sources/i, level: 1 }),
-        ).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^sources$/i, level: 2 })).toBeInTheDocument();
       });
     });
 
@@ -250,8 +249,8 @@ describe('BudgetSourcesPage', () => {
       renderPage();
 
       await waitFor(() => {
-        // $200,000.00 formatted — appears for both Total and Available
-        expect(screen.getAllByText('$200,000.00').length).toBeGreaterThanOrEqual(1);
+        // €200,000.00 formatted — appears for both Total and Available
+        expect(screen.getAllByText('€200,000.00').length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -263,8 +262,8 @@ describe('BudgetSourcesPage', () => {
       renderPage();
 
       await waitFor(() => {
-        // usedAmount = 0 → $0.00; availableAmount = 200000 → $200,000.00
-        expect(screen.getByText('$0.00')).toBeInTheDocument();
+        // usedAmount = 0 → €0.00; availableAmount = 200000 → €200,000.00
+        expect(screen.getByText('€0.00')).toBeInTheDocument();
       });
     });
 

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -12,6 +12,8 @@ import {
   deleteBudgetSource,
 } from '../../lib/budgetSourcesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { formatCurrency, formatPercent } from '../../lib/formatters.js';
+import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './BudgetSourcesPage.module.css';
 
 // ---- Display helpers ----
@@ -46,19 +48,6 @@ function getStatusClass(styles: Record<string, string>, status: BudgetSourceStat
     closed: styles.statusClosed ?? '',
   };
   return map[status] ?? '';
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
-}
-
-function formatPercent(rate: number): string {
-  return `${rate.toFixed(2)}%`;
 }
 
 // ---- Editing state shape ----
@@ -309,7 +298,13 @@ export function BudgetSourcesPage() {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading}>Loading budget sources...</div>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.loading}>Loading budget sources...</div>
+        </div>
       </div>
     );
   }
@@ -317,12 +312,18 @@ export function BudgetSourcesPage() {
   if (error && sources.length === 0) {
     return (
       <div className={styles.container}>
-        <div className={styles.errorCard} role="alert">
-          <h2 className={styles.errorTitle}>Error</h2>
-          <p>{error}</p>
-          <button type="button" className={styles.button} onClick={() => void loadSources()}>
-            Retry
-          </button>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.errorCard} role="alert">
+            <h2 className={styles.errorTitle}>Error</h2>
+            <p>{error}</p>
+            <button type="button" className={styles.button} onClick={() => void loadSources()}>
+              Retry
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -333,7 +334,15 @@ export function BudgetSourcesPage() {
       <div className={styles.content}>
         {/* Page header */}
         <div className={styles.pageHeader}>
-          <h1 className={styles.pageTitle}>Budget Sources</h1>
+          <h1 className={styles.pageTitle}>Budget</h1>
+        </div>
+
+        {/* Budget sub-navigation */}
+        <BudgetSubNav />
+
+        {/* Section header */}
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Sources</h2>
           <button
             type="button"
             className={styles.button}

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.module.css
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.module.css
@@ -26,6 +26,22 @@
   margin: 0;
 }
 
+/* ---- Section header (below sub-nav) ---- */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
 /* ---- Banners ---- */
 
 .successBanner {
@@ -732,8 +748,9 @@
     padding: var(--spacing-4);
   }
 
-  /* Stack page header vertically */
-  .pageHeader {
+  /* Stack page header and section header vertically on mobile */
+  .pageHeader,
+  .sectionHeader {
     flex-direction: column;
     align-items: stretch;
   }

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
@@ -165,14 +165,15 @@ describe('SubsidyProgramsPage', () => {
   // ─── Page structure ────────────────────────────────────────────────────────
 
   describe('page structure', () => {
-    it('renders the page heading "Subsidy Programs"', async () => {
+    it('renders the page heading "Budget" and section heading "Subsidy Programs"', async () => {
       mockFetchSubsidyPrograms.mockResolvedValueOnce(emptyProgramsResponse);
 
       renderPage();
 
       await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
         expect(
-          screen.getByRole('heading', { name: /subsidy programs/i, level: 1 }),
+          screen.getByRole('heading', { name: /subsidy programs/i, level: 2 }),
         ).toBeInTheDocument();
       });
     });
@@ -335,7 +336,7 @@ describe('SubsidyProgramsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByText('$5,000.00')).toBeInTheDocument();
+        expect(screen.getByText('€5,000.00')).toBeInTheDocument();
       });
     });
 

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../lib/subsidyProgramsApi.js';
 import { fetchBudgetCategories } from '../../lib/budgetCategoriesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { formatCurrency } from '../../lib/formatters.js';
+import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './SubsidyProgramsPage.module.css';
 
 // ---- Display helpers ----
@@ -27,19 +29,14 @@ const STATUS_LABELS: Record<SubsidyApplicationStatus, string> = {
 
 const REDUCTION_TYPE_LABELS: Record<SubsidyReductionType, string> = {
   percentage: 'Percentage (%)',
-  fixed: 'Fixed Amount ($)',
+  fixed: 'Fixed Amount (€)',
 };
 
 function formatReduction(reductionType: SubsidyReductionType, reductionValue: number): string {
   if (reductionType === 'percentage') {
     return `${reductionValue}%`;
   }
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(reductionValue);
+  return formatCurrency(reductionValue);
 }
 
 function formatDeadline(deadline: string | null): string {
@@ -340,7 +337,13 @@ export function SubsidyProgramsPage() {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading}>Loading subsidy programs...</div>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.loading}>Loading subsidy programs...</div>
+        </div>
       </div>
     );
   }
@@ -348,12 +351,18 @@ export function SubsidyProgramsPage() {
   if (error && programs.length === 0) {
     return (
       <div className={styles.container}>
-        <div className={styles.errorCard} role="alert">
-          <h2 className={styles.errorTitle}>Error</h2>
-          <p>{error}</p>
-          <button type="button" className={styles.button} onClick={() => void loadData()}>
-            Retry
-          </button>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.errorCard} role="alert">
+            <h2 className={styles.errorTitle}>Error</h2>
+            <p>{error}</p>
+            <button type="button" className={styles.button} onClick={() => void loadData()}>
+              Retry
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -364,7 +373,15 @@ export function SubsidyProgramsPage() {
       <div className={styles.content}>
         {/* Page header */}
         <div className={styles.pageHeader}>
-          <h1 className={styles.pageTitle}>Subsidy Programs</h1>
+          <h1 className={styles.pageTitle}>Budget</h1>
+        </div>
+
+        {/* Budget sub-navigation */}
+        <BudgetSubNav />
+
+        {/* Section header */}
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Subsidy Programs</h2>
           <button
             type="button"
             className={styles.button}

--- a/client/src/pages/VendorsPage/VendorsPage.module.css
+++ b/client/src/pages/VendorsPage/VendorsPage.module.css
@@ -26,6 +26,22 @@
   margin: 0;
 }
 
+/* ---- Section header (below sub-nav) ---- */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
 /* ---- Banners ---- */
 
 .errorBanner {
@@ -749,7 +765,8 @@
     font-size: var(--font-size-2xl);
   }
 
-  .pageHeader {
+  .pageHeader,
+  .sectionHeader {
     flex-direction: column;
     align-items: stretch;
   }

--- a/client/src/pages/VendorsPage/VendorsPage.test.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.test.tsx
@@ -108,13 +108,14 @@ describe('VendorsPage', () => {
   // ─── Page structure ────────────────────────────────────────────────────────
 
   describe('page structure', () => {
-    it('renders the page heading "Vendors"', async () => {
+    it('renders the page heading "Budget" and section heading "Vendors"', async () => {
       mockFetchVendors.mockResolvedValueOnce(emptyResponse);
 
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: /^vendors$/i, level: 1 })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /^vendors$/i, level: 2 })).toBeInTheDocument();
       });
     });
 

--- a/client/src/pages/VendorsPage/VendorsPage.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import type { Vendor, CreateVendorRequest, VendorListQuery } from '@cornerstone/shared';
 import { fetchVendors, createVendor, deleteVendor } from '../../lib/vendorsApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './VendorsPage.module.css';
 
 export function VendorsPage() {
@@ -225,7 +226,13 @@ export function VendorsPage() {
   if (isLoading && vendors.length === 0) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading}>Loading vendors...</div>
+        <div className={styles.content}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>Budget</h1>
+          </div>
+          <BudgetSubNav />
+          <div className={styles.loading}>Loading vendors...</div>
+        </div>
       </div>
     );
   }
@@ -235,7 +242,15 @@ export function VendorsPage() {
       <div className={styles.content}>
         {/* Page header */}
         <div className={styles.pageHeader}>
-          <h1 className={styles.pageTitle}>Vendors</h1>
+          <h1 className={styles.pageTitle}>Budget</h1>
+        </div>
+
+        {/* Budget sub-navigation */}
+        <BudgetSubNav />
+
+        {/* Section header */}
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Vendors</h2>
           <button type="button" className={styles.button} onClick={openCreateModal}>
             Add Vendor
           </button>


### PR DESCRIPTION
## Summary

- **BudgetSubNav component** (`client/src/components/BudgetSubNav/`): new horizontal tab bar appearing on all five budget section pages (Overview, Categories, Vendors, Sources, Subsidies). Uses React Router `NavLink` with `end` prop — each tab highlights only its exact route. Scrolls horizontally on mobile with no visible scrollbar. Fully token-based styling (no hardcoded colours).
- **Shared `formatters.ts`** (`client/src/lib/formatters.ts`): `formatCurrency(amount)` (EUR, 2dp) and `formatPercent(rate)` consolidated from four separate local implementations (two of which used USD). All budget pages now format currency identically.
- **Budget pages unified header**: each budget section page now renders a shared `<h1>Budget</h1>` (gives consistent sidebar context) plus a section-level `<h2>` (e.g., "Categories", "Sources") with an action button. The sub-nav tab bar appears between the two.
- **Sidebar consolidation**: five individual budget links (Budget Overview, Budget Categories, Vendors, Budget Sources, Subsidies) collapsed into a single "Budget" `NavLink` at `/budget`. Without `end`, it stays active on any `/budget/*` path. VendorDetailPage is intentionally outside the sub-nav.
- **Responsive**: `sectionHeader` has `flex-direction: column` on mobile; tab bar uses `overflow-x: auto` with scrollbar hidden. Touch target sizing follows existing patterns.
- **Dark mode**: all new CSS exclusively uses design tokens from `tokens.css`.
- **Test updates**: minimal changes to Sidebar, AppShell, App, and per-page test files to reflect the new heading hierarchy and EUR currency — keeping CI green. QA agent owns the full test suite.

## Test plan

- [ ] Verify all 5 budget section pages show the tab bar with correct active highlighting
- [ ] Navigate between budget tabs and confirm the sidebar "Budget" link stays highlighted
- [ ] Confirm currency values throughout budget section all display EUR (€) symbol
- [ ] Check responsive layout: tab bar scrolls horizontally on narrow viewport; section headers stack on mobile
- [ ] Verify dark mode: tab bar, section headers, all token-based (no white/black flash)
- [ ] Confirm VendorDetailPage does NOT show the sub-nav
- [ ] Run `npm test` — 2388 tests pass
- [ ] Run `npm run lint` — 0 errors
- [ ] Run `npm run typecheck` — clean
- [ ] Run `npm audit --omit=dev` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)