### PR TITLE
test(e2e): add EPIC-04 household items E2E test coverage

### DIFF
--- a/e2e/fixtures/apiHelpers.ts
+++ b/e2e/fixtures/apiHelpers.ts
@@ -113,3 +113,30 @@ export async function createMilestoneViaApi(
 export async function deleteMilestoneViaApi(page: Page, id: number): Promise<void> {
   await page.request.delete(`${API.milestones}/${id}`);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Household Items
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function createHouseholdItemViaApi(
+  page: Page,
+  data: {
+    name: string;
+    category?: string;
+    status?: string;
+    room?: string;
+    quantity?: number;
+    [key: string]: unknown;
+  },
+): Promise<string> {
+  const response = await page.request.post(API.householdItems, {
+    data: { category: 'other', status: 'planned', ...data },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as { householdItem: { id: string } };
+  return body.householdItem.id;
+}
+
+export async function deleteHouseholdItemViaApi(page: Page, id: string): Promise<void> {
+  await page.request.delete(`${API.householdItems}/${id}`);
+}

--- a/e2e/fixtures/testData.ts
+++ b/e2e/fixtures/testData.ts
@@ -28,6 +28,7 @@ export const ROUTES = {
   tags: '/tags',
   timeline: '/timeline',
   householdItems: '/household-items',
+  householdItemsNew: '/household-items/new',
   profile: '/profile',
   userManagement: '/admin/users',
 };
@@ -50,4 +51,5 @@ export const API = {
   milestones: '/api/milestones',
   timeline: '/api/timeline',
   schedule: '/api/schedule',
+  householdItems: '/api/household-items',
 };

--- a/e2e/pages/HouseholdItemCreatePage.ts
+++ b/e2e/pages/HouseholdItemCreatePage.ts
@@ -1,0 +1,183 @@
+/**
+ * Page Object Model for the Household Item Create page (/household-items/new)
+ *
+ * EPIC-04 Story 4.4: Create & Edit Form
+ *
+ * The page renders:
+ * - A header with a back button ("← Back to Household Items", a <button>)
+ *   and h1 "New Household Item"
+ * - A form with household item fields:
+ *   - #name (text, required) — shows validation error when empty on submit
+ *   - #description (textarea)
+ *   - #category (select) — options: furniture, appliances, fixtures, decor, electronics, outdoor, storage, other
+ *   - #status (select) — options: planned, purchased, scheduled, arrived
+ *   - #quantity (number, min 1)
+ *   - #vendorId (select)
+ *   - #url (text)
+ *   - #room (text)
+ *   - #orderDate, #earliestDeliveryDate, #latestDeliveryDate, #actualDeliveryDate (date inputs)
+ *   - Tags: TagPicker component
+ * - Submit button: text "Create Item" / "Creating..."
+ * - Cancel button: text "Cancel"
+ * - Error banner for server-side errors
+ *
+ * Key DOM observations from source code:
+ * - Back button is a <button> with onClick navigate('/household-items')
+ * - Submit button is type="submit", disabled during isSubmitting
+ * - On success, navigates to /household-items/:id (the detail page)
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+export const HOUSEHOLD_ITEM_CREATE_ROUTE = '/household-items/new';
+
+export interface HouseholdItemFormData {
+  name?: string;
+  description?: string;
+  category?: string;
+  status?: string;
+  quantity?: string;
+  vendorId?: string;
+  url?: string;
+  room?: string;
+  orderDate?: string;
+  earliestDeliveryDate?: string;
+  latestDeliveryDate?: string;
+  actualDeliveryDate?: string;
+}
+
+export class HouseholdItemCreatePage {
+  readonly page: Page;
+
+  // Header
+  readonly heading: Locator;
+  readonly backButton: Locator;
+
+  // Form fields
+  readonly nameInput: Locator;
+  readonly descriptionInput: Locator;
+  readonly categorySelect: Locator;
+  readonly statusSelect: Locator;
+  readonly quantityInput: Locator;
+  readonly vendorSelect: Locator;
+  readonly urlInput: Locator;
+  readonly roomInput: Locator;
+  readonly orderDateInput: Locator;
+  readonly earliestDeliveryDateInput: Locator;
+  readonly latestDeliveryDateInput: Locator;
+  readonly actualDeliveryDateInput: Locator;
+
+  // Form actions
+  readonly submitButton: Locator;
+  readonly cancelButton: Locator;
+
+  // Error/validation display
+  readonly errorBanner: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // Header
+    this.heading = page.getByRole('heading', {
+      level: 1,
+      name: 'New Household Item',
+      exact: true,
+    });
+    this.backButton = page.getByRole('button', { name: /← Back to Household Items/i });
+
+    // Form fields
+    this.nameInput = page.locator('#name');
+    this.descriptionInput = page.locator('#description');
+    this.categorySelect = page.locator('#category');
+    this.statusSelect = page.locator('#status');
+    this.quantityInput = page.locator('#quantity');
+    this.vendorSelect = page.locator('#vendorId');
+    this.urlInput = page.locator('#url');
+    this.roomInput = page.locator('#room');
+    this.orderDateInput = page.locator('#orderDate');
+    this.earliestDeliveryDateInput = page.locator('#earliestDeliveryDate');
+    this.latestDeliveryDateInput = page.locator('#latestDeliveryDate');
+    this.actualDeliveryDateInput = page.locator('#actualDeliveryDate');
+
+    // Form actions
+    this.submitButton = page.getByRole('button', { name: /Create Item|Creating\.\.\./i });
+    this.cancelButton = page.getByRole('button', { name: 'Cancel', exact: true });
+
+    // Errors
+    this.errorBanner = page.locator('[class*="errorBanner"]');
+  }
+
+  /**
+   * Navigate to the household item create page and wait for the heading.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(HOUSEHOLD_ITEM_CREATE_ROUTE);
+    await this.heading.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /**
+   * Fill multiple form fields at once.
+   */
+  async fillForm(data: HouseholdItemFormData): Promise<void> {
+    if (data.name !== undefined) {
+      await this.nameInput.fill(data.name);
+    }
+    if (data.description !== undefined) {
+      await this.descriptionInput.fill(data.description);
+    }
+    if (data.category !== undefined) {
+      await this.categorySelect.selectOption(data.category);
+    }
+    if (data.status !== undefined) {
+      await this.statusSelect.selectOption(data.status);
+    }
+    if (data.quantity !== undefined) {
+      await this.quantityInput.fill(data.quantity);
+    }
+    if (data.url !== undefined) {
+      await this.urlInput.fill(data.url);
+    }
+    if (data.room !== undefined) {
+      await this.roomInput.fill(data.room);
+    }
+    if (data.orderDate !== undefined) {
+      await this.orderDateInput.fill(data.orderDate);
+    }
+    if (data.earliestDeliveryDate !== undefined) {
+      await this.earliestDeliveryDateInput.fill(data.earliestDeliveryDate);
+    }
+    if (data.latestDeliveryDate !== undefined) {
+      await this.latestDeliveryDateInput.fill(data.latestDeliveryDate);
+    }
+    if (data.actualDeliveryDate !== undefined) {
+      await this.actualDeliveryDateInput.fill(data.actualDeliveryDate);
+    }
+  }
+
+  /**
+   * Submit the form and wait for navigation to the detail page.
+   * Returns the new item's ID extracted from the URL.
+   */
+  async submitAndWaitForDetail(): Promise<string> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/household-items') &&
+        resp.request().method() === 'POST' &&
+        resp.status() === 201,
+    );
+    await this.submitButton.click();
+    await responsePromise;
+    await this.page.waitForURL('**/household-items/**');
+    // Extract the ID from the URL path
+    const url = this.page.url();
+    const match = url.match(/\/household-items\/([^/]+)$/);
+    return match ? match[1] : '';
+  }
+
+  /**
+   * Submit the form without waiting for navigation (used for error cases).
+   */
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+}

--- a/e2e/pages/HouseholdItemDetailPage.ts
+++ b/e2e/pages/HouseholdItemDetailPage.ts
@@ -1,0 +1,84 @@
+/**
+ * Page Object Model for the Household Item Detail page (/household-items/:id)
+ *
+ * EPIC-04 Story 4.5: Detail Page
+ *
+ * The page renders:
+ * - A back link "← Household Items" navigating to /household-items
+ * - h1 with the item name (inline-editable via autosave)
+ * - An "Edit" button (navigates to /household-items/:id/edit)
+ * - A status badge showing current status
+ * - Fields: category, room, vendor, URL, quantity, description, dates
+ * - Budget section: budget lines, subsidies, planned/actual totals
+ * - Work Item Dependencies section: link HI to work items or milestones for scheduling
+ * - Documents section: LinkedDocumentsSection (Paperless-ngx integration)
+ * - Delete button with confirmation modal
+ *
+ * Key DOM observations from source code:
+ * - h1 is the item name (autosave inline editable via contentEditable)
+ * - Back link is a <Link> (not a button) with text "← Household Items"
+ * - Edit button navigates to /household-items/:id/edit
+ * - Delete confirmation modal uses role="dialog"
+ * - Budget section h2: "Budget" (rendered conditionally based on budget lines)
+ * - Documents section uses LinkedDocumentsSection (same as work items, invoices)
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+export class HouseholdItemDetailPage {
+  readonly page: Page;
+
+  // Page header
+  readonly heading: Locator;
+  readonly backLink: Locator;
+  readonly editButton: Locator;
+
+  // Content sections
+  readonly budgetSection: Locator;
+  readonly documentsSection: Locator;
+  readonly documentsHeading: Locator;
+
+  // Delete
+  readonly deleteModal: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // h1 heading — the item name (editable)
+    this.heading = page.getByRole('heading', { level: 1 });
+
+    // Back link is a <Link> in the breadcrumb with text "Household Items"
+    // NOTE: The AppShell sidebar also has a "Household Items" nav link.
+    // Use first() to get the breadcrumb link, not the sidebar nav link.
+    this.backLink = page.getByRole('link', { name: 'Household Items', exact: true }).first();
+
+    // Edit button — located in the pageActions area; class="editButton"
+    // Multiple "Edit" buttons may exist (budget line edit). Use first() to get the page-level one.
+    this.editButton = page.locator('[class*="editButton"]').first();
+
+    // Budget section
+    this.budgetSection = page.locator('[class*="budgetSection"], [class*="budget"]').first();
+
+    // Documents section
+    this.documentsHeading = page.getByRole('heading', { level: 2, name: 'Documents', exact: true });
+    this.documentsSection = page.getByRole('region', { name: 'Documents', exact: true });
+
+    // Delete confirmation modal
+    this.deleteModal = page.locator('[role="dialog"]');
+  }
+
+  /**
+   * Navigate to the household item detail page.
+   */
+  async goto(id: string): Promise<void> {
+    await this.page.goto(`/household-items/${id}`);
+    await this.heading.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /**
+   * Get the heading text (item name).
+   */
+  async getHeadingText(): Promise<string> {
+    return (await this.heading.textContent()) ?? '';
+  }
+}

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -1,12 +1,31 @@
 /**
- * Page Object Model for the Household Items page (/household-items)
+ * Page Object Model for the Household Items list page (/household-items)
  *
- * The Household Items page is currently a stub that renders:
- *   - An h1 "Household Items"
- *   - A <p> describing the planned purchase tracking functionality
+ * EPIC-04: Household Items & Furniture Management
  *
- * When household item management is implemented, expand this POM with
- * locators for the item list, purchase order forms, delivery date inputs, etc.
+ * The page renders:
+ * - A page header with h1 "Household Items" and a "New Item" button
+ * - A search input (aria-label="Search household items") with 300ms debounce
+ * - Filter panel (role="search", aria-label="Household item filters") with:
+ *   - #category-filter (select)
+ *   - #status-filter (select)
+ *   - #room-input (text input)
+ *   - #vendor-filter (select)
+ *   - #sort-filter (select)
+ *   - Toggle sort order button (aria-label="Toggle sort order")
+ * - A data table (desktop, class tableContainer) and card list (mobile, class cardsContainer)
+ * - Pagination controls when totalPages > 1
+ * - An empty state when no items exist or no items match filters
+ * - A delete confirmation modal (role="dialog", aria-labelledby="hi-delete-modal-title")
+ * - An error banner (role="alert", class errorBanner) for API errors
+ *
+ * Key DOM observations from source code:
+ * - "New Item" is a <button> that calls navigate('/household-items/new')
+ * - Delete modal: aria-labelledby="hi-delete-modal-title", confirm button: class confirmDeleteButton
+ * - Empty state h2: "No household items yet" or "No household items match your filters"
+ * - Table rows are clickable and navigate to detail page
+ * - Actions menu button: aria-label="Actions for {item.name}" (⋮)
+ * - Search debounce: 300ms, room filter debounce: 300ms
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -16,18 +35,226 @@ export const HOUSEHOLD_ITEMS_ROUTE = '/household-items';
 export class HouseholdItemsPage {
   readonly page: Page;
 
+  // Page header
   readonly heading: Locator;
-  readonly description: Locator;
+  readonly newItemButton: Locator;
+
+  // Search and filter controls
+  readonly searchInput: Locator;
+  readonly categoryFilter: Locator;
+  readonly statusFilter: Locator;
+  readonly roomInput: Locator;
+  readonly vendorFilter: Locator;
+  readonly sortFilter: Locator;
+  readonly sortOrderButton: Locator;
+
+  // Table (desktop view)
+  readonly tableContainer: Locator;
+  readonly tableBody: Locator;
+
+  // Cards (mobile view)
+  readonly cardsContainer: Locator;
+
+  // Pagination
+  readonly pagination: Locator;
+  readonly prevPageButton: Locator;
+  readonly nextPageButton: Locator;
+
+  // Empty state
+  readonly emptyState: Locator;
+
+  // Error banner
+  readonly errorBanner: Locator;
+
+  // Delete confirmation modal
+  readonly deleteModal: Locator;
+  readonly deleteConfirmButton: Locator;
+  readonly deleteCancelButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
+    // Page header
     this.heading = page.getByRole('heading', { level: 1, name: 'Household Items', exact: true });
-    this.description = page.locator('[class*="description"]').first();
+    this.newItemButton = page.getByRole('button', { name: /New Item/i });
+
+    // Search and filters
+    this.searchInput = page.getByLabel('Search household items');
+    this.categoryFilter = page.locator('#category-filter');
+    this.statusFilter = page.locator('#status-filter');
+    this.roomInput = page.locator('#room-input');
+    this.vendorFilter = page.locator('#vendor-filter');
+    this.sortFilter = page.locator('#sort-filter');
+    this.sortOrderButton = page.getByLabel('Toggle sort order');
+
+    // Table (desktop)
+    this.tableContainer = page.locator('[class*="tableContainer"]');
+    this.tableBody = this.tableContainer.locator('tbody');
+
+    // Mobile cards
+    this.cardsContainer = page.locator('[class*="cardsContainer"]');
+
+    // Pagination — use `.first()` because `[class*="pagination"]` matches the outer container
+    // and child elements (paginationInfo, paginationButton, etc.)
+    this.pagination = page.locator('[class*="pagination"]').first();
+    this.prevPageButton = page.getByLabel('Previous page');
+    this.nextPageButton = page.getByLabel('Next page');
+
+    // Empty state
+    this.emptyState = page.locator('[class*="emptyState"]');
+
+    // Error banner (outside modal)
+    this.errorBanner = page.locator('[role="alert"][class*="errorBanner"]');
+
+    // Delete confirmation modal
+    this.deleteModal = page.locator('[role="dialog"][aria-labelledby="hi-delete-modal-title"]');
+    this.deleteConfirmButton = this.deleteModal.locator('[class*="confirmDeleteButton"]');
+    this.deleteCancelButton = this.deleteModal.getByRole('button', {
+      name: 'Cancel',
+      exact: true,
+    });
   }
 
+  /**
+   * Navigate to the household items list page.
+   */
   async goto(): Promise<void> {
     await this.page.goto(HOUSEHOLD_ITEMS_ROUTE);
     await this.heading.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Wait for the household items list to finish loading.
+   * Races: table rows visible, mobile cards visible, or empty state visible.
+   */
+  async waitForLoaded(): Promise<void> {
+    await Promise.race([
+      this.tableBody.locator('tr').first().waitFor({ state: 'visible' }),
+      this.cardsContainer.locator('[class*="card"]').first().waitFor({ state: 'visible' }),
+      this.emptyState.waitFor({ state: 'visible' }),
+    ]);
+  }
+
+  /**
+   * Get the names of all household items currently shown in the table (desktop)
+   * or cards (mobile).
+   */
+  async getItemNames(): Promise<string[]> {
+    // Try table first (titleCell class)
+    const titleCells = await this.tableBody.locator('[class*="titleCell"]').all();
+    if (titleCells.length > 0) {
+      const names: string[] = [];
+      for (const cell of titleCells) {
+        const text = await cell.textContent();
+        if (text) names.push(text.trim());
+      }
+      return names;
+    }
+
+    // Mobile fallback: card title elements
+    const cardTitles = await this.cardsContainer.locator('[class*="cardTitle"]').all();
+    const names: string[] = [];
+    for (const el of cardTitles) {
+      const text = await el.textContent();
+      if (text) names.push(text.trim());
+    }
+    return names;
+  }
+
+  /**
+   * Type a search query and wait for the API response and DOM to update.
+   * The response listener is registered BEFORE the fill to avoid a race with
+   * the 300ms debounce.
+   */
+  async search(query: string): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+    );
+    await this.searchInput.fill(query);
+    await responsePromise;
+    await this.waitForLoaded();
+  }
+
+  /**
+   * Clear the search input and wait for the API response and DOM to update.
+   */
+  async clearSearch(): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+    );
+    await this.searchInput.clear();
+    await responsePromise;
+    await this.waitForLoaded();
+  }
+
+  /**
+   * Open the delete modal for the item with the given name.
+   * Uses the table on desktop and falls back to cards on mobile.
+   */
+  async openDeleteModal(name: string): Promise<void> {
+    const tableVisible = await this.tableContainer.isVisible();
+
+    if (tableVisible) {
+      const rows = await this.tableBody.locator('tr').all();
+      for (const row of rows) {
+        const rowText = await row.textContent();
+        if (rowText?.includes(name)) {
+          await row.locator(`[aria-label="Actions for ${name}"]`).click();
+          await row.getByRole('menuitem', { name: 'Delete' }).click();
+          await this.deleteModal.waitFor({ state: 'visible' });
+          return;
+        }
+      }
+    }
+
+    // Mobile fallback
+    const cards = await this.cardsContainer.locator('[class*="card"]').all();
+    for (const card of cards) {
+      const cardText = await card.textContent();
+      if (cardText?.includes(name)) {
+        await card.locator(`[aria-label="Actions for ${name}"]`).click();
+        await card.getByRole('menuitem', { name: 'Delete' }).click();
+        await this.deleteModal.waitFor({ state: 'visible' });
+        return;
+      }
+    }
+
+    throw new Error(`Household item with name "${name}" not found in list`);
+  }
+
+  /**
+   * Confirm the deletion in the delete modal.
+   */
+  async confirmDelete(): Promise<void> {
+    const deleteResponsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/household-items') &&
+        resp.request().method() === 'DELETE' &&
+        resp.status() === 204,
+    );
+    await this.deleteConfirmButton.click();
+    await deleteResponsePromise;
+    await this.deleteModal.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Cancel the delete modal without deleting.
+   */
+  async cancelDelete(): Promise<void> {
+    await this.deleteCancelButton.click();
+    await this.deleteModal.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Get pagination info text (e.g. "Showing 1 to 25 of 30 items"), or null if not visible.
+   */
+  async getPaginationInfoText(): Promise<string | null> {
+    try {
+      const info = this.page.locator('[class*="paginationInfo"]');
+      await info.waitFor({ state: 'visible' });
+      return await info.textContent();
+    } catch {
+      return null;
+    }
   }
 }

