### PR TITLE
docs: add household items management guide and update docs site (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ A self-hosted home building project management tool for homeowners. Track work i
 - **Budget Management** -- Budget categories, financing sources, vendor invoices, subsidies, overview dashboard with projections
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
-- **Document Integration** -- Browse and link documents from Paperless-ngx to work items and invoices
+- **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, and work item linking
+- **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices
 - **Authentication** -- Local accounts with setup wizard, OIDC single sign-on
 - **User Management** -- Admin and Member roles, admin panel
 - **Dark Mode** -- Light, Dark, or System theme
@@ -68,7 +69,7 @@ Open `http://localhost:3000` -- the setup wizard will guide you through creating
 - [x] **EPIC-05**: Budget Management
 - [x] **EPIC-06**: Timeline and Gantt Chart
 - [x] **EPIC-08**: Paperless-ngx Integration
-- [ ] **EPIC-04**: Household Items
+- [x] **EPIC-04**: Household Items
 - [ ] **EPIC-07**: Reporting and Export
 - [ ] **EPIC-09**: Dashboard and Overview
 - [ ] **EPIC-10**: UX Polish and Accessibility

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,20 +1,16 @@
 ## What's New
 
-Cornerstone now integrates with Paperless-ngx for document management. Browse your entire document archive from within Cornerstone, and link invoices, contracts, permits, and receipts directly to work items and vendor invoices -- keeping all project-related documents one click away.
+Cornerstone now supports household item management -- track furniture, appliances, fixtures, and other purchases alongside your construction work items. Each household item integrates with the existing budget system, timeline, document linking, and vendor invoices, giving you a complete view of both construction work and home furnishing purchases.
 
 ### Highlights
 
-- **Document Browser** -- A dedicated page to search, filter by tags, and browse all documents in your Paperless-ngx instance, with thumbnail previews, pagination, and a detail panel showing document metadata and content excerpts
-- **Document Linking** -- Attach Paperless-ngx documents to work items and vendor invoices with a picker modal, view linked documents as thumbnail cards, and open them directly in Paperless-ngx
-- **Secure Proxy Architecture** -- All Paperless-ngx communication is proxied through the Cornerstone backend, keeping your API token server-side and simplifying network configuration
-- **Graceful Degradation** -- Clear status messages when Paperless-ngx is not configured or unreachable, with retry functionality and preserved link records even when the connection is temporarily unavailable
-- **Responsive & Accessible** -- Full keyboard navigation, ARIA roles, focus management, screen reader announcements, and a responsive layout that works on desktop, tablet, and mobile
-
-### Configuration
-
-To enable the integration, set two environment variables and restart Cornerstone:
-
-```
-PAPERLESS_URL=https://paperless.example.com
-PAPERLESS_API_TOKEN=your-api-token-here
-```
+- **Household Item Management** -- Create and manage household items with categories (furniture, appliances, fixtures, decor, electronics, outdoor, storage), purchase lifecycle statuses (planned, purchased, scheduled, arrived), room assignments, quantities, vendor references, and product URLs
+- **Budget Integration** -- Add budget lines to household items with confidence levels, budget categories, and financing sources -- household item costs appear in the project-wide budget overview alongside work item costs
+- **Work Item Linking** -- Link household items to construction work items for installation coordination, ensuring items arrive when the related construction phase is ready
+- **Delivery Scheduling & Timeline Dependencies** -- Track order dates and delivery windows, add dependencies on work items and milestones so delivery dates integrate with the Gantt chart and scheduling engine
+- **Invoice Linking** -- Link vendor invoices to household item budget lines to track actual costs and transition estimates to real amounts
+- **Document Linking** -- Attach Paperless-ngx documents (product specs, receipts, warranties) directly to household items
+- **Subsidy Support** -- Apply subsidy programs to household item costs for budget reductions
+- **Tags, Notes & Search** -- Organize items with color-coded tags, add timestamped notes, and search/filter/sort across all household items
+- **Responsive & Accessible** -- Full keyboard navigation, screen reader support, and a responsive layout with table view on desktop and card view on mobile
+- **Cost Breakdown Improvements** -- The budget overview cost breakdown table now includes a perspective toggle, column tints for visual clarity, and sum/remaining rows for quick financial summaries

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -77,6 +77,7 @@ const config = {
               { label: 'Work Items', to: '/guides/work-items' },
               { label: 'Budget', to: '/guides/budget' },
               { label: 'Timeline', to: '/guides/timeline' },
+              { label: 'Household Items', to: '/guides/household-items' },
               { label: 'Documents', to: '/guides/documents' },
               { label: 'Roadmap', to: '/roadmap' },
             ],

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -65,6 +65,17 @@ const sidebars = {
         'guides/documents/linking-documents',
       ],
     },
