### PR TITLE
fix(ci): detect semantic-release version from Created tag output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           OUTPUT=$(npx semantic-release 2>&1) || true
           echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "Published release"; then
-            VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?' || echo "")
+          if echo "$OUTPUT" | grep -q "Created tag v"; then
+            VERSION=$(echo "$OUTPUT" | grep -oP 'Created tag v\K[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?' || echo "")
             echo "new-release-published=true" >> "$GITHUB_OUTPUT"
             echo "new-release-version=$VERSION" >> "$GITHUB_OUTPUT"
             if echo "$VERSION" | grep -q "beta"; then


### PR DESCRIPTION
## Summary

- The release workflow grepped for "Published release" to detect new versions
- But semantic-release actually outputs "Published **GitHub** release: URL" — the word "GitHub" breaks the pattern match
- This caused Docker push and merge-back jobs to be skipped on EVERY release (including v1.8.0 and v1.9.0)
- Fix: match on "Created tag vX.Y.Z" which is reliably emitted and contains the version directly

## Test plan

- [ ] Next release on beta or main correctly detects the version and triggers Docker + merge-back jobs