### PR TITLE
feat(skills): add multi-item support to /develop skill

### DIFF
--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -1,23 +1,37 @@
 ---
 name: develop
-description: 'Full development cycle for a single user story or bug fix. Covers implementation, testing, PR, review, merge, and user verification.'
+description: 'Full development cycle for one or more user stories and/or bug fixes. Covers implementation, testing, PR, review, merge, and user verification — single items or batched into one PR.'
 ---
 
 # Develop — Story & Bug Fix Workflow
 
-You are the orchestrator running a full development cycle for a single user story or bug fix. Follow these 11 steps in order. **Do NOT skip steps.** The orchestrator delegates all work — never write production code, tests, or architectural artifacts directly.
+You are the orchestrator running a full development cycle for one or more user stories and/or bug fixes. Follow these 11 steps in order. **Do NOT skip steps.** The orchestrator delegates all work — never write production code, tests, or architectural artifacts directly.
 
-**When to use:** Implementing a single user story from an epic, or fixing an isolated bug/defect/UAT failure.
+**When to use:** Implementing a single user story, fixing an isolated bug, or bundling multiple small items (bugs and/or stories) into a single development session and PR.
 **When NOT to use:** Planning a new epic (use `/epic-start`). Closing an epic after all stories are done (use `/epic-close`).
 
 ## Input
 
-`$ARGUMENTS` contains either:
+`$ARGUMENTS` contains one of the following:
 
-- A **GitHub Issue number** (existing story or bug), OR
+- A **GitHub Issue number** (e.g., `#42` or `42`)
 - A **bug description** (PO will create the issue)
+- A **semicolon-separated list** of issue numbers and/or descriptions (e.g., `#42; #55`, `42; the login page crashes`, `#42; #55; the budget total is wrong`)
+- A **file path** prefixed with `@` (e.g., `@/tmp/bugs.txt`) — the file contains one item per line (issue number or description); empty lines and lines starting with `#` are ignored
 
-If empty, ask the user to provide an issue number or describe the bug before proceeding.
+If empty, ask the user to provide an issue number, description, or list before proceeding.
+
+### Mode Detection
+
+After parsing `$ARGUMENTS`:
+
+1. **Parse entries**: Split by `;` for inline input, or read lines from the `@`-prefixed file path. Trim each entry.
+2. **Classify each entry**: Digits (with optional `#` prefix) → issue number. Everything else → description.
+3. **Determine mode**:
+   - **1 entry** → **single-item mode** (existing flow)
+   - **2+ entries** → **multi-item mode** (batched flow)
+
+In multi-item mode, maintain an ordered **items list** throughout the workflow. Each item tracks: issue number, title, label (`user-story` or `bug`), and source (existing issue or newly created).
 
 ## Steps
 
@@ -31,7 +45,9 @@ git fetch origin beta && git rebase origin/beta
 
 If already rebased at session start, skip.
 
-### 2. Resolve Issue
+### 2. Resolve Issues
+
+#### Single-item mode
 
 Determine if `$ARGUMENTS` is an issue number or a description:
 
@@ -57,7 +73,30 @@ Confirm the issue exists, note its labels (`user-story` or `bug`), and proceed t
 
 **Important:** Do NOT create the GitHub Issue until the user explicitly approves the spec.
 
+#### Multi-item mode
+
+Process each entry in the items list:
+
+1. **Issue numbers**: Resolve each with `gh issue view <number>`. Record title, labels, and acceptance criteria.
+2. **Descriptions**: For each description entry, launch the **product-owner** agent to draft a spec (same format as single-item). Present each spec to the user for approval.
+   - **Approved**: Create a GitHub Issue immediately (labeled `bug` or `user-story`), add to Projects board, link to parent epic if applicable. Record the new issue number in the items list.
+   - **Rejected**: Drop the item from the items list.
+
+If all items are rejected, abort the session. If at least one remains, continue.
+
+Print a summary table before proceeding:
+
+```
+| #   | Issue | Title                          | Label      |
+| --- | ----- | ------------------------------ | ---------- |
+| 1   | #42   | Tooltip positioning is wrong   | bug        |
+| 2   | #55   | Budget rounding error          | bug        |
+| 3   | #61   | Add export button to Gantt     | user-story |
+```
+
 ### 3. Visual Spec (conditional)
+
+#### Single-item mode
 
 **Skip this step for bug fixes** (issues labeled `bug`).
 
@@ -65,34 +104,66 @@ If the story touches UI (`client/src/`), launch the **ux-designer** to post a st
 
 Skip for backend-only stories (no `client/src/` changes expected).
 