+    {
+      type: 'category',
+      label: 'Household Items',
+      link: { type: 'doc', id: 'guides/household-items/index' },
+      items: [
+        'guides/household-items/creating-editing-items',
+        'guides/household-items/budget-and-invoices',
+        'guides/household-items/work-item-linking',
+        'guides/household-items/delivery-and-dependencies',
+      ],
+    },
     'guides/appearance/dark-mode',
     'roadmap',
   ],

--- a/docs/src/guides/budget/subsidies.md
+++ b/docs/src/guides/budget/subsidies.md
@@ -37,7 +37,7 @@ Only subsidies with **Approved** or **Disbursed** status are applied to budget c
 
 ## How Subsidies Affect the Budget
 
-Subsidies reduce the total cost shown in the [Budget Overview](budget-overview). A subsidy applies to all budget lines in its linked category across all work items:
+Subsidies reduce the total cost shown in the [Budget Overview](budget-overview). A subsidy applies to all budget lines in its linked category across all work items and [household items](/guides/household-items):
 
 - **Percentage subsidy**: Reduces the category total by the specified percentage
 - **Fixed-amount subsidy**: Subtracts the flat amount from the category total

--- a/docs/src/guides/documents/linking-documents.md
+++ b/docs/src/guides/documents/linking-documents.md
@@ -5,13 +5,14 @@ title: Linking Documents
 
 # Linking Documents
 
-You can link Paperless-ngx documents to **work items** and **vendor invoices** so that related documents -- contracts, receipts, permits, plans -- are always accessible from the entity they belong to.
+You can link Paperless-ngx documents to **work items**, **household items**, and **vendor invoices** so that related documents -- contracts, receipts, permits, plans, warranties -- are always accessible from the entity they belong to.
 
 ## Where Documents Appear
 
 A **Documents** section appears on:
 
 - **Work item detail pages** -- Link contracts, permits, receipts, and plans to the work item they relate to
+- **Household item detail pages** -- Link product specs, receipts, warranties, and delivery confirmations to household items
 - **Invoice detail pages** -- Link invoice PDFs and supporting documents to vendor invoices
 
 Each section shows the number of linked documents as a badge next to the heading.

