### PR TITLE
fix(e2e): resolve modal backdrop click, description edit, and WebKit timeout failures

### DIFF
--- a/e2e/tests/budget/budget-sources.spec.ts
+++ b/e2e/tests/budget/budget-sources.spec.ts
@@ -76,7 +76,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     const sourcesPage = new BudgetSourcesPage(page);
 
     await sourcesPage.goto();
-    await sourcesPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await sourcesPage.heading.waitFor({ state: 'visible' });
 
     // h1 "Budget"
     await expect(sourcesPage.heading).toBeVisible();
@@ -91,7 +92,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     const sourcesPage = new BudgetSourcesPage(page);
 
     await sourcesPage.goto();
-    await sourcesPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await sourcesPage.heading.waitFor({ state: 'visible' });
 
     const subNav = page.getByRole('navigation', { name: 'Budget section navigation' });
     await expect(subNav).toBeVisible();
@@ -134,7 +136,8 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
       await sourcesPage.goto();
       await sourcesPage.waitForSourcesLoaded();
 
-      await expect(sourcesPage.emptyState).toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(sourcesPage.emptyState).toBeVisible();
       const emptyText = await sourcesPage.emptyState.textContent();
       expect(emptyText?.toLowerCase()).toMatch(/no budget sources yet/);
     } finally {
@@ -146,7 +149,8 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
     const sourcesPage = new BudgetSourcesPage(page);
 
     await sourcesPage.goto();
-    await sourcesPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await sourcesPage.heading.waitFor({ state: 'visible' });
 
     await expect(sourcesPage.addSourceButton).toBeVisible();
     await expect(sourcesPage.addSourceButton).toBeEnabled();
@@ -179,7 +183,8 @@ test.describe('Create source — full fields', { tag: '@responsive' }, () => {
       });
 
       // Then: Form closes and success banner appears
-      await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(sourcesPage.createFormHeading).not.toBeVisible();
 
       const successText = await sourcesPage.getSuccessBannerText();
       expect(successText).toContain(sourceName);
@@ -214,7 +219,8 @@ test.describe('Create source — full fields', { tag: '@responsive' }, () => {
       await sourcesPage.createSource({ name: sourceName, totalAmount: 50000 });
 
       // Form dismissed
-      await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(sourcesPage.createFormHeading).not.toBeVisible();
 
       // Add Source button re-enabled
       await expect(sourcesPage.addSourceButton).toBeEnabled();
@@ -244,7 +250,8 @@ test.describe('Create source — minimal fields', { tag: '@responsive' }, () => 
 
       await sourcesPage.createSource({ name: sourceName, totalAmount: 75000 });
 
-      await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(sourcesPage.createFormHeading).not.toBeVisible();
 
       await sourcesPage.waitForSourcesLoaded();
       const names = await sourcesPage.getSourceNames();
@@ -277,7 +284,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(sourcesPage.createSubmitButton).toBeDisabled();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Create Source" button is disabled when amount field is empty', async ({ page }) => {
@@ -294,7 +302,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(sourcesPage.createSubmitButton).toBeDisabled();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Create Source" button enabled when both name and amount are filled', async ({ page }) => {
@@ -310,7 +319,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(sourcesPage.createSubmitButton).toBeEnabled();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Add Source" button is disabled while create form is open', async ({ page }) => {
@@ -323,7 +333,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(sourcesPage.addSourceButton).toBeDisabled();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 
   test('Cancel button dismisses create form without creating a source', async ({ page }) => {
@@ -339,7 +350,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await sourcesPage.createTotalAmountInput.fill('10000');
     await sourcesPage.createCancelButton.click();
 
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
 
     const namesAfter = await sourcesPage.getSourceNames();
     expect(namesAfter).not.toContain('Should Not Be Created');
@@ -489,7 +501,8 @@ test.describe('Delete source', { tag: '@responsive' }, () => {
     await sourcesPage.confirmDelete();
 
     // Modal closes
-    await expect(sourcesPage.deleteModal).not.toBeVisible({ timeout: 8000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.deleteModal).not.toBeVisible();
 
     // Success banner appears
     const successText = await sourcesPage.getSuccessBannerText();
@@ -572,7 +585,8 @@ test.describe('Delete blocked by 409', { tag: '@responsive' }, () => {
       expect(errorText?.toLowerCase()).toMatch(/cannot be deleted|referenced|budget entries/);
 
       // Confirm button is hidden after error
-      await expect(sourcesPage.deleteConfirmButton).not.toBeVisible({ timeout: 3000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(sourcesPage.deleteConfirmButton).not.toBeVisible();
 
       // Modal still open
       await expect(sourcesPage.deleteModal).toBeVisible();
@@ -617,7 +631,8 @@ test.describe('Responsive layout', { tag: '@responsive' }, () => {
     await expect(sourcesPage.createSubmitButton).toBeVisible();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 });
 
@@ -633,7 +648,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await sourcesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await sourcesPage.heading.waitFor({ state: 'visible' });
 
     // Heading visible
     await expect(sourcesPage.heading).toBeVisible();
@@ -656,7 +672,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await sourcesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await sourcesPage.heading.waitFor({ state: 'visible' });
     await sourcesPage.openCreateForm();
 
     await expect(sourcesPage.createNameInput).toBeVisible();
@@ -664,7 +681,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
     await expect(sourcesPage.createSubmitButton).toBeVisible();
 
     await sourcesPage.createCancelButton.click();
-    await expect(sourcesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(sourcesPage.createFormHeading).not.toBeVisible();
   });
 
   test('Delete modal usable in dark mode', async ({ page, testPrefix }) => {
@@ -680,7 +698,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await sourcesPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await sourcesPage.heading.waitFor({ state: 'visible' });
       await sourcesPage.waitForSourcesLoaded();
 
       await sourcesPage.openDeleteModal(sourceName);

--- a/e2e/tests/budget/subsidy-programs.spec.ts
+++ b/e2e/tests/budget/subsidy-programs.spec.ts
@@ -81,7 +81,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     const subsidyPage = new SubsidyProgramsPage(page);
 
     await subsidyPage.goto();
-    await subsidyPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await subsidyPage.heading.waitFor({ state: 'visible' });
 
     await expect(subsidyPage.heading).toBeVisible();
     await expect(subsidyPage.heading).toHaveText('Budget');
@@ -94,7 +95,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     const subsidyPage = new SubsidyProgramsPage(page);
 
     await subsidyPage.goto();
-    await subsidyPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await subsidyPage.heading.waitFor({ state: 'visible' });
 
     const subNav = page.getByRole('navigation', { name: 'Budget section navigation' });
     await expect(subNav).toBeVisible();
@@ -136,7 +138,8 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
       await subsidyPage.goto();
       await subsidyPage.waitForProgramsLoaded();
 
-      await expect(subsidyPage.emptyState).toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(subsidyPage.emptyState).toBeVisible();
       const emptyText = await subsidyPage.emptyState.textContent();
       expect(emptyText?.toLowerCase()).toMatch(/no subsidy programs yet/);
     } finally {
@@ -148,7 +151,8 @@ test.describe('Empty state', { tag: '@responsive' }, () => {
     const subsidyPage = new SubsidyProgramsPage(page);
 
     await subsidyPage.goto();
-    await subsidyPage.heading.waitFor({ state: 'visible', timeout: 5000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await subsidyPage.heading.waitFor({ state: 'visible' });
 
     await expect(subsidyPage.addProgramButton).toBeVisible();
     await expect(subsidyPage.addProgramButton).toBeEnabled();
@@ -185,7 +189,8 @@ test.describe('Create program — percentage type', { tag: '@responsive' }, () =
       });
 
       // Then: Form closes and success banner appears
-      await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(subsidyPage.createFormHeading).not.toBeVisible();
 
       const successText = await subsidyPage.getSuccessBannerText();
       expect(successText).toContain(programName);
@@ -262,7 +267,8 @@ test.describe('Create program — fixed-amount type', { tag: '@responsive' }, ()
         applicationStatus: 'eligible',
       });
 
-      await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(subsidyPage.createFormHeading).not.toBeVisible();
 
       await subsidyPage.waitForProgramsLoaded();
       const names = await subsidyPage.getProgramNames();
@@ -302,7 +308,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(subsidyPage.createSubmitButton).toBeDisabled();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Create Program" button is disabled when reduction value is empty', async ({ page }) => {
@@ -318,7 +325,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(subsidyPage.createSubmitButton).toBeDisabled();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Create Program" button enabled when name and reduction value filled', async ({ page }) => {
@@ -334,7 +342,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(subsidyPage.createSubmitButton).toBeEnabled();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('"Add Program" button is disabled while create form is open', async ({ page }) => {
@@ -347,7 +356,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await expect(subsidyPage.addProgramButton).toBeDisabled();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('Cancel dismisses create form without creating a program', async ({ page }) => {
@@ -363,7 +373,8 @@ test.describe('Create validation', { tag: '@responsive' }, () => {
     await subsidyPage.createReductionValueInput.fill('5');
     await subsidyPage.createCancelButton.click();
 
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
 
     const countAfter = await subsidyPage.getProgramsCount();
     expect(countAfter).toBe(countBefore);
@@ -387,7 +398,8 @@ test.describe('Category checkboxes in create form', { tag: '@responsive' }, () =
     await subsidyPage.openCreateForm();
 
     // The checkbox list should be visible
-    await expect(subsidyPage.createCategoryCheckboxList).toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createCategoryCheckboxList).toBeVisible();
 
     // At least one default category (e.g. "Materials") should be listed
     const categoryNames = await subsidyPage.getCreateFormCategoryNames();
@@ -395,7 +407,8 @@ test.describe('Category checkboxes in create form', { tag: '@responsive' }, () =
     expect(categoryNames).toContain('Materials');
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('Checking a category associates it with a created program', async ({ page, testPrefix }) => {
@@ -415,7 +428,8 @@ test.describe('Category checkboxes in create form', { tag: '@responsive' }, () =
         categoryNames: ['Materials'],
       });
 
-      await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(subsidyPage.createFormHeading).not.toBeVisible();
       await subsidyPage.waitForProgramsLoaded();
 
       // Row for the created program should show the category pill
@@ -570,7 +584,8 @@ test.describe('Delete program', { tag: '@responsive' }, () => {
     await subsidyPage.confirmDelete();
 
     // Modal closes
-    await expect(subsidyPage.deleteModal).not.toBeVisible({ timeout: 8000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.deleteModal).not.toBeVisible();
 
     // Success banner
     const successText = await subsidyPage.getSuccessBannerText();
@@ -653,7 +668,8 @@ test.describe('Delete blocked by 409', { tag: '@responsive' }, () => {
       expect(errorText?.toLowerCase()).toMatch(/cannot be deleted|referenced|budget entries/);
 
       // Confirm button hidden after error
-      await expect(subsidyPage.deleteConfirmButton).not.toBeVisible({ timeout: 3000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(subsidyPage.deleteConfirmButton).not.toBeVisible();
 
       // Modal still open
       await expect(subsidyPage.deleteModal).toBeVisible();
@@ -699,7 +715,8 @@ test.describe('Responsive layout', { tag: '@responsive' }, () => {
     await expect(subsidyPage.createSubmitButton).toBeVisible();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 });
 
@@ -715,7 +732,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await subsidyPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await subsidyPage.heading.waitFor({ state: 'visible' });
 
     await expect(subsidyPage.heading).toBeVisible();
     await expect(subsidyPage.addProgramButton).toBeVisible();
@@ -734,7 +752,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await subsidyPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await subsidyPage.heading.waitFor({ state: 'visible' });
     await subsidyPage.openCreateForm();
 
     await expect(subsidyPage.createNameInput).toBeVisible();
@@ -742,7 +761,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
     await expect(subsidyPage.createSubmitButton).toBeVisible();
 
     await subsidyPage.createCancelButton.click();
-    await expect(subsidyPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(subsidyPage.createFormHeading).not.toBeVisible();
   });
 
   test('Delete modal usable in dark mode', async ({ page, testPrefix }) => {
@@ -758,7 +778,8 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await subsidyPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await subsidyPage.heading.waitFor({ state: 'visible' });
       await subsidyPage.waitForProgramsLoaded();
 
       await subsidyPage.openDeleteModal(programName);

--- a/e2e/tests/tags/tag-management.spec.ts
+++ b/e2e/tests/tags/tag-management.spec.ts
@@ -187,7 +187,8 @@ test.describe('Create tag — happy path (Scenario 2)', { tag: '@responsive' }, 
       await tagsPage.createTag(tagName);
 
       // Then: Success banner visible
-      await tagsPage.successBanner.waitFor({ state: 'visible', timeout: 5000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await tagsPage.successBanner.waitFor({ state: 'visible' });
 
       // And: The name input is cleared
       await expect(tagsPage.createTagNameInput).toHaveValue('');
@@ -528,7 +529,8 @@ test.describe('Delete tag — confirm (Scenario 8)', { tag: '@responsive' }, () 
     await tagsPage.confirmDelete();
 
     // Then: The modal closes
-    await expect(tagsPage.deleteModal).not.toBeVisible({ timeout: 8000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(tagsPage.deleteModal).not.toBeVisible();
 
     // And: A success banner appears
     const successText = await tagsPage.getSuccessBannerText();
@@ -559,7 +561,8 @@ test.describe('Delete tag — confirm (Scenario 8)', { tag: '@responsive' }, () 
     // Delete via UI
     await tagsPage.openDeleteModal(tagName);
     await tagsPage.confirmDelete();
-    await expect(tagsPage.deleteModal).not.toBeVisible({ timeout: 8000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(tagsPage.deleteModal).not.toBeVisible();
 
     // Then: The count in the heading decreased by 1
     const countAfter = await tagsPage.getTagCount();
@@ -590,7 +593,8 @@ test.describe('Delete tag — cancel (Scenario 9)', { tag: '@responsive' }, () =
       await tagsPage.cancelDelete();
 
       // Then: The modal is closed
-      await expect(tagsPage.deleteModal).not.toBeVisible({ timeout: 5000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(tagsPage.deleteModal).not.toBeVisible();
 
       // And: The tag is still in the list
       const names = await tagsPage.getTagNames();
@@ -618,11 +622,14 @@ test.describe('Delete tag — cancel (Scenario 9)', { tag: '@responsive' }, () =
       await tagsPage.openDeleteModal(tagName);
       await expect(tagsPage.deleteModal).toBeVisible();
 
-      // Click the backdrop (outside the modal content box)
-      await page.locator('[class*="modalBackdrop"]').click();
+      // Click the backdrop at the top-left corner — outside the centered modal content box.
+      // Clicking center would hit the modal content div that sits on top of the backdrop.
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await page.locator('[class*="modalBackdrop"]').click({ position: { x: 10, y: 10 } });
 
       // Then: The modal closes
-      await expect(tagsPage.deleteModal).not.toBeVisible({ timeout: 5000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(tagsPage.deleteModal).not.toBeVisible();
 
       // And: The tag is still present
       const names = await tagsPage.getTagNames();
@@ -657,7 +664,8 @@ test.describe('Empty state (Scenario 10)', { tag: '@responsive' }, () => {
       await tagsPage.goto();
 
       // Then: The empty state paragraph is visible
-      await expect(tagsPage.emptyState).toBeVisible({ timeout: 8000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(tagsPage.emptyState).toBeVisible();
 
       // And: The empty state text matches expected message
       const emptyText = await tagsPage.emptyState.textContent();
@@ -745,7 +753,8 @@ test.describe('Dark mode rendering (Scenario 12)', { tag: '@responsive' }, () =>
       document.documentElement.setAttribute('data-theme', 'dark');
     });
 
-    await tagsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+    // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+    await tagsPage.heading.waitFor({ state: 'visible' });
 
     // Heading is visible
     await expect(tagsPage.heading).toBeVisible();
@@ -774,7 +783,8 @@ test.describe('Dark mode rendering (Scenario 12)', { tag: '@responsive' }, () =>
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await tagsPage.heading.waitFor({ state: 'visible', timeout: 8000 });
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await tagsPage.heading.waitFor({ state: 'visible' });
       await tagsPage.waitForTagsLoaded();
       await tagsPage.openDeleteModal(tagName);
 

--- a/e2e/tests/work-items/work-item-detail.spec.ts
+++ b/e2e/tests/work-items/work-item-detail.spec.ts
@@ -108,7 +108,8 @@ test.describe('Back button navigation (Scenario 2)', { tag: '@responsive' }, () 
 
       await detailPage.backButton.click();
 
-      await page.waitForURL('**/work-items', { timeout: 5000 });
+      // No explicit timeout — uses project-level navigationTimeout (15s for WebKit).
+      await page.waitForURL('**/work-items');
       expect(page.url()).toContain('/work-items');
       expect(page.url()).not.toMatch(/\/work-items\/[a-z0-9]/);
     } finally {
@@ -228,7 +229,8 @@ test.describe('Add subtask (Scenario 4)', { tag: '@responsive' }, () => {
 
       // Toggle on
       await checkbox.click();
-      await expect(checkbox).toBeChecked({ timeout: 5000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(checkbox).toBeChecked();
     } finally {
       if (createdId) await deleteWorkItemViaApi(page, createdId);
     }
@@ -313,7 +315,8 @@ test.describe(
         expect(errorText).toBeNull();
 
         // Vendor picker select is visible (because availableVendors.length > 0)
-        await expect(detailPage.vendorPicker).toBeVisible({ timeout: 7000 });
+        // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+        await expect(detailPage.vendorPicker).toBeVisible();
       } finally {
         if (workItemId) await deleteWorkItemViaApi(page, workItemId);
         if (vendorId) await page.request.delete(`${API.vendors}/${vendorId}`);
@@ -400,12 +403,13 @@ test.describe('Inline description edit (Scenario 6)', { tag: '@responsive' }, ()
         .getByRole('button', { name: 'Cancel', exact: true })
         .click();
 
-      // Original description should still be visible
+      // Original description should still be visible.
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
       await expect(
         detailPage.descriptionSection
           .locator('[class*="description"]')
           .filter({ hasText: originalDescription }),
-      ).toBeVisible({ timeout: 5000 });
+      ).toBeVisible();
     } finally {
       if (createdId) await deleteWorkItemViaApi(page, createdId);
     }
@@ -438,7 +442,8 @@ test.describe('Delete work item (Scenario 7)', { tag: '@responsive' }, () => {
     // Confirm deletion — navigates to /work-items
     await detailPage.confirmDelete();
 
-    await page.waitForURL('**/work-items', { timeout: 7000 });
+    // No explicit timeout — uses project-level navigationTimeout (15s for WebKit).
+    await page.waitForURL('**/work-items');
     expect(page.url()).toContain('/work-items');
     expect(page.url()).not.toMatch(/\/work-items\/[a-z0-9]/);
 
@@ -468,7 +473,8 @@ test.describe('Delete work item (Scenario 7)', { tag: '@responsive' }, () => {
       expect(page.url()).toContain(`/work-items/${createdId}`);
 
       // Modal is closed
-      await expect(detailPage.deleteConfirmButton).not.toBeVisible({ timeout: 3000 });
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(detailPage.deleteConfirmButton).not.toBeVisible();
     } finally {
       if (createdId) await deleteWorkItemViaApi(page, createdId);
     }
@@ -492,7 +498,8 @@ test.describe('Error state for non-existent ID (Scenario 8)', { tag: '@responsiv
     const backButton = detailPage.errorState.getByRole('button', {
       name: /Back to Work Items/i,
     });
-    await expect(backButton).toBeVisible({ timeout: 7000 });
+    // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+    await expect(backButton).toBeVisible();
   });
 
   test('Error state "Back to Work Items" button navigates to the list', async ({ page }) => {
@@ -508,7 +515,8 @@ test.describe('Error state for non-existent ID (Scenario 8)', { tag: '@responsiv
     });
     await backButton.click();
 
-    await page.waitForURL('**/work-items', { timeout: 5000 });
+    // No explicit timeout — uses project-level navigationTimeout (15s for WebKit).
+    await page.waitForURL('**/work-items');
     expect(page.url()).toContain('/work-items');
     expect(page.url()).not.toMatch(/\/work-items\/[a-z0-9]/);
   });
@@ -583,7 +591,8 @@ test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () =>
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await detailPage.heading.waitFor({ state: 'visible', timeout: 7000 });
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await detailPage.heading.waitFor({ state: 'visible' });
 
       // Key elements visible in dark mode
       await expect(detailPage.heading).toBeVisible();
@@ -614,7 +623,8 @@ test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () =>
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
-      await detailPage.heading.waitFor({ state: 'visible', timeout: 7000 });
+      // No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+      await detailPage.heading.waitFor({ state: 'visible' });
       await detailPage.openDeleteModal();
 
       // Modal confirm and cancel buttons visible in dark mode


### PR DESCRIPTION
## Summary

- **Modal backdrop cancel (tags, all viewports)**: The backdrop click test was clicking the geometric center of the full-viewport backdrop element, which lands on the centered modal content div. Fixed by clicking at `{ position: { x: 10, y: 10 } }` (top-left corner, outside the modal box).

- **Work item description inline-edit (desktop)**: In edit mode, `[class*="description"]` matched three elements (`.description`, `.descriptionEdit`, `.descriptionTextarea`), triggering Playwright's strict mode error. Fixed `WorkItemDetailPage.startEditingDescription()` to use a `:not()` chain, and `saveDescription()` now waits for the textarea to be hidden before returning so callers can assert on the display-mode description immediately.

- **WebKit timeout failures (tablet/mobile, all budget/subsidy/tags/work-item tests)**: All `{ timeout: N }` overrides in test assertions were removed from `tag-management.spec.ts`, `work-item-detail.spec.ts`, `budget-sources.spec.ts`, and `subsidy-programs.spec.ts`. Explicit timeouts override the project-level `expect.timeout: 15_000` for WebKit, causing assertions to fail on slower WebKit workers. Tests now rely on project-level defaults.

## Bug Report Filed

GitHub issue #175 was filed for a frontend application bug: `createBudgetSource`, `updateBudgetSource`, `createSubsidyProgram`, and `updateSubsidyProgram` in the API client return bare entity types but the server wraps responses in `{ budgetSource: {...} }` / `{ subsidyProgram: {...} }`. This causes React to crash (blank page) on create, and shows `"undefined"` in success messages on update. These test failures cannot be fixed in test code — they require a fix in `client/src/lib/budgetSourcesApi.ts` and `client/src/lib/subsidyProgramsApi.ts`.

## Test plan

- [ ] CI passes on this PR (lint, format, typecheck, build)
- [ ] E2E tag backdrop cancel test passes on desktop, tablet, and mobile
- [ ] E2E work item description edit test passes on desktop
- [ ] WebKit tablet/mobile tests no longer time out on modal dismiss assertions
- [ ] Budget sources and subsidy programs tests remain in the same state (blocked on app bug #175)

🤖 Generated with [Claude Code](https://claude.com/claude-code)