### PR TITLE
fix(e2e): correct API response shape parsing in helpers and mocks

### DIFF
--- a/e2e/fixtures/apiHelpers.ts
+++ b/e2e/fixtures/apiHelpers.ts
@@ -25,8 +25,8 @@ export async function createWorkItemViaApi(
 ): Promise<string> {
   const response = await page.request.post(API.workItems, { data });
   expect(response.ok()).toBeTruthy();
-  const body = (await response.json()) as { workItem: { id: string } };
-  return body.workItem.id;
+  const body = (await response.json()) as { id: string };
+  return body.id;
 }
 
 export async function deleteWorkItemViaApi(page: Page, id: string): Promise<void> {
@@ -63,8 +63,8 @@ export async function createBudgetSourceViaApi(
     data: { sourceType: 'savings', status: 'active', ...data },
   });
   expect(response.ok()).toBeTruthy();
-  const body = (await response.json()) as { id: string };
-  return body.id;
+  const body = (await response.json()) as { budgetSource: { id: string } };
+  return body.budgetSource.id;
 }
 
 export async function deleteBudgetSourceViaApi(page: Page, id: string): Promise<void> {
@@ -88,8 +88,8 @@ export async function createSubsidyProgramViaApi(
     data: { reductionType: 'percentage', ...data },
   });
   expect(response.ok()).toBeTruthy();
-  const body = (await response.json()) as { id: string };
-  return body.id;
+  const body = (await response.json()) as { subsidyProgram: { id: string } };
+  return body.subsidyProgram.id;
 }
 
 export async function deleteSubsidyProgramViaApi(page: Page, id: string): Promise<void> {

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -149,7 +149,7 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(emptyOverviewResponse()),
+          body: JSON.stringify({ overview: emptyOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -192,7 +192,7 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(responseBody),
+          body: JSON.stringify({ overview: responseBody }),
         });
       } else {
         await route.continue();
@@ -227,7 +227,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -262,7 +262,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -294,7 +294,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -326,7 +326,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -355,7 +355,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -388,7 +388,7 @@ test.describe('Category breakdown table', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();
@@ -532,7 +532,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(populatedOverviewResponse()),
+          body: JSON.stringify({ overview: populatedOverviewResponse() }),
         });
       } else {
         await route.continue();


### PR DESCRIPTION
## Summary

- Fixed 3 shared API helpers in `e2e/fixtures/apiHelpers.ts` that parsed response bodies incorrectly, causing ~80 test failures across work-items and budget specs
  - `createWorkItemViaApi`: expected `{workItem:{id}}` but API returns flat `{id}`
  - `createBudgetSourceViaApi`: expected `{id}` but API returns `{budgetSource:{id}}`
  - `createSubsidyProgramViaApi`: expected `{id}` but API returns `{subsidyProgram:{id}}`
- Fixed all budget overview mock responses in `budget-overview.spec.ts` to include the `{overview:...}` wrapper that the frontend client expects (`fetchBudgetOverview` returns `response.overview`)

## Test plan

- [ ] CI quality gates pass (lint, typecheck, build, unit tests)
- [ ] E2E tests pass — work items list/create/detail specs now create/delete test data successfully
- [ ] E2E tests pass — budget overview mocked tests render correct data instead of empty/error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)