### PR TITLE
fix(e2e): resolve 2 vendor detail desktop test failures

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
     {
       name: 'desktop',
       dependencies: ['auth-setup'],
+      expect: { timeout: 7_000 }, // React SPA transitions need more than the 5s default
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1920, height: 1080 },


### PR DESCRIPTION
## Summary

- Add `expect.timeout: 7_000` to the desktop Playwright project — desktop was using the 5000ms Playwright default while tablet/mobile had 15_000ms. React SPA transitions need more time for `toHaveText` auto-retry.
- Wait for vendor detail info card to render after URL change before asserting heading text or clicking breadcrumb — prevents the h1 from matching "Budget" (list page) during React transition.
- Replace opaque `expect(response.ok()).toBeTruthy()` in `createVendorViaApi` with descriptive error including status code and response body for diagnosability.

## Test plan

- [ ] E2E suite passes on CI (desktop, tablet, mobile)
- [ ] The two previously failing tests (`vendors.spec.ts:338` and `vendors.spec.ts:1038`) now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)