### PR TITLE
ci(e2e): add e2e-warmup job to deduplicate cache management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,74 @@ jobs:
           path: cornerstone-e2e.tar
           retention-days: 1
 
+  e2e-warmup:
+    name: E2E Cache Warmup
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true'
+    outputs:
+      playwright-version: ${{ steps.playwright-version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install E2E dependencies
+        run: npm ci -w e2e
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | tr -d '[:space:]')" >> $GITHUB_OUTPUT
+        working-directory: e2e
+
+      - name: Restore browser cache
+        id: browser-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+
+      - name: Install Playwright browsers
+        if: steps.browser-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium webkit
+        working-directory: e2e
+
+      - name: Save browser cache
+        if: steps.browser-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+
+      - name: Configure apt and dpkg for CI
+        run: |
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | sudo tee /etc/apt/apt.conf.d/99keep-debs
+          echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
+
+      - name: Restore apt cache
+        id: apt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+
+      - name: Install Playwright system dependencies
+        run: sudo npx playwright install-deps chromium webkit
+        working-directory: e2e
+
+      - name: Save apt cache
+        if: steps.apt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+
   docker-pr-release:
     name: Docker PR Release
     runs-on: ubuntu-latest
@@ -129,7 +197,7 @@ jobs:
   e2e-smoke:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
-    needs: [detect-changes, docker]
+    needs: [detect-changes, docker, e2e-warmup]
     if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true'
     timeout-minutes: 15
 
@@ -154,22 +222,11 @@ jobs:
       - name: Install E2E dependencies
         run: npm ci -w e2e
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(npx playwright --version | tr -d '[:space:]')" >> $GITHUB_OUTPUT
-        working-directory: e2e
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
+      - name: Restore browser cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium webkit
-        working-directory: e2e
+          key: playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Configure apt and dpkg for CI
         run: |
@@ -177,22 +234,14 @@ jobs:
           echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
 
       - name: Restore apt cache
-        id: apt-cache
         uses: actions/cache/restore@v4
         with:
           path: /var/cache/apt/archives
-          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+          key: apt-playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Install Playwright system dependencies
         run: sudo npx playwright install-deps chromium webkit
         working-directory: e2e
-
-      - name: Save apt cache
-        if: steps.apt-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
       - name: Run E2E smoke tests
         run: npm run test:e2e:smoke
@@ -211,7 +260,7 @@ jobs:
   e2e:
     name: E2E Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
-    needs: [detect-changes, docker]
+    needs: [detect-changes, docker, e2e-warmup]
     if: "github.base_ref == 'main' && (needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.ci == 'true')"
     timeout-minutes: 15
     strategy:
@@ -244,22 +293,11 @@ jobs:
       - name: Install E2E dependencies
         run: npm ci -w e2e
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(npx playwright --version | tr -d '[:space:]')" >> $GITHUB_OUTPUT
-        working-directory: e2e
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
+      - name: Restore browser cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium webkit
-        working-directory: e2e
+          key: playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Configure apt and dpkg for CI
         run: |
@@ -267,22 +305,14 @@ jobs:
           echo 'force-unsafe-io' | sudo tee /etc/dpkg/dpkg.cfg.d/ci-unsafe-io
 
       - name: Restore apt cache
-        id: apt-cache
         uses: actions/cache/restore@v4
         with:
           path: /var/cache/apt/archives
-          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+          key: apt-playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Install Playwright system dependencies
         run: sudo npx playwright install-deps chromium webkit
         working-directory: e2e
-
-      - name: Save apt cache
-        if: steps.apt-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
 
       - name: Run E2E tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: npm run test:e2e:shard


### PR DESCRIPTION
## Summary
- Adds a dedicated `e2e-warmup` job that runs once to populate both Playwright browser and apt caches
- Eliminates redundant cache installs and save races across `e2e-smoke` (1 job) and `e2e` shards (8 jobs)
- Downstream E2E jobs now only restore from pre-warmed caches — no version detection, browser install, or cache save steps

## Test plan
- [ ] `e2e-warmup` job runs and populates caches
- [ ] `e2e-smoke` restores from warmed caches (no browser install step)
- [ ] E2E shard jobs restore from warmed caches
- [ ] All E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)