### PR TITLE
test(e2e): replace waitForResponse with URL+networkidle sync in HI list tests

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -163,37 +163,45 @@ export class HouseholdItemsPage {
   }
 
   /**
-   * Type a search query and wait for the API response and DOM to update.
-   * The response listener is registered BEFORE the fill to avoid a race with
-   * the 300ms debounce.
+   * Type a search query and wait for the DOM to reflect the results.
    *
-   * An explicit 50s timeout is used because debounce (300ms) + API round-trip
-   * can exceed 25s on heavily-loaded CI runners when all 16 shards run
-   * concurrently (each with 2 workers = 32 browser contexts against one
-   * SQLite container). Tests that call this method must extend their test
-   * timeout to 60s so the waitForResponse can run to completion.
+   * Strategy:
+   * 1. Fill the input.
+   * 2. Wait for URL to update to ?q=<query> — confirms the 300ms debounce
+   *    fired and React set the URL param (client-side, no server needed).
+   * 3. Wait for network idle — server response arrives and React updates DOM.
+   * 4. Wait for DOM to show rows/cards/empty-state.
+   *
+   * This avoids waitForResponse() which times out under heavy CI load (all
+   * 16 shards × 2 workers = 32 concurrent contexts against one SQLite
+   * container can block the server for >50s on writes, starving reads).
+   * networkidle (500ms of no requests) provides a server-agnostic signal that
+   * the fetch completed without hardcoding a specific timeout.
    */
   async search(query: string): Promise<void> {
-    const responsePromise = this.page.waitForResponse(
-      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-      { timeout: 50000 },
-    );
     await this.searchInput.fill(query);
-    await responsePromise;
+    // Step 2: wait for URL to update (debounce complete, React state updated)
+    await this.page.waitForURL((url) => url.searchParams.get('q') === query, {
+      timeout: 5000,
+    });
+    // Step 3: wait for server response (network goes idle after fetch completes)
+    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
+    // Step 4: wait for DOM update
     await this.waitForLoaded();
   }
 
   /**
-   * Clear the search input and wait for the API response and DOM to update.
-   * An explicit 50s timeout is used for the same reason as search().
+   * Clear the search input and wait for the DOM to reflect unfiltered results.
    */
   async clearSearch(): Promise<void> {
-    const responsePromise = this.page.waitForResponse(
-      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-      { timeout: 50000 },
-    );
     await this.searchInput.clear();
-    await responsePromise;
+    // Wait for URL ?q param to clear (debounce complete, React state updated)
+    await this.page.waitForURL(
+      (url) => !url.searchParams.has('q') || url.searchParams.get('q') === '',
+      { timeout: 5000 },
+    );
+    // Wait for server response then DOM update
+    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
     await this.waitForLoaded();
   }
 
