### PR TITLE
fix(ci): reduce E2E worker concurrency and double shards to fix timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shardTotal: [16]
     env:
       SHARD_INDEX: ${{ matrix.shardIndex }}
       SHARD_TOTAL: ${{ matrix.shardTotal }}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
 
-  /* CI workers: 1 per vCPU (4 vCPUs on ubuntu-latest). With 8 shards splitting the
-     suite, each shard runs ~3-4 test files. 4 workers avoids CPU contention that
-     caused flakiness at higher counts (8 workers on a single runner). */
-  workers: process.env.CI ? 4 : undefined,
+  /* CI workers: 2 on ubuntu-latest (2 vCPUs). With 16 shards splitting the
+     suite, each shard runs ~1-2 test files. Halved from 4 to reduce CPU
+     contention that caused desktop tests to hit the 10s timeout. */
+  workers: process.env.CI ? 2 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters
      When sharding, use blob reporter so reports can be merged across shards. */
@@ -111,8 +111,8 @@ export default defineConfig({
     },
   ],
 
-  /* Test timeout — most passing tests complete in 2-5s; some multi-step tests need up to 10s */
-  timeout: 10_000, // 10 seconds per test (desktop default)
+  /* Test timeout — most passing tests complete in 2-5s; some multi-step tests need up to 15s */
+  timeout: 15_000, // 15 seconds per test (desktop default)
 
   /* Global timeout: cap the entire suite at 30 minutes on CI to prevent stuck runs */
   globalTimeout: process.env.CI ? 30 * 60 * 1000 : undefined,


### PR DESCRIPTION
## Summary
- Halve Playwright CI workers from 4 to 2 (matches ubuntu-latest 2 vCPUs)
- Double E2E shards from 8 to 16 to compensate for fewer workers per runner
- Bump global test timeout from 10s to 15s as additional safety margin

## Context
Desktop E2E tests were intermittently hitting the 10s timeout on CI due to CPU contention — 4 workers competing for 2 vCPUs on ubuntu-latest runners.

## Test plan
- [ ] CI quality gates pass
- [ ] E2E smoke tests pass with new worker/shard config

🤖 Generated with [Claude Code](https://claude.com/claude-code)