### PR TITLE
fix(ci): ensure apt cache is saved for Playwright system deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,18 +171,28 @@ jobs:
         run: npx playwright install chromium webkit
         working-directory: e2e
 
-      - name: Cache apt packages
-        uses: actions/cache@v4
+      - name: Configure apt and dpkg for CI
+        run: |
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | sudo tee /etc/apt/apt.conf.d/99keep-debs
+          echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
+
+      - name: Restore apt cache
+        id: apt-cache
+        uses: actions/cache/restore@v4
         with:
           path: /var/cache/apt/archives
           key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
-      - name: Speed up dpkg
-        run: echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
-
       - name: Install Playwright system dependencies
         run: sudo npx playwright install-deps chromium webkit
         working-directory: e2e
+
+      - name: Save apt cache
+        if: steps.apt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
       - name: Run E2E smoke tests
         run: npm run test:e2e:smoke
@@ -251,18 +261,28 @@ jobs:
         run: npx playwright install chromium webkit
         working-directory: e2e
 
-      - name: Cache apt packages
-        uses: actions/cache@v4
+      - name: Configure apt and dpkg for CI
+        run: |
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | sudo tee /etc/apt/apt.conf.d/99keep-debs
+          echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
+
+      - name: Restore apt cache
+        id: apt-cache
+        uses: actions/cache/restore@v4
         with:
           path: /var/cache/apt/archives
           key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
-      - name: Speed up dpkg
-        run: echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
-
       - name: Install Playwright system dependencies
         run: sudo npx playwright install-deps chromium webkit
         working-directory: e2e
+
+      - name: Save apt cache
+        if: steps.apt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
       - name: Run E2E tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: npm run test:e2e:shard


### PR DESCRIPTION
## Summary

- Set `Keep-Downloaded-Packages "true"` so apt retains `.deb` files after install (Ubuntu runners clean them by default)
- Use explicit `actions/cache/restore@v4` + `actions/cache/save@v4` instead of `actions/cache@v4` so archives are captured immediately after install, not in a post-job step
- Only saves on cache miss to avoid redundant uploads

Follow-up fix for #218 where the apt cache step was added but never actually saved anything.

## Test plan

- [ ] First CI run: cache miss → `Save apt cache` step uploads archives
- [ ] Verify `apt-playwright-*` entry in `gh cache list`
- [ ] Subsequent CI run: cache hit → `Save apt cache` skipped → install-deps faster
- [ ] All E2E jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)