--- a/docs/src/guides/household-items/budget-and-invoices.md
+++ b/docs/src/guides/household-items/budget-and-invoices.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+title: Budget & Invoices
+---
+
+# Budget & Invoices
+
+Household items integrate with the project-wide budget system. Each item can have budget lines that track estimated and actual costs, and these costs appear alongside work item costs in the [Budget Overview](/guides/budget/budget-overview).
+
+## Adding Budget Lines
+
+On the household item detail page, switch to the **Budget** tab. Click **Add Budget Line** and provide:
+
+- **Description** -- Optional label for this budget line (e.g., "Base unit cost", "Shipping")
+- **Planned Amount** -- Your estimated cost
+- **Confidence Level** -- How reliable the estimate is:
+
+| Confidence Level | Margin | Meaning |
+|-----------------|--------|---------|
+| **Own Estimate** | +/- 20% | Your personal rough estimate |
+| **Professional Estimate** | +/- 10% | An estimate from a professional |
+| **Quote** | +/- 5% | A formal quote from a vendor |
+| **Invoice** | 0% | An actual invoice -- the real cost |
+
+- **Budget Category** -- Which category this cost belongs to (e.g., "Kitchen", "Fixtures")
+- **Financing Source** -- Which funding source will pay for it
+- **Vendor** -- Optional vendor for this specific budget line
+
+## Multiple Budget Lines
+
+A single household item can have multiple budget lines. For example, a kitchen appliance might have separate lines for the unit cost, delivery fee, and installation -- each potentially in a different budget category or funded by a different financing source.
+
+## Invoice Linking
+
+When a vendor invoice arrives for a household item purchase, you can link invoice line items to the item's budget lines. This replaces the estimate with the actual cost:
+
+1. Navigate to the vendor's invoice detail page (via **Budget > Invoices**)
+2. On an invoice line item, select the household item's budget line as the linked budget
+3. The actual cost updates automatically
+
+See [Vendors & Invoices](/guides/budget/vendors-and-invoices) for details on creating invoices.
+
+## Subsidies
+
+Household items can benefit from subsidy programs. On the detail page, you can link applicable subsidy programs to the item. Only subsidies with **Approved** or **Disbursed** status affect budget calculations.
+
+See [Subsidies](/guides/budget/subsidies) for details on managing subsidy programs.
+
+## Budget Overview Integration
+
+Household item costs are included in the project-wide [Budget Overview](/guides/budget/budget-overview) alongside work item costs. The budget overview dashboard shows total planned costs, actual costs, and subsidy reductions across both work items and household items, with projections that account for confidence margins.

--- a/docs/src/guides/household-items/creating-editing-items.md
+++ b/docs/src/guides/household-items/creating-editing-items.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 1
+title: Creating & Editing Items
+---
+
+# Creating & Editing Items
+
+## Creating a Household Item
+
+Navigate to **Household Items** in the sidebar and click **New Household Item**. The create form collects:
+
+- **Name** (required) -- A descriptive name for the item (e.g., "Kitchen island pendant lights")
+- **Category** -- The item type: Furniture, Appliances, Fixtures, Decor, Electronics, Outdoor, Storage, or Other (defaults to Other)
+- **Status** -- Purchase lifecycle status: Planned, Purchased, Scheduled, or Arrived (defaults to Planned)
+- **Description** -- Optional longer description or notes about the item
+- **Room** -- Optional room or location where the item will be placed (e.g., "Kitchen", "Master bedroom")
+- **Quantity** -- Number of units (defaults to 1)
+- **Vendor** -- Optional vendor or retailer for this item
+- **URL** -- Optional product link for reference
+- **Order Date** -- When the item was or will be ordered
+- **Earliest Delivery Date** -- Start of the expected delivery window
+- **Latest Delivery Date** -- End of the expected delivery window
+- **Tags** -- Optional color-coded labels for organization
+
+Click **Create** to save the new household item. You will be taken to the item's detail page where you can add budget lines, notes, dependencies, and more.
+
+## Editing a Household Item
+
+There are two ways to edit a household item:
+
+### Inline Editing
+
+On the detail page, click any editable field to modify it directly. Changes are saved automatically when you click away or press Enter.
+
+### Edit Page
+
+Click the **Edit** button on the detail page to open the full edit form. This is useful when you want to update multiple fields at once.
+
+## Notes
+
+Add timestamped notes to any household item from the detail page. Notes show the author and creation time, and are displayed newest-first.
+
+Click **Add Note** to expand the note editor, type your note, and click **Save**.
+
+:::caution
+Deleting a note is permanent and cannot be undone.
+:::
+
+## Tags
+
+Household items share the same tag system as work items. You can assign any existing tag to a household item, or create new tags. Tags are useful for cross-cutting categorization -- for example, tagging items by priority ("Urgent", "Nice to have") or by source ("IKEA", "Local supplier").
+
+## Deleting a Household Item
+
+On the detail page, click the **Delete** button. A confirmation dialog will appear before the item is permanently removed.
+
+:::caution
+Deleting a household item also removes all associated budget lines, notes, tags, dependencies, subsidy links, and document links. This action cannot be undone.
+:::

