### PR TITLE
fix(e2e): mark vendor detail all-fields test as slow

### DIFF
--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -342,6 +342,9 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
     page,
     testPrefix,
   }) => {
+    // This test creates a vendor, searches, navigates to detail, and asserts
+    // 10+ fields/stats — legitimately takes 12-15s even on desktop Chromium.
+    test.slow();
     const vendorsPage = new VendorsPage(page);
     const detailPage = new VendorDetailPage(page);
     let createdId: string | null = null;


### PR DESCRIPTION
## Summary

- Add `test.slow()` to the "Clicking a vendor name navigates to the detail page with all fields" test, tripling its timeout from 10s to 30s
- This test creates a vendor via API, navigates to list, searches, clicks to detail, then asserts 10+ fields, stats, and invoice sections — legitimately takes 12-15s even on Chromium
- Same test passes on tablet (14.9s / 60s timeout) — the desktop 10s timeout was simply too tight

Previous run: 843 passed, **1 failed** (this test), 6 flaky, 25 skipped

## Test plan

- [ ] CI passes (Quality Gates + Docker)
- [ ] E2E suite shows 0 permanent failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)