### PR TITLE
fix(budget): unwrap server response wrappers in API client functions

### DIFF
--- a/client/src/lib/budgetSourcesApi.test.ts
+++ b/client/src/lib/budgetSourcesApi.test.ts
@@ -183,7 +183,7 @@ describe('budgetSourcesApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleSource,
+        json: async () => ({ budgetSource: sampleSource }),
       } as Response);
 
       const requestData = {
@@ -206,7 +206,7 @@ describe('budgetSourcesApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleSource,
+        json: async () => ({ budgetSource: sampleSource }),
       } as Response);
 
       const result = await createBudgetSource({
@@ -228,7 +228,7 @@ describe('budgetSourcesApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleSource,
+        json: async () => ({ budgetSource: sampleSource }),
       } as Response);
 
       const requestData = {
@@ -289,7 +289,7 @@ describe('budgetSourcesApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedSource,
+        json: async () => ({ budgetSource: updatedSource }),
       } as Response);
 
       const updateData = { name: 'Updated Loan' };
@@ -314,7 +314,7 @@ describe('budgetSourcesApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedSource,
+        json: async () => ({ budgetSource: updatedSource }),
       } as Response);
 
       const result = await updateBudgetSource('src-1', {
@@ -333,7 +333,7 @@ describe('budgetSourcesApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedSource,
+        json: async () => ({ budgetSource: updatedSource }),
       } as Response);
 
       const updateData = { status: 'closed' as const };
@@ -353,7 +353,7 @@ describe('budgetSourcesApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedSource,
+        json: async () => ({ budgetSource: updatedSource }),
       } as Response);
 
       const updateData = { interestRate: null };
@@ -397,7 +397,7 @@ describe('budgetSourcesApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedSource,
+        json: async () => ({ budgetSource: updatedSource }),
       } as Response);
 
       await updateBudgetSource('custom-id', { name: 'Updated' });

--- a/client/src/lib/budgetSourcesApi.ts
+++ b/client/src/lib/budgetSourcesApi.ts
@@ -24,18 +24,20 @@ export function fetchBudgetSource(id: string): Promise<BudgetSourceResponse> {
 /**
  * Creates a new budget source.
  */
-export function createBudgetSource(data: CreateBudgetSourceRequest): Promise<BudgetSource> {
-  return post<BudgetSource>('/budget-sources', data);
+export async function createBudgetSource(data: CreateBudgetSourceRequest): Promise<BudgetSource> {
+  const response = await post<BudgetSourceResponse>('/budget-sources', data);
+  return response.budgetSource;
 }
 
 /**
  * Updates an existing budget source.
  */
-export function updateBudgetSource(
+export async function updateBudgetSource(
   id: string,
   data: UpdateBudgetSourceRequest,
 ): Promise<BudgetSource> {
-  return patch<BudgetSource>(`/budget-sources/${id}`, data);
+  const response = await patch<BudgetSourceResponse>(`/budget-sources/${id}`, data);
+  return response.budgetSource;
 }
 
 /**

--- a/client/src/lib/subsidyProgramsApi.test.ts
+++ b/client/src/lib/subsidyProgramsApi.test.ts
@@ -202,7 +202,7 @@ describe('subsidyProgramsApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleProgram,
+        json: async () => ({ subsidyProgram: sampleProgram }),
       } as Response);
 
       const requestData = {
@@ -225,7 +225,7 @@ describe('subsidyProgramsApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleProgram,
+        json: async () => ({ subsidyProgram: sampleProgram }),
       } as Response);
 
       const result = await createSubsidyProgram({
@@ -251,7 +251,7 @@ describe('subsidyProgramsApi', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
-        json: async () => sampleProgram,
+        json: async () => ({ subsidyProgram: sampleProgram }),
       } as Response);
 
       const requestData = {
@@ -314,7 +314,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       const updateData = { name: 'Updated Rebate' };
@@ -339,7 +339,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       const result = await updateSubsidyProgram('prog-1', {
@@ -359,7 +359,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       const updateData = { reductionType: 'fixed' as const };
@@ -379,7 +379,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       const updateData = { description: null };
@@ -399,7 +399,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       const updateData = { categoryIds: ['cat-1', 'cat-2'] };
@@ -448,7 +448,7 @@ describe('subsidyProgramsApi', () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => updatedProgram,
+        json: async () => ({ subsidyProgram: updatedProgram }),
       } as Response);
 
       await updateSubsidyProgram('custom-prog-id', { name: 'Updated' });

--- a/client/src/lib/subsidyProgramsApi.ts
+++ b/client/src/lib/subsidyProgramsApi.ts
@@ -24,18 +24,22 @@ export function fetchSubsidyProgram(id: string): Promise<SubsidyProgramResponse>
 /**
  * Creates a new subsidy program.
  */
-export function createSubsidyProgram(data: CreateSubsidyProgramRequest): Promise<SubsidyProgram> {
-  return post<SubsidyProgram>('/subsidy-programs', data);
+export async function createSubsidyProgram(
+  data: CreateSubsidyProgramRequest,
+): Promise<SubsidyProgram> {
+  const response = await post<SubsidyProgramResponse>('/subsidy-programs', data);
+  return response.subsidyProgram;
 }
 
 /**
  * Updates an existing subsidy program.
  */
-export function updateSubsidyProgram(
+export async function updateSubsidyProgram(
   id: string,
   data: UpdateSubsidyProgramRequest,
 ): Promise<SubsidyProgram> {
-  return patch<SubsidyProgram>(`/subsidy-programs/${id}`, data);
+  const response = await patch<SubsidyProgramResponse>(`/subsidy-programs/${id}`, data);
+  return response.subsidyProgram;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `createBudgetSource` and `updateBudgetSource` in `budgetSourcesApi.ts` returned the raw `{ budgetSource: ... }` server response wrapper instead of the unwrapped `BudgetSource` entity
- `createSubsidyProgram` and `updateSubsidyProgram` in `subsidyProgramsApi.ts` had the same issue with `{ subsidyProgram: ... }`
- This caused page crashes on create (accessing `.name` on the wrapper object returns `undefined`) and incorrect success messages on update
- Unit test mocks updated to return wrapped responses matching the server's actual format

Fixes #175

## Test plan

- [x] 183 unit tests pass across 4 affected test suites
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] E2E budget sources and subsidy programs tests should now pass (previously 24 of 27 failures were caused by this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)