### PR TITLE
fix(timeline): address non-blocking review polish from EPIC-06 UAT

### DIFF
--- a/client/src/components/GanttChart/GanttTooltip.module.css
+++ b/client/src/components/GanttChart/GanttTooltip.module.css
@@ -3,6 +3,10 @@
  * ============================================================ */
 
 .tooltip {
+  /* Local custom properties for tooltip surface — override in dark mode below */
+  --color-tooltip-subdued: rgba(255, 255, 255, 0.55);
+  --color-tooltip-bullet: rgba(255, 255, 255, 0.4);
+
   position: fixed;
   z-index: var(--z-modal);
   background: var(--color-bg-inverse);
@@ -127,7 +131,7 @@
 .linkedItemsLabel {
   display: block;
   font-size: var(--font-size-xs);
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--color-tooltip-subdued);
   margin-bottom: var(--spacing-1);
 }
 
@@ -153,12 +157,12 @@
   content: '•';
   position: absolute;
   left: 0;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--color-tooltip-bullet);
 }
 
 .linkedItemsOverflow {
   font-size: var(--font-size-xs);
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--color-tooltip-subdued);
   font-style: italic;
   padding-left: var(--spacing-2);
   line-height: 1.5;
@@ -179,6 +183,9 @@
 /* In dark mode, bg-inverse = gray-100 (light), so text and badge colors flip */
 
 [data-theme='dark'] .tooltip {
+  --color-tooltip-subdued: rgba(0, 0, 0, 0.5);
+  --color-tooltip-bullet: rgba(0, 0, 0, 0.3);
+
   background: var(--color-bg-inverse);
   color: var(--color-text-inverse);
 }
@@ -195,20 +202,8 @@
   color: rgba(0, 0, 0, 0.5);
 }
 
-[data-theme='dark'] .linkedItemsLabel {
-  color: rgba(0, 0, 0, 0.5);
-}
-
 [data-theme='dark'] .linkedItem {
   color: var(--color-text-inverse);
-}
-
-[data-theme='dark'] .linkedItem::before {
-  color: rgba(0, 0, 0, 0.3);
-}
-
-[data-theme='dark'] .linkedItemsOverflow {
-  color: rgba(0, 0, 0, 0.4);
 }
 
 [data-theme='dark'] .detailValue {

--- a/client/src/pages/TimelinePage/TimelinePage.module.css
+++ b/client/src/pages/TimelinePage/TimelinePage.module.css
@@ -676,7 +676,7 @@
 }
 
 .dialogMilestoneDateChanged {
-  color: var(--color-warning, var(--color-text-primary));
+  color: var(--color-warning);
   font-weight: var(--font-weight-medium);
 }
 

--- a/client/src/pages/TimelinePage/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage/TimelinePage.tsx
@@ -15,6 +15,7 @@ import {
   COLUMN_WIDTHS,
   COLUMN_WIDTH_MIN,
   COLUMN_WIDTH_MAX,
+  SIDEBAR_WIDTH,
 } from '../../components/GanttChart/ganttUtils.js';
 import type { ScheduledItem, TimelineMilestone } from '@cornerstone/shared';
 import styles from './TimelinePage.module.css';
@@ -429,7 +430,7 @@ export function TimelinePage() {
   // On mount and when zoom changes, compute the responsive default column width
   useEffect(() => {
     const el = chartAreaRef.current;
-    const areaWidth = el ? el.clientWidth - 260 /* sidebar */ : 0; // rough sidebar width
+    const areaWidth = el ? el.clientWidth - SIDEBAR_WIDTH : 0; // sidebar width from ganttUtils
     setColumnWidth(computeDefaultColumnWidth(zoom, areaWidth));
   }, [zoom]);
 

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.module.css
@@ -102,6 +102,14 @@
   opacity: 1;
 }
 
+.secondaryNavButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  opacity: 1;
+  position: relative;
+  z-index: 1;
+}
+
 .headerRow {
   display: flex;
   justify-content: space-between;

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -138,6 +138,9 @@
   --color-danger-text-on-light: var(--color-red-700);
   --color-danger-input-border: var(--color-red-400);
 
+  /* --- Warning (orange/amber) --- */
+  --color-warning: var(--color-orange-400);
+
   /* --- Success (green) --- */
   --color-success: var(--color-green-500);
   --color-success-hover: var(--color-green-600);
@@ -414,6 +417,9 @@
   --color-primary-bg: rgba(59, 130, 246, 0.15);
   --color-primary-bg-hover: rgba(59, 130, 246, 0.25);
   --color-primary-badge-text: var(--color-blue-300);
+
+  /* --- Warning --- */
+  --color-warning: var(--color-orange-300);
 
   /* --- Danger / Error --- */
   --color-danger: var(--color-red-400);


### PR DESCRIPTION
## Summary

Addresses 4 non-blocking review observations flagged on PR #267 during the EPIC-06 UAT cycle.

- **Use `SIDEBAR_WIDTH` constant in `TimelinePage.tsx`**: The sidebar width calculation on the chart area used the hardcoded literal `260` instead of the `SIDEBAR_WIDTH` constant exported from `ganttUtils.ts`. Now imports and uses the constant so both are always in sync.

- **Replace hardcoded `rgba()` values in `GanttTooltip.module.css`**: The linked items label, bullet pseudo-element, and overflow text were using raw `rgba(255, 255, 255, ...)` values. Introduced two scoped CSS custom properties (`--color-tooltip-subdued` and `--color-tooltip-bullet`) on `.tooltip` with light-mode defaults, overridden in the `[data-theme='dark']` block. Removes the three now-redundant individual dark-mode overrides for those selectors.

- **Add `--color-warning` semantic token**: `TimelinePage.module.css` referenced `var(--color-warning)` but no such token existed, requiring a `var(--color-text-primary)` fallback. Added `--color-warning` to `tokens.css` as a proper semantic token (`--color-orange-400` in light mode, `--color-orange-300` in dark mode) and removed the fallback from the consuming rule.

- **Add `:focus-visible` to `.secondaryNavButton`**: The "View on Timeline" contextual nav button in `WorkItemDetailPage` was missing a keyboard focus ring. Added a `:focus-visible` rule matching the established pattern used throughout the project (`outline: none; box-shadow: var(--shadow-focus); position: relative; z-index: 1;`).

## Test plan

- [ ] Verify Gantt chart renders correctly and sidebar width calculation remains accurate
- [ ] Hover over a milestone bar in the Gantt chart — tooltip linked items list should display correctly in both light and dark modes
- [ ] Run auto-schedule with milestones that have linked work items — the "New Projected" date column in the confirmation dialog should appear in orange (warning color)
- [ ] Open a work item detail page and use keyboard Tab to reach the "View on Timeline" button — it should show a visible blue focus ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)