### PR TITLE
fix(gantt): improve dependency arrow rendering and add critical path toggle

### DIFF
--- a/client/src/components/GanttChart/GanttArrows.tsx
+++ b/client/src/components/GanttChart/GanttArrows.tsx
@@ -1,6 +1,11 @@
 import { memo, useMemo } from 'react';
 import type { TimelineDependency, DependencyType } from '@cornerstone/shared';
-import { computeArrowPath, computeArrowhead, ARROW_STANDOFF } from './arrowUtils.js';
+import {
+  computeArrowPath,
+  computeArrowhead,
+  ARROW_STANDOFF,
+  ARROWHEAD_SIZE as ARROWHEAD_SIZE_IMPORT,
+} from './arrowUtils.js';
 import type { BarRect } from './arrowUtils.js';
 import { BAR_HEIGHT, BAR_OFFSET_Y, ROW_HEIGHT } from './ganttUtils.js';
 import styles from './GanttArrows.module.css';
@@ -70,13 +75,9 @@ export interface GanttArrowsProps {
 // Arrowhead size
 // ---------------------------------------------------------------------------
 
-const ARROWHEAD_SIZE = 6;
+const ARROWHEAD_SIZE = ARROWHEAD_SIZE_IMPORT;
 const ARROW_STROKE_DEFAULT = 1.5;
 const ARROW_STROKE_CRITICAL = 2;
-const ARROW_STROKE_MILESTONE = 1.5;
-
-/** Dash pattern for milestone linkage arrows. */
-const MILESTONE_ARROW_DASH = '5 3';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -401,28 +402,27 @@ export const GanttArrows = memo(function GanttArrows({
           );
         })}
 
-      {/* Milestone linkage arrows (dashed, rendered above work-item arrows) */}
+      {/* Milestone linkage arrows (same style as default work-item arrows) */}
       {milestoneArrows.map((a) => {
         const arrowhead = computeArrowhead(a.tipX, a.tipY, a.tipDirection, ARROWHEAD_SIZE);
         return (
           <g
             key={a.key}
-            opacity={visible ? 0.65 : 0}
+            opacity={visible ? 0.5 : 0}
             role="graphics-symbol"
             aria-label={a.ariaLabel}
           >
             <path
               d={a.pathD}
-              stroke={colors.milestoneArrow}
-              strokeWidth={ARROW_STROKE_MILESTONE}
-              strokeDasharray={MILESTONE_ARROW_DASH}
-              className={styles.arrowMilestone}
+              stroke={colors.defaultArrow}
+              strokeWidth={ARROW_STROKE_DEFAULT}
+              className={styles.arrowDefault}
               aria-hidden="true"
             />
             <polygon
               points={arrowhead}
-              fill={colors.milestoneArrow}
-              className={styles.arrowheadMilestone}
+              fill={colors.defaultArrow}
+              className={styles.arrowheadDefault}
               aria-hidden="true"
             />
           </g>

--- a/client/src/pages/TimelinePage/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage/TimelinePage.tsx
@@ -150,6 +150,7 @@ const ZOOM_STEP_FACTOR = 0.2; // 20% per step
 export function TimelinePage() {
   const [zoom, setZoom] = useState<ZoomLevel>('month');
   const [showArrows, setShowArrows] = useState(true);
+  const [highlightCriticalPath, setHighlightCriticalPath] = useState(true);
   const { data, isLoading, error, refetch } = useTimeline();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -288,6 +289,45 @@ export function TimelinePage() {
                 title={showArrows ? 'Hide dependency arrows' : 'Show dependency arrows'}
               >
                 <ArrowsIcon active={showArrows} />
+              </button>
+
+              {/* Critical path highlight toggle (icon-only) */}
+              <button
+                type="button"
+                className={`${styles.arrowsToggle} ${highlightCriticalPath ? styles.arrowsToggleActive : ''}`}
+                aria-pressed={highlightCriticalPath}
+                aria-label={
+                  highlightCriticalPath
+                    ? 'Hide critical path highlighting'
+                    : 'Show critical path highlighting'
+                }
+                onClick={() => setHighlightCriticalPath((v) => !v)}
+                title={
+                  highlightCriticalPath
+                    ? 'Hide critical path highlighting'
+                    : 'Show critical path highlighting'
+                }
+                data-testid="critical-path-toggle"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  width="16"
+                  height="16"
+                  fill="none"
+                  aria-hidden="true"
+                  style={{ display: 'block' }}
+                >
+                  {/* Lightning bolt icon for critical path */}
+                  <path
+                    d="M11 2L5 11h4l-1 7 6-9h-4l1-7z"
+                    stroke="currentColor"
+                    strokeWidth={highlightCriticalPath ? 2 : 1.5}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    fill={highlightCriticalPath ? 'currentColor' : 'none'}
+                  />
+                </svg>
               </button>
 
               {/* Zoom level toggle */}
@@ -466,6 +506,7 @@ export function TimelinePage() {
               columnWidth={columnWidth}
               onItemClick={handleItemClick}
               showArrows={showArrows}
+              highlightCriticalPath={highlightCriticalPath}
               onMilestoneClick={() => setShowMilestonePanel(true)}
               onCtrlScroll={(delta) => adjustColumnWidth(delta > 0 ? 1 : -1)}
             />


### PR DESCRIPTION
## Summary

- **Waterfall ordering**: Work items sorted by start date ascending (nulls last) so the Gantt chart reads top-to-bottom chronologically
- **Row-gap arrow routing**: Cross-row dependency arrows route horizontal segments through the 8px gap between row boundaries instead of through bar centers, avoiding collisions with other work items
- **Path-arrowhead fix**: Eliminated the 6px gap between path end and arrowhead base by terminating all paths at `tipX ± ARROWHEAD_SIZE`
- **Unified connector colors**: Milestone arrows now use the same style as default dependency arrows (same color, stroke, opacity, no dashing)
- **Critical path toggle**: New lightning bolt toggle button in the toolbar to show/hide critical path highlighting for a cleaner view

## Test plan

- [x] All 79 arrowUtils unit tests pass with updated assertions for new routing and path-arrowhead connection
- [ ] Visual verification: waterfall ordering, horizontals in row gaps, arrowheads connect to lines, uniform connector colors, critical path toggle works
- [ ] CI quality gates pass (lint, typecheck, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)