+#### Multi-item mode
+
+Run for any UI-touching stories (`user-story` label) in the items list. Launch the **ux-designer** once, covering all UI stories in the batch, posting specs on each story's GitHub Issue.
+
+Skip entirely if all items are bugs or all are backend-only.
+
 ### 4. Branch
+
+#### Single-item mode
 
 Rename the worktree branch based on the issue label:
 
 - `user-story` label → `git branch -m feat/<issue-number>-<short-description>`
 - `bug` label → `git branch -m fix/<issue-number>-<short-description>`
 
+#### Multi-item mode
+
+Determine the branch type and name:
+
+- **All bugs** → `fix/<lowest-issue>-<highest-issue>-<short-description>`
+- **Any stories** → `feat/<lowest-issue>-<highest-issue>-<short-description>`
+
+Where `<lowest-issue>` and `<highest-issue>` are the smallest and largest issue numbers in the batch, and `<short-description>` is a brief summary of the batch (e.g., `gantt-budget-fixes`).
+
 Skip if the branch is already named correctly.
 
 ### 5. Move to In Progress
 
-Move the issue to **In Progress** on the Projects board:
+Move the issue(s) to **In Progress** on the Projects board.
+
+#### Single-item mode
 
 ```bash
 ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
 gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "296eeabe" } }) { clientMutationId } }'
 ```
 
+#### Multi-item mode
+
+Run the same GraphQL mutation for **each issue** in the items list.
+
 ### 6. Implement + Test (parallel)
 
 Launch agents in parallel:
 
+#### Single-item mode
+
 - **Developer(s)**: Launch `backend-developer` and/or `frontend-developer` — in parallel if the work spans both layers, single agent if isolated to one. Frontend developers reference the ux-designer's visual spec (if posted in step 3). Both use the specification from the Github issue created for this task.
 - **QA**: Launch `qa-integration-tester` to write unit tests (95%+ coverage target) and integration tests covering the acceptance criteria in the Github issue.
 
+#### Multi-item mode
+
+- **Developer(s)**: Launch `backend-developer` and/or `frontend-developer` with the **full items list** — all issue numbers, titles, and acceptance criteria. Instruct them to address all items in a single implementation pass.
+- **QA**: Launch `qa-integration-tester` with the full items list. Tests must cover acceptance criteria from **all** issues in the batch.
+
 ### 7. Commit & PR
 
-Stage and commit all changes (the pre-commit hook runs all quality gates automatically). Push the branch and create a PR targeting `beta`:
+Stage and commit all changes (the pre-commit hook runs all quality gates automatically). Push the branch and create a PR targeting `beta`.
+
+#### Single-item mode
 
 ```bash
 gh pr create --base beta --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
@@ -113,6 +184,39 @@ EOF
 
 Include `Fixes #<issue-number>` in the PR body. Use `feat(scope):` for stories, `fix(scope):` for bugs.
 
+#### Multi-item mode
+
+**PR title**: Descriptive conventional commit summary with issue refs:
+
+- **All bugs** → `fix(<scope>): <description> (#42, #55)`
+- **Any stories** → `feat(<scope>): <description> (#42, #55, #61)`
+
+Scope is optional but encouraged — cover the affected areas (e.g., `gantt, budget`).
+
+**PR body**: Per-item summary bullets, then one `Fixes #N` line per issue:
+
+```bash
+gh pr create --base beta --title "<type>(<scope>): <description> (#42, #55)" --body "$(cat <<'EOF'
+## Summary
+
+- **#42** — Fixed tooltip positioning in Gantt chart
+- **#55** — Corrected budget rounding for decimal values
+- **#61** — Added export button to Gantt toolbar
+
+Fixes #42
+Fixes #55
+Fixes #61
+
+## Test plan
+- [ ] Unit tests pass (95%+ coverage on all items)
+- [ ] Integration tests pass
+- [ ] Pre-commit hook quality gates pass
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
 ### 8. CI + Review (parallel)
 
 Launch CI watch and agent reviews **at the same time**:
@@ -121,10 +225,12 @@ Launch CI watch and agent reviews **at the same time**:
 - **Reviews** (launch in parallel - make sure to keep the review short if the changes are minimal):
   - `product-architect` — architecture compliance, test coverage, code quality
   - `security-engineer` — OWASP Top 10 review, input validation, auth gaps
-  - `product-owner` — requirements coverage, acceptance criteria (stories only, skip for bugs)
+  - `product-owner` — requirements coverage, acceptance criteria (**stories only**; skip if all items are bugs)
   - `ux-designer` — token adherence, visual consistency, accessibility (only for PRs touching `client/src/`, skip otherwise)
 
 Review results are posted as **comments on the PR**. All review agents must prefix their comments with their agent name (e.g., `**[product-architect]**`).
+
+In multi-item mode, reviewers must validate that **all items** in the batch are addressed.
 
 If CI fails, fix the issues on the branch and push again.
 
@@ -153,16 +259,28 @@ After the PR is merged, present the user with:
    ```
    gh run list --limit 5
    ```
-4. **Implementation summary**: A concise summary of what was changed, which files were modified, and how the issue was resolved
+4. **Implementation summary**: A concise summary of what was changed, which files were modified, and how the issue(s) were resolved
+
+In multi-item mode, present a **per-item summary table**:
+
+```
+| Issue | Title                          | Status   |
+| ----- | ------------------------------ | -------- |
+| #42   | Tooltip positioning is wrong   | Resolved |
+| #55   | Budget rounding error          | Resolved |
+| #61   | Add export button to Gantt     | Resolved |
+```
 
 Ask the user to verify the changes. Wait for explicit confirmation:
 
 - **User confirms** → proceed to step 11
 - **User reports issues** → take the user's feedback as new input and loop back to **step 6** (Implement + Test) on a new branch to address it
 
-### 11. Close Issue & Clean Up
+### 11. Close Issues & Clean Up
 
 After user confirmation:
+
+#### Single-item mode
 
 1. Close the issue:
    ```
