### PR TITLE
ci: skip CI triggers for auto-fix bot commits

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -50,5 +50,5 @@ jobs:
           git config user.name "cornerstone-bot[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "style: auto-fix lint and format"
+          git commit -m "style: auto-fix lint and format [skip ci]"
           git push origin beta


### PR DESCRIPTION
## Summary

- Adds `[skip ci]` to the auto-fix workflow's commit message so its pushes to `beta` don't trigger the release workflow

## Test plan

- [ ] Verify auto-fix bot commits on `beta` no longer trigger the Release workflow
- [ ] Verify normal pushes to `beta` still trigger the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)