### PR TITLE
test(e2e): fix remaining shard failures — extend timeouts, fix calendar race

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -167,14 +167,16 @@ export class HouseholdItemsPage {
    * The response listener is registered BEFORE the fill to avoid a race with
    * the 300ms debounce.
    *
-   * An explicit 25s timeout is used because debounce (300ms) + API round-trip
-   * can exceed 10s on heavily-loaded CI runners, especially for WebKit
-   * (tablet/mobile) where the browser itself is slower.
+   * An explicit 50s timeout is used because debounce (300ms) + API round-trip
+   * can exceed 25s on heavily-loaded CI runners when all 16 shards run
+   * concurrently (each with 2 workers = 32 browser contexts against one
+   * SQLite container). Tests that call this method must extend their test
+   * timeout to 60s so the waitForResponse can run to completion.
    */
   async search(query: string): Promise<void> {
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-      { timeout: 25000 },
+      { timeout: 50000 },
     );
     await this.searchInput.fill(query);
     await responsePromise;
@@ -183,12 +185,12 @@ export class HouseholdItemsPage {
 
   /**
    * Clear the search input and wait for the API response and DOM to update.
-   * An explicit 25s timeout is used for the same reason as search().
+   * An explicit 50s timeout is used for the same reason as search().
    */
   async clearSearch(): Promise<void> {
     const responsePromise = this.page.waitForResponse(
       (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-      { timeout: 25000 },
+      { timeout: 50000 },
     );
     await this.searchInput.clear();
     await responsePromise;

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -118,6 +118,11 @@ test.describe('Empty state — no items (Scenario 3)', { tag: '@responsive' }, (
 // Scenario 4: Filter empty state when search matches nothing
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Empty state — filter no match (Scenario 4)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse because the shared
+  // SQLite test container gets heavily loaded when all 16 CI shards run in
+  // parallel (32 concurrent browser contexts). Desktop default timeout (15s)
+  // is too short; tablet/mobile already have 60s via playwright.config.ts.
+  test.describe.configure({ timeout: 60_000 });
   test('Filter empty state shown when search matches no household items', async ({
     page,
     testPrefix,
@@ -157,6 +162,9 @@ test.describe(
   'Item appears in list after API creation (Scenario 5)',
   { tag: '@responsive' },
   () => {
+    // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+    test.describe.configure({ timeout: 60_000 });
+
     test('Household item created via API appears in the list', async ({ page, testPrefix }) => {
       const listPage = new HouseholdItemsPage(page);
       let createdId: string | null = null;
@@ -216,6 +224,9 @@ test.describe(
 // Scenario 6: Search filters the list
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Search by name filters list to matching items only', async ({ page, testPrefix }) => {
     const listPage = new HouseholdItemsPage(page);
     const created: string[] = [];
@@ -246,6 +257,9 @@ test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
 // Scenario 7: Category filter narrows results
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Category filter narrows list to items in selected category', async ({
     page,
     testPrefix,
@@ -272,6 +286,7 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
       // Select 'furniture' category
       const filterResponsePromise = page.waitForResponse(
         (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+        { timeout: 50000 },
       );
       await listPage.categoryFilter.selectOption('furniture');
       await filterResponsePromise;
@@ -292,6 +307,9 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
 // Scenario 8: Status filter narrows results
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Status filter narrows list to items with selected status', async ({ page, testPrefix }) => {
     const listPage = new HouseholdItemsPage(page);
     const created: string[] = [];
@@ -311,6 +329,7 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       const filterResponsePromise = page.waitForResponse(
         (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+        { timeout: 50000 },
       );
       await listPage.statusFilter.selectOption('planned');
       await filterResponsePromise;
@@ -331,6 +350,9 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 // Scenario 9: Status badge rendered correctly
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Status badges render for planned, purchased, scheduled, arrived items', async ({
     page,
     testPrefix,
@@ -371,6 +393,9 @@ test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () 
 // Scenario 10: Delete modal — confirm removes item
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Confirming delete removes the household item from the list', async ({
     page,
     testPrefix,
@@ -397,6 +422,7 @@ test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, 
 
     const listRefreshPromise = page.waitForResponse(
       (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
+      { timeout: 50000 },
     );
     await listPage.confirmDelete();
     await listRefreshPromise;
@@ -412,6 +438,9 @@ test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, 
 // Scenario 11: Delete modal — cancel leaves item
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Delete modal — cancel (Scenario 11)', { tag: '@responsive' }, () => {
+  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  test.describe.configure({ timeout: 60_000 });
+
   test('Cancelling delete modal leaves the household item in the list', async ({
     page,
     testPrefix,

--- a/e2e/tests/timeline/timeline-calendar.spec.ts
+++ b/e2e/tests/timeline/timeline-calendar.spec.ts
@@ -269,6 +269,10 @@ test.describe('Week grid renders (Scenario 7)', () => {
     await timelinePage.gotoCalendar();
     await timelinePage.calendarWeekButton.click();
 
+    // Wait for the label to switch from month format ("March 2026") to week
+    // format ("Mar 1–7, 2026") before capturing it — the click is async and
+    // React state update may lag behind the click action.
+    await expect(timelinePage.calendarPeriodLabel).not.toHaveText(/^\w+ \d{4}$/);
     const currentWeekLabel = await timelinePage.getCalendarPeriodLabel();
 
     // Navigate forward


### PR DESCRIPTION
## Summary

Fixes remaining E2E shard failures on PR #508 (EPIC-04 beta→main promotion) after the previous fix PR #515.

### Root causes fixed

**Household Items list tests — Shards 3 (desktop), 9 (tablet), 15 (mobile)**

1. `waitForResponse` timeout still too low (25s): when all 16 CI shards run concurrently (16 × 2 workers = 32 browser contexts against one SQLite Docker container), API response times can exceed 25s. Increased to 50s in `HouseholdItemsPage.search()`, `clearSearch()`, and all inline `waitForResponse` calls in scenarios 7, 8, 10.

2. Test timeout too low for desktop: the desktop project uses a 15s test timeout (from `playwright.config.ts`), which is shorter than the 50s `waitForResponse`. The test timeout fired first, aborting the wait before the API could respond. Fixed by adding `test.describe.configure({ timeout: 60_000 })` to Scenarios 4–11 in `household-items-list.spec.ts`.

**Timeline calendar "Today button" test — Shard 5 (desktop)**

Race condition: `calendarWeekButton.click()` is asynchronous; reading `calendarPeriodLabel` immediately after captured the stale month-format label ("March 2026") before React re-rendered to week format ("Mar 1–7, 2026"). After navigating forward and clicking "Today", the label correctly showed week format — making the `toBe()` comparison fail. Fixed by awaiting `expect(calendarPeriodLabel).not.toHaveText(/^\w+ \d{4}$/)` before capturing the label, which auto-retries until React updates the DOM.

### Files changed

- `e2e/pages/HouseholdItemsPage.ts` — `search()` / `clearSearch()` timeouts: 25s → 50s
- `e2e/tests/household-items/household-items-list.spec.ts` — `test.describe.configure({ timeout: 60_000 })` on Scenarios 4–11; explicit 50s timeouts on inline `waitForResponse` calls
- `e2e/tests/timeline/timeline-calendar.spec.ts` — await label format change before capturing `currentWeekLabel`

<!-- REVIEW_METRICS
{
  "agent": "qa-integration-tester",
  "verdict": "approve",
  "findings": { "critical": 0, "high": 0, "medium": 0, "low": 0, "informational": 0 }
}
-->