### PR TITLE
fix(e2e): update budget page heading selectors for sub-navigation

### DIFF
--- a/e2e/pages/BudgetCategoriesPage.ts
+++ b/e2e/pages/BudgetCategoriesPage.ts
@@ -64,7 +64,7 @@ export class BudgetCategoriesPage {
     this.page = page;
 
     // Page header
-    this.heading = page.getByRole('heading', { level: 1, name: 'Budget Categories', exact: true });
+    this.heading = page.getByRole('heading', { level: 1, name: 'Budget', exact: true });
     this.addCategoryButton = page.getByRole('button', { name: 'Add Category', exact: true });
 
     // Global banners — scoped to first role="alert" outside the form/modal for each type

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -80,7 +80,7 @@ export class VendorsPage {
     this.page = page;
 
     // Page header
-    this.heading = page.getByRole('heading', { level: 1, name: 'Vendors', exact: true });
+    this.heading = page.getByRole('heading', { level: 1, name: 'Budget', exact: true });
     this.addVendorButton = page.getByRole('button', { name: 'Add Vendor', exact: true });
 
     // Search / sort

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -771,13 +771,17 @@ test.describe('Empty state (Scenario 18)', { tag: '@responsive' }, () => {
 // Page structure and navigation
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page structure and accessibility', { tag: '@responsive' }, () => {
-  test('Page has correct h1 heading "Budget Categories"', async ({ page }) => {
+  test('Page has correct h1 heading "Budget"', async ({ page }) => {
     const categoriesPage = new BudgetCategoriesPage(page);
 
     await categoriesPage.goto();
 
     await expect(categoriesPage.heading).toBeVisible();
-    await expect(categoriesPage.heading).toHaveText('Budget Categories');
+    await expect(categoriesPage.heading).toHaveText('Budget');
+
+    // Verify the correct sub-page loaded via the h2 section heading
+    const sectionHeading = page.getByRole('heading', { level: 2, name: /^Categories/ });
+    await expect(sectionHeading).toBeVisible();
   });
 
   test('"Add Category" button is visible on page load', async ({ page }) => {

--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -1013,12 +1013,16 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
     expect(page.url()).toContain('/budget/vendors');
   });
 
-  test('Page heading is "Vendors" (h1)', async ({ page }) => {
+  test('Page heading is "Budget" (h1)', async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
     await vendorsPage.goto();
     await expect(vendorsPage.heading).toBeVisible();
-    await expect(vendorsPage.heading).toHaveText('Vendors');
+    await expect(vendorsPage.heading).toHaveText('Budget');
+
+    // Verify the correct sub-page loaded via the h2 section heading
+    const sectionHeading = page.getByRole('heading', { level: 2, name: 'Vendors' });
+    await expect(sectionHeading).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- The EPIC-05 refinement (PR #159) changed budget page `<h1>` headings from page-specific titles ("Budget Categories", "Vendors") to a shared `<h1>Budget</h1>` with sub-navigation tabs
- E2E page objects and test assertions were never updated to match, causing **all** budget-categories and vendors E2E tests to timeout (200+ test executions)
- Updates heading selectors in `BudgetCategoriesPage` and `VendorsPage` POMs from page-specific names to `"Budget"`
- Updates heading assertion tests and adds h2 section heading checks to verify the correct sub-page loaded

## Test plan
- [ ] CI E2E tests pass — all budget-categories and vendors tests should now succeed
- [ ] Non-budget E2E tests remain unaffected
- [ ] Quality gates (lint, typecheck, format:check) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)