### PR TITLE
fix(gantt): improve dependency builder readability

### DIFF
--- a/client/src/components/DependencySentenceBuilder/DependencySentenceBuilder.module.css
+++ b/client/src/components/DependencySentenceBuilder/DependencySentenceBuilder.module.css
@@ -24,7 +24,7 @@
 
 /* Inline verb select — styled to look like part of the sentence */
 .verbSelect {
-  padding: 0.25rem 1.5rem 0.25rem 0.375rem;
+  padding: 0.25rem 1rem 0.25rem 0.375rem;
   border: 1px solid var(--color-border-strong);
   border-radius: 0.25rem;
   font-size: var(--font-size-sm);

--- a/client/src/components/WorkItemPicker/WorkItemPicker.tsx
+++ b/client/src/components/WorkItemPicker/WorkItemPicker.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { WorkItemSummary, WorkItemStatus } from '@cornerstone/shared';
 import { listWorkItems } from '../../lib/workItemsApi.js';
-import { StatusBadge } from '../StatusBadge/StatusBadge.js';
+
 import styles from './WorkItemPicker.module.css';
 
 /** Maps work item status values to their CSS custom property for the left-border color. */
@@ -276,7 +276,6 @@ export function WorkItemPicker({
                 onClick={() => handleSelect(item)}
               >
                 <span className={styles.resultTitle}>{item.title}</span>
-                <StatusBadge status={item.status} />
               </button>
             ))}
 


### PR DESCRIPTION
## Summary
- Remove `StatusBadge` from `WorkItemPicker` dropdown results — titles now have the full dropdown width instead of being truncated by status pills
- Compact verb select padding in `DependencySentenceBuilder` to reclaim horizontal space
- Selected items still show the status-colored left border for visual context

## Test plan
- [ ] Open a work item detail page → Dependencies section
- [ ] Click a picker slot in the dependency builder and verify dropdown results show only titles (no status badge pills)
- [ ] Verify selected items still display the status-colored left border
- [ ] Verify verb selects (`finish`/`start`) appear slightly more compact
- [ ] Test on mobile viewport — layout should still stack properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)