### PR TITLE
fix(e2e): use object destructuring in testPrefix fixture

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -23,7 +23,7 @@ export const test = base.extend<{
   // Unique prefix per worker+project to prevent data collisions in shared DB.
   // Format: "E2E-<3-char-project><workerIndex>" e.g. "E2E-des0", "E2E-tab2", "E2E-mob1"
   testPrefix: [
-    async (_fixtures, use, testInfo: TestInfo) => {
+    async ({ authenticatedPage: _ap }, use, testInfo: TestInfo) => {
       const project = testInfo.project.name.slice(0, 3); // "des", "tab", "mob"
       await use(`E2E-${project}${testInfo.workerIndex}`);
     },


### PR DESCRIPTION
## Summary
- Playwright requires fixture function first args to use object destructuring (`{ }`) not plain parameters
- `_fixtures` caused `First argument must use the object destructuring pattern` error, failing all E2E tests
- Changed to `{ authenticatedPage: _ap }` to satisfy both Playwright and ESLint's `no-empty-pattern`

## Test plan
- [ ] CI Quality Gates pass (lint, typecheck, tests)
- [ ] E2E tests no longer crash at fixture initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)