### PR TITLE
fix(gantt): refine arrow rendering, critical path styling, and bar labels

### DIFF
--- a/client/src/components/GanttChart/GanttArrows.module.css
+++ b/client/src/components/GanttChart/GanttArrows.module.css
@@ -8,13 +8,37 @@
  * properties that don't rely on color resolution.
  * ============================================================ */
 
+/* Arrow group — captures hover events for the whole arrow */
+.arrowGroup {
+  pointer-events: stroke;
+  cursor: default;
+  transition: opacity var(--transition-normal);
+}
+
+.arrowGroup:hover {
+  opacity: 1 !important;
+}
+
+/* Invisible wider hit-area path for easier hover targeting */
+.arrowHitArea {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 12;
+  pointer-events: stroke;
+}
+
 /* Default (non-critical) connector path */
 .arrowDefault {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  /* Smooth in/out when arrows are toggled */
-  transition: opacity var(--transition-normal);
+  transition:
+    opacity var(--transition-normal),
+    stroke-width var(--transition-fast);
+}
+
+.arrowGroup:hover .arrowDefault {
+  stroke-width: 2.5;
 }
 
 /* Critical path connector path */
@@ -22,7 +46,13 @@
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  transition: opacity var(--transition-normal);
+  transition:
+    opacity var(--transition-normal),
+    stroke-width var(--transition-fast);
+}
+
+.arrowGroup:hover .arrowCritical {
+  stroke-width: 3;
 }
 
 /* Default arrowhead */
@@ -40,10 +70,25 @@
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  transition: opacity var(--transition-normal);
+  transition:
+    opacity var(--transition-normal),
+    stroke-width var(--transition-fast);
+}
+
+.arrowGroup:hover .arrowMilestone {
+  stroke-width: 2.5;
 }
 
 /* Milestone linkage arrowhead */
 .arrowheadMilestone {
+  transition: opacity var(--transition-normal);
+}
+
+/* Dotted critical path connection (no explicit dependency) */
+.arrowDotted {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 4 4;
   transition: opacity var(--transition-normal);
 }

--- a/client/src/components/GanttChart/GanttBar.module.css
+++ b/client/src/components/GanttChart/GanttBar.module.css
@@ -17,17 +17,3 @@
 .rect {
   /* fill is set inline via JS; no CSS fill here */
 }
-
-.label {
-  font-size: var(--font-size-2xs);
-  font-weight: var(--font-weight-medium);
-  fill: var(--color-text-inverse);
-  pointer-events: none;
-  user-select: none;
-}
-
-/* Critical path border overlay (SVG rect drawn over the bar fill). */
-/* stroke color is set inline via JS; this class handles pointer behavior only. */
-.criticalOverlay {
-  pointer-events: none;
-}

--- a/client/src/components/GanttChart/GanttBar.test.tsx
+++ b/client/src/components/GanttChart/GanttBar.test.tsx
@@ -7,7 +7,7 @@
 import { jest, describe, it, expect } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GanttBar } from './GanttBar.js';
-import { BAR_HEIGHT, BAR_OFFSET_Y, ROW_HEIGHT, TEXT_LABEL_MIN_WIDTH } from './ganttUtils.js';
+import { BAR_HEIGHT, BAR_OFFSET_Y, ROW_HEIGHT } from './ganttUtils.js';
 import type { WorkItemStatus } from '@cornerstone/shared';
 
 // CSS modules mocked via identity-obj-proxy
