### PR TITLE
fix(test): resolve CI test flakiness in App.test and E2E budget-overview

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -74,14 +74,18 @@ describe('App', () => {
     render(<App />);
     expect(document.body).toBeInTheDocument();
     // Wait for auth check and lazy-loaded component to resolve
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument(), {
+      timeout: 5000,
+    });
   });
 
   it('renders the AppShell layout with sidebar and header', async () => {
     render(<App />);
 
     // Wait for auth loading to complete
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument(), {
+      timeout: 5000,
+    });
 
     // Sidebar should be present
     const sidebar = screen.getByRole('complementary');

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -268,7 +268,9 @@ test.describe('Budget Health Hero', { tag: '@responsive' }, () => {
       await overviewPage.waitForLoaded();
 
       // Then: The BudgetBar stacked bar chart is visible (role="img")
-      await expect(page.getByRole('img')).toBeVisible({ timeout: 8000 });
+      await expect(page.getByRole('img', { name: /Budget breakdown/ })).toBeVisible({
+        timeout: 8000,
+      });
     } finally {
       await page.unroute(`${API.budgetOverview}`);
     }


### PR DESCRIPTION
## Summary

- **App.test.tsx**: Increased `waitFor` timeout from default 1000ms to 5000ms for lazy-loading assertions. The React.lazy import + auth check chain takes longer on CI runners than locally, causing intermittent timeouts.
- **budget-overview.spec.ts**: Changed `page.getByRole('img')` to `page.getByRole('img', { name: /Budget breakdown/ })` to avoid Playwright strict mode violation — the bare selector matched both the logo SVG and the BudgetBar component.

Fixes CI failures on PR #160.

## Test plan

- [ ] Quality Gates CI passes (unit tests green)
- [ ] E2E smoke tests pass
- [ ] Full E2E suite: budget-overview "Budget bar is visible" passes on desktop/tablet/mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)