### PR TITLE
chore: consolidate agent references and fix documentation inconsistencies

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -4,8 +4,7 @@
 
 **The backend-developer MUST NEVER write test files.** This rule has no exceptions.
 
-- `qa-integration-tester` owns **all** unit tests, integration tests, and service tests
-- `e2e-test-engineer` owns **all** Playwright E2E tests
+- `qa-integration-tester` owns **all** unit tests, integration tests, service tests, and Playwright E2E tests
 - Developer agents implement production code only — never `*.test.ts` files
 - Violating this rule causes BLOCKING PR rejection (as happened in PR #152)
 - If you find yourself writing a test file, stop and delegate to the QA agent instead

--- a/.claude/agent-memory/frontend-developer/MEMORY.md
+++ b/.claude/agent-memory/frontend-developer/MEMORY.md
@@ -4,8 +4,7 @@
 
 **The frontend-developer MUST NEVER write test files.** This rule has no exceptions.
 
-- `qa-integration-tester` owns **all** unit tests, integration tests, and component tests
-- `e2e-test-engineer` owns **all** Playwright E2E tests
+- `qa-integration-tester` owns **all** unit tests, integration tests, component tests, and Playwright E2E tests
 - Developer agents implement production code only — never `*.test.ts` / `*.test.tsx` files
 - Violating this rule causes BLOCKING PR rejection (as happened in PR #152 where frontend-developer wrote 211 tests)
 - If you find yourself writing a test file, stop and delegate to the QA agent instead

--- a/.claude/agent-memory/product-owner/MEMORY.md
+++ b/.claude/agent-memory/product-owner/MEMORY.md
@@ -118,14 +118,14 @@ Created 11 issues (#328-#338) from user feedback:
 
 ### Three-Phase Validation (per CLAUDE.md)
 
-1. **Planning Phase**: uat-validator drafts scenarios → qa-integration-tester reviews for testability → user approves
+1. **Planning Phase**: product-owner drafts UAT scenarios → qa-integration-tester reviews for testability → user approves
 2. **Development Phase**: developers implement → qa-integration-tester writes all tests (95%+ coverage target)
 3. **Validation Phase**: product-owner reviews PR → checks all ACs + UAT alignment + test coverage
 
 ### PO Review Checklist
 
 - Verify ALL acceptance criteria from the story are met (line-by-line check)
-- Verify UAT scenarios are addressed (cross-reference uat-validator comment on issue)
+- Verify UAT scenarios are addressed (cross-reference product-owner UAT comment on issue)
 - Verify qa-integration-tester wrote the tests (check commit author, not developer)
 - Verify 95%+ test coverage on new/modified code (run coverage or review test files)
 - Verify all agent responsibilities fulfilled (QA wrote tests, architect reviewed, UAT scenarios exist)
@@ -143,7 +143,7 @@ Created 11 issues (#328-#338) from user feedback:
 
 - **Missing keyboard focus indicators** — always check for :focus or :focus-visible styles (WCAG 2.1 AA requirement)
 - **Test authorship** — verify qa-integration-tester wrote tests, not developer (Co-Authored-By trailer in commit)
-- **Incomplete UAT coverage** — check if all scenarios from uat-validator are addressed in implementation
+- **Incomplete UAT coverage** — check if all scenarios from product-owner UAT are addressed in implementation
 - **Dependency pinning** — always check new deps use exact versions (no `^` or `~`). Found caret range on css-minimizer-webpack-plugin in PR #49 and @fastify/cookie in PR #57. This is a recurring issue.
 - **Scope creep in CLAUDE.md** — process/convention changes should be separate PRs, not bundled with feature work
 - **Schema migrations with sessions table** — it's correct to include `sessions` table in the same migration as `users` if both are part of the same auth infrastructure (avoids fragmented migrations). Verified in PR #55.
@@ -175,7 +175,7 @@ Created 11 issues (#328-#338) from user feedback:
 - **computeUsedAmount placeholder pattern** — Story 5.4 (PR #153): `computeUsedAmount` returns 0 until Story 5.6 adds budget_source_id FK to work_items. This is an ACCEPTED pattern for cross-story dependencies — document with TODO (Story 6) comment and the AC is considered CONDITIONAL PASS. The delete protection is similarly a placeholder and will be wired up in Story 5.6.
 - **Frontend totalAmount validation boundary** — PR #153: Frontend allows totalAmount = 0 (min={0}, checks `< 0`), but backend uses `exclusiveMinimum: 0`. Server rejects 0 with 400. Flag for refinement so client-side validation is consistent with server.
 - **statusExhausted badge semantic color** — PR #153: "Exhausted" status badge uses gray (`--color-status-not-started-bg`) instead of yellow/amber. Semantically "exhausted" should signal warning. Flag for UX review.
-- **E2E test gate is MANDATORY** — PR #157 (Story #148) had all 7 ACs met and 99 unit/integration tests passing, but CI showed "E2E Tests: SKIPPED". This is a BLOCKING issue per CLAUDE.md. When UAT scenarios are marked "Automated (E2E)", Playwright test coverage is mandatory before PO can approve. Requested changes and asked e2e-test-engineer to write tests in e2e/tests/budget/.
+- **E2E test gate is MANDATORY** — PR #157 (Story #148) had all 7 ACs met and 99 unit/integration tests passing, but CI showed "E2E Tests: SKIPPED". This is a BLOCKING issue per CLAUDE.md. When UAT scenarios are marked "Automated (E2E)", Playwright test coverage is mandatory before PO can approve. Requested changes and asked qa-integration-tester to write tests in e2e/tests/budget/.
 - **Conditional row rendering vs placeholder pattern** — PR #400 (Story 4.5): Vendor and URL rows used `{item.vendor && (...)}` which hides the entire row when null. AC #11 requires "--" placeholder for all optional fields. This is the same pattern as the VendorDetailPage Notes row issue from PR #151. ALWAYS check that optional field rows render unconditionally with ternary: `{item.field ? <value> : '\u2014'}`.
 - **CONFIDENCE_MARGINS display: fraction vs percentage** — PR #401 (Story 4.6): `CONFIDENCE_MARGINS` values are decimal fractions (0.2 = 20%). The WorkItemDetailPage correctly uses `Math.round(CONFIDENCE_MARGINS[...] * 100)` to display "20%". HouseholdItemDetailPage displayed raw value "0.2%". When reusing shared constants, verify the display conversion matches the established pattern.
 - **Raw date string rendering** — PR #402 (Story 4.7): HouseholdItemDetailPage displayed `workItem.startDate` and `workItem.endDate` as raw ISO strings instead of using `formatDate()`. The same PR correctly used `formatDate()` on WorkItemDetailPage for `hi.expectedDeliveryDate`. ALWAYS verify that date fields from API responses are passed through `formatDate()` before rendering. This is the 3rd occurrence of a "raw value display" bug (after CONFIDENCE_MARGINS and the initial expectedDeliveryDate fix in commit ccb50f7).

--- a/.claude/agent-memory/qa-integration-tester/epic03-uat-review.md
+++ b/.claude/agent-memory/qa-integration-tester/epic03-uat-review.md
@@ -13,7 +13,7 @@ Reviewed 366 UAT scenarios across 8 stories (#87-#94). 95%+ automatable via unit
 - Validation rules → unit tests
 - Database constraints → integration tests with temp DB
 
-### 🔵 E2E-Testable (Playwright, owned by e2e-test-engineer)
+### 🔵 E2E-Testable (Playwright, owned by qa-integration-tester)
 
 - UI interactions (forms, dropdowns, modals)
 - Browser-level keyboard shortcuts
@@ -76,7 +76,7 @@ Standard targets for EPIC-03:
 - Algorithms (cycle detection)
 - Client-side hooks (unit tests with `@testing-library/react`)
 
-### E2E Tests (e2e-test-engineer responsibility)
+### E2E Tests (qa-integration-tester responsibility)
 
 - Browser-level UI interactions
 - Forms, dropdowns, modals, date pickers

--- a/.claude/agents/dev-team-lead.md
+++ b/.claude/agents/dev-team-lead.md
@@ -36,7 +36,7 @@ You are invoked in exactly one mode per session, indicated by `[MODE: spec]`, `[
 
 You are the delivery lead — the bridge between the orchestrator's requirements and the implementing agents. You produce specs that are precise enough for a fast, focused agent to execute without ambiguity. You review their output for correctness. You handle all git operations for the final commit.
 
-You do **not** write production code yourself. You do **not** make architecture decisions (flag to the architect). You do **not** handle external PR reviews or merging (the orchestrator owns those). You do **not** write E2E tests (the e2e-test-engineer handles those separately during epic close).
+You do **not** write production code yourself. You do **not** make architecture decisions (flag to the architect). You do **not** handle external PR reviews or merging (the orchestrator owns those). You do **not** write E2E tests (the qa-integration-tester handles those separately during epic close).
 
 ## Mandatory Context Reading (Mode: spec and review)
 

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -86,7 +86,7 @@ If no refinement items exist, skip to step 5.
 
 ### 5. E2E Validation
 
-Launch the **e2e-test-engineer** agent to:
+Launch the **qa-integration-tester** agent to:
 
 - Confirm all existing Playwright E2E tests pass
 - Verify every approved UAT scenario (from story issues) has E2E coverage
@@ -98,12 +98,12 @@ This approval is **required** before proceeding to manual UAT validation.
 
 ### 6. UAT Validation
 
-Launch the **uat-validator** agent to:
+Launch the **product-owner** agent to produce UAT scenarios, then the orchestrator coordinates validation:
 
 - Produce a UAT Validation Report covering all stories in the epic
 - Provide step-by-step manual validation instructions to the user
 
-**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), treat E2E pass + uat-validator report as sufficient validation. Post the UAT report as a comment on the epic issue and proceed to step 7 without waiting for user walkthrough.
+**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), treat E2E pass + qa-integration-tester report as sufficient validation. Post the UAT report as a comment on the epic issue and proceed to step 7 without waiting for user walkthrough.
 
 **Interactive mode** (default): Present the report to the user. The user walks through each scenario:
 

--- a/.claude/skills/epic-run/SKILL.md
+++ b/.claude/skills/epic-run/SKILL.md
@@ -32,7 +32,7 @@ This skill activates **AUTO_MODE** for the session. When AUTO_MODE is active:
 | Phase 1 | Plan approval       | Post plan to epic issue, auto-proceed              |
 | Phase 2 | Bug spec approval   | Auto-approve PO spec, create issue immediately     |
 | Phase 2 | PR merge approval   | Auto-merge after CI green + all reviewers approved |
-| Phase 3 | UAT validation      | E2E pass + uat-validator report = sufficient       |
+| Phase 3 | UAT validation      | E2E pass + qa-integration-tester report = sufficient |
 | Phase 3 | Promotion to `main` | **WAIT for user (ALWAYS)** — never auto-approved   |
 
 ## Error Handling: Retry-Then-Pause
@@ -336,7 +336,7 @@ Review all story PRs for non-blocking review comments. If refinement items exist
 
 ### 3.4 E2E Validation
 
-Launch the **e2e-test-engineer** agent to:
+Launch the **qa-integration-tester** agent to:
 
 - Confirm all existing Playwright E2E tests pass
 - Verify every UAT scenario has E2E coverage
@@ -346,9 +346,9 @@ Launch the **e2e-test-engineer** agent to:
 
 ### 3.5 UAT Validation (AUTO_MODE)
 
-Launch the **uat-validator** agent to produce a UAT Validation Report.
+Launch the **product-owner** agent to produce UAT scenarios, then the orchestrator coordinates validation and produces a UAT Validation Report.
 
-**AUTO_MODE**: E2E pass + uat-validator report = sufficient. Do NOT wait for user walkthrough. Post the UAT report as a comment on the epic issue and proceed.
+**AUTO_MODE**: E2E pass + qa-integration-tester report = sufficient. Do NOT wait for user walkthrough. Post the UAT report as a comment on the epic issue and proceed.
 
 ### 3.6 Documentation
 
@@ -391,7 +391,7 @@ gh pr create --base main --head beta --title "release: promote epic #<epic-numbe
 <Paste metrics report from step 3.2>
 
 ## UAT Validation
-All UAT scenarios passed (AUTO_MODE: E2E + uat-validator report).
+All UAT scenarios passed (AUTO_MODE: E2E + qa-integration-tester report).
 See validation report in comments.
 
 ## Review Summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Cornerstone is a web-based home building project management application designed
 
 ## Agent Team
 
-This project uses a team of 11 specialized Claude Code agents defined in `.claude/agents/`:
+This project uses a team of 9 specialized Claude Code agents defined in `.claude/agents/`:
 
 | Agent                   | Role                                                                                                                                    |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -20,10 +20,8 @@ This project uses a team of 11 specialized Claude Code agents defined in `.claud
 | `dev-team-lead`         | Spec-writer, reviewer, and committer (Sonnet): decomposes work into implementation specs, reviews agent output, commits and monitors CI |
 | `backend-developer`     | API endpoints, business logic, auth, database operations (Haiku, launched by orchestrator with dev-team-lead specs)                     |
 | `frontend-developer`    | UI components, pages, interactions, API client (Haiku, launched by orchestrator with dev-team-lead specs)                               |
-| `qa-integration-tester` | Unit test coverage (95%+ target), integration tests, performance testing, bug reports                                                   |
-| `e2e-test-engineer`     | Playwright E2E browser tests, test container infrastructure, UAT scenario coverage                                                      |
+| `qa-integration-tester` | Unit test coverage (95%+ target), integration tests, Playwright E2E browser tests, performance testing, bug reports                     |
 | `security-engineer`     | Security audits, vulnerability reports, remediation guidance                                                                            |
-| `uat-validator`         | UAT scenarios, manual validation steps, user sign-off per epic                                                                          |
 | `docs-writer`           | Documentation site (`docs/`), lean README.md, user-facing guides after UAT approval                                                     |
 
 ## GitHub Tools Strategy
@@ -77,11 +75,9 @@ The GitHub Projects board uses 4 statuses: Backlog, Todo, In Progress, Done. All
 - **Implementation specs** → `dev-team-lead` agent (produces specs, reviews code, commits)
 - **Backend code** → `backend-developer` agent (Haiku, launched by orchestrator with dev-team-lead specs)
 - **Frontend code** → `frontend-developer` agent (Haiku, launched by orchestrator with dev-team-lead specs)
-- **Unit/integration tests** → `qa-integration-tester` agent (launched by orchestrator with dev-team-lead specs)
+- **Unit/integration/E2E tests** → `qa-integration-tester` agent (launched by orchestrator with dev-team-lead specs)
 - **Visual specs, design tokens, brand assets, CSS files** → `ux-designer` agent
 - **Schema/API design, ADRs, wiki** → `product-architect` agent
-- **E2E tests** → `e2e-test-engineer` agent
-- **UAT scenarios** → `uat-validator` agent
 - **Story definitions** → `product-owner` agent
 - **Security reviews** → `security-engineer` agent
 - **User-facing documentation** (docs site + README) → `docs-writer` agent
@@ -106,7 +102,7 @@ The orchestrator uses four skills to drive work. Each skill contains the full op
 | `/epic-start` | Plan approval       | Wait for user         | Post plan to epic issue, auto-proceed              |
 | `/develop`    | Bug spec approval   | Wait for user         | Auto-approve PO spec, create issue immediately     |
 | `/develop`    | PR merge approval   | Wait for user         | Auto-merge after CI green + all reviewers approved |
-| `/epic-close` | UAT validation      | User walkthrough      | E2E pass + uat-validator report = sufficient       |
+| `/epic-close` | UAT validation      | User walkthrough      | E2E pass + qa-integration-tester report = sufficient |
 | `/epic-close` | Promotion to `main` | **Wait for user**     | **Wait for user (ALWAYS)** — never auto-approved   |
 
 ## Acceptance & Validation
@@ -120,7 +116,7 @@ Every epic follows a two-phase validation lifecycle. **Development phase** (`/de
 - **Iterate until right** — failed validation triggers a fix-and-revalidate loop
 - **Acceptance criteria live on GitHub Issues** — stored on story issues, summarized on promotion PRs
 - **Security review required** — the `security-engineer` must review every story PR
-- **Test agents own all tests** — `qa-integration-tester` owns unit + integration tests; `e2e-test-engineer` owns Playwright E2E tests. Developer agents do not write tests.
+- **Test agents own all tests** — `qa-integration-tester` owns unit, integration, and Playwright E2E tests. Developer agents do not write tests.
 - **Flat delegation model** — the orchestrator launches all agents directly. The `dev-team-lead` produces implementation specs, reviews agent output, and handles commits/CI. The orchestrator routes specs to `backend-developer`, `frontend-developer`, and `qa-integration-tester`.
 
 ## Git & Commit Conventions
@@ -214,7 +210,7 @@ Cornerstone uses a two-tier release model:
 
 ### Branch Protection
 
-Both `main` and `beta` require PRs with passing `Quality Gates` and `Docker` status checks. Force pushes and deletions are blocked on both branches.
+Both `main` and `beta` require PRs with passing `Quality Gates`, `Docker`, and `Merge E2E Reports` status checks. Force pushes and deletions are blocked on both branches.
 
 ## Tech Stack
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@docusaurus/core": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
-"@mdx-js/react": "3.1.1",
+    "@mdx-js/react": "3.1.1",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary

- Removes `e2e-test-engineer` and `uat-validator` agent references (no definition files existed for either)
- Consolidates all test ownership under `qa-integration-tester` (unit, integration, and Playwright E2E)
- Adds missing `Merge E2E Reports` to branch protection docs in CLAUDE.md
- Fixes `docs/package.json` indentation for `@mdx-js/react`
- Updates all agent memory files to reflect consolidated ownership

## Test plan
- [x] `grep -r "e2e-test-engineer\|uat-validator" .claude/ CLAUDE.md` returns zero matches
- [x] CLAUDE.md agent table has exactly 9 rows
- [x] `docs/package.json` is valid JSON with proper indentation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>