### PR TITLE
feat(household-items): household item detail page (#391)

### DIFF
--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.module.css
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.module.css
@@ -269,9 +269,9 @@
 }
 
 .deliveryStep {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
+  border-radius: var(--radius-circle);
   background-color: var(--color-bg-tertiary);
   border: 2px solid var(--color-border-strong);
   margin-bottom: var(--spacing-2);
@@ -286,7 +286,7 @@
 
 .deliveryLine {
   position: absolute;
-  top: 11px;
+  top: 11px; /* half of step circle (spacing-6 / 2 - line height / 2) */
   left: 50%;
   width: 100%;
   height: 2px;
@@ -389,7 +389,7 @@
   background-color: var(--color-danger-bg);
   border: 1px solid var(--color-danger-border);
   border-radius: var(--radius-md);
-  color: var(--color-danger-active);
+  color: var(--color-danger-text-on-light);
   padding: var(--spacing-3);
   font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-4);
@@ -460,7 +460,7 @@
 }
 
 .editButton:hover {
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-bg-hover);
 }
 
 .editButton:focus-visible {
@@ -715,10 +715,30 @@
 }
 
 /* ============================================================
- * RESPONSIVE — Tablet (768px – 1024px)
+ * ACCESSIBILITY — Reduced Motion
  * ============================================================ */
 
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .secondaryButton,
+  .editButton,
+  .deleteButton,
+  .cancelButton,
+  .confirmDeleteButton,
+  .deliveryStep,
+  .deliveryLine,
+  .backLink,
+  .infoLink,
+  .workItemLink {
+    transition: none;
+  }
+}
+
+/* ============================================================
+ * RESPONSIVE — Tablet (768px – 1023px)
+ * ============================================================ */
+
+@media (min-width: 768px) and (max-width: 1023px) {
   .container {
     padding: var(--spacing-6);
   }

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import type * as HouseholdItemsApiTypes from '../../lib/householdItemsApi.js';
@@ -127,6 +127,15 @@ describe('HouseholdItemDetailPage', () => {
       renderPage();
 
       expect(screen.getByText('Loading household item...')).toBeInTheDocument();
+    });
+
+    it('loading state has status role for accessibility', async () => {
+      // Don't resolve the API call immediately
+      mockGetHouseholdItem.mockReturnValue(new Promise(() => {}));
+      renderPage();
+
+      const loadingEl = screen.getByText('Loading household item...');
+      expect(loadingEl).toHaveAttribute('role', 'status');
     });
 
     it('calls getHouseholdItem with the correct id', async () => {
@@ -394,6 +403,10 @@ describe('HouseholdItemDetailPage', () => {
       });
 
       expect(screen.queryByRole('link', { name: 'IKEA' })).not.toBeInTheDocument();
+      // Vendor row is still rendered with "—" placeholder
+      expect(screen.getByText('Vendor')).toBeInTheDocument();
+      const dashValues = screen.getAllByText('\u2014');
+      expect(dashValues.length).toBeGreaterThan(0);
     });
 
     it('shows dash for missing URL', async () => {
@@ -406,6 +419,10 @@ describe('HouseholdItemDetailPage', () => {
       });
 
       expect(screen.queryByRole('link', { name: /https:\/\/example.com/ })).not.toBeInTheDocument();
+      // Product URL row is still rendered with "—" placeholder
+      expect(screen.getByText('Product URL')).toBeInTheDocument();
+      const dashValues = screen.getAllByText('\u2014');
+      expect(dashValues.length).toBeGreaterThan(0);
     });
 
     it('shows "No tags" for empty tags array', async () => {
@@ -735,6 +752,29 @@ describe('HouseholdItemDetailPage', () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       });
     });
