### PR TITLE
fix(household-items): transform status values during table rebuild in migration 0014

### DIFF
--- a/server/src/db/migrations/0014_rename_hi_status_values.sql
+++ b/server/src/db/migrations/0014_rename_hi_status_values.sql
@@ -9,13 +9,7 @@
 -- SQLite does not support ALTER TABLE ... MODIFY CONSTRAINT.
 -- We must rebuild the table with a new CHECK constraint.
 
--- Step 1: Rename existing values before rebuilding
-UPDATE household_items SET status = 'planned'   WHERE status = 'not_ordered';
-UPDATE household_items SET status = 'purchased'  WHERE status = 'ordered';
-UPDATE household_items SET status = 'scheduled'  WHERE status = 'in_transit';
-UPDATE household_items SET status = 'arrived'    WHERE status = 'delivered';
-
--- Step 2: Rebuild table with new CHECK constraint
+-- Step 1: Rebuild table with new CHECK constraint (values transformed during copy)
 CREATE TABLE household_items_new (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
@@ -39,15 +33,24 @@ CREATE TABLE household_items_new (
 );
 
 INSERT INTO household_items_new
-  SELECT id, name, description, category, status, vendor_id, url, room,
-         quantity, order_date, expected_delivery_date, actual_delivery_date,
-         earliest_delivery_date, latest_delivery_date, created_by, created_at, updated_at
+  SELECT id, name, description, category,
+         CASE status
+           WHEN 'not_ordered' THEN 'planned'
+           WHEN 'ordered'     THEN 'purchased'
+           WHEN 'in_transit'  THEN 'scheduled'
+           WHEN 'delivered'   THEN 'arrived'
+           ELSE status
+         END,
+         vendor_id, url, room, quantity, order_date,
+         expected_delivery_date, actual_delivery_date,
+         earliest_delivery_date, latest_delivery_date,
+         created_by, created_at, updated_at
   FROM household_items;
 
 DROP TABLE household_items;
 ALTER TABLE household_items_new RENAME TO household_items;
 
--- Step 3: Recreate indexes
+-- Step 2: Recreate indexes
 CREATE INDEX idx_household_items_category ON household_items(category);
 CREATE INDEX idx_household_items_status ON household_items(status);
 CREATE INDEX idx_household_items_room ON household_items(room);


### PR DESCRIPTION
## Summary

- Fixes migration 0014 CHECK constraint failure on databases with existing household item data
- Moves status value transformation (`not_ordered`→`planned`, etc.) from UPDATE statements into CASE expressions within the `INSERT INTO...SELECT`, avoiding writes against the old CHECK constraint

Fixes #458

## Test plan

- [ ] CI quality gates pass
- [ ] Verify against a database with pre-existing household items using old status values

🤖 Generated with [Claude Code](https://claude.com/claude-code)