--- a/e2e/tests/household-items/household-item-create.spec.ts
+++ b/e2e/tests/household-items/household-item-create.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * E2E tests for the Household Item Create page (/household-items/new)
+ *
+ * EPIC-04 Story 4.4: Create & Edit Form
+ *
+ * Scenarios covered:
+ * 1.  Page loads with h1 "New Household Item"
+ * 2.  Back button navigates to /household-items
+ * 3.  All primary form fields are visible
+ * 4.  Create item with name only — success, redirects to detail page
+ * 5.  Create item with all major fields — success
+ * 6.  Submit without name shows validation error
+ * 7.  Category select has all expected options
+ * 8.  Status select has all expected options
+ * 9.  Cancel navigates back to the list
+ * 10. Responsive — no horizontal scroll on current viewport
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import {
+  HouseholdItemCreatePage,
+  HOUSEHOLD_ITEM_CREATE_ROUTE,
+} from '../../pages/HouseholdItemCreatePage.js';
+import { deleteHouseholdItemViaApi } from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Page loads with correct heading
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
+  test('New Household Item page loads with correct heading', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    await expect(createPage.heading).toBeVisible();
+    await expect(createPage.heading).toHaveText('New Household Item');
+  });
+
+  test('Back button and Cancel button are visible on page load', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    await expect(createPage.backButton).toBeVisible();
+    await expect(createPage.cancelButton).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Back button navigates to /household-items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Back button navigation (Scenario 2)', { tag: '@responsive' }, () => {
+  test('"← Back to Household Items" button navigates to /household-items', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+    await createPage.backButton.click();
+
+    await page.waitForURL('**/household-items');
+    expect(page.url()).toContain('/household-items');
+    expect(page.url()).not.toContain('/household-items/new');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: All primary form fields are visible
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Form fields visible (Scenario 3)', { tag: '@responsive' }, () => {
+  test('All primary form fields are visible on page load', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    await expect(createPage.nameInput).toBeVisible();
+    await expect(createPage.categorySelect).toBeVisible();
+    await expect(createPage.statusSelect).toBeVisible();
+    await expect(createPage.quantityInput).toBeVisible();
+    await expect(createPage.submitButton).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Create item with name only — redirects to detail
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Create with name only — happy path (Scenario 4)', { tag: '@responsive' }, () => {
+  test(
+    'Creating a household item with name only redirects to the detail page',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const createPage = new HouseholdItemCreatePage(page);
+      let createdId: string | null = null;
+      const name = `${testPrefix} HI Create Name Only`;
+
+      try {
+        await createPage.goto();
+        await createPage.fillForm({ name });
+        createdId = await createPage.submitAndWaitForDetail();
+
+        // Should have navigated to the detail page
+        expect(page.url()).toContain('/household-items/');
+        expect(page.url()).not.toContain('/new');
+        expect(createdId).toBeTruthy();
+
+        // Detail page heading should show the item name
+        const heading = page.getByRole('heading', { level: 1 });
+        await expect(heading).toBeVisible();
+        const headingText = await heading.textContent();
+        expect(headingText?.trim()).toContain(name);
+      } finally {
+        if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: Create item with all major fields
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Create with all fields (Scenario 5)', { tag: '@responsive' }, () => {
+  test('Creating household item with all major fields succeeds', async ({ page, testPrefix }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+    let createdId: string | null = null;
+    const name = `${testPrefix} HI Create All Fields`;
+
+    try {
+      await createPage.goto();
+      await createPage.fillForm({
+        name,
+        description: 'A comfortable sofa for the living room',
+        category: 'furniture',
+        status: 'planned',
+        quantity: '2',
+        room: 'Living Room',
+        url: 'https://example.com/sofa',
+        orderDate: '2026-04-01',
+        earliestDeliveryDate: '2026-05-01',
+        latestDeliveryDate: '2026-06-01',
+      });
+
+      createdId = await createPage.submitAndWaitForDetail();
+
+      // Should be on the detail page
+      expect(page.url()).toContain('/household-items/');
+      expect(createdId).toBeTruthy();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: Submit without name shows validation error
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Validation error — empty name (Scenario 6)', { tag: '@responsive' }, () => {
+  test('Submitting without a name shows validation error and stays on create page', async ({
+    page,
+  }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    // Submit without filling the name
+    await createPage.submit();
+
+    // Should still be on the create page
+    expect(page.url()).toContain('/household-items/new');
+
+    // Validation error should appear near the name field
+    const nameError = page.locator('[class*="errorText"]').first();
+    await expect(nameError).toBeVisible({ timeout: 5000 });
+    const errorText = await nameError.textContent();
+    expect(errorText?.toLowerCase()).toMatch(/name|required/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 7: Category select options
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Category options (Scenario 7)', { tag: '@responsive' }, () => {
+  test('Category select contains all expected options', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    const expectedCategories = [
+      'Furniture',
+      'Appliances',
+      'Fixtures',
+      'Decor',
+      'Electronics',
+      'Outdoor',
+      'Storage',
+      'Other',
+    ];
+
+    for (const category of expectedCategories) {
+      const option = createPage.categorySelect.locator('option', { hasText: category });
+      await expect(option).toHaveCount(1);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 8: Status select options
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Status options (Scenario 8)', { tag: '@responsive' }, () => {
+  test('Status select contains all expected options', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+
+    const expectedStatuses = ['Planned', 'Purchased', 'Scheduled', 'Arrived'];
+
+    for (const status of expectedStatuses) {
+      const option = createPage.statusSelect.locator('option', { hasText: status });
+      await expect(option).toHaveCount(1);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 9: Cancel navigates back to list
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Cancel navigation (Scenario 9)', { tag: '@responsive' }, () => {
+  test('"Cancel" button navigates back to /household-items', async ({ page }) => {
+    const createPage = new HouseholdItemCreatePage(page);
+
+    await createPage.goto();
+    await createPage.cancelButton.click();
+
+    await page.waitForURL('**/household-items');
+    expect(page.url()).toContain('/household-items');
+    expect(page.url()).not.toContain('/new');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 10: Responsive — no horizontal scroll
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Responsive layout (Scenario 10)', { tag: '@responsive' }, () => {
+  test('New Household Item page renders without horizontal scroll', async ({ page }) => {
+    await page.goto(HOUSEHOLD_ITEM_CREATE_ROUTE);
+    await page.getByRole('heading', { level: 1, name: 'New Household Item' }).waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth;
+    });
+
+    expect(hasHorizontalScroll).toBe(false);
+  });
+
+  test('Create page renders correctly in dark mode', async ({ page }) => {
+    await page.goto(HOUSEHOLD_ITEM_CREATE_ROUTE);
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+    await page.getByRole('heading', { level: 1, name: 'New Household Item' }).waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth;
+    });
+    expect(hasHorizontalScroll).toBe(false);
+  });
+});

--- a/e2e/tests/household-items/household-item-detail.spec.ts
+++ b/e2e/tests/household-items/household-item-detail.spec.ts
@@ -1,0 +1,355 @@
+/**
+ * E2E tests for the Household Item Detail page (/household-items/:id)
+ *
+ * EPIC-04 Stories covered:
+ * - 4.5: Detail Page
+ * - 4.6: Budget Integration (budget lines, subsidies)
+ * - 4.7: Work Item Linking (timeline dependencies)
+ * - 8.6: Document Linking for Household Items
+ * - 4.8: Responsive & Accessibility
+ *
+ * Scenarios covered:
+ * 1.  Page loads with item name as heading
+ * 2.  Back link navigates to /household-items
+ * 3.  Edit button navigates to /household-items/:id/edit
+ * 4.  Budget section is visible on the detail page
+ * 5.  Documents section heading "Documents" is visible
+ * 6.  "+  Add Document" button is disabled when Paperless is not configured
+ * 7.  "Not configured" banner is shown in Documents section
+ * 8.  404 / error state for non-existent item ID
+ * 9.  Responsive — no horizontal scroll on current viewport
+ * 10. Dark mode rendering
+ * 11. Documents section has accessible aria-labelledby heading
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { HouseholdItemDetailPage } from '../../pages/HouseholdItemDetailPage.js';
+import { createHouseholdItemViaApi, deleteHouseholdItemViaApi } from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Page loads with item name as heading
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
+  test(
+    'Household Item detail page loads with the item name as the h1 heading',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const detailPage = new HouseholdItemDetailPage(page);
+      let createdId: string | null = null;
+      const name = `${testPrefix} HI Detail Heading Test`;
+
+      try {
+        createdId = await createHouseholdItemViaApi(page, { name });
+
+        await detailPage.goto(createdId);
+
+        await expect(detailPage.heading).toBeVisible();
+        const headingText = await detailPage.getHeadingText();
+        expect(headingText.trim()).toContain(name);
+      } finally {
+        if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Back link navigates to /household-items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Back breadcrumb navigation (Scenario 2)', { tag: '@responsive' }, () => {
+  test('"Household Items" breadcrumb link navigates to /household-items', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new HouseholdItemDetailPage(page);
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Back Link Test`,
+      });
+
+      await detailPage.goto(createdId);
+
+      await detailPage.backLink.click();
+
+      await page.waitForURL('**/household-items');
+      expect(page.url()).toContain('/household-items');
+      // Should not be on the detail page
+      expect(page.url()).not.toMatch(/\/household-items\/[a-zA-Z0-9-]+$/);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Edit button navigates to edit page
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Edit button navigation (Scenario 3)', { tag: '@responsive' }, () => {
+  test('"Edit" button navigates to /household-items/:id/edit', async ({ page, testPrefix }) => {
+    const detailPage = new HouseholdItemDetailPage(page);
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Button Test`,
+      });
+
+      await detailPage.goto(createdId);
+
+      await detailPage.editButton.click();
+
+      await page.waitForURL(`**/household-items/${createdId}/edit`);
+      expect(page.url()).toContain('/edit');
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Budget section visible (Story 4.6)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Budget section visible (Scenario 4 — Story 4.6)', { tag: '@responsive' }, () => {
+  test('Budget section is present on the household item detail page', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Budget Section Test`,
+      });
+
+      await page.goto(`/household-items/${createdId}`);
+      await page.getByRole('heading', { level: 1 }).waitFor({ state: 'visible', timeout: 10000 });
+
+      // The budget section heading should be visible
+      // HouseholdItemDetailPage renders a Budget section with h2
+      const budgetHeading = page.getByRole('heading', { name: /budget/i, level: 2 });
+      await expect(budgetHeading).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('"Add Budget Line" or similar button is visible in the budget section', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Budget Add Test`,
+      });
+
+      await page.goto(`/household-items/${createdId}`);
+      await page.getByRole('heading', { level: 1 }).waitFor({ state: 'visible', timeout: 10000 });
+
+      // The budget section should have an "Add Budget Line" button
+      const addBudgetButton = page.getByRole('button', {
+        name: /add budget line|add line/i,
+      });
+      await expect(addBudgetButton).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenarios 5–7, 11: Documents section (Story 8.6)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Documents section — Story 8.6 (Scenarios 5–7, 11)', { tag: '@responsive' }, () => {
+  test('"Documents" section heading is visible on household item detail', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Doc Section Heading`,
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.goto(createdId);
+
+      await expect(detailPage.documentsHeading).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('"+ Add Document" button is disabled when Paperless is not configured', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Doc Add Btn Test`,
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.goto(createdId);
+
+      const addDocButton = page.getByRole('button', { name: '+ Add Document', exact: true });
+      await expect(addDocButton).toBeVisible({ timeout: 10000 });
+      await expect(addDocButton).toBeDisabled();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('"Not configured" banner is shown in Documents section on HI detail', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Doc Not Configured`,
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.goto(createdId);
+
+      const notConfiguredText = page.getByText('Paperless-ngx is not configured');
+      await expect(notConfiguredText).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('Documents section has accessible #documents-section-title heading', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Doc A11y Title`,
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.goto(createdId);
+
+      const sectionTitle = page.locator('#documents-section-title');
+      await expect(sectionTitle).toBeVisible({ timeout: 10000 });
+      await expect(sectionTitle).toHaveText(/Documents/);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 8: 404 / error state for non-existent item ID
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('404 / error state (Scenario 8)', { tag: '@responsive' }, () => {
+  test('Navigating to a non-existent household item shows error state', async ({ page }) => {
+    await page.goto('/household-items/non-existent-id-000');
+
+    // The page should either show a not-found message or redirect
+    // The HouseholdItemDetailPage shows "not found" text when item doesn't exist
+    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i);
+    await expect(notFoundText).toBeVisible({ timeout: 10000 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 9: Responsive — no horizontal scroll
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Responsive layout (Scenario 9)', { tag: '@responsive' }, () => {
+  test('Household Item detail page renders without horizontal scroll', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Detail Responsive`,
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.goto(createdId);
+
+      const hasHorizontalScroll = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > window.innerWidth;
+      });
+
+      expect(hasHorizontalScroll).toBe(false);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 10: Dark mode rendering
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Dark mode rendering (Scenario 10)', { tag: '@responsive' }, () => {
+  test('Household Item detail page renders correctly in dark mode', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Detail Dark Mode`,
+      });
+
+      await page.goto(`/household-items/${createdId}`);
+      await page.evaluate(() => {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.heading.waitFor({ state: 'visible', timeout: 10000 });
+
+      await expect(detailPage.heading).toBeVisible();
+
+      const hasHorizontalScroll = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > window.innerWidth;
+      });
+      expect(hasHorizontalScroll).toBe(false);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('Documents section renders in dark mode on HI detail', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Doc Dark Mode`,
+      });
+
+      await page.goto(`/household-items/${createdId}`);
+      await page.evaluate(() => {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      });
+
+      const detailPage = new HouseholdItemDetailPage(page);
+      await detailPage.heading.waitFor({ state: 'visible', timeout: 10000 });
+
+      await expect(detailPage.documentsHeading).toBeVisible({ timeout: 10000 });
+
+      const addDocButton = page.getByRole('button', { name: '+ Add Document', exact: true });
+      await expect(addDocButton).toBeVisible();
+      await expect(addDocButton).toBeDisabled();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});

--- a/e2e/tests/household-items/household-item-edit.spec.ts
+++ b/e2e/tests/household-items/household-item-edit.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * E2E tests for the Household Item Edit page (/household-items/:id/edit)
+ *
+ * EPIC-04 Story 4.4: Create & Edit Form
+ *
+ * Scenarios covered:
+ * 1.  Edit page loads with h1 "Edit Household Item"
+ * 2.  Form is pre-populated with the existing item data
+ * 3.  Back button navigates to the detail page
+ * 4.  Save changes successfully updates the item
+ * 5.  Clear the name field — validation error shown
+ * 6.  404 state for non-existent item ID
+ * 7.  Responsive — no horizontal scroll on current viewport
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { createHouseholdItemViaApi, deleteHouseholdItemViaApi } from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Edit page loads with correct heading
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
+  test('Edit Household Item page loads with correct heading', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Heading Test`,
+      });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+
+      const heading = page.getByRole('heading', { level: 1, name: 'Edit Household Item' });
+      await expect(heading).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('Save Changes button and Cancel button are visible', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Buttons Test`,
+      });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      const saveButton = page.getByRole('button', { name: /Save Changes|Saving\.\.\./i });
+      await expect(saveButton).toBeVisible();
+
+      const cancelButton = page.getByRole('button', { name: 'Cancel', exact: true });
+      await expect(cancelButton).toBeVisible();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Form pre-populated with existing data
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Form pre-population (Scenario 2)', { tag: '@responsive' }, () => {
+  test('Edit form is pre-populated with the existing item name', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+    const name = `${testPrefix} HI Edit Pre-Population`;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, { name, category: 'furniture' });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      // The name input should be pre-filled
+      const nameInput = page.locator('#name');
+      await expect(nameInput).toHaveValue(name);
+
+      // The category select should be pre-selected to 'furniture'
+      const categorySelect = page.locator('#category');
+      await expect(categorySelect).toHaveValue('furniture');
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Back button navigates to detail page
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Back button navigation (Scenario 3)', { tag: '@responsive' }, () => {
+  test('"← Back to Item" navigates to the item detail page', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Back Test`,
+      });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      // Back button text is "← Back to Item" (from HouseholdItemEditPage source)
+      const backButton = page.getByRole('button', { name: /← Back to Item/i });
+      await backButton.click();
+
+      // Should navigate to the detail page
+      await page.waitForURL(`**/household-items/${createdId}`);
+      expect(page.url()).toContain(`/household-items/${createdId}`);
+      expect(page.url()).not.toContain('/edit');
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Save changes updates the item
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Save changes — happy path (Scenario 4)', { tag: '@responsive' }, () => {
+  test('Saving changes updates the item name and navigates to detail page', async ({
+    page,
+    testPrefix,
+  }) => {
+    let createdId: string | null = null;
+    const originalName = `${testPrefix} HI Edit Save Original`;
+    const updatedName = `${testPrefix} HI Edit Save Updated`;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, { name: originalName });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      // Update the name
+      const nameInput = page.locator('#name');
+      await nameInput.fill(updatedName);
+
+      // Save
+      const saveResponsePromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes(`/api/household-items/${createdId}`) &&
+          resp.request().method() === 'PATCH' &&
+          resp.status() === 200,
+      );
+      const saveButton = page.getByRole('button', { name: /Save Changes|Saving\.\.\./i });
+      await saveButton.click();
+      await saveResponsePromise;
+
+      // Should navigate back to the detail page
+      await page.waitForURL(`**/household-items/${createdId}`);
+      expect(page.url()).toContain(`/household-items/${createdId}`);
+      expect(page.url()).not.toContain('/edit');
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: Validation error when name is cleared
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Validation — empty name (Scenario 5)', { tag: '@responsive' }, () => {
+  test('Clearing the name and saving shows a validation error', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Validate Name`,
+      });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      // Clear the name field
+      const nameInput = page.locator('#name');
+      await nameInput.fill('');
+
+      // Attempt to save
+      const saveButton = page.getByRole('button', { name: /Save Changes|Saving\.\.\./i });
+      await saveButton.click();
+
+      // Should still be on the edit page
+      expect(page.url()).toContain('/edit');
+
+      // Validation error should appear
+      const nameError = page.locator('[class*="errorText"]').first();
+      await expect(nameError).toBeVisible({ timeout: 5000 });
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: 404 state for non-existent item
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('404 state (Scenario 6)', { tag: '@responsive' }, () => {
+  test('Navigating to edit page for non-existent item shows not-found state', async ({ page }) => {
+    await page.goto('/household-items/non-existent-id-edit-000/edit');
+
+    // The edit page renders a not-found state when the item doesn't exist
+    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i);
+    await expect(notFoundText).toBeVisible({ timeout: 10000 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 7: Responsive layout
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Responsive layout (Scenario 7)', { tag: '@responsive' }, () => {
+  test('Edit page renders without horizontal scroll', async ({ page, testPrefix }) => {
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Edit Responsive`,
+      });
+
+      await page.goto(`/household-items/${createdId}/edit`);
+      await page.getByRole('heading', { level: 1, name: 'Edit Household Item' }).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+
+      const hasHorizontalScroll = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > window.innerWidth;
+      });
+
+      expect(hasHorizontalScroll).toBe(false);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -1,0 +1,625 @@
+/**
+ * E2E tests for the Household Items list page (/household-items)
+ *
+ * EPIC-04 Stories covered:
+ * - 4.3: List Page (filtering, sorting, status badges)
+ * - 4.8: Responsive & Accessibility
+ *
+ * Scenarios covered:
+ * 1.  Page loads with h1 "Household Items"
+ * 2.  "New Item" button navigates to /household-items/new
+ * 3.  Empty state when no items exist (mocked)
+ * 4.  Filter empty state when search matches nothing
+ * 5.  Item created via API appears in the list
+ * 6.  Search filters the list
+ * 7.  Category filter narrows results
+ * 8.  Status filter narrows results
+ * 9.  Status badge rendered correctly (planned, purchased, scheduled, arrived)
+ * 10. Delete modal — confirm removes item
+ * 11. Delete modal — cancel leaves item
+ * 12. Pagination visible when API returns totalPages > 1 (mocked)
+ * 13. Responsive — no horizontal scroll on current viewport
+ * 14. Mobile: card view shown when viewport < 768px
+ * 15. Desktop: table view shown when viewport >= 768px
+ * 16. Dark mode rendering
+ * 17. Filter panel has accessible role="search" landmark
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { HouseholdItemsPage, HOUSEHOLD_ITEMS_ROUTE } from '../../pages/HouseholdItemsPage.js';
+import { API } from '../../fixtures/testData.js';
+import { createHouseholdItemViaApi, deleteHouseholdItemViaApi } from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Page loads with h1 "Household Items"
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
+  test(
+    'Household Items list page loads with h1 "Household Items"',
+    { tag: '@smoke' },
+    async ({ page }) => {
+      const listPage = new HouseholdItemsPage(page);
+
+      await listPage.goto();
+
+      await expect(listPage.heading).toBeVisible();
+      await expect(listPage.heading).toHaveText('Household Items');
+    },
+  );
+
+  test('Page URL is /household-items', async ({ page }) => {
+    await page.goto(HOUSEHOLD_ITEMS_ROUTE);
+    await page.waitForURL('/household-items');
+    expect(page.url()).toContain('/household-items');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: "New Item" button navigates to /household-items/new
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('"New Item" navigation (Scenario 2)', { tag: '@responsive' }, () => {
+  test('"New Item" button navigates to the create page', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await listPage.goto();
+    await expect(listPage.newItemButton).toBeVisible();
+
+    await listPage.newItemButton.click();
+
+    await page.waitForURL('**/household-items/new');
+    expect(page.url()).toContain('/household-items/new');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Empty state when no items exist (mocked)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Empty state — no items (Scenario 3)', { tag: '@responsive' }, () => {
+  test('Empty state shown when no household items exist (mocked empty response)', async ({
+    page,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await page.route(`${API.householdItems}*`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [],
+            pagination: { page: 1, pageSize: 25, totalItems: 0, totalPages: 0 },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    try {
+      await listPage.goto();
+
+      await expect(listPage.emptyState).toBeVisible({ timeout: 7000 });
+
+      const emptyText = await listPage.emptyState.textContent();
+      expect(emptyText?.toLowerCase()).toMatch(/no household items yet/);
+
+      // CTA button to create the first item
+      const ctaButton = listPage.emptyState.getByRole('button', {
+        name: /Create First Item/i,
+      });
+      await expect(ctaButton).toBeVisible();
+    } finally {
+      await page.unroute(`${API.householdItems}*`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Filter empty state when search matches nothing
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Empty state — filter no match (Scenario 4)', { tag: '@responsive' }, () => {
+  test('Filter empty state shown when search matches no household items', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Filter Empty Test`,
+      });
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      await listPage.search('ZZZNOMATCH99999XYZABC');
+
+      await expect(listPage.emptyState).toBeVisible({ timeout: 7000 });
+      const emptyText = await listPage.emptyState.textContent();
+      expect(emptyText?.toLowerCase()).toMatch(/no household items match your filters/);
+
+      // "Clear All Filters" button visible
+      const clearButton = listPage.emptyState.getByRole('button', {
+        name: /Clear All Filters/i,
+      });
+      await expect(clearButton).toBeVisible();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: Item created via API appears in list
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Item appears in list after API creation (Scenario 5)',
+  { tag: '@responsive' },
+  () => {
+    test('Household item created via API appears in the list', async ({ page, testPrefix }) => {
+      const listPage = new HouseholdItemsPage(page);
+      let createdId: string | null = null;
+      const name = `${testPrefix} HI API Created Item`;
+
+      try {
+        createdId = await createHouseholdItemViaApi(page, { name });
+
+        await listPage.goto();
+        await listPage.waitForLoaded();
+
+        await listPage.search(name);
+
+        const names = await listPage.getItemNames();
+        expect(names).toContain(name);
+      } finally {
+        if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+      }
+    });
+
+    test('Table shows item name, category, status columns on desktop', async ({
+      page,
+      testPrefix,
+    }) => {
+      const viewport = page.viewportSize();
+      if (!viewport || viewport.width < 768) {
+        test.skip();
+        return;
+      }
+
+      const listPage = new HouseholdItemsPage(page);
+      let createdId: string | null = null;
+      const name = `${testPrefix} HI Table Columns Test`;
+
+      try {
+        createdId = await createHouseholdItemViaApi(page, { name, category: 'furniture' });
+
+        await listPage.goto();
+        await listPage.waitForLoaded();
+        await listPage.search(name);
+
+        await expect(listPage.tableContainer).toBeVisible();
+
+        const table = listPage.tableContainer.locator('table');
+        await expect(table.getByRole('columnheader', { name: 'Name' })).toBeVisible();
+        await expect(table.getByRole('columnheader', { name: 'Category' })).toBeVisible();
+        await expect(table.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+        await expect(table.getByRole('columnheader', { name: 'Actions' })).toBeVisible();
+      } finally {
+        if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: Search filters the list
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
+  test('Search by name filters list to matching items only', async ({ page, testPrefix }) => {
+    const listPage = new HouseholdItemsPage(page);
+    const created: string[] = [];
+    const alphaName = `${testPrefix} HI Alpha Sofa`;
+    const betaName = `${testPrefix} HI Beta Lamp`;
+
+    try {
+      created.push(await createHouseholdItemViaApi(page, { name: alphaName }));
+      created.push(await createHouseholdItemViaApi(page, { name: betaName }));
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      await listPage.search(`${testPrefix} HI Alpha`);
+
+      const names = await listPage.getItemNames();
+      expect(names).toContain(alphaName);
+      expect(names).not.toContain(betaName);
+    } finally {
+      for (const id of created) {
+        await deleteHouseholdItemViaApi(page, id);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 7: Category filter narrows results
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
+  test('Category filter narrows list to items in selected category', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+    const created: string[] = [];
+    const furnitureName = `${testPrefix} HI Cat Furniture Chair`;
+    const applianceName = `${testPrefix} HI Cat Appliance Washer`;
+
+    try {
+      created.push(
+        await createHouseholdItemViaApi(page, { name: furnitureName, category: 'furniture' }),
+      );
+      created.push(
+        await createHouseholdItemViaApi(page, { name: applianceName, category: 'appliances' }),
+      );
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      // First search to narrow to our prefix, then apply category filter
+      await listPage.search(`${testPrefix} HI Cat`);
+
+      // Select 'furniture' category
+      const filterResponsePromise = page.waitForResponse(
+        (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+      );
+      await listPage.categoryFilter.selectOption('furniture');
+      await filterResponsePromise;
+      await listPage.waitForLoaded();
+
+      const names = await listPage.getItemNames();
+      expect(names).toContain(furnitureName);
+      expect(names).not.toContain(applianceName);
+    } finally {
+      for (const id of created) {
+        await deleteHouseholdItemViaApi(page, id);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 8: Status filter narrows results
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
+  test('Status filter narrows list to items with selected status', async ({ page, testPrefix }) => {
+    const listPage = new HouseholdItemsPage(page);
+    const created: string[] = [];
+    const plannedName = `${testPrefix} HI Status Planned Desk`;
+    const purchasedName = `${testPrefix} HI Status Purchased Couch`;
+
+    try {
+      created.push(await createHouseholdItemViaApi(page, { name: plannedName, status: 'planned' }));
+      created.push(
+        await createHouseholdItemViaApi(page, { name: purchasedName, status: 'purchased' }),
+      );
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      await listPage.search(`${testPrefix} HI Status`);
+
+      const filterResponsePromise = page.waitForResponse(
+        (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+      );
+      await listPage.statusFilter.selectOption('planned');
+      await filterResponsePromise;
+      await listPage.waitForLoaded();
+
+      const names = await listPage.getItemNames();
+      expect(names).toContain(plannedName);
+      expect(names).not.toContain(purchasedName);
+    } finally {
+      for (const id of created) {
+        await deleteHouseholdItemViaApi(page, id);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 9: Status badge rendered correctly
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () => {
+  test('Status badges render for planned, purchased, scheduled, arrived items', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+    const created: string[] = [];
+
+    const statuses = ['planned', 'purchased', 'scheduled', 'arrived'] as const;
+    const nameMap: Record<string, string> = {};
+
+    try {
+      for (const status of statuses) {
+        const name = `${testPrefix} HI Badge ${status}`;
+        nameMap[status] = name;
+        created.push(await createHouseholdItemViaApi(page, { name, status }));
+      }
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      await listPage.search(`${testPrefix} HI Badge`);
+
+      // Each status should have a visible badge in the page
+      for (const status of statuses) {
+        const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
+        const badge = page.locator('[class*="badge"]', { hasText: statusLabel }).first();
+        await expect(badge).toBeVisible();
+      }
+    } finally {
+      for (const id of created) {
+        await deleteHouseholdItemViaApi(page, id);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 10: Delete modal — confirm removes item
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, () => {
+  test('Confirming delete removes the household item from the list', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+    const name = `${testPrefix} HI Delete Confirm`;
+
+    // Create item (no cleanup var — deleted via UI)
+    const createdId = await createHouseholdItemViaApi(page, { name });
+
+    await listPage.goto();
+    await listPage.waitForLoaded();
+
+    await listPage.search(name);
+    const namesBefore = await listPage.getItemNames();
+    expect(namesBefore).toContain(name);
+
+    await listPage.openDeleteModal(name);
+    await expect(listPage.deleteModal).toBeVisible();
+
+    // Modal contains the item name
+    const modalText = await listPage.deleteModal.textContent();
+    expect(modalText).toContain(name);
+
+    const listRefreshPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+    );
+    await listPage.confirmDelete();
+    await listRefreshPromise;
+
+    const namesAfter = await listPage.getItemNames();
+    expect(namesAfter).not.toContain(name);
+
+    void createdId;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 11: Delete modal — cancel leaves item
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Delete modal — cancel (Scenario 11)', { tag: '@responsive' }, () => {
+  test('Cancelling delete modal leaves the household item in the list', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new HouseholdItemsPage(page);
+    let createdId: string | null = null;
+    const name = `${testPrefix} HI Delete Cancel`;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, { name });
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+      await listPage.search(name);
+
+      await listPage.openDeleteModal(name);
+      await listPage.cancelDelete();
+
+      const names = await listPage.getItemNames();
+      expect(names).toContain(name);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 12: Pagination visible when >25 items (mocked)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Pagination (Scenario 12)', { tag: '@responsive' }, () => {
+  test('Pagination controls visible when API returns totalPages > 1', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await page.route(`${API.householdItems}*`, async (route) => {
+      if (route.request().method() === 'GET') {
+        const items = Array.from({ length: 25 }, (_, i) => ({
+          id: `mock-hi-${i}`,
+          name: `Mock Household Item ${String(i + 1).padStart(2, '0')}`,
+          category: 'furniture',
+          status: 'planned',
+          room: null,
+          vendor: null,
+          totalPlannedAmount: null,
+          targetDeliveryDate: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }));
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items,
+            pagination: { page: 1, pageSize: 25, totalItems: 26, totalPages: 2 },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    try {
+      await listPage.goto();
+
+      await expect(listPage.pagination).toBeVisible({ timeout: 7000 });
+      await expect(listPage.nextPageButton).toBeVisible();
+      await expect(listPage.prevPageButton).toBeVisible();
+
+      // Previous page disabled on page 1
+      await expect(listPage.prevPageButton).toBeDisabled();
+
+      const infoText = await listPage.getPaginationInfoText();
+      expect(infoText).toMatch(/showing|of 26/i);
+    } finally {
+      await page.unroute(`${API.householdItems}*`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 13–15: Responsive layout
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Responsive layout (Scenarios 13–15)', { tag: '@responsive' }, () => {
+  test('Household Items list page renders without horizontal scroll', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await listPage.goto();
+
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth;
+    });
+
+    expect(hasHorizontalScroll).toBe(false);
+  });
+
+  test('Mobile: card view is shown when viewport is < 768px', async ({ page, testPrefix }) => {
+    const viewport = page.viewportSize();
+
+    if (!viewport || viewport.width >= 768) {
+      test.skip();
+      return;
+    }
+
+    const listPage = new HouseholdItemsPage(page);
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Mobile Card Test`,
+      });
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      const cards = await listPage.cardsContainer.locator('[class*="card"]').all();
+      expect(cards.length).toBeGreaterThan(0);
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+
+  test('Desktop: table is visible when viewport is >= 768px', async ({ page, testPrefix }) => {
+    const viewport = page.viewportSize();
+
+    if (!viewport || viewport.width < 768) {
+      test.skip();
+      return;
+    }
+
+    const listPage = new HouseholdItemsPage(page);
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createHouseholdItemViaApi(page, {
+        name: `${testPrefix} HI Desktop Table Test`,
+      });
+
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      await expect(listPage.tableContainer).toBeVisible();
+    } finally {
+      if (createdId) await deleteHouseholdItemViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 16: Dark mode rendering
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Dark mode rendering (Scenario 16)', { tag: '@responsive' }, () => {
+  test('Household Items list page renders correctly in dark mode', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await page.goto(HOUSEHOLD_ITEMS_ROUTE);
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await listPage.heading.waitFor({ state: 'visible', timeout: 7000 });
+
+    await expect(listPage.heading).toBeVisible();
+
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth;
+    });
+    expect(hasHorizontalScroll).toBe(false);
+  });
+
+  test('Search input and filter controls visible in dark mode', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await page.goto(HOUSEHOLD_ITEMS_ROUTE);
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await listPage.heading.waitFor({ state: 'visible', timeout: 7000 });
+
+    await expect(listPage.searchInput).toBeVisible();
+    await expect(listPage.categoryFilter).toBeVisible();
+    await expect(listPage.statusFilter).toBeVisible();
+    await expect(listPage.sortOrderButton).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 17: Filter panel accessible landmark
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Accessibility (Scenario 17)', { tag: '@responsive' }, () => {
+  test('Filter panel has accessible role="search" landmark', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await listPage.goto();
+
+    // The filter panel has role="search" and aria-label="Household item filters"
+    const filterRegion = page.getByRole('search', { name: 'Household item filters' });
+    await expect(filterRegion).toBeVisible();
+  });
+
+  test('Search input has accessible label', async ({ page }) => {
+    const listPage = new HouseholdItemsPage(page);
+
+    await listPage.goto();
+
+    await expect(listPage.searchInput).toBeVisible();
+    // The aria-label is "Search household items"
+    const label = await listPage.searchInput.getAttribute('aria-label');
+    expect(label).toBe('Search household items');
+  });
+});

--- a/e2e/tests/navigation/stub-pages.spec.ts
+++ b/e2e/tests/navigation/stub-pages.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Smoke tests for stub pages — Dashboard, Household Items
+ * Smoke tests for stub pages — Dashboard
  *
  * These pages are placeholder implementations that will be expanded in future
  * epics.  The tests here verify that:
@@ -14,11 +14,12 @@
  * test now lives in e2e/tests/timeline/timeline-gantt.spec.ts.
  * NOTE: Documents page was removed (standalone browser unnecessary). Document
  * linking tests remain in e2e/tests/documents/documents-linked-sections.spec.ts.
+ * NOTE: Household Items has graduated to a full feature page (EPIC-04). Its
+ * tests now live in e2e/tests/household-items/.
  */
 
 import { test, expect } from '../../fixtures/auth.js';
 import { DashboardPage } from '../../pages/DashboardPage.js';
-import { HouseholdItemsPage } from '../../pages/HouseholdItemsPage.js';
 
 test.describe('Stub pages — smoke tests', { tag: '@responsive' }, () => {
   test('Dashboard page loads with heading', { tag: '@smoke' }, async ({ page }) => {
@@ -27,13 +28,5 @@ test.describe('Stub pages — smoke tests', { tag: '@responsive' }, () => {
     await expect(dashboard.heading).toBeVisible();
     await expect(dashboard.heading).toHaveText('Dashboard');
     await expect(dashboard.description).toBeVisible();
-  });
-
-  test('Household Items page loads with heading', async ({ page }) => {
-    const householdItems = new HouseholdItemsPage(page);
-    await householdItems.goto();
-    await expect(householdItems.heading).toBeVisible();
-    await expect(householdItems.heading).toHaveText('Household Items');
-    await expect(householdItems.description).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Adds full Playwright E2E test coverage for EPIC-04 (Household Items & Furniture Management). Prior to this PR, the only E2E coverage for household items was a single stub smoke test verifying the page loaded. EPIC-04 is now fully implemented across 4 pages (list, create, detail, edit), so this PR brings E2E coverage in line with the rest of the application.

### Coverage added (80+ tests across 4 spec files)

**`e2e/tests/household-items/household-items-list.spec.ts`** (Stories 4.3, 4.8)
- Page load with h1 "Household Items"
- "New Item" button navigation
- Empty state (mocked)
- Filter empty state (search no match)
- Item appears in list after API creation
- Search filtering
- Category filter
- Status filter
- Status badge rendering (planned/purchased/scheduled/arrived)
- Delete modal — confirm removes item
- Delete modal — cancel leaves item
- Pagination with mocked response
- Responsive (no horizontal scroll)
- Mobile: card view visible
- Desktop: table visible
- Dark mode rendering
- Filter panel accessible `role="search"` landmark

**`e2e/tests/household-items/household-item-create.spec.ts`** (Story 4.4)
- Page load with h1 "New Household Item"
- Back button navigation
- All form fields visible
- Create with name only — happy path, redirect to detail
- Create with all major fields
- Validation error on empty name
- Category select options (all 8 categories)
- Status select options (all 4 statuses)
- Cancel navigation
- Responsive + dark mode

**`e2e/tests/household-items/household-item-detail.spec.ts`** (Stories 4.5, 4.6, 4.7, 8.6, 4.8)
- Page load with item name as heading
- Breadcrumb link navigation
- Edit button navigation
- Budget section visible (Story 4.6)
- "Add Budget Line" button visible
- Documents section heading (Story 8.6)
- "+ Add Document" button disabled when Paperless not configured
- "Not configured" banner shown
- `#documents-section-title` accessible heading
- 404/error state for non-existent ID
- Responsive + dark mode

**`e2e/tests/household-items/household-item-edit.spec.ts`** (Story 4.4)
- Edit page heading
- Save/Cancel buttons visible
- Form pre-populated with existing item data
- Back button navigates to detail
- Save changes — happy path
- Validation error on cleared name
- 404 state for non-existent item
- Responsive

### Supporting changes

- **`e2e/pages/HouseholdItemsPage.ts`**: Fully rewritten from stub POM to production-ready POM with all locators, search/filter methods, delete modal helpers, pagination helpers
- **`e2e/pages/HouseholdItemCreatePage.ts`**: New POM for `/household-items/new`
- **`e2e/pages/HouseholdItemDetailPage.ts`**: New POM for `/household-items/:id`
- **`e2e/fixtures/apiHelpers.ts`**: Added `createHouseholdItemViaApi` / `deleteHouseholdItemViaApi`
- **`e2e/fixtures/testData.ts`**: Added `API.householdItems` and `ROUTES.householdItemsNew` constants
- **`e2e/tests/navigation/stub-pages.spec.ts`**: Removed household items stub test (page graduated to full feature — EPIC-04)

## Coverage Matrix

| Story | Feature | E2E Covered |
|-------|---------|-------------|
| 4.1 | Schema & Migration | N/A (backend only) |
| 4.2 | CRUD API | Via API helpers in all tests |
| 4.3 | List Page | household-items-list.spec.ts |
| 4.4 | Create & Edit Form | household-item-create.spec.ts, household-item-edit.spec.ts |
| 4.5 | Detail Page | household-item-detail.spec.ts |
| 4.6 | Budget Integration | household-item-detail.spec.ts (budget section visible + Add Budget Line) |
| 4.7 | Work Item Linking | household-item-detail.spec.ts (page loads without error; deep interaction via unit tests) |
| 4.8 | Responsive & A11y | All spec files tagged `@responsive` |
| 4.9 | Invoice Linking | household-item-detail.spec.ts (page loads) |
| 4.10 | Timeline Dependencies | household-item-detail.spec.ts (page loads) |
| 8.6 | Document Linking | household-item-detail.spec.ts (Documents section, disabled state) |

## Test plan

- [ ] CI sharded E2E suite passes on `beta`
- [ ] Smoke tests (`@smoke` tag) pass: list page load, create redirect
- [ ] Responsive tests across desktop/tablet/mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)