### PR TITLE
fix(e2e): remove all hardcoded timeout: 5000 from POMs and specs

### DIFF
--- a/e2e/pages/AppShellPage.ts
+++ b/e2e/pages/AppShellPage.ts
@@ -31,23 +31,23 @@ export class AppShellPage {
     // On mobile, the React app shell may not have finished rendering when openSidebar()
     // is called immediately after page.goto(), causing isSidebarOpen() to read a
     // null attribute and menuButton.click() to race against the mount cycle.
-    await this.sidebar.waitFor({ state: 'attached', timeout: 5000 });
+    await this.sidebar.waitFor({ state: 'attached' });
     const isOpen = await this.isSidebarOpen();
     if (!isOpen) {
       await this.menuButton.click();
       // Wait for data-open attribute to become "true" (sidebar CSS uses transform, not display)
-      await this.page.locator('aside[data-open="true"]').waitFor({ timeout: 5000 });
+      await this.page.locator('aside[data-open="true"]').waitFor();
     }
   }
 
   async closeSidebar(): Promise<void> {
     // Wait for the sidebar element to be present in the DOM before reading its state.
-    await this.sidebar.waitFor({ state: 'attached', timeout: 5000 });
+    await this.sidebar.waitFor({ state: 'attached' });
     const isOpen = await this.isSidebarOpen();
     if (isOpen) {
       await this.sidebarCloseButton.click();
       // Wait for data-open attribute to become "false"
-      await this.page.locator('aside[data-open="false"]').waitFor({ timeout: 5000 });
+      await this.page.locator('aside[data-open="false"]').waitFor();
     }
   }
 

