### PR TITLE
ci: publish pr-<number> Docker image after quality gates pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image
-        run: docker build -t cornerstone:e2e .
+        run: docker build --build-arg APP_VERSION=pr-${{ github.event.pull_request.number }} -t cornerstone:e2e .
 
       - name: Save image
         run: docker save cornerstone:e2e -o cornerstone-e2e.tar
@@ -71,6 +71,32 @@ jobs:
           name: cornerstone-docker-image
           path: cornerstone-e2e.tar
           retention-days: 1
+
+  docker-pr-release:
+    name: Docker PR Release
+    runs-on: ubuntu-latest
+    needs: [quality-gates, docker, e2e-smoke]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: cornerstone-docker-image
+
+      - name: Load image
+        run: docker load -i cornerstone-e2e.tar
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Tag and push PR image
+        run: |
+          docker tag cornerstone:e2e steilerdev/cornerstone:pr-${{ github.event.pull_request.number }}
+          docker push steilerdev/cornerstone:pr-${{ github.event.pull_request.number }}
 
   e2e-smoke:
     name: E2E Smoke Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ All agents must clearly identify themselves in commits and GitHub interactions:
   - Examples: `feat/42-work-item-crud`, `fix/55-budget-calc`, `ci/18-dependabot-auto-merge`
   - Use the conventional commit type as the prefix
   - Include the GitHub Issue number when one exists
+- **Never push a `worktree-<anything>` branch.** Worktree branches carry auto-generated names. Before pushing, always rename the branch to match the naming convention above: `git branch -m <type>/<issue-number>-<short-description>`. If the scope of work is not yet clear, determine it before pushing — do not publish placeholder branch names.
 
 ### Session Isolation (Worktrees)
 


### PR DESCRIPTION
## Summary

- Stamps `APP_VERSION=pr-<number>` at Docker build time so the version is baked into the image
- Adds a `docker-pr-release` job that re-tags the already-built artifact and pushes `steilerdev/cornerstone:pr-<number>` to Docker Hub once `quality-gates` and `docker` succeed
- Fork/Dependabot PRs are skipped via a `head.repo` guard (no secrets available)
- Adds a `CLAUDE.md` rule prohibiting pushing `worktree-*` branches — branch must be renamed before any push

## Test plan

- [ ] Open a PR — verify `Docker PR Release` job appears and completes after quality gates pass
- [ ] Confirm `steilerdev/cornerstone:pr-<number>` is published on Docker Hub
- [ ] Verify `docker run --rm steilerdev/cornerstone:pr-<number> node -e "console.log(require('./package.json').version)"` prints `pr-<number>`
- [ ] Confirm fork/Dependabot PRs skip the push job

🤖 Generated with [Claude Code](https://claude.com/claude-code)