### PR TITLE
chore(budget): EPIC-05 refinement — PR review observations

### DIFF
--- a/client/src/pages/VendorDetailPage/VendorDetailPage.module.css
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.module.css
@@ -70,7 +70,7 @@
 }
 
 .pageTitle {
-  font-size: var(--font-size-4xl);
+  font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
   margin: 0;
@@ -198,6 +198,12 @@
 
 .infoLink:hover {
   color: var(--color-primary-hover);
+}
+
+.infoLink:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 /* ---- Coming soon placeholder (kept for reference, no longer used) ---- */
@@ -691,7 +697,7 @@
 }
 
 .secondaryButton:hover {
-  background-color: var(--color-border);
+  background-color: var(--color-bg-hover);
 }
 
 .secondaryButton:focus-visible {
@@ -780,7 +786,7 @@
 }
 
 .cancelButton:hover:not(:disabled) {
-  background-color: var(--color-border);
+  background-color: var(--color-bg-hover);
 }
 
 .cancelButton:focus-visible {

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
@@ -320,7 +320,7 @@ describe('VendorDetailPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /vendors/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /vendors/i })).toBeInTheDocument();
       });
     });
   });
@@ -746,7 +746,7 @@ describe('VendorDetailPage', () => {
 
       await waitFor(() => {
         expect(within(dialog).getByRole('alert')).toBeInTheDocument();
-        expect(within(dialog).getByText(/referenced by one or more invoices/i)).toBeInTheDocument();
+        expect(within(dialog).getByText(/associated invoices or work items/i)).toBeInTheDocument();
       });
     });
 

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import type {
   VendorDetail,
   UpdateVendorRequest,
@@ -214,7 +214,7 @@ export function VendorDetailPage() {
       if (err instanceof ApiClientError) {
         if (err.statusCode === 409) {
           setDeleteError(
-            'This vendor cannot be deleted because they are referenced by one or more invoices.',
+            'This vendor cannot be deleted because they have associated invoices or work items. Remove those references first.',
           );
         } else {
           setDeleteError(err.error.message);
@@ -444,13 +444,9 @@ export function VendorDetailPage() {
       <div className={styles.content}>
         {/* Back navigation */}
         <div className={styles.breadcrumb}>
-          <button
-            type="button"
-            className={styles.backLink}
-            onClick={() => navigate('/budget/vendors')}
-          >
+          <Link to="/budget/vendors" className={styles.backLink}>
             Vendors
-          </button>
+          </Link>
           <span className={styles.breadcrumbSeparator} aria-hidden="true">
             /
           </span>
@@ -658,12 +654,12 @@ export function VendorDetailPage() {
                 <dt className={styles.infoLabel}>Address</dt>
                 <dd className={styles.infoValue}>{vendor.address || '—'}</dd>
               </div>
-              {vendor.notes && (
-                <div className={styles.infoRow}>
-                  <dt className={styles.infoLabel}>Notes</dt>
-                  <dd className={`${styles.infoValue} ${styles.infoValueNotes}`}>{vendor.notes}</dd>
-                </div>
-              )}
+              <div className={styles.infoRow}>
+                <dt className={styles.infoLabel}>Notes</dt>
+                <dd className={`${styles.infoValue} ${vendor.notes ? styles.infoValueNotes : ''}`}>
+                  {vendor.notes || '—'}
+                </dd>
+              </div>
               <div className={styles.infoRow}>
                 <dt className={styles.infoLabel}>Created by</dt>
                 <dd className={styles.infoValue}>{vendor.createdBy?.displayName ?? '—'}</dd>

--- a/client/src/pages/VendorsPage/VendorsPage.module.css
+++ b/client/src/pages/VendorsPage/VendorsPage.module.css
@@ -161,7 +161,7 @@
 }
 
 .sortOrderButton:hover {
-  background-color: var(--color-border);
+  background-color: var(--color-bg-hover);
 }
 
 .sortOrderButton:focus-visible {
@@ -290,6 +290,12 @@
 .contactLink:hover {
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+.contactLink:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 .actionsCell {
@@ -422,7 +428,7 @@
 }
 
 .secondaryButton:hover {
-  background-color: var(--color-border);
+  background-color: var(--color-bg-hover);
 }
 
 .secondaryButton:focus-visible {
@@ -492,7 +498,7 @@
 }
 
 .cancelButton:hover:not(:disabled) {
-  background-color: var(--color-border);
+  background-color: var(--color-bg-hover);
 }
 
 .cancelButton:focus-visible {

--- a/client/src/pages/VendorsPage/VendorsPage.test.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.test.tsx
@@ -584,7 +584,7 @@ describe('VendorsPage', () => {
       await waitFor(() => {
         // The dialog should show the in-use error message
         expect(within(dialog).getByRole('alert')).toBeInTheDocument();
-        expect(within(dialog).getByText(/referenced by one or more invoices/i)).toBeInTheDocument();
+        expect(within(dialog).getByText(/associated invoices or work items/i)).toBeInTheDocument();
       });
     });
 

--- a/client/src/pages/VendorsPage/VendorsPage.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.tsx
@@ -210,7 +210,7 @@ export function VendorsPage() {
       if (err instanceof ApiClientError) {
         if (err.statusCode === 409) {
           setDeleteError(
-            'This vendor cannot be deleted because they are referenced by one or more invoices.',
+            'This vendor cannot be deleted because they have associated invoices or work items. Remove those references first.',
           );
         } else {
           setDeleteError(err.error.message);
@@ -269,7 +269,7 @@ export function VendorsPage() {
         <div className={styles.searchCard}>
           <input
             type="search"
-            placeholder="Search vendors by name, specialty, phone, or email..."
+            placeholder="Search vendors by name or specialty..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             className={styles.searchInput}


### PR DESCRIPTION
## Summary

Addresses non-blocking review observations collected from all EPIC-05 PR reviews (#150-#158):

- **VendorDetailPage/VendorsPage**: 409 delete error message now mentions both invoices and work items
- **VendorsPage**: Search placeholder corrected to "name or specialty" (matches backend)
- **VendorDetailPage**: Notes row always rendered (shows "—" when empty)
- **VendorDetailPage**: pageTitle font-size reduced to 3xl (detail page hierarchy)
- **VendorDetailPage**: Back link changed from `<button>` to `<Link>` for proper semantics
- **Both vendor pages**: Added `:focus-visible` rules on contactLink/infoLink
- **Both vendor pages**: Secondary button hover uses `--color-bg-hover` instead of `--color-border` for better dark mode contrast

## Test plan

- [x] All 2,388 tests pass
- [x] Lint, typecheck, format:check all clean
- [x] Minimal test updates for changed error messages and Link vs button element

🤖 Generated with [Claude Code](https://claude.com/claude-code)