### PR TITLE
test(e2e): fix strict mode violations and tag seed race conditions

### DIFF
--- a/e2e/fixtures/apiHelpers.ts
+++ b/e2e/fixtures/apiHelpers.ts
@@ -42,9 +42,24 @@ export async function createTagViaApi(
   data: { name: string; color?: string },
 ): Promise<string> {
   const response = await page.request.post(API.tags, { data });
+  if (response.ok()) {
+    const body = (await response.json()) as { id: string; name: string; color: string | null };
+    return body.id;
+  }
+  // On 409 (tag name already exists due to parallel shard workers), fall back
+  // to fetching all tags and finding the pre-existing one by name.
+  if (response.status() === 409) {
+    const listResponse = await page.request.get(API.tags);
+    expect(listResponse.ok()).toBeTruthy();
+    const tags = (await listResponse.json()) as Array<{ id: string; name: string }>;
+    const existing = tags.find((t) => t.name === data.name);
+    expect(existing).toBeDefined();
+    return existing!.id;
+  }
+  // Unexpected failure — surface the error
   expect(response.ok()).toBeTruthy();
-  const body = (await response.json()) as { id: string; name: string; color: string | null };
-  return body.id;
+  // This line is unreachable but satisfies TypeScript
+  return '';
 }
 
 export async function deleteTagViaApi(page: Page, id: string): Promise<void> {

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -100,8 +100,9 @@ export class HouseholdItemsPage {
     this.prevPageButton = page.getByLabel('Previous page');
     this.nextPageButton = page.getByLabel('Next page');
 
-    // Empty state
-    this.emptyState = page.locator('[class*="emptyState"]');
+    // Empty state — use .first() to avoid strict mode: child elements such as
+    // emptyStateTitle/emptyStateDescription also contain "emptyState" in their class names.
+    this.emptyState = page.locator('[class*="emptyState"]').first();
 
     // Error banner (outside modal)
     this.errorBanner = page.locator('[role="alert"][class*="errorBanner"]');

--- a/e2e/pages/TagManagementPage.ts
+++ b/e2e/pages/TagManagementPage.ts
@@ -93,7 +93,9 @@ export class TagManagementPage {
 
     // Existing tags section
     this.existingTagsHeading = page.getByRole('heading', { level: 2, name: /Existing Tags/ });
-    this.emptyState = page.locator('[class*="emptyState"]');
+    // Use .first() to avoid strict mode: child elements (emptyStateTitle,
+    // emptyStateDescription) also contain "emptyState" in their class names.
+    this.emptyState = page.locator('[class*="emptyState"]').first();
     this.tagsList = page.locator('[class*="tagsList"]');
 
     // Delete modal — the modal has role="dialog" aria-modal="true" but no aria-labelledby.

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -94,8 +94,9 @@ export class VendorsPage {
       .filter({ hasText: /failed|error/i })
       .first();
 
-    // Empty state
-    this.emptyState = page.locator('[class*="emptyState"]');
+    // Empty state — use .first() to avoid strict mode: child elements such as
+    // emptyStateTitle/emptyStateDescription also contain "emptyState" in their class names.
+    this.emptyState = page.locator('[class*="emptyState"]').first();
     this.emptyStateHeading = this.emptyState.getByRole('heading');
 
     // Table (desktop)

--- a/e2e/pages/WorkItemsPage.ts
+++ b/e2e/pages/WorkItemsPage.ts
@@ -90,8 +90,9 @@ export class WorkItemsPage {
     this.prevPageButton = page.getByLabel('Previous page');
     this.nextPageButton = page.getByLabel('Next page');
 
-    // Empty state
-    this.emptyState = page.locator('[class*="emptyState"]');
+    // Empty state — use .first() to avoid strict mode: child elements such as
+    // emptyStateTitle/emptyStateDescription also contain "emptyState" in their class names.
+    this.emptyState = page.locator('[class*="emptyState"]').first();
 
     // Error banner (outside modal)
     this.errorBanner = page.locator('[role="alert"][class*="errorBanner"]');

--- a/e2e/tests/household-items/household-item-detail.spec.ts
+++ b/e2e/tests/household-items/household-item-detail.spec.ts
@@ -258,8 +258,10 @@ test.describe('404 / error state (Scenario 8)', { tag: '@responsive' }, () => {
     await page.goto('/household-items/non-existent-id-000');
 
     // The page should either show a not-found message or redirect
-    // The HouseholdItemDetailPage shows "not found" text when item doesn't exist
-    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i);
+    // The HouseholdItemDetailPage shows "not found" text when item doesn't exist.
+    // Use .first() to avoid strict mode violation: the page renders both a heading
+    // and a description element that match the pattern.
+    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i).first();
     await expect(notFoundText).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/tests/household-items/household-item-edit.spec.ts
+++ b/e2e/tests/household-items/household-item-edit.spec.ts
@@ -215,8 +215,10 @@ test.describe('404 state (Scenario 6)', { tag: '@responsive' }, () => {
   test('Navigating to edit page for non-existent item shows not-found state', async ({ page }) => {
     await page.goto('/household-items/non-existent-id-edit-000/edit');
 
-    // The edit page renders a not-found state when the item doesn't exist
-    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i);
+    // The edit page renders a not-found state when the item doesn't exist.
+    // Use .first() to avoid strict mode violation: the page renders both a heading
+    // and a description element that match the pattern.
+    const notFoundText = page.getByText(/not found|doesn't exist|has been removed/i).first();
     await expect(notFoundText).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -52,11 +52,13 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     // Given: User navigates to Work Items page
     await page.goto(ROUTES.workItems);
 
-    // Then: Work Items link should be active
+    // Then: Work Items link should be active.
+    // Use an explicit timeout on toPass() — the default (5s) can be too short
+    // on slow CI workers while React Router updates aria-current after navigation.
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Work Items');
       expect(isActive).toBe(true);
-    }).toPass();
+    }).toPass({ timeout: 15000 });
 
     // When: User navigates to Budget
     await page.goto(ROUTES.budget);
@@ -65,13 +67,13 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Budget');
       expect(isActive).toBe(true);
-    }).toPass();
+    }).toPass({ timeout: 15000 });
 
     // And: Work Items link should not be active
     await expect(async () => {
       const isActive = await appShell.isNavLinkActive('Work Items');
       expect(isActive).toBe(false);
-    }).toPass();
+    }).toPass({ timeout: 15000 });
   });
 
   test('All nav links rendered and visible', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes 4 categories of E2E test failures causing 9/16 shard failures on PR #508 (beta → main promotion).

### Bug 1 & 2: Strict mode — multiple elements matched

**`getByText(/not found|doesn't exist|has been removed/i)` matched 2 elements** in not-found tests: the heading AND the description paragraph both match the pattern. Fixed by appending `.first()`.

Files: `household-item-detail.spec.ts`, `household-item-edit.spec.ts`

**`page.locator('[class*="emptyState"]')` resolved to 2 elements** because child elements (e.g. `emptyStateTitle`, `emptyStateDescription`) also contain `"emptyState"` in their CSS module class names. Fixed by appending `.first()` to target the container only — matching the approach already used in `BudgetOverviewPage.ts`.

Files: `TagManagementPage.ts`, `WorkItemsPage.ts`, `HouseholdItemsPage.ts`, `VendorsPage.ts`

### Bug 3: Navigation sidebar active link test timeout

`toPass()` was called without an explicit timeout, falling back to the default 5 seconds. On slow CI workers, React Router can take longer to update `aria-current` after `page.goto()`. Fixed by adding `{ timeout: 15000 }` to all three `toPass()` calls in the `'Active link highlighting'` test.

File: `sidebar-navigation.spec.ts`

### Bug 4: Tag seed race condition in shared `apiHelpers.ts`

The shared `createTagViaApi` helper in `apiHelpers.ts` did not handle `409 ConflictError`, causing test setup to fail when multiple parallel shard workers tried to create a tag with the same name. Applied the same fallback pattern from PR #507 (`capture-docs-screenshots.spec.ts`): on 409, GET all tags and resolve the pre-existing one by name.

File: `apiHelpers.ts`

## Test plan

- [ ] CI E2E shards all pass (previously 9/16 failing)
- [ ] Smoke test passes on Chromium desktop
- [ ] No strict-mode locator violations in household-items or budget tests
- [ ] Navigation active-link test passes on all viewports including mobile WebKit

🤖 Generated with [Claude Code](https://claude.com/claude-code)