### PR TITLE
test(e2e): fix tag seed race condition and navigation selector ambiguity

### DIFF
--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -49,12 +49,26 @@ async function seedWorkItems(request: Parameters<typeof test>[2], baseUrl: strin
     { name: 'Exterior', color: '#10b981' },
   ];
 
+  // Create tags sequentially to avoid 409 conflicts when multiple parallel
+  // shard workers run this beforeAll concurrently against the same container.
+  // On 409 (tag name already exists), fall back to fetching all tags and
+  // finding the pre-existing one by name so work items can still reference it.
   const tagIds: number[] = [];
   for (const tag of tags) {
     const res = await request.post(`${baseUrl}/api/tags`, { data: tag });
     if (res.ok()) {
       const body = (await res.json()) as { id: number };
       tagIds.push(body.id);
+    } else if (res.status() === 409) {
+      // Tag already created by another parallel worker — look it up by name
+      const listRes = await request.get(`${baseUrl}/api/tags`);
+      if (listRes.ok()) {
+        const listBody = (await listRes.json()) as Array<{ id: number; name: string }>;
+        const existing = listBody.find((t) => t.name === tag.name);
+        if (existing) {
+          tagIds.push(existing.id);
+        }
+      }
     }
   }
 
@@ -167,8 +181,10 @@ test.describe('Documentation screenshots', () => {
     await page.goto(`${baseUrl}${ROUTES.workItems}`);
     await page.waitForLoadState('networkidle');
 
-    // Ensure list is populated before screenshotting
-    await expect(page.getByRole('heading', { name: /work items/i })).toBeVisible();
+    // Ensure list is populated before screenshotting.
+    // Use level: 1 to target only the page h1, not the sidebar nav link which
+    // also matches /work items/i and would cause a strict-mode violation.
+    await expect(page.getByRole('heading', { level: 1, name: /work items/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {


### PR DESCRIPTION
## Summary

Fixes two E2E infrastructure bugs that were causing 9/16 shards to fail consistently on the promotion PR #506 (beta → main).

### Bug 1: Tag creation race condition in screenshot seed data

`capture-docs-screenshots.spec.ts` has a `test.beforeAll` that creates tags with hardcoded names ("Electrical", "Plumbing", "Exterior") via `seedWorkItems()`. When 16 shards run in parallel, the desktop/tablet/mobile projects all execute this `beforeAll` concurrently against the same shared container — causing `HTTP 409 ConflictError: A tag with this name already exists`. The 409 then left `tagIds` with fewer entries than expected, causing work items to be created with invalid tag IDs, triggering downstream `ValidationError: Tag not found`.

**Fix**: On HTTP 409, fall back to `GET /api/tags` and resolve the pre-existing tag by name, so `tagIds` is always fully populated regardless of whether this worker won or lost the creation race.

### Bug 2: Navigation sidebar heading selector matches 2 elements

`capture-docs-screenshots.spec.ts` line 171:
```ts
// Before (strict-mode violation — matches sidebar nav + page h1):
await expect(page.getByRole('heading', { name: /work items/i })).toBeVisible();

// After (targets only the page h1):
await expect(page.getByRole('heading', { level: 1, name: /work items/i })).toBeVisible();
```

The sidebar nav link for "Work Items" also matches `getByRole('heading', ...)` in the DOM, causing Playwright strict mode to reject it as ambiguous. Adding `level: 1` restricts the selector to only the `<h1>` page heading.

## Files Changed

- `e2e/tests/screenshots/capture-docs-screenshots.spec.ts` — only E2E test infrastructure, no production code modified

## Test Plan

- [ ] CI E2E shards pass (previously 9/16 failing)
- [ ] All 3 projects (desktop, tablet, mobile) run screenshot seed without 409 errors
- [ ] `Work items list` screenshot test no longer hits strict-mode violation

**[qa-integration-tester]** Fixes targeted at `e2e/tests/screenshots/capture-docs-screenshots.spec.ts` only. No production code was modified.