### PR TITLE
test(e2e): fix remaining shard failures — emptyState, search timeout, nav active link

### DIFF
--- a/e2e/pages/BudgetOverviewPage.ts
+++ b/e2e/pages/BudgetOverviewPage.ts
@@ -61,11 +61,10 @@ export class BudgetOverviewPage {
     });
     this.retryButton = this.errorCard.getByRole('button', { name: 'Retry', exact: true });
 
-    // Empty state: class `.emptyState` rendered when no budget data exists.
-    // Use div[class*="emptyState"] to avoid matching child elements
-    // (.emptyStateTitle, .emptyStateDescription) which also contain "emptyState" in
-    // their class names and would cause a strict mode violation.
-    this.emptyState = page.locator('div[class*="emptyState"]');
+    // Empty state: the outermost container with a CSS-module class beginning "emptyState".
+    // Use .first() to avoid strict mode: there can be a second div (e.g. chart empty state)
+    // whose class also starts with "emptyState", causing "resolved to 2 elements" errors.
+    this.emptyState = page.locator('div[class*="emptyState"]').first();
 
     // Budget Health Hero card: <section aria-labelledby="budget-health-heading">
     this.heroCard = page.locator('[aria-labelledby="budget-health-heading"]');

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -166,10 +166,14 @@ export class HouseholdItemsPage {
    * Type a search query and wait for the API response and DOM to update.
    * The response listener is registered BEFORE the fill to avoid a race with
    * the 300ms debounce.
+   *
+   * An explicit 10s timeout overrides the global actionTimeout (5s) because
+   * the debounce + API round-trip can exceed 5s on slow CI runners.
    */
   async search(query: string): Promise<void> {
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+      { timeout: 10000 },
     );
     await this.searchInput.fill(query);
     await responsePromise;
@@ -178,10 +182,12 @@ export class HouseholdItemsPage {
 
   /**
    * Clear the search input and wait for the API response and DOM to update.
+   * An explicit 10s timeout overrides the global actionTimeout (5s).
    */
   async clearSearch(): Promise<void> {
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+      { timeout: 10000 },
     );
     await this.searchInput.clear();
     await responsePromise;

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -278,22 +278,30 @@ export class VendorsPage {
 
   /**
    * Type into the search field and wait for the debounced API response.
+   * Register the response listener BEFORE fill to avoid a race with the debounce.
+   * Explicit 10s timeout overrides global actionTimeout (5s) for slow CI runners.
    */
   async search(query: string): Promise<void> {
-    await this.searchInput.fill(query);
-    await this.page.waitForResponse(
+    const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/vendors') && resp.status() === 200,
+      { timeout: 10000 },
     );
+    await this.searchInput.fill(query);
+    await responsePromise;
   }
 
   /**
    * Clear the search input and wait for the debounced API response.
+   * Register the response listener BEFORE clear to avoid a race with the debounce.
+   * Explicit 10s timeout overrides global actionTimeout (5s) for slow CI runners.
    */
   async clearSearch(): Promise<void> {
-    await this.searchInput.clear();
-    await this.page.waitForResponse(
+    const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/vendors') && resp.status() === 200,
+      { timeout: 10000 },
     );
+    await this.searchInput.clear();
+    await responsePromise;
   }
 
   /**

--- a/e2e/pages/WorkItemsPage.ts
+++ b/e2e/pages/WorkItemsPage.ts
@@ -166,8 +166,11 @@ export class WorkItemsPage {
    * attempt to read titles or interact with list items.
    */
   async search(query: string): Promise<void> {
+    // Explicit 10s timeout overrides global actionTimeout (5s): debounce + API
+    // round-trip can exceed 5s on slow CI runners.
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/work-items') && resp.status() === 200,
+      { timeout: 10000 },
     );
     await this.searchInput.fill(query);
     await responsePromise;
@@ -184,6 +187,7 @@ export class WorkItemsPage {
   async clearSearch(): Promise<void> {
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/work-items') && resp.status() === 200,
+      { timeout: 10000 },
     );
     await this.searchInput.clear();
     await responsePromise;

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -53,27 +53,21 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     await page.goto(ROUTES.workItems);
 
     // Then: Work Items link should be active.
-    // Use an explicit timeout on toPass() — the default (5s) can be too short
-    // on slow CI workers while React Router updates aria-current after navigation.
-    await expect(async () => {
-      const isActive = await appShell.isNavLinkActive('Work Items');
-      expect(isActive).toBe(true);
-    }).toPass({ timeout: 15000 });
+    // Use expect().toHaveAttribute() directly — Playwright auto-retries within expect.timeout
+    // (7s desktop / 15s WebKit). The toPass() pattern consumed the entire test timeout (15s)
+    // as its retry window and caused the test to time out on slow CI runners.
+    const workItemsLink = appShell.nav.getByRole('link', { name: 'Work Items' });
+    await expect(workItemsLink).toHaveAttribute('aria-current', 'page');
 
     // When: User navigates to Budget
     await page.goto(ROUTES.budget);
 
     // Then: Budget link should be active
-    await expect(async () => {
-      const isActive = await appShell.isNavLinkActive('Budget');
-      expect(isActive).toBe(true);
-    }).toPass({ timeout: 15000 });
+    const budgetLink = appShell.nav.getByRole('link', { name: 'Budget' });
+    await expect(budgetLink).toHaveAttribute('aria-current', 'page');
 
-    // And: Work Items link should not be active
-    await expect(async () => {
-      const isActive = await appShell.isNavLinkActive('Work Items');
-      expect(isActive).toBe(false);
-    }).toPass({ timeout: 15000 });
+    // And: Work Items link should not be active (aria-current absent or not 'page')
+    await expect(workItemsLink).not.toHaveAttribute('aria-current', 'page');
   });
 
   test('All nav links rendered and visible', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes 3 remaining categories of E2E test failures identified from CI shard logs on PR #508 (beta → main promotion). Addresses shards 2, 3, 4, 7, 9, 10, 13, 14, 15.

### Bug 1: BudgetOverviewPage emptyState strict mode (shards 2, 7, 13)

`div[class*="emptyState"]` resolved to 2 elements:
1. `<div class="emptyState_MEb3u">` — the main empty state container
2. `<div class="emptyState__MYq0">` — a secondary empty state div in the chart/table area

Fix: add `.first()` to `BudgetOverviewPage.ts`, consistent with all other POMs.

### Bug 2: HouseholdItemsPage/VendorsPage/WorkItemsPage search timeout (shards 3, 9, 14, 15)

`waitForResponse()` inherited the global `actionTimeout` of **5s**, which was too short for debounce (300ms) + API round-trip on slow CI runners. All 9 failures in shard 3 trace to `HouseholdItemsPage.ts:171`.

Fixes:
- `HouseholdItemsPage.search()` and `clearSearch()`: add `{ timeout: 10000 }`
- `WorkItemsPage.search()` and `clearSearch()`: add `{ timeout: 10000 }` (proactive — same pattern)
- `VendorsPage.search()` and `clearSearch()`: add `{ timeout: 10000 }` + fix race condition (register response promise BEFORE fill/clear, not after)

### Bug 3: Sidebar active link test timeout (shards 4, 10)

`toPass({ timeout: 15000 })` consumed the entire per-test timeout (15s) as its retry window. Three sequential `toPass()` calls caused the test to run for 15.4–15.7s and hit the hard test timeout.

Fix: replace `toPass()` with direct `expect(link).toHaveAttribute('aria-current', 'page')` assertions, which Playwright auto-retries within `expect.timeout` (7s desktop / 15s WebKit) — much more efficient and completes in well under 1s once React Router updates the attribute.

## Test plan

- [ ] CI E2E shards all pass (previously 9/16 failing after PR #510)
- [ ] Budget overview empty state test passes on all 3 viewports (shards 2, 7, 13)
- [ ] Household items list search/filter tests pass on all 3 viewports (shards 3, 9, 14, 15)
- [ ] Sidebar active link test passes on desktop and tablet (shards 4, 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)