### PR TITLE
ci: add release summary enrichment and DockerHub README sync

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -146,7 +146,40 @@ When a new epic ships, update the relevant content pages in `docs/src/`:
 - Run `npm run docs:screenshots` to capture new screenshots (requires running app via testcontainers)
 - For features without screenshots yet, use the `:::info Screenshot needed` admonition
 
-### 3. Updating README.md
+### 3. Writing RELEASE_SUMMARY.md
+
+During each epic promotion, write a `RELEASE_SUMMARY.md` file at the repo root. This file is prepended to the auto-generated GitHub Release notes by `release.yml`, giving end users a human-readable summary instead of just a commit list.
+
+**Expected format:**
+
+```markdown
+## What's New
+
+Brief 2-3 sentence prose summary for end users.
+
+### Highlights
+
+- **Feature A** — concise description
+- **Feature B** — concise description
+
+### Breaking Changes
+
+- Description of any breaking change and migration steps (omit section if none)
+
+### Known Issues
+
+- Description of known limitations or bugs (omit section if none)
+```
+
+**Rules:**
+
+- Write for end users, not developers — no commit hashes, PR numbers, or internal jargon
+- The Breaking Changes and Known Issues sections are only included when applicable — omit them entirely if there are none
+- The file persists in the repo and gets overwritten each epic promotion
+- If the file doesn't exist (e.g., hotfix releases), the CI pipeline gracefully falls back to auto-generated notes only
+- Commit `RELEASE_SUMMARY.md` to `beta` alongside the docs site and README updates
+
+### 4. Updating README.md
 
 Keep the README lean. Only update it when:
 
@@ -155,7 +188,7 @@ Keep the README lean. Only update it when:
 - Quick start commands change
 - The docs site URL changes
 
-### 4. Accuracy Requirements
+### 5. Accuracy Requirements
 
 - **Only document available features** — never describe planned features as if they exist
 - **Verify Docker commands** — confirm image name, port, volume mount path
@@ -175,6 +208,7 @@ Before committing:
 - [ ] The roadmap reflects actual GitHub Issue state
 - [ ] README.md remains a lean pointer (no detailed config tables)
 - [ ] Screenshots are referenced correctly or have `:::info Screenshot needed` admonitions
+- [ ] `RELEASE_SUMMARY.md` is written for epic promotions (prose summary, no commit hashes or PR numbers)
 
 ## Workflow
 
@@ -183,8 +217,9 @@ Before committing:
 3. Update or create docs site pages as needed
 4. Update `sidebars.ts` if pages were added or removed
 5. Update `README.md` if top-level feature list or roadmap changed
-6. Run `npm run docs:build` to verify the site builds
-7. Commit with: `docs: update docs site with [description of changes]`
+6. Write or update `RELEASE_SUMMARY.md` for epic promotions
+7. Run `npm run docs:build` to verify the site builds
+8. Commit with: `docs: update docs site with [description of changes]`
 
 Follow the branching strategy in `CLAUDE.md` (feature branches + PRs, never push directly to `main` or `beta`).
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,26 @@ jobs:
             echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Enrich release notes with summary
+        if: >-
+          steps.semantic.outputs.new-release-published == 'true' &&
+          steps.semantic.outputs.is-prerelease == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.semantic.outputs.new-release-version }}"
+          if [ ! -f RELEASE_SUMMARY.md ]; then
+            echo "No RELEASE_SUMMARY.md found — keeping auto-generated notes"
+            exit 0
+          fi
+
+          echo "Prepending RELEASE_SUMMARY.md to release v${VERSION}"
+          SUMMARY=$(cat RELEASE_SUMMARY.md)
+          EXISTING=$(gh release view "v${VERSION}" --json body --jq '.body')
+
+          COMBINED=$(printf '%s\n\n---\n\n%s' "$SUMMARY" "$EXISTING")
+          echo "$COMBINED" | gh release edit "v${VERSION}" --notes-file -
+
   # ---------------------------------------------------------------------------
   # Job 2: Docker Build & Push
   # ---------------------------------------------------------------------------
@@ -215,3 +235,29 @@ jobs:
             --head main \
             --title "chore: merge main (v${VERSION}) back into beta" \
             --body "Syncs the v${VERSION} release tag from main into beta so semantic-release correctly bumps to the next version."
+
+  # ---------------------------------------------------------------------------
+  # Job 5: Push README.md to DockerHub
+  # ---------------------------------------------------------------------------
+  dockerhub-readme:
+    name: DockerHub README
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: >-
+      needs.release.outputs.new-release-published == 'true' &&
+      needs.release.outputs.is-prerelease == 'false'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Push README to DockerHub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: steilerdev/cornerstone
+          readme-filepath: ./README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ All agents must clearly identify themselves:
   12. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`
 
 - **Epic-level steps** (after all stories in an epic are complete, merged to `beta`, and refinement is done):
-  1. **Documentation**: Launch `docs-writer` to update the docs site (`docs/`) and `README.md` with newly shipped features. Commit to `beta`.
+  1. **Documentation**: Launch `docs-writer` to update the docs site (`docs/`), `README.md`, and `RELEASE_SUMMARY.md` with newly shipped features. Commit to `beta`.
   2. **Epic promotion**: Create a PR from `beta` to `main` using a **merge commit** (not squash): `gh pr create --base main --head beta --title "..." --body "..."`
      a. Post UAT validation criteria and manual testing steps as comments on the promotion PR — this gives the user a single place to review what was built and how to validate it
      b. Wait for all CI checks to pass on the PR. If any check fails, investigate and resolve before proceeding
@@ -248,6 +248,8 @@ Cornerstone uses a two-tier release model:
 - **`beta` -> `main`** (epic promotion): Merge commit (preserves individual commits so semantic-release can analyze them)
 
 - **Merge-back after promotion:** `release.yml` automates a `main` → `beta` PR after each epic promotion. If it fails, manually resolve so the stable tag is reachable from beta's history.
+- **Release summary enrichment:** On stable releases, `release.yml` prepends `RELEASE_SUMMARY.md` (if present) to the auto-generated changelog on the GitHub Release. The `docs-writer` agent writes this file during epic promotion. If the file is absent (e.g., hotfix releases), the auto-generated notes remain untouched.
+- **DockerHub README sync:** On stable releases, `release.yml` pushes `README.md` to the DockerHub repository description via `peter-evans/dockerhub-description@v4`.
 - **Hotfixes:** Cherry-pick any `main` hotfix back to `beta` immediately.
 
 ### Branch Protection


### PR DESCRIPTION
## Summary

- **Release summary enrichment**: On stable releases, `release.yml` now prepends `RELEASE_SUMMARY.md` (if present) to the auto-generated changelog on the GitHub Release, giving end users a human-readable summary. Falls back gracefully when the file is absent (e.g., hotfix releases).
- **DockerHub README sync**: New `dockerhub-readme` job pushes `README.md` to the DockerHub repository description on every stable release via `peter-evans/dockerhub-description@v4`.
- **docs-writer agent**: Updated to own `RELEASE_SUMMARY.md` as part of the epic promotion workflow, with format guidelines and quality checklist entry.

## Test plan

- [ ] Verify YAML syntax of `release.yml` is valid
- [ ] Confirm release summary step only runs for stable releases (`is-prerelease == 'false'`)
- [ ] Confirm DockerHub README job depends on `release` + `docker` and only runs for stable releases
- [ ] First real test happens on next stable release (beta → main promotion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)