@@ -234,6 +242,8 @@ export class HouseholdItemsPage {
 
   /**
    * Confirm the deletion in the delete modal.
+   * Uses an explicit 30s timeout for the DELETE response to handle server
+   * load on CI runners (all 16 shards × 2 workers concurrent).
    */
   async confirmDelete(): Promise<void> {
     const deleteResponsePromise = this.page.waitForResponse(
@@ -241,6 +251,7 @@ export class HouseholdItemsPage {
         resp.url().includes('/api/household-items') &&
         resp.request().method() === 'DELETE' &&
         resp.status() === 204,
+      { timeout: 30000 },
     );
     await this.deleteConfirmButton.click();
     await deleteResponsePromise;

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -118,10 +118,9 @@ test.describe('Empty state — no items (Scenario 3)', { tag: '@responsive' }, (
 // Scenario 4: Filter empty state when search matches nothing
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Empty state — filter no match (Scenario 4)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse because the shared
-  // SQLite test container gets heavily loaded when all 16 CI shards run in
-  // parallel (32 concurrent browser contexts). Desktop default timeout (15s)
-  // is too short; tablet/mobile already have 60s via playwright.config.ts.
+  // Extend test timeout: multi-step test (create → navigate → search → assert
+  // → delete) takes longer than the desktop default 15s, especially on mobile
+  // WebKit under full CI shard load.
   test.describe.configure({ timeout: 60_000 });
   test('Filter empty state shown when search matches no household items', async ({
     page,
@@ -162,7 +161,8 @@ test.describe(
   'Item appears in list after API creation (Scenario 5)',
   { tag: '@responsive' },
   () => {
-    // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+    // Extend test timeout: multi-step test (create → navigate → search → assert
+    // → delete) takes longer than the desktop default 15s on mobile WebKit.
     test.describe.configure({ timeout: 60_000 });
 
     test('Household item created via API appears in the list', async ({ page, testPrefix }) => {
@@ -224,7 +224,8 @@ test.describe(
 // Scenario 6: Search filters the list
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Search by name filters list to matching items only', async ({ page, testPrefix }) => {
@@ -257,7 +258,8 @@ test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
 // Scenario 7: Category filter narrows results
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Category filter narrows list to items in selected category', async ({
@@ -283,13 +285,13 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
       // First search to narrow to our prefix, then apply category filter
       await listPage.search(`${testPrefix} HI Cat`);
 
-      // Select 'furniture' category
-      const filterResponsePromise = page.waitForResponse(
-        (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-        { timeout: 50000 },
-      );
+      // Select 'furniture' category — wait for URL then networkidle (avoids
+      // server-dependent waitForResponse which times out under CI load).
       await listPage.categoryFilter.selectOption('furniture');
-      await filterResponsePromise;
+      await page.waitForURL((url) => url.searchParams.get('category') === 'furniture', {
+        timeout: 10000,
+      });
+      await page.waitForLoadState('networkidle', { timeout: 55000 });
       await listPage.waitForLoaded();
 
       const names = await listPage.getItemNames();
@@ -307,7 +309,8 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
 // Scenario 8: Status filter narrows results
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Status filter narrows list to items with selected status', async ({ page, testPrefix }) => {
@@ -327,12 +330,13 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       await listPage.search(`${testPrefix} HI Status`);
 
-      const filterResponsePromise = page.waitForResponse(
-        (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-        { timeout: 50000 },
-      );
+      // Select 'planned' status — wait for URL then networkidle (avoids
+      // server-dependent waitForResponse which times out under CI load).
       await listPage.statusFilter.selectOption('planned');
-      await filterResponsePromise;
+      await page.waitForURL((url) => url.searchParams.get('status') === 'planned', {
+        timeout: 10000,
+      });
+      await page.waitForLoadState('networkidle', { timeout: 55000 });
       await listPage.waitForLoaded();
 
       const names = await listPage.getItemNames();
@@ -350,7 +354,8 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 // Scenario 9: Status badge rendered correctly
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Status badges render for planned, purchased, scheduled, arrived items', async ({
@@ -393,7 +398,8 @@ test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () 
 // Scenario 10: Delete modal — confirm removes item
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Confirming delete removes the household item from the list', async ({
@@ -420,12 +426,11 @@ test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, 
     const modalText = await listPage.deleteModal.textContent();
     expect(modalText).toContain(name);
 
-    const listRefreshPromise = page.waitForResponse(
-      (resp) => resp.url().includes('/api/household-items') && resp.status() === 200,
-      { timeout: 50000 },
-    );
     await listPage.confirmDelete();
-    await listRefreshPromise;
+    // Wait for the delete + list refresh requests to complete (networkidle
+    // avoids server-dependent waitForResponse which times out under CI load).
+    await page.waitForLoadState('networkidle', { timeout: 55000 });
+    await listPage.waitForLoaded();
 
     const namesAfter = await listPage.getItemNames();
     expect(namesAfter).not.toContain(name);
@@ -438,7 +443,8 @@ test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, 
 // Scenario 11: Delete modal — cancel leaves item
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Delete modal — cancel (Scenario 11)', { tag: '@responsive' }, () => {
-  // Extend timeout: search() uses a 50s waitForResponse (see Scenario 4).
+  // Extend test timeout: these tests create real API data, search/filter, and
+  // delete — multi-step flows that take longer on mobile WebKit under CI load.
   test.describe.configure({ timeout: 60_000 });
 
   test('Cancelling delete modal leaves the household item in the list', async ({


### PR DESCRIPTION
## Summary

Fixes persistent shard failures (3, 9, 15) on PR #508 (EPIC-04 beta→main promotion) after previous attempts with 25s and 50s `waitForResponse` timeouts still failed.

### Root Cause Analysis

The `waitForResponse()` strategy is fundamentally broken for this test scenario under 16-shard CI load. The shared SQLite Docker container processes 32 concurrent browser contexts (16 shards × 2 workers). Each test's `finally` block runs `deleteHouseholdItemViaApi` to clean up — these DELETE operations hold SQLite write locks, starving GET read queries for the household-items list.

Result: the GET `/api/household-items` request fired by `search()` waits in the SQLite WAL queue for an indeterminate time, exceeding any static timeout we set (10s → 25s → 50s all failed consistently).

### Fix

Replace `waitForResponse()` with a client-side URL + network-idle synchronization strategy:

1. **Fill input** (triggers 300ms debounce)
2. **`waitForURL(?q=<query>)`** — waits for React to update the URL param, which happens client-side after debounce fires. Fast (≤5s), no server dependency.
3. **`waitForLoadState('networkidle', { timeout: 55s })`** — waits for 500ms of no network activity, signalling the server fetch completed. Server-agnostic — doesn't care about response codes or specific URLs.
4. **`waitForLoaded()`** — confirms DOM shows rows/cards/empty-state

Same approach for `clearSearch()`, category filter (Scenario 7), status filter (Scenario 8), and delete-confirm list refresh (Scenario 10).

Also adds `{ timeout: 30000 }` to `confirmDelete()`'s DELETE 204 wait for CI load tolerance.

### Files Changed

- `e2e/pages/HouseholdItemsPage.ts` — `search()`, `clearSearch()`, `confirmDelete()` synchronization strategy
- `e2e/tests/household-items/household-items-list.spec.ts` — Scenarios 7, 8, 10 filter/delete sync

<!-- REVIEW_METRICS
{
  "agent": "qa-integration-tester",
  "verdict": "approve",
  "findings": { "critical": 0, "high": 0, "medium": 0, "low": 0, "informational": 0 }
}
-->