### PR TITLE
Promote beta to main: EPIC-05 release commits + fixes

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,8 +6,8 @@ const config = {
   tagline: 'A self-hosted home building project management tool',
   favicon: 'img/favicon.svg',
 
-  url: 'https://steilerDev.github.io',
-  baseUrl: '/cornerstone/',
+  url: 'https://cornerstone.steiler.dev',
+  baseUrl: '/',
 
   organizationName: 'steilerDev',
   projectName: 'cornerstone',


### PR DESCRIPTION
## Summary

Merges beta into main with conflict resolution. This replaces the squash-merged EPIC-05 promotion (#160) with proper conventional commits that semantic-release can parse.

### Included changes

**EPIC-05 conventional commit summaries** (PR #232, empty commits):
- feat(budget): categories, financing sources, subsidies, budget lines, overview dashboard
- feat(vendors): vendor/contractor management
- feat(invoices): invoice tracking + standalone invoices page
- fix(budget): various calculation and UI fixes
- test(e2e): 845+ E2E tests
- docs(budget): user guides
- ci: change detection, smoke tests, pre-commit hook

**Post-EPIC-05 fixes:**
- fix(e2e): storageState pattern for login screenshot test (#228)
- fix(docs): baseUrl set to / for custom domain (#230)
- fix(ci): E2E sharding, cache warmup, worker concurrency (#217-227)

### Conflict resolution

Only conflict was docs/docusaurus.config.js -- resolved by taking beta (custom domain baseUrl: /).

### Merge instructions

**Merge with merge commit** (not squash): gh pr merge --merge

This preserves the individual conventional commits so semantic-release produces a minor release with proper notes.