### PR TITLE
fix(scheduling): recompute end date from duration for root nodes

### DIFF
--- a/server/src/services/schedulingEngine.ts
+++ b/server/src/services/schedulingEngine.ts
@@ -504,12 +504,19 @@ export function schedule(params: ScheduleParams): ScheduleResult {
     }
 
     // Compute EF from ES + duration.
-    // Exception: for non-completed root nodes with an explicit endDate, use that
-    // endDate as EF to preserve user-set dates when duration is unset or implicit.
-    // This prevents auto-reschedule from overwriting an explicit endDate with es+0
-    // when durationDays is null.
+    // Exception: for non-completed root nodes with an explicit endDate AND no explicit
+    // durationDays, use that endDate as EF to preserve user-set dates when duration is
+    // unset or implicit. This prevents auto-reschedule from overwriting an explicit
+    // endDate with es+0 when durationDays is null.
+    // When durationDays IS set, always compute EF = addDays(es, duration) so that
+    // changing durationDays is reflected in the scheduled end date.
     let ef: string;
-    if (isNonCompletedRoot && item.endDate != null && item.endDate >= es) {
+    if (
+      isNonCompletedRoot &&
+      item.endDate != null &&
+      item.endDate >= es &&
+      (item.durationDays === null || item.durationDays === undefined)
+    ) {
       ef = item.endDate;
     } else {
       ef = addDays(es, duration);


### PR DESCRIPTION
## Summary
- Root nodes with explicit endDate were preserving the old endDate even when durationDays changed, because the scheduling engine's EF computation skipped `addDays(es, duration)` for non-completed root nodes with an existing endDate
- Fixed by adding a `durationDays === null` check to the condition — only preserve explicit endDate when no duration is set
- Added 3 new unit tests: EF computed from duration (not stale endDate), endDate preservation when duration is null (regression), and duration change propagation

Fixes #319

## Test plan
- [ ] New unit tests verify duration changes affect EF for root nodes
- [ ] Regression test ensures endDate preservation when duration is null
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>