### PR TITLE
fix(budget): fix invoice/work-item cross-linking

### DIFF
--- a/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
@@ -312,11 +312,16 @@ export function InvoiceDetailPage() {
                 </span>
               </dd>
             </div>
-            {invoice.workItemBudgetId && (
+            {invoice.workItemBudget && (
               <div className={styles.infoRow}>
-                <dt className={styles.infoLabel}>Budget Line</dt>
+                <dt className={styles.infoLabel}>Work Item</dt>
                 <dd className={styles.infoValue}>
-                  <span className={styles.budgetLineId}>{invoice.workItemBudgetId}</span>
+                  <Link
+                    to={`/work-items/${invoice.workItemBudget.workItemId}`}
+                    className={styles.infoLink}
+                  >
+                    {invoice.workItemBudget.workItemTitle}
+                  </Link>
                 </dd>
               </div>
             )}

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -1246,7 +1246,7 @@ export default function WorkItemDetailPage() {
                               {line.invoices.map((inv) => (
                                 <Link
                                   key={inv.id}
-                                  to={`/budget/vendors/${inv.vendorId}`}
+                                  to={`/budget/invoices/${inv.id}`}
                                   className={styles.invoicePopoverItem}
                                   onClick={() => setInvoicePopoverBudgetId(null)}
                                 >


### PR DESCRIPTION
## Summary

- **InvoiceDetailPage**: Replace the "Budget Line" row (which showed a raw UUID) with a "Work Item" row displaying the linked work item's title as a link to `/work-items/:id`. Uses `invoice.workItemBudget` already returned by the API — no additional fetch needed.
- **WorkItemDetailPage**: Invoice popover items now link to `/budget/invoices/:id` (invoice detail page) instead of `/budget/vendors/:vendorId`.

## Test plan

- [ ] Open an invoice detail page for an invoice linked to a budget line — confirm "Work Item" row appears with the work item title as a clickable link, and clicking it navigates to the correct work item page
- [ ] Open an invoice detail page for an invoice with no budget line link — confirm the row is absent
- [ ] Open a work item detail page with budget lines that have invoices — open the invoice popover and click an invoice — confirm it navigates to `/budget/invoices/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)