### PR TITLE
perf(e2e): halve failure time, add action/nav timeouts, 8 workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker
     if: github.base_ref == 'main'
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/e2e/pages/BudgetCategoriesPage.ts
+++ b/e2e/pages/BudgetCategoriesPage.ts
@@ -118,7 +118,7 @@ export class BudgetCategoriesPage {
   async goto(): Promise<void> {
     await this.page.goto(BUDGET_CATEGORIES_ROUTE);
     // Wait for the page heading to appear (data loaded)
-    await this.heading.waitFor({ state: 'visible', timeout: 8000 });
+    await this.heading.waitFor({ state: 'visible', timeout: 5000 });
   }
 
   /**
@@ -165,7 +165,7 @@ export class BudgetCategoriesPage {
       await this.page
         .locator('[class*="categoryRow"]')
         .first()
-        .waitFor({ state: 'visible', timeout: 10000 });
+        .waitFor({ state: 'visible', timeout: 5000 });
     } catch {
       return null;
     }
@@ -360,8 +360,8 @@ export class BudgetCategoriesPage {
       this.page
         .locator('[class*="categoryRow"]')
         .first()
-        .waitFor({ state: 'visible', timeout: 8000 }),
-      this.emptyState.waitFor({ state: 'visible', timeout: 8000 }),
+        .waitFor({ state: 'visible', timeout: 5000 }),
+      this.emptyState.waitFor({ state: 'visible', timeout: 5000 }),
     ]);
   }
 

--- a/e2e/pages/UserManagementPage.ts
+++ b/e2e/pages/UserManagementPage.ts
@@ -88,7 +88,7 @@ export class UserManagementPage {
 
   async getUserRow(email: string): Promise<Locator | null> {
     // Wait for table data to load
-    await this.table.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 10000 });
+    await this.table.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 5000 });
     const rows = await this.getUserRows();
     for (const row of rows) {
       const rowEmail = await row.locator('td').nth(1).textContent();

--- a/e2e/pages/VendorDetailPage.ts
+++ b/e2e/pages/VendorDetailPage.ts
@@ -130,7 +130,7 @@ export class VendorDetailPage {
 
   async goto(vendorId: string): Promise<void> {
     await this.page.goto(`/budget/vendors/${vendorId}`);
-    await this.pageTitle.waitFor({ state: 'visible', timeout: 8000 });
+    await this.pageTitle.waitFor({ state: 'visible', timeout: 5000 });
   }
 
   /**
@@ -138,7 +138,7 @@ export class VendorDetailPage {
    */
   async goBackToVendors(): Promise<void> {
     await this.backToVendorsButton.click();
-    await this.page.waitForURL('/budget/vendors', { timeout: 10000 });
+    await this.page.waitForURL('/budget/vendors', { timeout: 5000 });
   }
 
   /**
@@ -179,7 +179,7 @@ export class VendorDetailPage {
    */
   async saveEdit(): Promise<void> {
     await this.saveChangesButton.click();
-    await this.editNameInput.waitFor({ state: 'hidden', timeout: 10000 });
+    await this.editNameInput.waitFor({ state: 'hidden', timeout: 5000 });
   }
 
   /**

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -142,7 +142,7 @@ export class VendorsPage {
   async goto(): Promise<void> {
     await this.page.goto(VENDORS_ROUTE);
     // Wait for either the heading (data loaded) or the loading indicator to clear
-    await this.heading.waitFor({ state: 'visible', timeout: 8000 });
+    await this.heading.waitFor({ state: 'visible', timeout: 5000 });
   }
 
   /**
@@ -197,7 +197,7 @@ export class VendorsPage {
    */
   async getTableRowByName(vendorName: string): Promise<Locator | null> {
     try {
-      await this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 10000 });
+      await this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 5000 });
     } catch {
       return null;
     }
@@ -298,8 +298,8 @@ export class VendorsPage {
    */
   async waitForVendorsLoaded(): Promise<void> {
     await Promise.race([
-      this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 8000 }),
-      this.emptyState.waitFor({ state: 'visible', timeout: 8000 }),
+      this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 5000 }),
+      this.emptyState.waitFor({ state: 'visible', timeout: 5000 }),
     ]);
   }
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
 