--- a/e2e/pages/BudgetCategoriesPage.ts
+++ b/e2e/pages/BudgetCategoriesPage.ts
@@ -119,7 +119,7 @@ export class BudgetCategoriesPage {
   async goto(): Promise<void> {
     await this.page.goto(BUDGET_CATEGORIES_ROUTE);
     // Wait for the page heading to appear (data loaded)
-    await this.heading.waitFor({ state: 'visible', timeout: 5000 });
+    await this.heading.waitFor({ state: 'visible' });
   }
 
   /**
@@ -127,7 +127,7 @@ export class BudgetCategoriesPage {
    */
   async openCreateForm(): Promise<void> {
     await this.addCategoryButton.click();
-    await this.createFormHeading.waitFor({ state: 'visible', timeout: 5000 });
+    await this.createFormHeading.waitFor({ state: 'visible' });
   }
 
   /**
@@ -163,10 +163,7 @@ export class BudgetCategoriesPage {
   async getCategoryRow(name: string): Promise<Locator | null> {
     // Wait for at least one row to be visible before searching
     try {
-      await this.page
-        .locator('[class*="categoryRow"]')
-        .first()
-        .waitFor({ state: 'visible', timeout: 5000 });
+      await this.page.locator('[class*="categoryRow"]').first().waitFor({ state: 'visible' });
     } catch {
       return null;
     }
@@ -219,7 +216,7 @@ export class BudgetCategoriesPage {
     // Wait for the edit form to appear (identified by its aria-label)
     await this.page
       .getByRole('form', { name: `Edit ${categoryName}` })
-      .waitFor({ state: 'visible', timeout: 5000 });
+      .waitFor({ state: 'visible' });
   }
 
   /**
@@ -289,7 +286,7 @@ export class BudgetCategoriesPage {
     }
     const deleteButton = row.getByRole('button', { name: `Delete ${categoryName}` });
     await deleteButton.click();
-    await this.deleteModal.waitFor({ state: 'visible', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'visible' });
   }
 
   /**
@@ -304,7 +301,7 @@ export class BudgetCategoriesPage {
    */
   async cancelDelete(): Promise<void> {
     await this.deleteCancelButton.click();
-    await this.deleteModal.waitFor({ state: 'hidden', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'hidden' });
   }
 
   /**
@@ -317,7 +314,7 @@ export class BudgetCategoriesPage {
         .locator('[role="alert"]')
         .filter({ hasText: /successfully/i })
         .first();
-      await banner.waitFor({ state: 'visible', timeout: 5000 });
+      await banner.waitFor({ state: 'visible' });
       return await banner.textContent();
     } catch {
       return null;
@@ -329,7 +326,7 @@ export class BudgetCategoriesPage {
    */
   async getCreateErrorText(): Promise<string | null> {
     try {
-      await this.createErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.createErrorBanner.waitFor({ state: 'visible' });
       return await this.createErrorBanner.textContent();
     } catch {
       return null;
@@ -341,7 +338,7 @@ export class BudgetCategoriesPage {
    */
   async getDeleteModalErrorText(): Promise<string | null> {
     try {
-      await this.deleteModalErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.deleteModalErrorBanner.waitFor({ state: 'visible' });
       return await this.deleteModalErrorBanner.textContent();
     } catch {
       return null;
@@ -361,11 +358,8 @@ export class BudgetCategoriesPage {
   async waitForCategoriesLoaded(): Promise<void> {
     // Either there's at least one row, or the empty state is visible
     await Promise.race([
-      this.page
-        .locator('[class*="categoryRow"]')
-        .first()
-        .waitFor({ state: 'visible', timeout: 5000 }),
-      this.emptyState.waitFor({ state: 'visible', timeout: 5000 }),
+      this.page.locator('[class*="categoryRow"]').first().waitFor({ state: 'visible' }),
+      this.emptyState.waitFor({ state: 'visible' }),
     ]);
   }
 

--- a/e2e/pages/BudgetOverviewPage.ts
+++ b/e2e/pages/BudgetOverviewPage.ts
@@ -124,7 +124,7 @@ export class BudgetOverviewPage {
       has: this.page.locator('[class*="statLabel"]').filter({ hasText: label }),
     });
     try {
-      await row.waitFor({ state: 'visible', timeout: 5000 });
+      await row.waitFor({ state: 'visible' });
     } catch {
       return null;
     }
@@ -138,7 +138,7 @@ export class BudgetOverviewPage {
    */
   async getTableRowCount(): Promise<number> {
     try {
-      await this.categoryBreakdownTableBody.waitFor({ state: 'visible', timeout: 5000 });
+      await this.categoryBreakdownTableBody.waitFor({ state: 'visible' });
       const rows = await this.categoryBreakdownTableBody.locator('tr').all();
       return rows.length;
     } catch {
@@ -151,7 +151,7 @@ export class BudgetOverviewPage {
    */
   async getTableRows(): Promise<Locator[]> {
     try {
-      await this.categoryBreakdownTableBody.waitFor({ state: 'visible', timeout: 5000 });
+      await this.categoryBreakdownTableBody.waitFor({ state: 'visible' });
       return await this.categoryBreakdownTableBody.locator('tr').all();
     } catch {
       return [];

--- a/e2e/pages/LoginPage.ts
+++ b/e2e/pages/LoginPage.ts
@@ -44,7 +44,7 @@ export class LoginPage {
 
   async getErrorBanner(): Promise<string | null> {
     try {
-      await this.errorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.errorBanner.waitFor({ state: 'visible' });
       return await this.errorBanner.textContent();
     } catch {
       return null;

--- a/e2e/pages/ProfilePage.ts
+++ b/e2e/pages/ProfilePage.ts
@@ -123,7 +123,7 @@ export class ProfilePage {
 
   async getDisplayNameSuccessBanner(): Promise<string | null> {
     try {
-      await this.displayNameSuccessBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.displayNameSuccessBanner.waitFor({ state: 'visible' });
       return await this.displayNameSuccessBanner.textContent();
     } catch {
       return null;
@@ -132,7 +132,7 @@ export class ProfilePage {
 
   async getDisplayNameErrorBanner(): Promise<string | null> {
     try {
-      await this.displayNameErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.displayNameErrorBanner.waitFor({ state: 'visible' });
       return await this.displayNameErrorBanner.textContent();
     } catch {
       return null;
@@ -141,7 +141,7 @@ export class ProfilePage {
 
   async getPasswordSuccessBanner(): Promise<string | null> {
     try {
-      await this.passwordSuccessBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.passwordSuccessBanner.waitFor({ state: 'visible' });
       return await this.passwordSuccessBanner.textContent();
     } catch {
       return null;
@@ -150,7 +150,7 @@ export class ProfilePage {
 
   async getPasswordErrorBanner(): Promise<string | null> {
     try {
-      await this.passwordErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.passwordErrorBanner.waitFor({ state: 'visible' });
       return await this.passwordErrorBanner.textContent();
     } catch {
       return null;

--- a/e2e/pages/UserManagementPage.ts
+++ b/e2e/pages/UserManagementPage.ts
@@ -88,7 +88,7 @@ export class UserManagementPage {
 
   async getUserRow(email: string): Promise<Locator | null> {
     // Wait for table data to load
-    await this.table.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 5000 });
+    await this.table.locator('tbody tr').first().waitFor({ state: 'visible' });
     const rows = await this.getUserRows();
     for (const row of rows) {
       const rowEmail = await row.locator('td').nth(1).textContent();
@@ -153,7 +153,7 @@ export class UserManagementPage {
 
   async getEditModalError(): Promise<string | null> {
     try {
-      await this.editModalError.waitFor({ state: 'visible', timeout: 5000 });
+      await this.editModalError.waitFor({ state: 'visible' });
       return await this.editModalError.textContent();
     } catch {
       return null;
@@ -162,7 +162,7 @@ export class UserManagementPage {
 
   async getDeactivateModalError(): Promise<string | null> {
     try {
-      await this.deactivateModalError.waitFor({ state: 'visible', timeout: 5000 });
+      await this.deactivateModalError.waitFor({ state: 'visible' });
       return await this.deactivateModalError.textContent();
     } catch {
       return null;

--- a/e2e/pages/VendorDetailPage.ts
+++ b/e2e/pages/VendorDetailPage.ts
@@ -132,7 +132,7 @@ export class VendorDetailPage {
 
   async goto(vendorId: string): Promise<void> {
     await this.page.goto(`/budget/vendors/${vendorId}`);
-    await this.pageTitle.waitFor({ state: 'visible', timeout: 5000 });
+    await this.pageTitle.waitFor({ state: 'visible' });
   }
 
   /**
@@ -140,7 +140,7 @@ export class VendorDetailPage {
    */
   async goBackToVendors(): Promise<void> {
     await this.backToVendorsButton.click();
-    await this.page.waitForURL('**/budget/vendors', { timeout: 5000 });
+    await this.page.waitForURL('**/budget/vendors');
   }
 
   /**
@@ -148,7 +148,7 @@ export class VendorDetailPage {
    */
   async startEdit(): Promise<void> {
     await this.editButton.click();
-    await this.editNameInput.waitFor({ state: 'visible', timeout: 5000 });
+    await this.editNameInput.waitFor({ state: 'visible' });
   }
 
   /**
@@ -181,7 +181,7 @@ export class VendorDetailPage {
    */
   async saveEdit(): Promise<void> {
     await this.saveChangesButton.click();
-    await this.editNameInput.waitFor({ state: 'hidden', timeout: 5000 });
+    await this.editNameInput.waitFor({ state: 'hidden' });
   }
 
   /**
@@ -189,7 +189,7 @@ export class VendorDetailPage {
    */
   async cancelEdit(): Promise<void> {
     await this.cancelEditButton.click();
-    await this.editNameInput.waitFor({ state: 'hidden', timeout: 5000 });
+    await this.editNameInput.waitFor({ state: 'hidden' });
   }
 
   /**
@@ -197,7 +197,7 @@ export class VendorDetailPage {
    */
   async openDeleteModal(): Promise<void> {
     await this.deleteButton.click();
-    await this.deleteModal.waitFor({ state: 'visible', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'visible' });
   }
 
   /**
@@ -212,7 +212,7 @@ export class VendorDetailPage {
    */
   async cancelDelete(): Promise<void> {
     await this.deleteCancelButton.click();
-    await this.deleteModal.waitFor({ state: 'hidden', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'hidden' });
   }
 
   /**
@@ -253,7 +253,7 @@ export class VendorDetailPage {
    */
   async getDeleteErrorText(): Promise<string | null> {
     try {
-      await this.deleteErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.deleteErrorBanner.waitFor({ state: 'visible' });
       return await this.deleteErrorBanner.textContent();
     } catch {
       return null;
@@ -265,7 +265,7 @@ export class VendorDetailPage {
    */
   async getEditErrorText(): Promise<string | null> {
     try {
-      await this.editErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.editErrorBanner.waitFor({ state: 'visible' });
       return await this.editErrorBanner.textContent();
     } catch {
       return null;

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -144,7 +144,7 @@ export class VendorsPage {
   async goto(): Promise<void> {
     await this.page.goto(VENDORS_ROUTE);
     // Wait for either the heading (data loaded) or the loading indicator to clear
-    await this.heading.waitFor({ state: 'visible', timeout: 5000 });
+    await this.heading.waitFor({ state: 'visible' });
   }
 
   /**
@@ -152,7 +152,7 @@ export class VendorsPage {
    */
   async openCreateModal(): Promise<void> {
     await this.addVendorButton.click();
-    await this.createModal.waitFor({ state: 'visible', timeout: 5000 });
+    await this.createModal.waitFor({ state: 'visible' });
   }
 
   /**
@@ -199,7 +199,7 @@ export class VendorsPage {
    */
   async getTableRowByName(vendorName: string): Promise<Locator | null> {
     try {
-      await this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 5000 });
+      await this.tableBody.locator('tr').first().waitFor({ state: 'visible' });
     } catch {
       return null;
     }
@@ -257,7 +257,7 @@ export class VendorsPage {
       .getByRole('button', { name: `Delete ${vendorName}` })
       .first()
       .click();
-    await this.deleteModal.waitFor({ state: 'visible', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'visible' });
   }
 
   /**
@@ -272,7 +272,7 @@ export class VendorsPage {
    */
   async cancelDelete(): Promise<void> {
     await this.deleteCancelButton.click();
-    await this.deleteModal.waitFor({ state: 'hidden', timeout: 5000 });
+    await this.deleteModal.waitFor({ state: 'hidden' });
   }
 
   /**
@@ -301,12 +301,9 @@ export class VendorsPage {
    */
   async waitForVendorsLoaded(): Promise<void> {
     await Promise.race([
-      this.tableBody.locator('tr').first().waitFor({ state: 'visible', timeout: 5000 }),
-      this.cardsContainer
-        .locator('[class*="card"]')
-        .first()
-        .waitFor({ state: 'visible', timeout: 5000 }),
-      this.emptyState.waitFor({ state: 'visible', timeout: 5000 }),
+      this.tableBody.locator('tr').first().waitFor({ state: 'visible' }),
+      this.cardsContainer.locator('[class*="card"]').first().waitFor({ state: 'visible' }),
+      this.emptyState.waitFor({ state: 'visible' }),
     ]);
   }
 
@@ -315,7 +312,7 @@ export class VendorsPage {
    */
   async getCreateErrorText(): Promise<string | null> {
     try {
-      await this.createErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.createErrorBanner.waitFor({ state: 'visible' });
       return await this.createErrorBanner.textContent();
     } catch {
       return null;
@@ -327,7 +324,7 @@ export class VendorsPage {
    */
   async getDeleteErrorText(): Promise<string | null> {
     try {
-      await this.deleteErrorBanner.waitFor({ state: 'visible', timeout: 5000 });
+      await this.deleteErrorBanner.waitFor({ state: 'visible' });
       return await this.deleteErrorBanner.textContent();
     } catch {
       return null;

--- a/e2e/pages/WorkItemCreatePage.ts
+++ b/e2e/pages/WorkItemCreatePage.ts
@@ -185,7 +185,7 @@ export class WorkItemCreatePage {
    */
   async cancel(): Promise<void> {
     await this.cancelButton.click();
-    await this.page.waitForURL('**/work-items', { timeout: 5000 });
+    await this.page.waitForURL('**/work-items');
   }
 
   /**

--- a/e2e/tests/admin/deactivate-user.spec.ts
+++ b/e2e/tests/admin/deactivate-user.spec.ts
@@ -60,9 +60,7 @@ test.describe('Deactivate User', () => {
     await userManagementPage.deactivateCancelButton.click();
 
     // Then: Modal should close
-    await expect(userManagementPage.deactivateModal).not.toBeVisible({
-      timeout: 5000,
-    });
+    await expect(userManagementPage.deactivateModal).not.toBeVisible();
 
     // And: User should still be active
     const adminRow = await userManagementPage.getUserRow(TEST_ADMIN.email);
@@ -80,9 +78,7 @@ test.describe('Deactivate User', () => {
     await userManagementPage.closeDeactivateModal();
 
     // Then: Modal should close
-    await expect(userManagementPage.deactivateModal).not.toBeVisible({
-      timeout: 5000,
-    });
+    await expect(userManagementPage.deactivateModal).not.toBeVisible();
   });
 
   /**

--- a/e2e/tests/admin/edit-user.spec.ts
+++ b/e2e/tests/admin/edit-user.spec.ts
@@ -41,7 +41,7 @@ test.describe('Edit User', () => {
     await userManagementPage.editUser({ displayName: newName });
 
     // Wait for modal to close
-    await expect(userManagementPage.editModal).not.toBeVisible({ timeout: 5000 });
+    await expect(userManagementPage.editModal).not.toBeVisible();
 
     // Then: Table should reflect the change
     const adminRow = await userManagementPage.getUserRow(TEST_ADMIN.email);
@@ -54,7 +54,7 @@ test.describe('Edit User', () => {
     // Restore original name
     await userManagementPage.openEditModal(TEST_ADMIN.email);
     await userManagementPage.editUser({ displayName: TEST_ADMIN.displayName });
-    await expect(userManagementPage.editModal).not.toBeVisible({ timeout: 5000 });
+    await expect(userManagementPage.editModal).not.toBeVisible();
   });
 
   test('Modal can be closed without saving', async ({ page }) => {
@@ -69,7 +69,7 @@ test.describe('Edit User', () => {
     await userManagementPage.editCancelButton.click();
 
     // Then: Modal should close
-    await expect(userManagementPage.editModal).not.toBeVisible({ timeout: 5000 });
+    await expect(userManagementPage.editModal).not.toBeVisible();
 
     // And: Changes should not be saved
     const adminRow = await userManagementPage.getUserRow(TEST_ADMIN.email);
@@ -91,7 +91,7 @@ test.describe('Edit User', () => {
     await userManagementPage.closeEditModal();
 
     // Then: Modal should close
-    await expect(userManagementPage.editModal).not.toBeVisible({ timeout: 5000 });
+    await expect(userManagementPage.editModal).not.toBeVisible();
   });
 
   test('Validation: empty display name rejected', async ({ page }) => {

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -195,7 +195,7 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
     expect(successText).toContain(categoryName);
 
     // And: The form closes
-    await expect(categoriesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.createFormHeading).not.toBeVisible();
 
     // And: The new category appears in the list
     const names = await categoriesPage.getCategoryNames();
@@ -218,9 +218,9 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
         // Delete via modal
         if (ariaLabel) {
           await deleteBtn.click();
-          await categoriesPage.deleteModal.waitFor({ state: 'visible', timeout: 5000 });
+          await categoriesPage.deleteModal.waitFor({ state: 'visible' });
           await categoriesPage.confirmDelete();
-          await categoriesPage.deleteModal.waitFor({ state: 'hidden', timeout: 5000 });
+          await categoriesPage.deleteModal.waitFor({ state: 'hidden' });
           createdId = 'deleted';
         }
         break;
@@ -257,7 +257,7 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
       await categoriesPage.getSuccessBannerText();
 
       // Then: The create form is dismissed (collapsed)
-      await expect(categoriesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+      await expect(categoriesPage.createFormHeading).not.toBeVisible();
 
       // And: "Add Category" button is enabled again
       await expect(categoriesPage.addCategoryButton).toBeEnabled();
@@ -335,7 +335,7 @@ test.describe('Create category validation (Scenario 5)', { tag: '@responsive' },
     await cancelButton.click();
 
     // Then: The form should be dismissed
-    await expect(categoriesPage.createFormHeading).not.toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.createFormHeading).not.toBeVisible();
 
     // And: No new category was created
     const countAfter = await categoriesPage.getCategoriesCount();
@@ -387,7 +387,7 @@ test.describe('Duplicate name validation (Scenario 6)', { tag: '@responsive' }, 
     await categoriesPage.createCategory({ name: 'Materials' });
 
     // Then: The create form remains visible (not closed on error)
-    await expect(categoriesPage.createFormHeading).toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.createFormHeading).toBeVisible();
   });
 });
 
@@ -431,7 +431,7 @@ test.describe('Edit category (Scenario 8 & 9)', { tag: '@responsive' }, () => {
     expect(successText).toContain('Design');
 
     // And: The edit form closes
-    await expect(categoriesPage.getEditForm('Design')).not.toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.getEditForm('Design')).not.toBeVisible();
 
     // And: The updated description is visible in the list
     const description = await categoriesPage.getCategoryDescription('Design');
@@ -474,7 +474,7 @@ test.describe('Edit category (Scenario 8 & 9)', { tag: '@responsive' }, () => {
     await cancelButton.click();
 
     // Then: The edit form is dismissed
-    await expect(categoriesPage.getEditForm('Equipment')).not.toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.getEditForm('Equipment')).not.toBeVisible();
 
     // And: The original name "Equipment" is still in the list
     const names = await categoriesPage.getCategoryNames();
@@ -581,7 +581,7 @@ test.describe('Delete category (Scenario 11)', { tag: '@responsive' }, () => {
     await categoriesPage.confirmDelete();
 
     // Then: The modal closes
-    await expect(categoriesPage.deleteModal).not.toBeVisible({ timeout: 5000 });
+    await expect(categoriesPage.deleteModal).not.toBeVisible();
 
     // And: Success banner appears
     const successText = await categoriesPage.getSuccessBannerText();

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -131,7 +131,7 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
 
   test('Navigating to /budget redirects to /budget/overview', async ({ page }) => {
     await page.goto('/budget');
-    await page.waitForURL('/budget/overview', { timeout: 5000 });
+    await page.waitForURL('/budget/overview');
     expect(page.url()).toContain('/budget/overview');
   });
 });
@@ -245,7 +245,7 @@ test.describe('Summary cards', { tag: '@responsive' }, () => {
       const cardTitles = ['Total Budget', 'Financing', 'Vendors', 'Subsidies'];
       for (const title of cardTitles) {
         const card = overviewPage.getSummaryCard(title);
-        await expect(card).toBeVisible({ timeout: 5000 });
+        await expect(card).toBeVisible();
         // Heading inside the card is present
         await expect(card.getByRole('heading', { name: title, exact: true })).toBeVisible();
       }
@@ -404,7 +404,7 @@ test.describe('Category breakdown table', { tag: '@responsive' }, () => {
       await expect(overviewPage.categoryBreakdownHeading).toHaveText('Category Breakdown');
 
       // The table is visible
-      await expect(overviewPage.categoryBreakdownTable).toBeVisible({ timeout: 5000 });
+      await expect(overviewPage.categoryBreakdownTable).toBeVisible();
 
       // Column headers present
       const table = overviewPage.categoryBreakdownTable;

--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -270,7 +270,7 @@ test.describe('Create vendor validation (Scenario 4)', { tag: '@responsive' }, (
 
     // Cleanup: close modal
     await vendorsPage.createCancelButton.click();
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
   });
 
   test('Submit button becomes enabled when name is filled in', async ({ page }) => {
@@ -288,7 +288,7 @@ test.describe('Create vendor validation (Scenario 4)', { tag: '@responsive' }, (
 
     // Cleanup: close modal
     await vendorsPage.createCancelButton.click();
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
   });
 
   test('Clearing the name after typing disables the submit button again', async ({ page }) => {
@@ -306,7 +306,7 @@ test.describe('Create vendor validation (Scenario 4)', { tag: '@responsive' }, (
     await expect(vendorsPage.createSubmitButton).toBeDisabled();
 
     await vendorsPage.createCancelButton.click();
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
   });
 
   test('Cancel button closes the modal without creating a vendor', async ({ page }) => {
@@ -322,7 +322,7 @@ test.describe('Create vendor validation (Scenario 4)', { tag: '@responsive' }, (
     await vendorsPage.createCancelButton.click();
 
     // Modal closes
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
 
     // List unchanged
     const namesAfter = await vendorsPage.getVendorNames();
@@ -845,7 +845,7 @@ test.describe('Pagination (Scenario 11)', { tag: '@responsive' }, () => {
       await vendorsPage.waitForVendorsLoaded();
 
       // Pagination section should NOT be visible
-      await expect(vendorsPage.pagination).not.toBeVisible({ timeout: 5000 });
+      await expect(vendorsPage.pagination).not.toBeVisible();
     } finally {
       await page.unroute(`${API.vendors}*`);
     }
@@ -1204,7 +1204,7 @@ test.describe('Responsive layout (Scenario 17)', { tag: '@responsive' }, () => {
     await expect(vendorsPage.createSubmitButton).toBeVisible();
 
     await vendorsPage.createCancelButton.click();
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
   });
 });
 
@@ -1248,7 +1248,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
     await expect(vendorsPage.createSubmitButton).toBeVisible();
 
     await vendorsPage.createCancelButton.click();
-    await expect(vendorsPage.createModal).not.toBeVisible({ timeout: 5000 });
+    await expect(vendorsPage.createModal).not.toBeVisible();
   });
 
   test('Vendor detail page renders correctly in dark mode', async ({ page, testPrefix }) => {

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -59,7 +59,7 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Work Items');
       expect(isActive).toBe(true);
-    }).toPass({ timeout: 5000 });
+    }).toPass();
 
     // When: User navigates to Budget
     await page.goto(ROUTES.budget);
@@ -68,13 +68,13 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Budget');
       expect(isActive).toBe(true);
-    }).toPass({ timeout: 5000 });
+    }).toPass();
 
     // And: Work Items link should not be active
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Work Items');
       expect(isActive).toBe(false);
-    }).toPass({ timeout: 5000 });
+    }).toPass();
   });
 
   test('All nav links rendered and visible', async ({ page }) => {

--- a/e2e/tests/profile/change-password.spec.ts
+++ b/e2e/tests/profile/change-password.spec.ts
@@ -61,7 +61,7 @@ test.describe('Change Password', { tag: '@responsive' }, () => {
     // Restore original password for subsequent tests
     await profilePage.goto();
     await profilePage.changePassword(newPassword, TEST_ADMIN.password, TEST_ADMIN.password);
-    await expect(profilePage.passwordSuccessBanner).toBeVisible({ timeout: 5000 });
+    await expect(profilePage.passwordSuccessBanner).toBeVisible();
 
     // Save updated session back to storageState — the logout above destroyed the
     // original auth-setup session in the database, so subsequent tests need this

--- a/e2e/tests/proxy/proxy-setup.spec.ts
+++ b/e2e/tests/proxy/proxy-setup.spec.ts
@@ -140,7 +140,7 @@ test.describe('Reverse Proxy Setup', { tag: '@responsive' }, () => {
         .getByRole('button', { name: /Open menu|Close menu/ });
       await menuButton.click();
       // Wait for sidebar to open (CSS transform-based, not display-based)
-      await page.locator('aside[data-open="true"]').waitFor({ timeout: 5000 });
+      await page.locator('aside[data-open="true"]').waitFor();
     }
 
     const logoutButton = page.getByRole('button', { name: /logout/i });

--- a/e2e/tests/work-items/work-item-create.spec.ts
+++ b/e2e/tests/work-items/work-item-create.spec.ts
@@ -73,7 +73,7 @@ test.describe('Back button navigation (Scenario 2)', { tag: '@responsive' }, () 
 
     await createPage.backButton.click();
 
-    await page.waitForURL('**/work-items', { timeout: 5000 });
+    await page.waitForURL('**/work-items');
     expect(page.url()).toContain('/work-items');
     // Verify we're on the list page (not the create page)
     expect(page.url()).not.toContain('/work-items/new');
@@ -252,7 +252,7 @@ test.describe('Cancel navigation (Scenario 6)', { tag: '@responsive' }, () => {
     await createPage.cancelButton.click();
 
     // Should navigate to the list
-    await page.waitForURL('**/work-items', { timeout: 5000 });
+    await page.waitForURL('**/work-items');
     expect(page.url()).toContain('/work-items');
     expect(page.url()).not.toContain('/work-items/new');
 
@@ -278,7 +278,7 @@ test.describe('Cancel navigation (Scenario 6)', { tag: '@responsive' }, () => {
     await createPage.fillTitle(`${testPrefix} Back Button Cancelled`);
     await createPage.backButton.click();
 
-    await page.waitForURL('**/work-items', { timeout: 5000 });
+    await page.waitForURL('**/work-items');
     expect(page.url()).toContain('/work-items');
     expect(page.url()).not.toContain('/work-items/new');
   });

--- a/e2e/tests/work-items/work-items-list.spec.ts
+++ b/e2e/tests/work-items/work-items-list.spec.ts
@@ -128,7 +128,7 @@ test.describe('"New Work Item" navigation (Scenario 3)', { tag: '@responsive' },
     await workItemsPage.newWorkItemButton.click();
 
     // Should navigate to /work-items/new
-    await page.waitForURL('**/work-items/new', { timeout: 5000 });
+    await page.waitForURL('**/work-items/new');
     expect(page.url()).toContain('/work-items/new');
   });
 });
@@ -423,7 +423,7 @@ test.describe('Pagination (Scenario 8)', { tag: '@responsive' }, () => {
       await workItemsPage.waitForLoaded();
 
       // Pagination should NOT be visible
-      await expect(workItemsPage.pagination).not.toBeVisible({ timeout: 5000 });
+      await expect(workItemsPage.pagination).not.toBeVisible();
     } finally {
       await page.unroute(`${API.workItems}*`);
     }


### PR DESCRIPTION
## Summary

- Removed 82 hardcoded `timeout: 5000` values across 19 POM and spec files
- These overrode project-level Playwright timeouts (7s desktop, 15s tablet/mobile), causing WebKit failures
- Project-level `actionTimeout` and `expect.timeout` now govern all `waitFor`/`expect` calls consistently
- Intentional timeouts (7s, 8s, 10s, 15s, 3s) were NOT changed

## Test plan

- [x] Zero `timeout: 5000` remaining in `e2e/pages/` and `e2e/tests/`
- [x] ESLint passes
- [ ] CI Quality Gates pass
- [ ] E2E vendor breadcrumb navigation test no longer fails due to 5s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)