--- a/docs/src/guides/household-items/delivery-and-dependencies.md
+++ b/docs/src/guides/household-items/delivery-and-dependencies.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 4
+title: Delivery & Dependencies
+---
+
+# Delivery & Dependencies
+
+Household items have a delivery-focused scheduling model. Unlike work items which have start and end dates with durations, household items are treated as zero-duration terminal nodes -- they represent a single delivery event that depends on other work being completed first.
+
+## Delivery Dates
+
+Each household item can track several dates:
+
+| Field | Description |
+|-------|-------------|
+| **Order Date** | When the item was or will be ordered |
+| **Earliest Delivery Date** | Start of the expected delivery window |
+| **Latest Delivery Date** | End of the expected delivery window |
+| **Target Delivery Date** | Computed from dependencies -- the earliest date the item could arrive based on predecessor completion |
+| **Actual Delivery Date** | When the item actually arrived |
+
+The **target delivery date** is automatically calculated by the scheduling engine based on the item's dependencies. If a household item depends on a work item that finishes on March 15, the target delivery date will be March 15 or later.
+
+## Late Detection
+
+A household item is flagged as **late** when its target delivery date has passed but the item has not yet arrived (no actual delivery date recorded). Late items are visually indicated in the list and detail views.
+
+## Timeline Dependencies
+
+Household items can depend on **work items** and **milestones**. All dependencies are treated as finish-to-start with zero lag -- the household item's delivery cannot happen until the predecessor is complete.
+
+### Adding Dependencies
+
+On the household item detail page, use the **Dependencies** section to add predecessors:
+
+1. Click **Add Dependency**
+2. Choose the predecessor type -- **Work Item** or **Milestone**
+3. Select the specific work item or milestone
+4. The target delivery date recalculates automatically
+
+### Viewing on the Gantt Chart
+
+Household items with dependencies appear on the [Gantt chart](/guides/timeline/gantt-chart) as diamond markers (similar to milestones). Dependency arrows connect predecessors to the household item, and the scheduling engine includes them in critical path calculations.
+
+### Example
+
+A typical dependency chain might look like:
+
+1. **Work item**: "Install kitchen cabinets" (ends March 10)
+2. **Household item**: "Kitchen countertop" (depends on cabinets, target delivery March 10)
+3. **Work item**: "Install countertop" (depends on countertop delivery)
+
+This ensures the countertop is not scheduled for delivery until the cabinets are installed, and the installation work does not start until the countertop arrives.

