### PR TITLE
ci: parallelize quality gates and add Docker BuildKit cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build shared package
+        run: npm run build -w shared
+
       - name: Run tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: node --experimental-vm-modules node_modules/.bin/jest --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 


### PR DESCRIPTION
## Summary

- Split sequential `quality-gates` job into parallel `static-analysis` + `test` (3 shards) jobs
- Add thin `quality-gates` aggregator job to preserve branch protection rule name
- Drop redundant `typecheck` and `build` steps (Docker job already builds everything)
- Switch Docker build to BuildKit with GHA cache backend (`setup-buildx-action` + `build-push-action`)

## Expected impact

- Quality gate wall time: ~5-7 min → ~1.5 min (bounded by slowest parallel job)
- Docker rebuild on source-only changes: ~3-5 min → ~1-2 min (cached layers)

## Test plan

- [ ] Verify `Static Analysis` and `Test (Shard N/3)` jobs run in parallel
- [ ] Verify `Quality Gates` aggregator passes when all sub-jobs succeed
- [ ] Verify Docker build shows "importing cache manifest" on subsequent runs
- [ ] Verify E2E smoke tests still receive Docker image artifact
- [ ] Verify `docker-pr-release` triggers with correct dependency chain
- [ ] Confirm branch protection rule `Quality Gates` still matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)