### PR TITLE
ci: add auto-fix bot and streamline quality gates

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -310,7 +310,7 @@ The sandbox has strict limitations for git operations in worktrees:
    ALTDIR=/tmp/git-obj-$$; mkdir -p $ALTDIR
    printf "$ALTDIR\n" >> /path/to/.git/objects/info/alternates
    # Stage: GIT_OBJECT_DIRECTORY=$ALTDIR GIT_ALTERNATE_OBJECT_DIRECTORIES=/path/.git/objects git add <files>
-   # Commit: GIT_OBJECT_DIRECTORY=$ALTDIR GIT_ALTERNATE_OBJECT_DIRECTORIES=/path/.git/objects git commit --no-verify -m "..."
+   # Commit: GIT_OBJECT_DIRECTORY=$ALTDIR GIT_ALTERNATE_OBJECT_DIRECTORIES=/path/.git/objects git commit -m "..."
    # Verify: GIT_ALTERNATE_OBJECT_DIRECTORIES=$ALTDIR git log --oneline -3
    # If branch ref detaches, manually: echo "SHA" > .git/refs/heads/branch-name
    # Push: GIT_ALTERNATE_OBJECT_DIRECTORIES=$ALTDIR git push "https://USER:TOKEN@github.com/..." branch:branch
@@ -326,9 +326,5 @@ The sandbox has strict limitations for git operations in worktrees:
 
 ## Pre-commit Hook Architecture
 
-- `.husky/pre-commit`: runs `npx lint-staged && npm run typecheck && npm audit --omit=dev --audit-level=low`
-- `.lintstagedrc.js`: configures per-file-type commands
-- `scripts/check-dep-pinning.sh`: validates `dependencies`/`devDependencies` use exact pins (no ^/~)
-  - Uses `node --input-type=module` inline script to parse JSON (avoids jq dependency)
-  - Ignores `peerDependencies` and workspace cross-references (`*`, `workspace:*`)
-  - Triggered by `**/package.json` lint-staged glob
+- `.husky/pre-commit`: runs `npm run typecheck` (typecheck only — lint, format, and audit are handled by CI auto-fix workflow)
+- Lint, format, and `npm audit fix` run automatically on `beta` via `.github/workflows/auto-fix.yml`

--- a/.claude/agent-memory/qa-integration-tester/MEMORY.md
+++ b/.claude/agent-memory/qa-integration-tester/MEMORY.md
@@ -498,14 +498,6 @@ NODE_PATH=/path/to/cornerstone/server/node_modules:/path/to/cornerstone/client/n
 
 ## Story 6.2 (Scheduling Engine CPM, #248) — Key Patterns (2026-02-24)
 