--- a/docs/src/guides/household-items/index.md
+++ b/docs/src/guides/household-items/index.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 7
+title: Household Items
+---
+
+# Household Items
+
+Household items let you track furniture, appliances, fixtures, and other purchases for your home -- separate from construction work items. Each household item has its own lifecycle from planning through delivery, with budget tracking, vendor management, delivery scheduling, and document linking.
+
+## Overview
+
+The household items system provides:
+
+- **Item Management** -- Create, edit, and track household purchases with categories, statuses, vendors, rooms, quantities, and product URLs
+- **Budget Integration** -- Add budget lines with confidence levels, budget categories, and financing sources -- household item costs appear in the project-wide budget overview
+- **Work Item Linking** -- Link household items to work items for installation coordination (e.g., "Kitchen sink" depends on "Plumbing rough-in")
+- **Delivery Scheduling** -- Track order dates, delivery windows (earliest/latest), actual delivery dates, and late detection
+- **Timeline Dependencies** -- Add dependencies on work items and milestones so delivery dates integrate with the project Gantt chart
+- **Invoice Linking** -- Link vendor invoices to household item budget lines to track actual costs
+- **Document Linking** -- Attach documents from [Paperless-ngx](/guides/documents) (product specs, receipts, warranties) to household items
+- **Tags & Notes** -- Organize items with color-coded tags and add timestamped notes
+- **Subsidy Support** -- Apply subsidy programs to household item costs for budget reduction
+
+## Categories
+
+Each household item is assigned a category:
+
+| Category | Description |
+|----------|-------------|
+| **Furniture** | Tables, chairs, sofas, beds, shelving |
+| **Appliances** | Kitchen appliances, laundry, HVAC units |
+| **Fixtures** | Faucets, light fixtures, door handles |
+| **Decor** | Artwork, curtains, rugs, decorative items |
+| **Electronics** | Smart home devices, speakers, networking |
+| **Outdoor** | Garden furniture, grills, outdoor lighting |
+| **Storage** | Cabinets, closet systems, garage storage |
+| **Other** | Anything that does not fit the above |
+
+## Statuses
+
+Household items move through a purchase lifecycle:
+
+| Status | Meaning |
+|--------|---------|
+| **Planned** | Item identified but not yet ordered |
+| **Purchased** | Order placed with vendor |
+| **Scheduled** | Delivery date confirmed |
+| **Arrived** | Item delivered |
+
+## List View
+
+The household items list page provides:
+
+- **Search** -- Full-text search across item names and descriptions
+- **Filtering** -- Filter by category, status, room, vendor, or tag
+- **Sorting** -- Sort by name, category, status, room, order date, delivery date, or creation date
+- **Pagination** -- Paginated results for large item lists
+- **Responsive layout** -- Table view on desktop, card view on mobile and tablet
+
+All filter and sort settings are synced to the URL, so your view is bookmarkable and shareable.
+
+:::info Screenshot needed
+A screenshot of the household items list page will be added on the next stable release.
+:::
+
+## Detail View
+
+Click any household item to see its full detail page with all fields, budget lines, notes, dependencies, linked work items, linked documents, and applied subsidies. Fields can be edited inline by clicking on them.
+
+:::info Screenshot needed
+A screenshot of the household item detail page will be added on the next stable release.
+:::
+
+## Next Steps
+
+- [Creating & Editing Items](creating-editing-items) -- How to create and manage household items
+- [Budget & Invoices](budget-and-invoices) -- Track costs and link invoices
+- [Work Item Linking](work-item-linking) -- Coordinate installation with work items
+- [Delivery & Dependencies](delivery-and-dependencies) -- Schedule deliveries with timeline dependencies

--- a/docs/src/guides/household-items/work-item-linking.md
+++ b/docs/src/guides/household-items/work-item-linking.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 3
+title: Work Item Linking
+---
+
+# Work Item Linking
+
+Household items can be linked to work items to coordinate installation. For example, you might link "Kitchen faucet" to the "Plumbing rough-in" work item so you know the faucet needs to arrive before plumbing work begins.
+
+## Linking from a Work Item
+
+On a work item detail page, a **Household Items** section shows all linked household items. Click **+ Link Household Item** to open a picker with search and filtering. Select an item to create the link.
+
+Each linked household item card shows the item name, category, status, and delivery dates.
+
+## Linking from a Household Item
+
+On a household item detail page, linked work items appear in the **Work Items** section. You can also manage links from this direction.
+
+## Unlinking
+
+Click the **Unlink** button on a linked item card to remove the association. This does not delete either the work item or the household item -- it only removes the link between them.
+
+## Use Cases
+
+- **Installation coordination** -- Link items to the work item that will install them so you can verify the item has arrived before scheduling the work
+- **Room planning** -- Link all items destined for a specific room to the work item that prepares that room
+- **Dependency tracking** -- Combined with [timeline dependencies](delivery-and-dependencies), linking ensures delivery dates align with the construction schedule

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -19,7 +19,7 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Cornerstone
 
-A self-hosted home building project management tool for homeowners. Track work items, budgets, timelines, and household item purchases from a single Docker container backed by SQLite -- no external database required.
+A self-hosted home building project management tool for homeowners. Track work items, budgets, timelines, household items, and documents from a single Docker container backed by SQLite -- no external database required.
 
 ## Who is Cornerstone for?
 
@@ -36,13 +36,14 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path highlighting, zoom controls, milestones, and automatic scheduling via the Critical Path Method
 - **Calendar View** -- Monthly and weekly calendar grids showing work items and milestones
 - **Milestones** -- Track major project checkpoints with target dates, projected completion, and late detection