-  /* Use 4 workers on CI (GitHub Actions ubuntu-latest has 4 vCPUs, 16GB RAM). */
-  workers: process.env.CI ? 4 : undefined,
+  /* Use 8 workers on CI to maximize parallelism. */
+  workers: process.env.CI ? 8 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html', { outputFolder: 'playwright-report' }], ['list']],
@@ -42,6 +42,12 @@ export default defineConfig({
 
     /* Record video on failure for CI debugging */
     video: 'retain-on-failure',
+
+    /* Fail click()/fill() fast instead of falling through to test timeout */
+    actionTimeout: 5000,
+
+    /* Fail page.goto() at 10s instead of test timeout */
+    navigationTimeout: 10000,
   },
 
   /* Global setup and teardown */
@@ -92,8 +98,8 @@ export default defineConfig({
   ],
 
   /* Test timeout */
-  timeout: 30000, // 30 seconds per test
+  timeout: 15000, // 15 seconds per test
 
-  /* Global timeout: cap the entire suite at 45 minutes on CI to prevent stuck runs */
-  globalTimeout: process.env.CI ? 45 * 60 * 1000 : undefined,
+  /* Global timeout: cap the entire suite at 30 minutes on CI to prevent stuck runs */
+  globalTimeout: process.env.CI ? 30 * 60 * 1000 : undefined,
 });

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -929,7 +929,7 @@ test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () =>
     });
 
     // Wait for categories to load
-    await categoriesPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+    await categoriesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
 
     // Then: The heading is visible (not hidden by theme issues)
     await expect(categoriesPage.heading).toBeVisible();
@@ -956,7 +956,7 @@ test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () =>
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await categoriesPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+    await categoriesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
     await categoriesPage.openCreateForm();
 
     // Form inputs should be visible in dark mode
@@ -980,7 +980,7 @@ test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () =>
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await categoriesPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+      await categoriesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
 
       // Open delete modal in dark mode
       await categoriesPage.openDeleteModal('E2E Dark Mode Delete Test');

--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -87,7 +87,7 @@ test.describe('Empty state (Scenario 1)', { tag: '@responsive' }, () => {
       await vendorsPage.goto();
 
       // Then: The empty state is visible
-      await expect(vendorsPage.emptyState).toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.emptyState).toBeVisible({ timeout: 8000 });
 
       // And: The heading mentions "No vendors yet"
       const emptyText = await vendorsPage.emptyState.textContent();
@@ -118,7 +118,7 @@ test.describe('Empty state (Scenario 1)', { tag: '@responsive' }, () => {
       await vendorsPage.search('ZZZNOMATCH99999');
 
       // Then: Empty state appears with a search-specific message
-      await expect(vendorsPage.emptyState).toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.emptyState).toBeVisible({ timeout: 8000 });
       const emptyText = await vendorsPage.emptyState.textContent();
       expect(emptyText?.toLowerCase()).toMatch(/no vendors match|try different/);
     } finally {
@@ -154,7 +154,7 @@ test.describe('Create vendor — full details (Scenario 2)', { tag: '@responsive
       });
 
       // Then: The modal closes
-      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 8000 });
 
       // And: The new vendor appears in the list
       await vendorsPage.waitForVendorsLoaded();
@@ -192,7 +192,7 @@ test.describe('Create vendor — full details (Scenario 2)', { tag: '@responsive
       await vendorsPage.createVendor({ name: 'E2E Create Reset Test Vendor' });
 
       // Then: The modal closes
-      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 8000 });
 
       // And: The "Add Vendor" button is still visible and enabled
       await expect(vendorsPage.addVendorButton).toBeVisible();
@@ -224,7 +224,7 @@ test.describe('Create vendor — name only (Scenario 3)', { tag: '@responsive' }
       await vendorsPage.createVendor({ name: 'E2E Name Only Vendor' });
 
       // Then: The modal closes — vendor was created
-      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 8000 });
 
       // And: The vendor appears in the list
       await vendorsPage.waitForVendorsLoaded();
@@ -346,7 +346,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
       await vendorsPage.clickView('E2E Detail View Vendor');
 
       // Then: I am on the vendor detail page
-      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 10000 });
+      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 8000 });
       expect(page.url()).toContain(`/budget/vendors/${createdId}`);
 
       // And: The page heading is the vendor name