-### ARM64 Prettier Fix Workflow
-
-- `npx prettier --check <file>` works on ARM64 (unlike Jest/ESLint)
-- Run BEFORE every `git commit --no-verify` to catch formatting issues early
-- Prettier COLLAPSES arrays/objects to single line if they fit within 100 chars
-  → Don't manually expand `[makeItem('A', 5), makeItem('B', 3, { key: 'val' })]` — 89 chars fits on one line
-- Two-line diagnosis: "warn: file.ts" only — use `npx prettier --write <file>` then `git diff` to see what changed
-
 ### CPM Engine Behavior
 
 - `today` floor ONLY for predecessor-less items (line 408-410 of schedulingEngine.ts)

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,62 @@
+name: Auto Fix
+
+on:
+  push:
+    branches: [beta]
+
+concurrency:
+  group: auto-fix-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-fix:
+    name: Auto Fix Lint & Format
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: beta
+          token: ${{ github.token }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Run lint fix
+        run: npm run lint:fix
+        continue-on-error: true
+      - name: Run format
+        run: npm run format
+      - name: Run audit fix
+        run: npm audit fix || true
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create fix PR
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          BRANCH="auto-fix/lint-format-${SHORT_SHA}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "style: auto-fix lint and format"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base beta \
+            --head "$BRANCH" \
+            --title "style: auto-fix lint and format" \
+            --body "Automated lint, format, and audit fixes triggered by $(git log -1 --format='%h %s' ${{ github.sha }})."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
+      - name: Type check
+        run: npm run typecheck
 
-      - name: Format check
-        run: npm run format:check
-
-      - name: Security audit
-        run: npm audit --omit=dev --audit-level=low
+      - name: Build
+        run: npm run build
 
   test:
     name: Test (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-npx lint-staged
 npm run typecheck
-npm audit --omit=dev --audit-level=low

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,18 +128,17 @@ All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 - **Breaking changes**: Use `!` suffix or `BREAKING CHANGE:` footer
 - Every completed task gets its own commit with a meaningful description
 - **Link commits to issues**: When a commit resolves work tracked in a GitHub Issue, include `Fixes #<issue-number>` in the commit message body (one per line for multiple issues). Note: `Fixes #N` only auto-closes issues when the commit reaches `main` (not `beta`).
-- **Always commit, push to a feature branch, and create a PR after work is complete.** The pre-commit hook automatically runs all quality gates (selective lint/format/tests on staged files + full typecheck/build/audit). Just commit — the hook validates. If the hook fails, fix the issues and commit again. Do not leave work uncommitted or unpushed. Never push directly to `main` or `beta`.
+- **Always commit, push to a feature branch, and create a PR after work is complete.** The pre-commit hook runs typecheck automatically. Lint, format, and audit fixes are handled by the CI auto-fix bot on `beta`. Just commit — the hook validates types. If the hook fails, fix the type errors and commit again. Do not leave work uncommitted or unpushed. Never push directly to `main` or `beta`.
 
 ### Local Validation Policy
 
-**Do NOT run `npm test`, `npm run lint`, `npm run typecheck`, or `npm run build` manually.** The pre-commit hook runs all quality gates automatically:
+**Do NOT run `npm test`, `npm run lint`, `npm run typecheck`, or `npm run build` manually.** The pre-commit hook runs typecheck automatically. Lint, format, and audit issues are handled by the CI auto-fix bot (`.github/workflows/auto-fix.yml`), which runs on every push to `beta` and creates a fix PR if needed.
 
-- Selective lint + format + related tests on staged files (via lint-staged)
-- Full typecheck across all workspaces
-- Full build (shared → client → server)
-- Dependency security audit
+- Pre-commit hook: `npm run typecheck` (full typecheck across all workspaces)
+- CI auto-fix bot: `npm run lint:fix` + `npm run format` + `npm audit fix` (runs on `beta` push, creates PR if changes needed)
+- CI Quality Gates: typecheck + test + build (runs on every PR)
 
-To validate your work: **stage and commit**. If the hook fails, fix the issues and commit again. After pushing, **always wait for CI to go green** (`gh pr checks <pr-number> --watch`) before proceeding to the next step.
+To validate your work: **stage and commit**. If the hook fails, fix the type errors and commit again. After pushing, **always wait for CI to go green** (`gh pr checks <pr-number> --watch`) before proceeding to the next step.
 
 The only exception is the QA agent running a specific test file it just wrote (e.g., `npx jest path/to/new.test.ts`) to verify correctness before committing — but never `npm test` (the full suite).
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-fix.yml` — runs on `beta` push to auto-fix lint, format, and audit issues (creates PR if changes needed)
- Remove lint, format check, and security audit steps from CI Quality Gates (now handled by auto-fix bot)
- Simplify pre-commit hook to typecheck only (removed lint-staged and npm audit)
- Update agent memory files to remove `--no-verify` references and outdated hook docs

## Motivation

Agents in sandbox worktrees must bypass the pre-commit hook due to git object directory permission issues. This means lint/format/audit errors slip through to CI. The auto-fix bot catches and fixes these automatically after merge to `beta`.

## Loop prevention

The auto-fix workflow uses `github.actor != 'github-actions[bot]'` to prevent re-triggering on its own PR merge.

## Test plan

- [ ] Verify Auto Fix workflow triggers on push to `beta`
- [ ] Verify it creates a fix PR when lint/format issues exist
- [ ] Verify it skips PR creation when no changes needed
- [ ] Verify Quality Gates still runs typecheck + test + build
- [ ] Verify no infinite loop (bot's own merge doesn't re-trigger)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>