### PR TITLE
ci(e2e): cache Playwright browser binaries across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(npx playwright --version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(npx playwright --version | tr -d '[:space:]')" >> $GITHUB_OUTPUT
         working-directory: e2e
 
       - name: Cache Playwright browsers
@@ -236,7 +236,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(npx playwright --version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(npx playwright --version | tr -d '[:space:]')" >> $GITHUB_OUTPUT
         working-directory: e2e
 
       - name: Cache Playwright browsers


### PR DESCRIPTION
## Summary

- Cache `~/.cache/ms-playwright` browser binaries using `actions/cache@v4` in both `e2e-smoke` and `e2e` (sharded) jobs
- Cache key: `playwright-<version>-<os>` — shared across all E2E jobs so whichever runs first warms the cache
- On cache hit, browser binary downloads (~1GB for Chromium + WebKit) are skipped entirely
- System dependencies (`install-deps`) always run since apt packages don't persist on ephemeral runners
- No restore-keys fallback — Playwright errors on version mismatch, so partial hits would be harmful

## Expected improvement

| Step | Before | After (cache hit) |
|------|--------|--------------------|
| Browser install (smoke) | 120-180s | ~10-20s (system deps only) |
| Browser install (shard) | 180-300s | ~10-20s (system deps only) |

## Test plan

- [ ] First CI run: cache miss → browsers downloaded → cache saved (check logs for "Cache not found")
- [ ] Subsequent push: cache hit → browser download skipped → only `install-deps` runs (check logs for "Cache restored")
- [ ] Smoke and shards share cache (same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)