### PR TITLE
fix: CI release detection + docs baseUrl for custom domain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           OUTPUT=$(npx semantic-release 2>&1) || true
           echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "Published release"; then
-            VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?' || echo "")
+          if echo "$OUTPUT" | grep -q "Created tag v"; then
+            VERSION=$(echo "$OUTPUT" | grep -oP 'Created tag v\K[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?' || echo "")
             echo "new-release-published=true" >> "$GITHUB_OUTPUT"
             echo "new-release-version=$VERSION" >> "$GITHUB_OUTPUT"
             if echo "$VERSION" | grep -q "beta"; then

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "@cornerstone/shared": "*",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-router-dom": "7.13.0"
+    "react-router-dom": "7.13.1"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@docusaurus/preset-classic": "3.9.2",
 "@mdx-js/react": "3.1.1",
     "prism-react-renderer": "2.4.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@cornerstone/shared": "*",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-router-dom": "7.13.0"
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@babel/core": "7.29.0",
@@ -76,45 +76,8 @@
         "@docusaurus/preset-classic": "3.9.2",
         "@mdx-js/react": "3.1.1",
         "prism-react-renderer": "2.4.1",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
-      }
-    },
-    "docs/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "docs/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "docs/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
+        "react": "19.2.4",
+        "react-dom": "19.2.4"
       }
     },
     "e2e": {
@@ -30214,9 +30177,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -30250,12 +30213,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.13.1"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

Staging PR to bring beta fixes to main:

1. **fix(ci): detect semantic-release version from Created tag output** (#235)
   - Release workflow grepped for "Published release" but semantic-release outputs "Published GitHub release" — the pattern never matched
   - Docker push and merge-back jobs were skipped on every release
   - Fix: match on "Created tag vX.Y.Z" instead

2. **fix(docs): set baseUrl to / for custom domain** (#230)
   - GitHub Pages custom domain cornerstone.steiler.dev serves from /
   - Previous baseUrl /cornerstone/ caused all assets to 404

3. **fix(e2e): storageState pattern for login screenshot** (#228)
   - Plus CI sharding/caching fixes (#217-227)

## Merge instructions

Use merge commit: gh pr merge --merge