+
+    it('closes delete modal on Escape key', async () => {
+      const user = userEvent.setup();
+      mockGetHouseholdItem.mockResolvedValue(makeItem());
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('linked work items display', () => {
@@ -776,6 +816,22 @@ describe('HouseholdItemDetailPage', () => {
   });
 
   describe('delivery progress indicator', () => {
+    it('renders delivery progress with accessible list semantics', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem());
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Standing Desk' })).toBeInTheDocument();
+      });
+
+      const progressList = screen.getByRole('list', { name: /delivery progress/i });
+      expect(progressList).toBeInTheDocument();
+
+      const steps = within(progressList).getAllByRole('listitem');
+      expect(steps).toHaveLength(4);
+    });
+
     it('shows correct progress for "ordered" status', async () => {
       mockGetHouseholdItem.mockResolvedValue(
         makeItem({ status: 'ordered' as HouseholdItemStatus }),

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import type {
   HouseholdItemDetail,
@@ -39,12 +39,46 @@ export function HouseholdItemDetailPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState('');
+  const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!id) return;
     void loadItem();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
+
+  useEffect(() => {
+    if (!showDeleteModal) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        closeDeleteModal();
+        return;
+      }
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        const focusableArray = Array.from(focusable);
+        if (focusableArray.length === 0) return;
+        const firstEl = focusableArray[0];
+        const lastEl = focusableArray[focusableArray.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === firstEl) {
+            e.preventDefault();
+            lastEl.focus();
+          }
+        } else {
+          if (document.activeElement === lastEl) {
+            e.preventDefault();
+            firstEl.focus();
+          }
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showDeleteModal, isDeleting, deleteError]);
 
   const loadItem = async () => {
     if (!id) return;
@@ -104,7 +138,9 @@ export function HouseholdItemDetailPage() {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loading}>Loading household item...</div>
+        <div className={styles.loading} role="status">
+          Loading household item...
+        </div>
       </div>
     );
   }
@@ -199,20 +235,22 @@ export function HouseholdItemDetailPage() {
               <dt className={styles.infoLabel}>Description</dt>
               <dd className={styles.infoValue}>{item.description ?? '\u2014'}</dd>
             </div>
-            {item.vendor && (
-              <div className={styles.infoRow}>
-                <dt className={styles.infoLabel}>Vendor</dt>
-                <dd className={styles.infoValue}>
+            <div className={styles.infoRow}>
+              <dt className={styles.infoLabel}>Vendor</dt>
+              <dd className={styles.infoValue}>
+                {item.vendor ? (
                   <Link to={`/budget/vendors/${item.vendor.id}`} className={styles.infoLink}>
                     {item.vendor.name}
                   </Link>
-                </dd>
-              </div>
-            )}
-            {item.url && (
-              <div className={styles.infoRow}>
-                <dt className={styles.infoLabel}>Product URL</dt>
-                <dd className={styles.infoValue}>
+                ) : (
+                  '\u2014'
+                )}
+              </dd>
+            </div>
+            <div className={styles.infoRow}>
+              <dt className={styles.infoLabel}>Product URL</dt>
+              <dd className={styles.infoValue}>
+                {item.url ? (
                   <a
                     href={item.url}
                     target="_blank"
@@ -221,9 +259,11 @@ export function HouseholdItemDetailPage() {
                   >
                     {item.url}
                   </a>
-                </dd>
-              </div>
-            )}
+                ) : (
+                  '\u2014'
+                )}
+              </dd>
+            </div>
             <div className={styles.infoRow}>
               <dt className={styles.infoLabel}>Room</dt>
               <dd className={styles.infoValue}>{item.room ?? '\u2014'}</dd>
@@ -257,7 +297,7 @@ export function HouseholdItemDetailPage() {
             <h2 className={styles.cardTitle}>Dates & Delivery</h2>
           </div>
           <div className={styles.deliveryProgressContainer}>
-            <div className={styles.deliveryProgress}>
+            <ol className={styles.deliveryProgress} aria-label="Delivery progress">
               {(['not_ordered', 'ordered', 'in_transit', 'delivered'] as const).map(
                 (stepStatus, index) => {
                   const stepLabels = {
@@ -276,9 +316,14 @@ export function HouseholdItemDetailPage() {
 
                   const currentStatusIndex = statusOrder[item.status];
                   const isActive = statusOrder[stepStatus] <= currentStatusIndex;
+                  const isCurrent = stepStatus === item.status;
 
                   return (
-                    <div key={stepStatus} className={styles.deliveryStepWrapper}>
+                    <li
+                      key={stepStatus}
+                      className={styles.deliveryStepWrapper}
+                      {...(isCurrent ? { 'aria-current': 'step' as const } : {})}
+                    >
                       <div
                         className={`${styles.deliveryStep} ${isActive ? styles.deliveryStepActive : ''}`}
                       />
@@ -288,11 +333,11 @@ export function HouseholdItemDetailPage() {
                         />
                       )}
                       <div className={styles.deliveryStepLabel}>{stepLabels[stepStatus]}</div>
-                    </div>
+                    </li>
                   );
                 },
               )}
-            </div>
+            </ol>
           </div>
           <dl className={styles.infoList}>
             <div className={styles.infoRow}>
@@ -365,7 +410,7 @@ export function HouseholdItemDetailPage() {
           aria-labelledby="delete-modal-title"
         >
           <div className={styles.modalBackdrop} onClick={closeDeleteModal} />
-          <div className={styles.modalContent}>
+          <div className={styles.modalContent} ref={modalRef}>
             <h2 id="delete-modal-title" className={styles.modalTitle}>
               Delete Household Item
             </h2>


### PR DESCRIPTION
## Summary
- Implements the full Household Item Detail Page with read-only view of all item properties
- Organized in sections: Details (description, vendor, URL, room, quantity, tags), Dates & Delivery (4-step progress indicator), Linked Work Items, and Metadata
- Includes delete confirmation modal, loading/error/404 states, and breadcrumb navigation
- 45 unit tests covering all states, interactions, and edge cases

Fixes #391

## Test plan
- [ ] All 45 unit tests pass
- [ ] Pre-commit hook quality gates pass
- [ ] CI Quality Gates pass
- [ ] Detail page renders correctly for items with all fields populated
- [ ] Detail page shows "—" for optional null fields
- [ ] Delete flow works with confirmation modal
- [ ] 404 state shows for non-existent items
- [ ] Vendor link navigates to vendor detail page
- [ ] Work item links navigate to work item detail pages

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>