### PR TITLE
perf(e2e): reduce test timeout from 15s to 7s

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -99,8 +99,8 @@ export default defineConfig({
     },
   ],
 
-  /* Test timeout */
-  timeout: 15000, // 15 seconds per test
+  /* Test timeout — most passing tests complete in 2-5s */
+  timeout: 7000, // 7 seconds per test
 
   /* Global timeout: cap the entire suite at 30 minutes on CI to prevent stuck runs */
   globalTimeout: process.env.CI ? 30 * 60 * 1000 : undefined,


### PR DESCRIPTION
## Summary

- Reduce Playwright per-test timeout from 15s to 7s
- Most passing tests complete in 2-5s; 7s gives adequate headroom
- Saves ~5 minutes on CI by halving the time spent waiting for failing tests to time out

## Test plan

- [x] `npm run lint` and `npm run format:check` pass
- [ ] CI passes (Quality Gates + Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)