@@ -48,9 +48,6 @@ describe('GanttBar', () => {
 
   it('sets bar rect x attribute correctly', () => {
     const { container } = renderInSvg({ ...DEFAULT_PROPS, x: 150 });
-    // There are two rects: one for clip path, one for the bar itself
-    const rects = container.querySelectorAll('rect');
-    // The visible bar rect has class 'rect' (via CSS module)
     const barRect = container.querySelector('rect.rect');
     expect(barRect).toHaveAttribute('x', '150');
   });
@@ -84,65 +81,6 @@ describe('GanttBar', () => {
     const { container } = renderInSvg(DEFAULT_PROPS);
     const barRect = container.querySelector('rect.rect');
     expect(barRect).toHaveAttribute('rx', '4');
-  });
-
-  // ── Text label ─────────────────────────────────────────────────────────────
-
-  it('shows text label when width >= TEXT_LABEL_MIN_WIDTH', () => {
-    const { container } = renderInSvg({
-      ...DEFAULT_PROPS,
-      width: TEXT_LABEL_MIN_WIDTH,
-      title: 'Foundation Work',
-    });
-    const text = container.querySelector('text');
-    expect(text).toBeInTheDocument();
-    expect(text!.textContent).toBe('Foundation Work');
-  });
-
-  it('hides text label when width < TEXT_LABEL_MIN_WIDTH', () => {
-    const { container } = renderInSvg({
-      ...DEFAULT_PROPS,
-      width: TEXT_LABEL_MIN_WIDTH - 1,
-      title: 'Foundation Work',
-    });
-    const text = container.querySelector('text');
-    expect(text).not.toBeInTheDocument();
-  });
-
-  it('text label x is bar x + 8 (padding)', () => {
-    const barX = 80;
-    const { container } = renderInSvg({ ...DEFAULT_PROPS, x: barX, width: 120 });
-    const text = container.querySelector('text');
-    expect(text).toHaveAttribute('x', String(barX + 8));
-  });
-
-  it('text label y is centered in the row', () => {
-    const rowIndex = 1;
-    const expectedTextY = rowIndex * ROW_HEIGHT + ROW_HEIGHT / 2;
-    const { container } = renderInSvg({ ...DEFAULT_PROPS, rowIndex, width: 120 });
-    const text = container.querySelector('text');
-    expect(text).toHaveAttribute('y', String(expectedTextY));
-  });
-
-  it('text label uses dominantBaseline="central" for vertical centering', () => {
-    const { container } = renderInSvg({ ...DEFAULT_PROPS, width: 120 });
-    const text = container.querySelector('text');
-    expect(text).toHaveAttribute('dominant-baseline', 'central');
-  });
-
-  // ── Clip path ──────────────────────────────────────────────────────────────
-
-  it('renders a clipPath element with correct id', () => {
-    const { container } = renderInSvg({ ...DEFAULT_PROPS, id: 'my-item' });
-    const clipPath = container.querySelector('clipPath');
-    expect(clipPath).toBeInTheDocument();
-    expect(clipPath).toHaveAttribute('id', 'bar-clip-my-item');
-  });
-
-  it('text element references the clip path', () => {
-    const { container } = renderInSvg({ ...DEFAULT_PROPS, id: 'clip-test', width: 120 });
-    const text = container.querySelector('text');
-    expect(text).toHaveAttribute('clip-path', 'url(#bar-clip-clip-test)');
   });
 
   // ── Accessibility ──────────────────────────────────────────────────────────

--- a/client/src/components/GanttChart/GanttBar.tsx
+++ b/client/src/components/GanttChart/GanttBar.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import type { MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { WorkItemStatus } from '@cornerstone/shared';
-import { BAR_HEIGHT, BAR_OFFSET_Y, ROW_HEIGHT, TEXT_LABEL_MIN_WIDTH } from './ganttUtils.js';
+import { BAR_HEIGHT, BAR_OFFSET_Y, ROW_HEIGHT } from './ganttUtils.js';
 import styles from './GanttBar.module.css';
 
 export interface GanttBarProps {
@@ -73,7 +73,6 @@ export const GanttBar = memo(function GanttBar({
 }: GanttBarProps) {
   const rowY = rowIndex * ROW_HEIGHT;
   const barY = rowY + BAR_OFFSET_Y;
-  const clipId = `bar-clip-${id}`;
   const statusLabel = STATUS_LABELS[status];
 
   // Build a descriptive aria-label including dates when available
@@ -81,10 +80,6 @@ export const GanttBar = memo(function GanttBar({
     startDate && endDate ? `, ${startDate} to ${endDate}` : startDate ? `, from ${startDate}` : '';
   const criticalSuffix = isCritical ? ', critical path' : '';
   const ariaLabel = `Work item: ${title}, ${statusLabel}${dateRange}${criticalSuffix}`;
-
-  // Whether to show the text label
-  const showLabel = width >= TEXT_LABEL_MIN_WIDTH;
-  const textY = rowY + ROW_HEIGHT / 2;
 
   function handleClick() {
     onClick?.(id);
@@ -112,11 +107,6 @@ export const GanttBar = memo(function GanttBar({
       data-testid={`gantt-bar-${id}`}
       style={{ cursor: 'pointer' }}
     >
-      {/* Clip path to constrain text within bar bounds */}
-      <clipPath id={clipId}>
-        <rect x={x} y={barY} width={width} height={BAR_HEIGHT} rx={4} />
-      </clipPath>
-
       {/* Bar rectangle */}
       <rect
         x={x}
@@ -125,35 +115,10 @@ export const GanttBar = memo(function GanttBar({
         height={BAR_HEIGHT}
         rx={4}
         fill={fill}
+        stroke={isCritical && criticalBorderColor ? criticalBorderColor : undefined}
+        strokeWidth={isCritical && criticalBorderColor ? 2 : undefined}
         className={styles.rect}
       />
-
-      {/* Critical path left accent stripe */}
-      {isCritical && criticalBorderColor && (
-        <rect
-          x={x}
-          y={barY}
-          width={3}
-          height={BAR_HEIGHT}
-          fill={criticalBorderColor}
-          clipPath={`url(#${clipId})`}
-          className={styles.criticalOverlay}
-          aria-hidden="true"
-        />
-      )}
-
-      {/* Text label inside bar (only when wide enough) */}
-      {showLabel && (
-        <text
-          x={x + 8}
-          y={textY}
-          dominantBaseline="central"
-          clipPath={`url(#${clipId})`}
-          className={styles.label}
-        >
-          {title}
-        </text>
-      )}
     </g>
   );
 });

--- a/client/src/components/GanttChart/GanttChart.tsx
+++ b/client/src/components/GanttChart/GanttChart.tsx
@@ -497,6 +497,7 @@ export function GanttChart({
             <GanttArrows
               dependencies={data.dependencies}
               criticalPathSet={criticalPathSet}
+              criticalPathOrder={highlightCriticalPath ? data.criticalPath : []}
               barRects={barRects}
               workItemTitles={workItemTitles}
               colors={arrowColors}

--- a/client/src/components/GanttChart/arrowUtils.test.ts
+++ b/client/src/components/GanttChart/arrowUtils.test.ts
@@ -173,10 +173,10 @@ describe('computeArrowPath — finish_to_start', () => {
       expect(result.tipY).toBe(expectedCenterY(succ.rowIndex));
     });
 
-    it('pathD starts at M with exit x (right edge + standoff)', () => {
+    it('pathD starts at M with bar right edge (not standoff)', () => {
       const result = computeArrowPath(pred, succ, 'finish_to_start');
-      const exitX = pred.x + pred.width + ARROW_STANDOFF;
-      expect(result.pathD).toMatch(new RegExp(`^M ${exitX}`));
+      const predRightEdge = pred.x + pred.width;
+      expect(result.pathD).toMatch(new RegExp(`^M ${predRightEdge}`));
     });
 
     it('pathD ends at arrowhead base (tipX - ARROWHEAD_SIZE)', () => {
@@ -185,9 +185,9 @@ describe('computeArrowPath — finish_to_start', () => {
       expect(result.pathD).toMatch(new RegExp(`H ${arrowBaseX}$`));
     });
 
-    it('cross-row pathD is a valid 5-segment path (M ... V ... H ... V ... H ...)', () => {
+    it('cross-row pathD is a valid 5-segment path (M ... H ... V ... H ... V ... H ...)', () => {
       const result = computeArrowPath(pred, succ, 'finish_to_start');
-      expect(result.pathD).toMatch(/^M \d+ \d+ V \d+ H \d+ V \d+ H \d+$/);
+      expect(result.pathD).toMatch(/^M \d+ \d+ H \d+ V \d+ H \d+ V \d+ H \d+$/);
     });
 
     it('horizontal channel is at the row boundary between pred and succ', () => {
@@ -231,10 +231,10 @@ describe('computeArrowPath — finish_to_start', () => {
       expect(result.tipX).toBe(succ.x);
     });
 
-    it('C-shape pathD starts at M with exit x (right edge + standoff)', () => {
+    it('C-shape pathD starts at M with bar right edge', () => {
       const result = computeArrowPath(pred, succ, 'finish_to_start');
-      const exitX = pred.x + pred.width + ARROW_STANDOFF;
-      expect(result.pathD).toMatch(new RegExp(`^M ${exitX}`));
+      const predRightEdge = pred.x + pred.width;
+      expect(result.pathD).toMatch(new RegExp(`^M ${predRightEdge}`));
     });
 
     it('C-shape cross-row routes through row-boundary gap', () => {
@@ -258,8 +258,8 @@ describe('computeArrowPath — finish_to_start', () => {
       const pred2 = makeBar(100, 80, 0);
       const succ2 = makeBar(204, 60, 1); // 100 + 80 + 24 = 204
       const result = computeArrowPath(pred2, succ2, 'finish_to_start');
-      // Cross-row: 5-segment path
-      expect(result.pathD).toMatch(/^M \d+ \d+ V \d+ H \d+ V \d+ H \d+$/);
+      // Cross-row: 5-segment path (H-V-H-V-H)
+      expect(result.pathD).toMatch(/^M \d+ \d+ H \d+ V \d+ H \d+ V \d+ H \d+$/);
     });
   });
 
@@ -473,10 +473,9 @@ describe('computeArrowPath — start_to_finish', () => {
       expect(result.tipY).toBe(expectedCenterY(succ.rowIndex));
     });
 
-    it('pathD starts at M with exit x (predecessor left - standoff)', () => {
+    it('pathD starts at M with predecessor left edge', () => {
       const result = computeArrowPath(pred, succ, 'start_to_finish');
-      const exitX = pred.x - ARROW_STANDOFF;
-      expect(result.pathD).toMatch(new RegExp(`^M ${exitX}`));
+      expect(result.pathD).toMatch(new RegExp(`^M ${pred.x}`));
     });
 
     it('pathD ends at arrowhead base (tipX + ARROWHEAD_SIZE for left-pointing)', () => {

--- a/client/src/components/GanttChart/arrowUtils.ts
+++ b/client/src/components/GanttChart/arrowUtils.ts
@@ -122,6 +122,8 @@ function computeFSArrow(predecessor: BarRect, successor: BarRect, arrowIndex: nu
 
   const sameRow = predecessor.rowIndex === successor.rowIndex;
 
+  const predRightEdge = predecessor.x + predecessor.width;
+
   if (entryX >= exitX) {
     if (sameRow) {
       // Same-row: simple 3-segment path
@@ -133,11 +135,10 @@ function computeFSArrow(predecessor: BarRect, successor: BarRect, arrowIndex: nu
         tipDirection: 'right',
       };
     }
-    // Cross-row standard: 5-segment path through row-boundary gap
+    // Cross-row standard: 5-segment path (H-V-H-V-H) through row-boundary gap
     const chY = channelY(predecessor.rowIndex, successor.rowIndex);
-    const spineX = entryX - stagger;
     return {
-      pathD: `M ${exitX} ${srcY} V ${chY} H ${spineX} V ${dstY} H ${arrowBaseX}`,
+      pathD: `M ${predRightEdge} ${srcY} H ${exitX + stagger} V ${chY} H ${entryX} V ${dstY} H ${arrowBaseX}`,
       tipX,
       tipY,
       tipDirection: 'right',
@@ -152,8 +153,9 @@ function computeFSArrow(predecessor: BarRect, successor: BarRect, arrowIndex: nu
     const pathD = `M ${exitX} ${srcY} H ${spineX} V ${bypassY} H ${entryX} V ${dstY} H ${arrowBaseX}`;
     return { pathD, tipX, tipY, tipDirection: 'right' };
   }
+  // Cross-row C-shape: 5-segment path (H-V-H-V-H) through row-boundary gap
   const chY = channelY(predecessor.rowIndex, successor.rowIndex);
-  const pathD = `M ${exitX} ${srcY} V ${chY} H ${entryX} V ${dstY} H ${arrowBaseX}`;
+  const pathD = `M ${predRightEdge} ${srcY} H ${spineX} V ${chY} H ${entryX} V ${dstY} H ${arrowBaseX}`;
   return { pathD, tipX, tipY, tipDirection: 'right' };
 }
 
@@ -259,10 +261,10 @@ function computeSFArrow(predecessor: BarRect, successor: BarRect): ArrowPath {
         tipDirection: 'left',
       };
     }
-    // Cross-row: 5-segment path through row-boundary gap
+    // Cross-row: 5-segment path (H-V-H-V-H) through row-boundary gap
     const chY = channelY(predecessor.rowIndex, successor.rowIndex);
     return {
-      pathD: `M ${exitX} ${srcY} V ${chY} H ${entryX} V ${dstY} H ${arrowBaseX}`,
+      pathD: `M ${predecessor.x} ${srcY} H ${exitX} V ${chY} H ${entryX} V ${dstY} H ${arrowBaseX}`,
       tipX,
       tipY,
       tipDirection: 'left',


### PR DESCRIPTION
## Summary

- **Arrow hover highlight**: dependency arrows now highlight on hover with increased opacity and stroke width; invisible 12px hit area for easier targeting
- **Critical path border**: bars on the critical path show a 2px colored border instead of the previous left accent stripe
- **No bar labels**: text labels removed from Gantt bar pills (title shown via sidebar and tooltip)
- **Consistent 5-segment routing**: all cross-row arrow types (FS, SS, FF, SF) now use the same H-V-H-V-H routing pattern through row-boundary gaps
- **Dotted implicit connections**: when critical path highlighting is enabled, consecutive critical path items without an explicit dependency are connected by a dotted line in the critical path color

## Test plan

- [x] Updated `arrowUtils.test.ts` to match new 5-segment path patterns for FS and SF
- [x] Updated `GanttBar.test.tsx` to remove label/clipPath assertions
- [ ] Verify hover highlighting visually on dependency arrows
- [ ] Verify critical path border styling on bars
- [ ] Verify dotted connections appear between unlinked critical path items
- [ ] Verify dotted connections disappear when critical path toggle is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)