### PR TITLE
ci(e2e): add smoke E2E tests and post-merge full E2E workflow

### DIFF
--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -218,6 +218,16 @@ If you discover something that requires a fix, write a bug report. If you need c
 
 ---
 
+## E2E Smoke Tests (Pre-PR Gate)
+
+Before signaling readiness for a PR, run the E2E smoke suite to catch fundamental breakage:
+
+1. Build the Docker image: `docker build -t cornerstone:e2e .`
+2. Run the smoke subset: `npm run test:e2e:smoke` (~2-3 min, desktop/Chromium only)
+3. If any smoke test fails, fix the issue before the PR is created
+
+This is mandatory for all stories that touch frontend code, API routes, or API response shapes. The smoke suite runs ~14 tagged `@smoke` tests covering one representative test per feature area.
+
 ## Quality Assurance Self-Checks
 
 Before considering your work complete, verify:
@@ -233,6 +243,7 @@ Before considering your work complete, verify:
 - [ ] Responsive layouts verified at all specified breakpoints
 - [ ] Performance metrics validated against baselines (bundle size, load time, API response time)
 - [ ] Docker deployment tested if applicable
+- [ ] E2E smoke tests pass locally (`npm run test:e2e:smoke`) — mandatory when story touches frontend/API
 
 ---
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,56 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [beta]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Login to DHI registry
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t cornerstone:e2e .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install E2E dependencies
+        run: npm ci -w e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium webkit --with-deps
+        working-directory: e2e
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-test-results
+          path: |
+            e2e/playwright-output/
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "npx playwright test",
+    "test:smoke": "npx playwright test --grep @smoke --project desktop",
     "test:report": "npx playwright show-report"
   },
   "devDependencies": {

--- a/e2e/tests/admin/user-list.spec.ts
+++ b/e2e/tests/admin/user-list.spec.ts
@@ -7,7 +7,7 @@ import { UserManagementPage } from '../../pages/UserManagementPage.js';
 import { TEST_ADMIN } from '../../fixtures/testData.js';
 
 test.describe('User List Display', () => {
-  test('Admin sees user list table', async ({ page }) => {
+  test('Admin sees user list table', { tag: '@smoke' }, async ({ page }) => {
     const userManagementPage = new UserManagementPage(page);
 
     // Given: User is an admin

--- a/e2e/tests/auth/auth-guard.spec.ts
+++ b/e2e/tests/auth/auth-guard.spec.ts
@@ -10,7 +10,7 @@ test.describe('Authentication Guard - Unauthenticated', () => {
   // Clear auth state for these tests
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('Unauthenticated access to / redirects to /login', async ({ page }) => {
+  test('Unauthenticated access to / redirects to /login', { tag: '@smoke' }, async ({ page }) => {
     // Given: User is not authenticated
 
     // When: User tries to access dashboard

--- a/e2e/tests/auth/login-logout.spec.ts
+++ b/e2e/tests/auth/login-logout.spec.ts
@@ -11,7 +11,7 @@ test.describe('Login and Logout', { tag: '@responsive' }, () => {
   // Clear auth state for these tests
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('Successful login redirects to dashboard', async ({ page }) => {
+  test('Successful login redirects to dashboard', { tag: '@smoke' }, async ({ page }) => {
     const loginPage = new LoginPage(page);
 
     // Given: User is on the login page

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -54,21 +54,25 @@ async function deleteCategoryViaApi(page: Page, id: string): Promise<void> {
 // Scenario 1 & 2: Default categories present and list view
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Default categories (Scenario 1 & 2)', { tag: '@responsive' }, () => {
-  test('All 10 default categories are present after fresh migration', async ({ page }) => {
-    // Given: EPIC-05 migration applied; default seeds loaded
-    const categoriesPage = new BudgetCategoriesPage(page);
+  test(
+    'All 10 default categories are present after fresh migration',
+    { tag: '@smoke' },
+    async ({ page }) => {
+      // Given: EPIC-05 migration applied; default seeds loaded
+      const categoriesPage = new BudgetCategoriesPage(page);
 
-    // When: I navigate to Budget > Categories
-    await categoriesPage.goto();
+      // When: I navigate to Budget > Categories
+      await categoriesPage.goto();
 
-    // Then: All 10 named default categories appear in the list
-    // (we check for presence rather than exact count=10 since parallel workers
-    //  may have created additional categories in the shared database)
-    const names = await categoriesPage.getCategoryNames();
-    for (const expectedName of DEFAULT_CATEGORIES) {
-      expect(names).toContain(expectedName);
-    }
-  });
+      // Then: All 10 named default categories appear in the list
+      // (we check for presence rather than exact count=10 since parallel workers
+      //  may have created additional categories in the shared database)
+      const names = await categoriesPage.getCategoryNames();
+      for (const expectedName of DEFAULT_CATEGORIES) {
+        expect(names).toContain(expectedName);
+      }
+    },
+  );
 
   test('List shows name, color swatch and sort order for each category', async ({ page }) => {
     // Given: Default categories are seeded

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -86,7 +86,7 @@ function populatedOverviewResponse() {
 // Page heading and navigation
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
-  test('Page loads with h1 "Budget" heading', async ({ page }) => {
+  test('Page loads with h1 "Budget" heading', { tag: '@smoke' }, async ({ page }) => {
     const overviewPage = new BudgetOverviewPage(page);
 
     await overviewPage.goto();

--- a/e2e/tests/budget/budget-sources.spec.ts
+++ b/e2e/tests/budget/budget-sources.spec.ts
@@ -72,7 +72,7 @@ async function deleteSourceViaApi(page: Page, id: string): Promise<void> {
 // Page heading and navigation
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
-  test('Page loads with h1 "Budget" and h2 "Sources"', async ({ page }) => {
+  test('Page loads with h1 "Budget" and h2 "Sources"', { tag: '@smoke' }, async ({ page }) => {
     const sourcesPage = new BudgetSourcesPage(page);
 
     await sourcesPage.goto();

--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -1090,7 +1090,7 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
     expect(page.url()).toContain('/budget/vendors');
   });
 
-  test('Page heading is "Budget" (h1)', async ({ page }) => {
+  test('Page heading is "Budget" (h1)', { tag: '@smoke' }, async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
     await vendorsPage.goto();

--- a/e2e/tests/infrastructure/migrations.spec.ts
+++ b/e2e/tests/infrastructure/migrations.spec.ts
@@ -9,16 +9,20 @@ import { test, expect } from '@playwright/test';
 import { TEST_ADMIN, API } from '../../fixtures/testData.js';
 
 test.describe('Database Migrations', () => {
-  test('should have healthy application after migrations', async ({ request }) => {
-    // Given: A fresh container with migrations applied
-    // When: Checking the health endpoint
-    const response = await request.get(API.health);
+  test(
+    'should have healthy application after migrations',
+    { tag: '@smoke' },
+    async ({ request }) => {
+      // Given: A fresh container with migrations applied
+      // When: Checking the health endpoint
+      const response = await request.get(API.health);
 
-    // Then: The application should be healthy
-    expect(response.ok()).toBeTruthy();
-    const body = await response.json();
-    expect(body).toHaveProperty('status', 'ok');
-  });
+      // Then: The application should be healthy
+      expect(response.ok()).toBeTruthy();
+      const body = await response.json();
+      expect(body).toHaveProperty('status', 'ok');
+    },
+  );
 
   test('should support full user lifecycle after migrations', async ({ request }) => {
     // Given: A fresh container with migrations applied

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -7,7 +7,7 @@ import { AppShellPage } from '../../pages/AppShellPage.js';
 import { ROUTES } from '../../fixtures/testData.js';
 
 test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
-  test('Navigate to each section via sidebar links', async ({ page }) => {
+  test('Navigate to each section via sidebar links', { tag: '@smoke' }, async ({ page }) => {
     const appShell = new AppShellPage(page);
     const viewport = page.viewportSize();
     const isMobile = viewport !== null && viewport.width < 1024;

--- a/e2e/tests/navigation/stub-pages.spec.ts
+++ b/e2e/tests/navigation/stub-pages.spec.ts
@@ -18,7 +18,7 @@ import { HouseholdItemsPage } from '../../pages/HouseholdItemsPage.js';
 import { DocumentsPage } from '../../pages/DocumentsPage.js';
 
 test.describe('Stub pages — smoke tests', { tag: '@responsive' }, () => {
-  test('Dashboard page loads with heading', async ({ page }) => {
+  test('Dashboard page loads with heading', { tag: '@smoke' }, async ({ page }) => {
     const dashboard = new DashboardPage(page);
     await dashboard.goto();
     await expect(dashboard.heading).toBeVisible();

--- a/e2e/tests/profile/view-profile.spec.ts
+++ b/e2e/tests/profile/view-profile.spec.ts
@@ -7,7 +7,7 @@ import { ProfilePage } from '../../pages/ProfilePage.js';
 import { TEST_ADMIN } from '../../fixtures/testData.js';
 
 test.describe('View Profile', () => {
-  test('All profile fields displayed', async ({ page }) => {
+  test('All profile fields displayed', { tag: '@smoke' }, async ({ page }) => {
     const profilePage = new ProfilePage(page);
 
     // Given: User is authenticated

--- a/e2e/tests/tags/tag-management.spec.ts
+++ b/e2e/tests/tags/tag-management.spec.ts
@@ -55,7 +55,7 @@ async function deleteTagViaApi(page: Page, id: string): Promise<void> {
 // Scenario 1: Page loads with heading
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
-  test('Tag Management page loads with h1 heading', async ({ page }) => {
+  test('Tag Management page loads with h1 heading', { tag: '@smoke' }, async ({ page }) => {
     const tagsPage = new TagManagementPage(page);
 
     // When: I navigate to the Tag Management page

--- a/e2e/tests/work-items/work-item-create.spec.ts
+++ b/e2e/tests/work-items/work-item-create.spec.ts
@@ -72,42 +72,43 @@ test.describe('Back button navigation (Scenario 2)', { tag: '@responsive' }, () 
 // Scenario 3: Create work item with title only — success, redirects to detail
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Create with title only — happy path (Scenario 3)', { tag: '@responsive' }, () => {
-  test('Creating a work item with title only redirects to the detail page', async ({
-    page,
-    testPrefix,
-  }) => {
-    const createPage = new WorkItemCreatePage(page);
-    let createdId: string | null = null;
+  test(
+    'Creating a work item with title only redirects to the detail page',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const createPage = new WorkItemCreatePage(page);
+      let createdId: string | null = null;
 
-    try {
-      await createPage.goto();
+      try {
+        await createPage.goto();
 
-      // Fill only the title
-      const title = `${testPrefix} Title Only Work Item`;
-      await createPage.fillTitle(title);
+        // Fill only the title
+        const title = `${testPrefix} Title Only Work Item`;
+        await createPage.fillTitle(title);
 
-      // Capture the response to get the new work item ID
-      const responsePromise = page.waitForResponse(
-        (resp) => resp.url().includes('/api/work-items') && resp.request().method() === 'POST',
-      );
+        // Capture the response to get the new work item ID
+        const responsePromise = page.waitForResponse(
+          (resp) => resp.url().includes('/api/work-items') && resp.request().method() === 'POST',
+        );
 
-      await createPage.submit();
+        await createPage.submit();
 
-      const response = await responsePromise;
-      const body = (await response.json()) as { workItem?: { id: string }; id?: string };
-      createdId = body.workItem?.id ?? body.id ?? null;
+        const response = await responsePromise;
+        const body = (await response.json()) as { workItem?: { id: string }; id?: string };
+        createdId = body.workItem?.id ?? body.id ?? null;
 
-      // Should redirect to /work-items/:id
-      await page.waitForURL('**/work-items/**', { timeout: 7000 });
-      expect(page.url()).toMatch(/\/work-items\/[a-z0-9-]+$/);
-      expect(page.url()).not.toContain('/work-items/new');
+        // Should redirect to /work-items/:id
+        await page.waitForURL('**/work-items/**', { timeout: 7000 });
+        expect(page.url()).toMatch(/\/work-items\/[a-z0-9-]+$/);
+        expect(page.url()).not.toContain('/work-items/new');
 
-      // Detail page shows the correct title
-      await expect(page.getByRole('heading', { level: 1 })).toHaveText(title, { timeout: 7000 });
-    } finally {
-      if (createdId) await deleteWorkItemViaApi(page, createdId);
-    }
-  });
+        // Detail page shows the correct title
+        await expect(page.getByRole('heading', { level: 1 })).toHaveText(title, { timeout: 7000 });
+      } finally {
+        if (createdId) await deleteWorkItemViaApi(page, createdId);
+      }
+    },
+  );
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/e2e/tests/work-items/work-items-list.spec.ts
+++ b/e2e/tests/work-items/work-items-list.spec.ts
@@ -23,7 +23,7 @@ import { createWorkItemViaApi, deleteWorkItemViaApi } from '../../fixtures/apiHe
 // Scenario 1: Page loads with h1 "Work Items"
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
-  test('Work Items list page loads with h1 "Work Items"', async ({ page }) => {
+  test('Work Items list page loads with h1 "Work Items"', { tag: '@smoke' }, async ({ page }) => {
     const workItemsPage = new WorkItemsPage(page);
 
     await workItemsPage.goto();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
     "test:e2e": "npm test -w e2e",
+    "test:e2e:smoke": "npm run test:smoke -w e2e",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",


### PR DESCRIPTION
## Summary

- Add `@smoke` tag to 14 representative E2E tests (one per feature area) and a `test:e2e:smoke` script (~2-3 min, desktop/Chromium only) for pre-PR smoke checking
- Add `.github/workflows/e2e.yml` to run the full E2E suite on every push to `beta` (non-blocking, post-merge)
- Update `CLAUDE.md` workflow (step 5b + post-merge note) and QA agent instructions with smoke pre-PR gate

## Test plan

- [ ] `npm run test:e2e:smoke` runs ~14 tests in desktop/Chromium only and completes in ~2-3 min
- [ ] Merging this PR to `beta` triggers the new `e2e.yml` workflow (visible in Actions tab)
- [ ] Existing `ci.yml` E2E job still runs only on PRs targeting `main` (unchanged)
- [ ] `npm run lint`, `npm run format:check`, and `npm run typecheck` pass (no syntax issues from tag additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)