@@ -173,6 +291,22 @@ After user confirmation:
    ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
    gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "c558f50d" } }) { clientMutationId } }'
    ```
+3. Clean up the branch:
+   ```
+   git checkout beta && git pull && git branch -d <branch-name>
+   ```
+4. Exit the session and remove the worktree:
+   ```
+   /exit
+   ```
+
+#### Multi-item mode
+
+1. Close **each issue** in the items list:
+   ```
+   gh issue close <issue-number>
+   ```
+2. Move **each issue** to **Done** on the Projects board (run the GraphQL mutation for each).
 3. Clean up the branch:
    ```
    git checkout beta && git pull && git branch -d <branch-name>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,15 +88,15 @@ The GitHub Projects board uses 4 statuses: Backlog, Todo, In Progress, Done. All
 
 The orchestrator uses three skills to drive work. Each skill contains the full operational checklist with exact commands and agent coordination. The orchestrator delegates all work — never writes production code, tests, or architectural artifacts directly.
 
-| Skill         | Purpose                                                                              | Input                            |
-| ------------- | ------------------------------------------------------------------------------------ | -------------------------------- |
-| `/epic-start` | Planning: PO creates stories, architect designs schema/API/ADRs                      | Epic description or issue number |
-| `/develop`    | Full dev cycle for one story or bug fix (implement, test, PR, review, merge, verify) | Issue number or bug description  |
-| `/epic-close` | Refinement, E2E validation, UAT, docs, promotion to `main`                           | Epic issue number                |
+| Skill         | Purpose                                                                    | Input                                                           |
+| ------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `/epic-start` | Planning: PO creates stories, architect designs schema/API/ADRs            | Epic description or issue number                                |
+| `/develop`    | Full dev cycle for one or more stories/bug fixes, bundled into a single PR | Issue number, description, semicolon-separated list, or `@file` |
+| `/epic-close` | Refinement, E2E validation, UAT, docs, promotion to `main`                 | Epic issue number                                               |
 
 ## Acceptance & Validation
 
-Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story PR. **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT with user, docs update, promotion.
+Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story/bug PR (single items or batched). **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT with user, docs update, promotion.
 
 ### Key Rules
 
@@ -154,7 +154,7 @@ All agents must clearly identify themselves:
 
 **NEVER `cd` to the base project directory to modify files.** All file edits, git operations, and commands must be performed from within the git worktree assigned at session start. The base project directory may have other sessions' uncommitted changes. This applies to subagents too — all file reads, writes, and exploration must use the worktree path.
 
-See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story) → `/epic-close` (once per epic after all stories merged).
+See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story, or batched for multiple small items) → `/epic-close` (once per epic after all stories merged).
 
 Note: Dependabot auto-merge (`.github/workflows/dependabot-auto-merge.yml`) targets `beta` — it handles automated dependency updates, not agent work.
 


### PR DESCRIPTION
## Summary

- Add multi-item support to the `/develop` skill, allowing multiple bugs and/or stories to be bundled into a single development session and PR
- Support semicolon-separated inline lists (`#42; #55`) and file-based input (`@/tmp/bugs.txt`)
- Update CLAUDE.md skill table, lifecycle description, and acceptance section to reflect batching capability

## Test plan
- [ ] Invoke `/develop #42; #55` with two existing issues to test inline multi-item flow
- [ ] Invoke `/develop @/tmp/bugs.txt` with a file to test file-based input
- [ ] Invoke `/develop #42` with a single issue to confirm single-item mode unchanged

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>