### PR TITLE
fix(e2e): resolve session invalidation race + vendor navigation flake

### DIFF
--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -362,6 +362,8 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
       await vendorsPage.waitForVendorsLoaded();
       // Search for the vendor to avoid pagination issues from parallel tests
       await vendorsPage.search(vendorName);
+      // Wait for the search results to render the vendor link before clicking
+      await expect(page.getByRole('link', { name: vendorName }).first()).toBeVisible();
 
       // When: I click on the vendor name link
       await vendorsPage.clickView(vendorName);
@@ -372,7 +374,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
       // And: The page heading is the vendor name
       // Wait for the detail page info card to render — the h1 transitions from
       // "Budget" (list page) to the vendor name after React fetches and renders
-      await detailPage.infoCard.waitFor({ state: 'visible' });
+      await expect(detailPage.infoCard).toBeVisible();
       await expect(detailPage.pageTitle).toHaveText(vendorName);
 
       // And: All vendor fields are shown in the info card
@@ -1058,13 +1060,15 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
       await vendorsPage.goto();
       await vendorsPage.waitForVendorsLoaded();
       await vendorsPage.search(vendorName);
+      // Wait for the search results to render the vendor link before clicking
+      await expect(page.getByRole('link', { name: vendorName }).first()).toBeVisible();
 
       // Navigate to detail (wait for URL change, not h1 which matches list page too)
       await vendorsPage.clickView(vendorName);
       await page.waitForURL('**/budget/vendors/*', { timeout: 8000 });
 
       // Wait for detail page to fully render before interacting with breadcrumb
-      await detailPage.infoCard.waitFor({ state: 'visible' });
+      await expect(detailPage.infoCard).toBeVisible();
 
       // Navigate back via breadcrumb
       await detailPage.goBackToVendors();

--- a/e2e/tests/profile/change-password.spec.ts
+++ b/e2e/tests/profile/change-password.spec.ts
@@ -12,6 +12,7 @@ test.describe('Change Password', { tag: '@responsive' }, () => {
   // Serialize tests within this describe block — they all modify the shared admin
   // user's password and must not run in parallel with each other.
   test.describe.configure({ mode: 'serial' });
+
   test('Local user sees password change form', async ({ page }) => {
     const profilePage = new ProfilePage(page);
 
@@ -30,43 +31,53 @@ test.describe('Change Password', { tag: '@responsive' }, () => {
     expect(isOidcUser).toBe(false);
   });
 
-  test('Local user changes password successfully', async ({ page }) => {
-    const profilePage = new ProfilePage(page);
+  test('Local user changes password successfully', async ({ browser }) => {
+    // Use an isolated browser context so the logout/re-login cycle does NOT
+    // destroy the shared storageState session used by parallel tests.
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const page = await context.newPage();
 
-    // Given: User is on profile page
-    await profilePage.goto();
+    try {
+      // Log in with a fresh session (separate from the shared one)
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+      await loginPage.login(TEST_ADMIN.email, TEST_ADMIN.password);
+      await expect(page).toHaveURL(ROUTES.home);
 
-    const newPassword = 'new-secure-password-123!';
+      const profilePage = new ProfilePage(page);
+      const newPassword = 'new-secure-password-123!';
 
-    // When: User changes password
-    await profilePage.changePassword(TEST_ADMIN.password, newPassword, newPassword);
+      // Given: User is on profile page
+      await profilePage.goto();
 
-    // Then: Success banner should appear
-    const successBanner = await profilePage.getPasswordSuccessBanner();
-    expect(successBanner).toBeTruthy();
-    expect(successBanner?.toLowerCase()).toContain('success');
+      // When: User changes password
+      await profilePage.changePassword(TEST_ADMIN.password, newPassword, newPassword);
 
-    // Verify new password works by logging out and back in
-    const appShell = new AppShellPage(page);
-    const viewport = page.viewportSize();
-    if (viewport && viewport.width < 1024) {
-      await appShell.openSidebar();
+      // Then: Success banner should appear
+      const successBanner = await profilePage.getPasswordSuccessBanner();
+      expect(successBanner).toBeTruthy();
+      expect(successBanner?.toLowerCase()).toContain('success');
+
+      // Verify new password works by logging out and back in
+      const appShell = new AppShellPage(page);
+      const viewport = page.viewportSize();
+      if (viewport && viewport.width < 1024) {
+        await appShell.openSidebar();
+      }
+      await appShell.logout();
+
+      await loginPage.login(TEST_ADMIN.email, newPassword);
+      await expect(page).toHaveURL(ROUTES.home);
+
+      // Restore original password for subsequent tests
+      await profilePage.goto();
+      await profilePage.changePassword(newPassword, TEST_ADMIN.password, TEST_ADMIN.password);
+      await expect(profilePage.passwordSuccessBanner).toBeVisible();
+    } finally {
+      await context.close();
     }
-    await appShell.logout();
-
-    const loginPage = new LoginPage(page);
-    await loginPage.login(TEST_ADMIN.email, newPassword);
-    await expect(page).toHaveURL(ROUTES.home);
-
-    // Restore original password for subsequent tests
-    await profilePage.goto();
-    await profilePage.changePassword(newPassword, TEST_ADMIN.password, TEST_ADMIN.password);
-    await expect(profilePage.passwordSuccessBanner).toBeVisible();
-
-    // Save updated session back to storageState — the logout above destroyed the
-    // original auth-setup session in the database, so subsequent tests need this
-    // new session cookie to remain authenticated.
-    await page.context().storageState({ path: 'test-results/.auth/admin.json' });
   });
 
   test('Wrong current password shows error', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Session invalidation race condition**: The change-password test used the shared storageState session and called `logout()`, destroying the session on the server. Parallel tests using the same session cookie got `401 Unauthorized`. Fix: use an isolated browser context with a fresh login, leaving the shared storageState untouched.
- **waitFor vs expect timeout mismatch**: `infoCard.waitFor()` used `actionTimeout` (5000ms) instead of `expect.timeout` (7000ms). Changed to `expect(infoCard).toBeVisible()`.
- **Search-to-click race**: After `search()` returns (API response received), React may still be re-rendering. Added `expect(link).toBeVisible()` to ensure the vendor link is rendered before clicking.

Previous run: 826 passed, **1 failed**, 23 flaky, 25 skipped

## Test plan

- [ ] CI passes (Quality Gates + Docker)
- [ ] E2E suite on promotion PR shows 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)