### PR TITLE
fix(work-items): reduce vendor pageSize from 500 to 100

### DIFF
--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -50,6 +50,7 @@ Own all Playwright E2E browser tests in `e2e/tests/`. This includes:
 - **Page Object Models**: Maintain page objects in `e2e/pages/` for stable, reusable UI interactions
 - **Complementary coverage**: Integration tests validate API behavior and business logic; E2E tests validate browser-level user flows. Ensure they are complementary, not redundant.
 - **Auth setup**: Authentication setup in `e2e/auth.setup.ts` using storageState
+- **Full page/route coverage**: Every page/route in the application must have E2E test coverage. When new pages are added during a story, E2E tests must be created before the story is considered complete. Fully implemented pages need comprehensive tests (CRUD, validation, responsive, dark mode). Stub/placeholder pages need at minimum a smoke test verifying the page loads and renders its heading.
 
 ### 3. Gantt Chart Testing (Integration)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,6 +449,7 @@ All automated testing is owned by the `qa-integration-tester` agent. Developer a
 - **Coverage**: `npm run test:coverage` — **95% unit test coverage target** on all new and modified code
 - Test files use `.test.ts` / `.test.tsx` extension
 - No separate `__tests__/` directories -- tests live next to the code they test
+- **E2E page coverage requirement**: Every page/route in the application must have E2E test coverage. Fully implemented pages need comprehensive tests (CRUD flows, validation, responsive layout, dark mode). Stub/placeholder pages need at minimum a smoke test verifying the page loads and renders its heading.
 
 ## Development Workflow
 

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
@@ -225,7 +225,7 @@ describe('WorkItemDetailPage', () => {
     mockFetchBudgetSources.mockResolvedValue({ budgetSources: [] });
     mockFetchVendors.mockResolvedValue({
       vendors: [],
-      pagination: { page: 1, pageSize: 500, totalItems: 0, totalPages: 0 },
+      pagination: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
     });
     mockFetchWorkItemVendors.mockResolvedValue([]);
     mockFetchSubsidyPrograms.mockResolvedValue({ subsidyPrograms: [] });

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -156,7 +156,7 @@ export default function WorkItemDetailPage() {
           listUsers(),
           fetchBudgetCategories(),
           fetchBudgetSources(),
-          fetchVendors({ pageSize: 500 }),
+          fetchVendors({ pageSize: 100 }),
           fetchWorkItemVendors(id!),
           fetchSubsidyPrograms(),
           fetchWorkItemSubsidies(id!),


### PR DESCRIPTION
## Summary

- **Bug fix**: `fetchVendors({ pageSize: 500 })` on the work item detail page exceeded the server's `pageSize: maximum: 100` schema validation, causing a 400 error that cascaded through `Promise.all` and blocked the entire page from loading ("Failed to load work item")
- **Policy update**: Added E2E page coverage requirement to `CLAUDE.md` and `.claude/agents/qa-integration-tester.md` — every page/route must have E2E tests before a story is considered complete

## Changes

| File | Change |
|------|--------|
| `client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx:159` | `pageSize: 500` → `pageSize: 100` |
| `client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx:228` | Mock updated to match |
| `CLAUDE.md` | Added E2E page coverage requirement to Testing Approach section |
| `.claude/agents/qa-integration-tester.md` | Added full page/route coverage requirement to Playwright section |

## Test plan

- [x] `npm test -- --testPathPatterns WorkItemDetailPage` — 16 tests pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)