### PR TITLE
fix(e2e): format long assertion line in timeline-responsive spec

### DIFF
--- a/e2e/tests/timeline/timeline-responsive.spec.ts
+++ b/e2e/tests/timeline/timeline-responsive.spec.ts
@@ -442,7 +442,10 @@ test.describe('ARIA roles and labels (Scenario 7)', { tag: '@responsive' }, () =
 
       // Sidebar rows list has role=list and aria-label
       await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute('role', 'list');
-      await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute('aria-label', 'Work items and milestones');
+      await expect(timelinePage.ganttSidebarRowsList).toHaveAttribute(
+        'aria-label',
+        'Work items and milestones',
+      );
     } finally {
       await page.unroute('**/api/timeline');
     }


### PR DESCRIPTION
## Summary
- Fixes Prettier formatting violation in `e2e/tests/timeline/timeline-responsive.spec.ts`
- The `aria-label` assertion line exceeded the 100-char line width after updating to `'Work items and milestones'` in PR #269
- This was the cause of the Quality Gates CI failure on the beta integration run

## Test plan
- [ ] `Quality Gates` CI check passes (format check no longer fails)
- [ ] Docker CI may still fail due to transient DHI registry 503 — not related to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)