+- **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, work item linking, and timeline dependencies
 - **Authentication** -- Local accounts with first-run setup wizard, plus OIDC single sign-on for existing identity providers
 - **User Management** -- Admin and Member roles with a dedicated admin panel
 - **Document Integration** -- Browse, search, and link documents from a connected [Paperless-ngx](https://docs.paperless-ngx.com/) instance to work items and invoices
 - **Dark Mode** -- Light, Dark, or System theme with instant switching
 - **Design System** -- Consistent visual language with CSS custom property tokens
 
-See the [Roadmap](roadmap) for upcoming features like household item tracking and reporting.
+See the [Roadmap](roadmap) for upcoming features like reporting and dashboards.
 
 ## Quick Links
 
@@ -50,6 +51,7 @@ See the [Roadmap](roadmap) for upcoming features like household item tracking an
 - [Work Items Guide](guides/work-items) -- Learn how to manage your project tasks
 - [Budget Guide](guides/budget) -- Track costs, invoices, and financing sources
 - [Timeline Guide](guides/timeline) -- Gantt chart, calendar view, and milestones
+- [Household Items Guide](guides/household-items) -- Manage furniture, appliances, and fixture purchases
 - [Documents Guide](guides/documents) -- Paperless-ngx integration for document linking
 - [OIDC Setup](guides/users/oidc-setup) -- Connect your identity provider
 - [Development](development) -- How Cornerstone is built by an AI agent team

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -17,10 +17,7 @@ Cornerstone is under active development. Here is the current state of planned fe
 - [x] **EPIC-05: Budget Management** ([#5](https://github.com/steilerDev/cornerstone/issues/5)) -- Budget categories, financing sources, work item cost tracking, vendor invoices, subsidy programs, budget overview dashboard
 - [x] **EPIC-06: Timeline and Gantt Chart** ([#6](https://github.com/steilerDev/cornerstone/issues/6)) -- Interactive Gantt chart, calendar view, milestones, CPM-based scheduling engine, dependency arrows, critical path highlighting
 - [x] **EPIC-08: Paperless-ngx Integration** ([#8](https://github.com/steilerDev/cornerstone/issues/8)) -- Document browser, document linking to work items and invoices, proxy architecture, thumbnail and metadata display
-
-## Planned
-
-- [ ] **EPIC-04: Household Items** ([#4](https://github.com/steilerDev/cornerstone/issues/4)) -- Furniture and appliance purchase tracking
+- [x] **EPIC-04: Household Items** ([#4](https://github.com/steilerDev/cornerstone/issues/4)) -- Furniture and appliance tracking with categories, delivery scheduling, budget integration, work item linking, timeline dependencies, invoice and document linking
 - [ ] **EPIC-07: Reporting and Export** ([#7](https://github.com/steilerDev/cornerstone/issues/7)) -- Document export and reporting features
 - [ ] **EPIC-09: Dashboard and Overview** ([#9](https://github.com/steilerDev/cornerstone/issues/9)) -- Project dashboard with budget summary and activity
 - [ ] **EPIC-10: UX Polish and Accessibility** ([#10](https://github.com/steilerDev/cornerstone/issues/10)) -- Accessibility improvements and UI refinements


### PR DESCRIPTION
## Summary

- Add comprehensive household items guide to the docs site (`docs/src/guides/household-items/`) with 5 pages: overview, creating & editing, budget & invoices, work item linking, and delivery & dependencies
- Update intro page, roadmap, sidebar, footer, document linking guide, and subsidies guide to reflect EPIC-04 completion
- Update README.md with household items in the feature list and roadmap (completed)
- Write RELEASE_SUMMARY.md for EPIC-04 GitHub Release changelog enrichment

## Test plan

- [x] `npm run docs:build` succeeds with no broken links
- [x] New pages have proper frontmatter (`title:`, `sidebar_position:`)
- [x] New pages are registered in `sidebars.js`
- [x] `> [!NOTE]` block at top of README.md is untouched
- [x] Roadmap reflects EPIC-04 as completed
- [x] No planned features described as available
- [ ] CI passes (Quality Gates, Docker)

**[docs-writer]** Documentation update for EPIC-04 Household Items & Furniture Management.

Co-Authored-By: Claude docs-writer (Opus 4.6) <noreply@anthropic.com>