### PR TITLE
fix(e2e): update E2E tests for budget lines rework

### DIFF
--- a/e2e/pages/BudgetOverviewPage.ts
+++ b/e2e/pages/BudgetOverviewPage.ts
@@ -7,7 +7,7 @@
  * - Loading indicator while data is fetched
  * - Error card with a Retry button if the API fails
  * - Empty state when no budget data has been entered
- * - A 4-card summary grid: Total Budget, Financing, Vendors, Subsidies
+ * - A 4-card summary grid: Planned Budget, Actual Cost, Financing, Subsidies
  * - A Category Breakdown table (may be empty if no categories are assigned)
  */
 
@@ -101,7 +101,7 @@ export class BudgetOverviewPage {
   }
 
   /**
-   * Get a summary card section by its title (e.g., "Total Budget", "Financing").
+   * Get a summary card section by its title (e.g., "Planned Budget", "Financing").
    * Cards are `<section aria-labelledby="card-<slug>">`.
    */
   getSummaryCard(title: string): Locator {
@@ -114,7 +114,7 @@ export class BudgetOverviewPage {
    * Searches for the stat row with the matching label text and returns the
    * value span text.
    *
-   * @param cardTitle - e.g., "Total Budget"
+   * @param cardTitle - e.g., "Planned Budget"
    * @param label - e.g., "Planned", "Actual Cost", "Variance"
    */
   async getSummaryCardValue(cardTitle: string, label: string): Promise<string | null> {

--- a/e2e/pages/WorkItemCreatePage.ts
+++ b/e2e/pages/WorkItemCreatePage.ts
@@ -13,9 +13,8 @@
  *   - #durationDays (number)
  *   - #startAfter, #startBefore (date inputs)
  *   - Tags: TagPicker component
- *   - Budget section (h2 "Budget"): #plannedBudget, #actualCost, #confidencePercent,
- *     #budgetCategoryId, #budgetSourceId
  *   - Dependencies: DependencySentenceBuilder
+ *   (Budget fields removed in Story 5.9 rework — managed via /api/work-items/:id/budgets)
  * - Submit button (class submitButton): text "Create Work Item" / "Creating..."
  * - Cancel button (class cancelButton): text "Cancel"
  * - Error banner (class errorBanner) for server-side errors
@@ -45,9 +44,6 @@ export interface WorkItemFormData {
   durationDays?: string;
   startAfter?: string;
   startBefore?: string;
-  plannedBudget?: string;
-  actualCost?: string;
-  confidencePercent?: string;
 }
 
 export class WorkItemCreatePage {
@@ -67,11 +63,6 @@ export class WorkItemCreatePage {
   readonly durationInput: Locator;
   readonly startAfterInput: Locator;
   readonly startBeforeInput: Locator;
-  readonly plannedBudgetInput: Locator;
-  readonly actualCostInput: Locator;
-  readonly confidencePercentInput: Locator;
-  readonly budgetCategorySelect: Locator;
-  readonly budgetSourceSelect: Locator;
 
   // Form actions
   readonly submitButton: Locator;
@@ -99,11 +90,6 @@ export class WorkItemCreatePage {
     this.durationInput = page.locator('#durationDays');
     this.startAfterInput = page.locator('#startAfter');
     this.startBeforeInput = page.locator('#startBefore');
-    this.plannedBudgetInput = page.locator('#plannedBudget');
-    this.actualCostInput = page.locator('#actualCost');
-    this.confidencePercentInput = page.locator('#confidencePercent');
-    this.budgetCategorySelect = page.locator('#budgetCategoryId');
-    this.budgetSourceSelect = page.locator('#budgetSourceId');
 
     // Form actions
     this.submitButton = page.getByRole('button', { name: /Create Work Item|Creating\.\.\./i });
@@ -161,15 +147,6 @@ export class WorkItemCreatePage {
     }
     if (data.startBefore !== undefined) {
       await this.startBeforeInput.fill(data.startBefore);
-    }
-    if (data.plannedBudget !== undefined) {
-      await this.plannedBudgetInput.fill(data.plannedBudget);
-    }
-    if (data.actualCost !== undefined) {
-      await this.actualCostInput.fill(data.actualCost);
-    }
-    if (data.confidencePercent !== undefined) {
-      await this.confidencePercentInput.fill(data.confidencePercent);
     }
   }
 

--- a/e2e/tests/work-items/work-item-create.spec.ts
+++ b/e2e/tests/work-items/work-item-create.spec.ts
@@ -48,18 +48,6 @@ test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
     await expect(createPage.statusSelect).toBeVisible();
     await expect(createPage.submitButton).toBeVisible();
   });
-
-  test('Budget section h2 "Budget" is visible', async ({ page }) => {
-    const createPage = new WorkItemCreatePage(page);
-
-    await createPage.goto();
-
-    await expect(
-      page.getByRole('heading', { level: 2, name: 'Budget', exact: true }),
-    ).toBeVisible();
-    await expect(createPage.plannedBudgetInput).toBeVisible();
-    await expect(createPage.budgetCategorySelect).toBeVisible();
-  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -145,8 +133,6 @@ test.describe('Create with all fields (Scenario 4)', { tag: '@responsive' }, () 
         startDate: '2026-03-01',
         endDate: '2026-06-30',
         durationDays: '30',
-        plannedBudget: '5000',
-        confidencePercent: '80',
       });
 
       const responsePromise = page.waitForResponse(
@@ -314,9 +300,9 @@ test.describe('Responsive layout (Scenario 7)', { tag: '@responsive' }, () => {
     await expect(createPage.submitButton).toBeVisible();
     await expect(createPage.cancelButton).toBeVisible();
 
-    // Budget section accessible (scroll into view if needed)
-    await createPage.plannedBudgetInput.scrollIntoViewIfNeeded();
-    await expect(createPage.plannedBudgetInput).toBeVisible();
+    // Back button accessible
+    await createPage.backButton.scrollIntoViewIfNeeded();
+    await expect(createPage.backButton).toBeVisible();
   });
 
   test('Create Work Item form renders in dark mode without horizontal scroll', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update 3 POMs and 3 test specs to match the budget lines model introduced in PR #187
- Rewrite mock response helpers to match the new `BudgetOverview` type (confidence margins, 4 remaining perspectives, no vendor/financing sub-objects)
- Remove budget fields from WorkItemCreatePage POM and tests (budget now managed via budget lines API)
- Replace vendor picker regression tests with budget section tests using `addBudgetLineButton`
- Remove the "Vendors card" test (card no longer exists in the overview)

## Test plan
- [ ] All 6 modified files pass ESLint and Prettier (verified locally)
- [ ] TypeScript compilation clean for modified files (verified locally)
- [ ] CI Quality Gates pass (lint, typecheck, unit tests, build)
- [ ] CI Docker build passes
- [ ] E2E tests that previously failed due to budget rework now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)