### PR TITLE
fix(docker): split build stages to avoid ARM64 QEMU crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 # =============================================================================
 # Cornerstone - Multi-stage Docker build
 # =============================================================================
-# Stage 1: Install dependencies and build (DHI dev image with npm + build tools)
-# Stage 2: Production runtime (DHI minimal image, no npm/build tools/shell)
+# Stage 1 (client-builder): Runs on the BUILD HOST's native arch to avoid
+#   QEMU emulation. Installs pure-JS deps and builds shared types + client
+#   (webpack). No native addons needed — better-sqlite3 is skipped via
+#   --ignore-scripts.
+# Stage 2 (builder): Runs on the TARGET arch (may use QEMU for ARM64).
+#   Installs deps with native addons (better-sqlite3), copies pre-built
+#   shared/client from stage 1, builds server (tsc only — lightweight).
+# Stage 3 (production): Minimal runtime image, no npm/build tools/shell.
 # =============================================================================
 # Standard build:
 #   docker build -t cornerstone .
@@ -13,13 +19,62 @@
 # =============================================================================
 
 # ---------------------------------------------------------------------------
-# Stage 1: Build
+# Stage 1: Client builder (native arch — no QEMU)
+# ---------------------------------------------------------------------------
+# $BUILDPLATFORM resolves to the Docker host's native architecture (e.g.
+# linux/amd64 on GitHub Actions), so webpack runs without QEMU emulation.
+# This avoids intermittent "Illegal instruction" crashes (exit code 132)
+# caused by V8 JIT generating code that QEMU's ARM64 emulation can't handle.
+FROM --platform=$BUILDPLATFORM dhi.io/node:24-alpine3.23-dev AS client-builder
+
+WORKDIR /app
+
+# Proxy build args — pass --build-arg HTTP_PROXY=... if behind a proxy
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+
+# Install proxy CA cert if provided. No build-base/python3 needed — all
+# client/shared deps are pure JavaScript (native addons skipped below).
+RUN --mount=type=secret,id=proxy-ca \
+    if [ -f /run/secrets/proxy-ca ]; then \
+      cat /run/secrets/proxy-ca >> /etc/ssl/certs/ca-certificates.crt && \
+      npm config set cafile /etc/ssl/certs/ca-certificates.crt; \
+    fi
+
+# Copy package files for dependency installation
+COPY package.json package-lock.json ./
+COPY shared/package.json shared/
+COPY server/package.json server/
+COPY client/package.json client/
+
+# Install all dependencies, skipping postinstall scripts. This avoids
+# compiling better-sqlite3 (the only native addon) — it's not needed for
+# shared (tsc) or client (webpack) builds.
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts
+
+# Stamp the release version into package.json (webpack's DefinePlugin reads
+# this to embed __APP_VERSION__ in the client bundle).
+ARG APP_VERSION=0.0.0-dev
+RUN npm pkg set "version=${APP_VERSION}"
+
+# Copy source for shared and client only (server not needed here)
+COPY tsconfig.base.json ./
+COPY shared/ shared/
+COPY client/ client/
+
+# Build shared types (tsc), then client (webpack)
+RUN npm run build -w shared && npm run build -w client
+
+# ---------------------------------------------------------------------------
+# Stage 2: Server builder (target arch — may use QEMU for ARM64)
 # ---------------------------------------------------------------------------
 FROM dhi.io/node:24-alpine3.23-dev AS builder
 
 WORKDIR /app
 
-# Proxy build args — pass --build-arg HTTP_PROXY=... if behind a proxy
+# Proxy build args
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG http_proxy
@@ -44,26 +99,28 @@ COPY client/package.json client/
 # source when no matching prebuild is available — no --build-from-source needed.
 RUN --mount=type=cache,target=/root/.npm npm ci
 
-# Stamp the release version into package.json (set at build time by CI;
-# defaults to 0.0.0-dev for local builds). This keeps the version visible
-# in the running container without committing it back to the repo.
+# Stamp the release version into package.json
 ARG APP_VERSION=0.0.0-dev
 RUN npm pkg set "version=${APP_VERSION}"
 
-# Copy source code
-COPY tsconfig.base.json ./
-COPY shared/ shared/
-COPY server/ server/
-COPY client/ client/
+# Copy pre-built shared types and client bundle from stage 1.
+# shared/tsconfig.json is needed for the server's project reference resolution.
+COPY --from=client-builder /app/shared/dist/ shared/dist/
+COPY --from=client-builder /app/client/dist/ client/dist/
+COPY shared/tsconfig.json shared/
 
-# Build shared types, then client (Webpack), then server (tsc)
-RUN npm run build
+# Copy server source and base tsconfig (needed for tsc)
+COPY tsconfig.base.json ./
+COPY server/ server/
+
+# Build server only (tsc — lightweight, QEMU-safe)
+RUN npm run build -w server
 
 # Remove devDependencies, preserve built artifacts and compiled native addons
 RUN npm prune --omit=dev
 
 # ---------------------------------------------------------------------------
-# Stage 2: Production (no shell — exec form only)
+# Stage 3: Production (no shell — exec form only)
 # ---------------------------------------------------------------------------
 FROM dhi.io/node:24-alpine3.23 AS production
 


### PR DESCRIPTION
## Summary

- Splits the single `builder` Docker stage into `client-builder` (native arch) + `builder` (target arch) to eliminate intermittent ARM64 QEMU crashes during multi-platform builds
- The `client-builder` stage uses `--platform=$BUILDPLATFORM` to run webpack natively, bypassing QEMU entirely for the crash-prone V8 JIT step
- The `builder` stage only runs `tsc` under QEMU (lightweight, safe), plus `npm ci` to compile `better-sqlite3` for the target architecture

## Context

Since multi-arch builds were added (PR #133, 2026-02-19), ~20% of `release.yml` runs fail on ARM64 with exit code 132 (`SIGILL` — Illegal instruction) during `webpack --mode production`. The root cause is V8's JIT compiler non-deterministically generating machine code that QEMU's ARM64 emulation can't execute. This will only get worse as the webpack bundle grows.

## Test plan

- [ ] PR CI runs the `Docker` job (`docker build -t cornerstone:e2e .`) — validates the 3-stage Dockerfile builds correctly on amd64
- [ ] After merge to `beta`, verify `release.yml` multi-platform buildx (`linux/amd64,linux/arm64`) succeeds without the QEMU crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)