### PR TITLE
fix(e2e): update sidebar aria-label to match milestone rows change

### DIFF
--- a/e2e/pages/TimelinePage.ts
+++ b/e2e/pages/TimelinePage.ts
@@ -13,7 +13,7 @@
  *   - Gantt chart: data-testid="gantt-chart", role="img"
  *   - Gantt SVG: data-testid="gantt-svg"
  *   - Gantt sidebar: data-testid="gantt-sidebar"
- *   - Sidebar rows list: role="list", aria-label="Work items"
+ *   - Sidebar rows list: role="list", aria-label="Work items and milestones"
  *   - Sidebar row: data-testid="gantt-sidebar-row-{id}"
  *   - Gantt header: data-testid="gantt-header"
  *   - Gantt skeleton: data-testid="gantt-chart-skeleton"
@@ -146,7 +146,7 @@ export class TimelinePage {
 
     // Gantt sidebar
     this.ganttSidebar = page.getByTestId('gantt-sidebar');
-    this.ganttSidebarRowsList = page.getByRole('list', { name: 'Work items' });
+    this.ganttSidebarRowsList = page.getByRole('list', { name: 'Work items and milestones' });
     this.ganttHeader = page.getByTestId('gantt-header');
 
     // Gantt bars

--- a/e2e/tests/timeline/timeline-responsive.spec.ts
+++ b/e2e/tests/timeline/timeline-responsive.spec.ts
@@ -442,7 +442,7 @@ test.describe('ARIA roles and labels (Scenario 7)', { tag: '@responsive' }, () =
 
       // Sidebar rows list has role=list and aria-label
       await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute('role', 'list');
-      await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute('aria-label', 'Work items');
+      await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute('aria-label', 'Work items and milestones');
     } finally {
       await page.unroute('**/api/timeline');
     }


### PR DESCRIPTION
## Summary
- Update E2E `TimelinePage` Page Object locator from `"Work items"` to `"Work items and milestones"`
- Update E2E responsive test assertion to match
- Fix 3 E2E shard failures (desktop/tablet/mobile) from beta integration run

The sidebar `aria-label` was changed in PR #267 (milestone rows in Gantt sidebar) but the E2E tests weren't updated.

## Test plan
- [ ] E2E shards 5/16, 11/16, 16/16 should now pass (timeline responsive accessibility test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)