### PR TITLE
fix(budget): surface budget line deletion errors to the user

### DIFF
--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -363,7 +363,13 @@ export default function WorkItemDetailPage() {
       setDeletingBudgetId(null);
       await reloadBudgetLines();
     } catch (err) {
-      setInlineError('Failed to delete budget line');
+      setDeletingBudgetId(null);
+      const apiErr = err as { statusCode?: number; message?: string };
+      if (apiErr.statusCode === 409) {
+        setInlineError(apiErr.message || 'Budget line cannot be deleted because it is in use');
+      } else {
+        setInlineError('Failed to delete budget line');
+      }
       console.error('Failed to delete budget line:', err);
     }
   };


### PR DESCRIPTION
## Summary

- Close the confirmation modal before setting the inline error so the error banner is visible to the user
- For 409 (BUDGET\_LINE\_IN\_USE) responses, show the specific API error message (e.g. "Budget line has linked invoices and cannot be deleted") instead of a generic fallback
- Follows the existing pattern used by `handleAddDependency` for 409 handling

## Root cause

In `confirmDeleteBudgetLine`, `setDeletingBudgetId(null)` only ran on success, leaving the modal open on error and hiding the inline error banner behind it.

## Test plan

- [ ] Create a work item with a budget line linked to an invoice
- [ ] Attempt to delete the budget line
- [ ] Confirm the modal closes, the inline error banner appears with the specific message, and the budget line remains in the list
- [ ] Verify generic error message shown for non-409 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)