### PR TITLE
fix(e2e): use storageState pattern for login page screenshot test

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test:shard": "npx playwright test --shard=$SHARD_INDEX/$SHARD_TOTAL",
     "test:report": "npx playwright show-report",
     "merge-reports": "npx playwright merge-reports --reporter html,list ./all-blob-reports",
-    "screenshots": "npx playwright test tests/screenshots/ --project=desktop-lg"
+    "screenshots": "npx playwright test tests/screenshots/ --project=desktop"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -5,7 +5,7 @@
  * and saves them to docs/static/img/screenshots/ for use in the docs site.
  *
  * Run with: npm run docs:screenshots
- * (configured to run only on the desktop-lg project at 1920x1080)
+ * (configured to run only on the desktop project at 1920x1080)
  *
  * Uses the existing testcontainer infrastructure and pre-authenticated
  * admin session for consistent, populated screenshots.
@@ -143,26 +143,20 @@ test.describe('Documentation screenshots', () => {
     await seedWorkItems(request, baseUrl);
   });
 
-  test('Login page', async ({ browser }) => {
-    // Use a fresh unauthenticated context for login page
-    const context = await browser.newContext();
-    const page = await context.newPage();
+  test.describe('Unauthenticated screenshots', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
 
-    await page.goto(`${baseUrl}${ROUTES.login}`);
-    // Wait for the JS bundle to fully load and React to render — fresh unauthenticated
-    // contexts must parse the full bundle before rendering, which can exceed 7s on slow CI runners
-    await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { name: /sign in|log in/i })).toBeVisible({
-      timeout: 15000,
+    test('Login page', async ({ page }) => {
+      await page.goto(ROUTES.login);
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByRole('heading', { name: /sign in|log in/i })).toBeVisible();
+
+      for (const theme of ['light', 'dark'] as const) {
+        await setTheme(page, theme);
+        await page.waitForTimeout(300);
+        await saveScreenshot(page, 'login', theme);
+      }
     });
-
-    for (const theme of ['light', 'dark'] as const) {
-      await setTheme(page, theme);
-      await page.waitForTimeout(300);
-      await saveScreenshot(page, 'login', theme);
-    }
-
-    await context.close();
   });
 
   test('Work items list', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Fixes the `Login page` screenshot test that fails in CI E2E shards 5 and 10 on the EPIC-05 promotion PR (#160)
- Root cause: `browser.newContext()` creates a bare context without project-level settings (viewport, baseURL, timeouts), so the SPA never renders within the timeout
- Switches to `test.use({ storageState: { cookies: [], origins: [] } })` which clears auth while preserving all project settings — the same pattern used by `auth-guard.spec.ts` and `login-logout.spec.ts`
- Fixes `screenshots` script referencing non-existent `desktop-lg` project (correct name is `desktop`)

## Test plan

- [ ] CI E2E shards 5 and 10 pass (previously failing on Login page screenshot test)
- [ ] Re-run EPIC-05 promotion PR (#160) CI after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)