### PR TITLE
ci: add path-based change detection to skip irrelevant jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          check() { echo "$CHANGED" | grep -qE "$1" && echo 'true' || echo 'false'; }
+
+          echo "app=$(check '^(shared|server|client)/|^(package\.json|package-lock\.json|tsconfig\.base\.json|eslint\.config\.js|\.prettierrc|jest\.config\.ts|Dockerfile|\.nvmrc)$')" >> "$GITHUB_OUTPUT"
+          echo "e2e=$(check '^e2e/')" >> "$GITHUB_OUTPUT"
+          echo "ci=$(check '^\.github/workflows/')" >> "$GITHUB_OUTPUT"
+
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.ci == 'true'
 
     steps:
       - name: Checkout
@@ -47,6 +73,8 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true'
 
     steps:
       - name: Checkout
@@ -75,8 +103,8 @@ jobs:
   docker-pr-release:
     name: Docker PR Release
     runs-on: ubuntu-latest
-    needs: [quality-gates, docker, e2e-smoke]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [detect-changes, quality-gates, docker, e2e-smoke]
+    if: "github.event.pull_request.head.repo.full_name == github.repository && (needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true')"
 
     steps:
       - name: Download image artifact
@@ -101,7 +129,8 @@ jobs:
   e2e-smoke:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
-    needs: docker
+    needs: [detect-changes, docker]
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true'
     timeout-minutes: 15
 
     steps:
@@ -146,8 +175,8 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: docker
-    if: github.base_ref == 'main'
+    needs: [detect-changes, docker]
+    if: "github.base_ref == 'main' && (needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true')"
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

- Adds a `detect-changes` job that uses `git diff` to classify changed files into three groups: `app` (shared/server/client + root config files), `e2e`, and `ci` (`.github/workflows/`)
- Each downstream job now has an `if:` guard so irrelevant jobs are skipped:
  - `quality-gates`: runs when `app` or `ci` changed
  - `docker`: runs when `app`, `e2e`, or `ci` changed
  - `e2e`: runs when targeting `main` AND `app`, `e2e`, or `ci` changed
- PRs that only touch docs, README, or wiki files will have all three jobs skipped — GitHub branch protection treats skipped jobs as passing for required status checks

## Optimization scenarios

| Changed files | quality-gates | docker | e2e |
|---|---|---|---|
| App code → beta | run | run | skip (beta PR) |
| App code → main | run | run | run |
| `e2e/**` only → beta | skip | run | skip (beta PR) |
| `e2e/**` only → main | skip | run | run |
| Docs / README / wiki only | skip | skip | skip |
| `.github/workflows/` change | run | run | skip (beta PR) |

## Test plan

- [ ] Open a PR that only modifies a `.md` file → all 3 CI jobs show as skipped
- [ ] Open a PR that only modifies `e2e/**` → `quality-gates` skipped, `docker` runs, `e2e` runs (if targeting `main`) or skipped (if targeting `beta`)
- [ ] Open a PR that modifies `server/**` → all 3 jobs run normally
- [ ] Open a PR that modifies `.github/workflows/ci.yml` → all 3 jobs run
- [ ] Confirm branch protection (`Quality Gates`, `Docker`) is satisfied on skipped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)