@@ -408,7 +408,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
     await page.goto('/budget/vendors/nonexistent-vendor-id-12345');
 
     // Then: An error card is shown
-    await expect(detailPage.errorCard).toBeVisible({ timeout: 10000 });
+    await expect(detailPage.errorCard).toBeVisible({ timeout: 8000 });
     const errorText = await detailPage.errorCard.textContent();
     expect(errorText?.toLowerCase()).toMatch(/not found|deleted|error/);
   });
@@ -551,7 +551,7 @@ test.describe('Delete vendor — no references (Scenario 8)', { tag: '@responsiv
     await vendorsPage.confirmDelete();
 
     // Then: The modal closes
-    await expect(vendorsPage.deleteModal).not.toBeVisible({ timeout: 10000 });
+    await expect(vendorsPage.deleteModal).not.toBeVisible({ timeout: 8000 });
 
     // And: The vendor is removed from the list
     await vendorsPage.waitForVendorsLoaded();
@@ -599,7 +599,7 @@ test.describe('Delete vendor — no references (Scenario 8)', { tag: '@responsiv
     await detailPage.confirmDelete();
 
     // Then: I am redirected to the vendors list
-    await page.waitForURL('/budget/vendors', { timeout: 10000 });
+    await page.waitForURL('/budget/vendors', { timeout: 8000 });
     expect(page.url()).toContain('/budget/vendors');
 
     // Note: vendor was deleted via UI — no API cleanup needed
@@ -757,7 +757,7 @@ test.describe('Pagination (Scenario 11)', { tag: '@responsive' }, () => {
       await vendorsPage.goto();
 
       // Then: Pagination controls are visible
-      await expect(vendorsPage.pagination).toBeVisible({ timeout: 10000 });
+      await expect(vendorsPage.pagination).toBeVisible({ timeout: 8000 });
       await expect(vendorsPage.nextPageButton).toBeVisible();
       await expect(vendorsPage.prevPageButton).toBeVisible();
 
@@ -993,13 +993,13 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
 
       // Navigate to detail
       await vendorsPage.clickView('E2E Navigation Vendor');
-      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 10000 });
+      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 8000 });
       expect(page.url()).toContain('/budget/vendors/');
 
       // Navigate back via breadcrumb
       await detailPage.goBackToVendors();
       expect(page.url()).toContain('/budget/vendors');
-      await vendorsPage.heading.waitFor({ state: 'visible', timeout: 10000 });
+      await vendorsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
     } finally {
       if (createdId) await deleteVendorViaApi(page, createdId);
     }
@@ -1151,7 +1151,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await vendorsPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+    await vendorsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
 
     // Heading visible
     await expect(vendorsPage.heading).toBeVisible();
@@ -1171,7 +1171,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await vendorsPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+    await vendorsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
     await vendorsPage.openCreateModal();
 
     // Modal inputs should be visible in dark mode
@@ -1194,7 +1194,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 15000 });
+      await detailPage.pageTitle.waitFor({ state: 'visible', timeout: 8000 });
 
       await expect(detailPage.pageTitle).toBeVisible();
       await expect(detailPage.editButton).toBeVisible();
@@ -1221,7 +1221,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await vendorsPage.heading.waitFor({ state: 'visible', timeout: 15000 });
+      await vendorsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
 
       await vendorsPage.openDeleteModal('E2E Dark Mode Delete Vendor');
 


### PR DESCRIPTION
## Summary
- **Test timeout**: 30s → 15s (per-test failure cost with retry: 60s → 30s)
- **Action timeout**: new 5s cap on `click()`/`fill()` (was falling through to test timeout)
- **Navigation timeout**: new 10s cap on `page.goto()` (was falling through to test timeout)
- **CI workers**: 4 → 8 (doubles parallelism)
- **CI job timeout**: 60 → 30 min
- **Global suite timeout**: 45 → 30 min
- **POM waitFor timeouts**: 8-10s → 5s across all page objects
- **Test-level timeouts**: 15s → 8s (dark mode), 10s → 8s (data load/modal/redirect waits)
- **Unchanged**: `retries: 1`, OIDC/auth setup timeouts, existing 3-5s timeouts

## Test plan
- [ ] CI Quality Gates pass (lint, typecheck, format, unit tests, build, audit)
- [ ] E2E tests run with new timeouts on promotion PR to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)