### PR TITLE
fix(e2e): use URL parsing for waitForResponse parameter matching

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -179,13 +179,22 @@ export class HouseholdItemsPage {
    * causing waitForLoaded() to see stale DOM.
    */
   async search(query: string): Promise<void> {
-    // Step 1: register response listener BEFORE the fill so we never miss it
-    const encodedQuery = encodeURIComponent(query);
+    // Step 1: register response listener BEFORE the fill so we never miss it.
+    // Use URL parsing instead of string matching because URLSearchParams
+    // encodes spaces as '+' while encodeURIComponent uses '%20'.
     const responsePromise = this.page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/household-items') &&
-        resp.url().includes(`q=${encodedQuery}`) &&
-        resp.request().method() === 'GET',
+      (resp) => {
+        try {
+          const url = new URL(resp.url());
+          return (
+            url.pathname.includes('/api/household-items') &&
+            url.searchParams.get('q') === query &&
+            resp.request().method() === 'GET'
+          );
+        } catch {
+          return false;
+        }
+      },
       { timeout: 55000 },
     );
     // Step 2: fill the search input (triggers 300ms debounce)
@@ -204,12 +213,21 @@ export class HouseholdItemsPage {
    * Clear the search input and wait for the DOM to reflect unfiltered results.
    */
   async clearSearch(): Promise<void> {
-    // Register response listener BEFORE clearing so we never miss the refetch
+    // Register response listener BEFORE clearing so we never miss the refetch.
+    // Use URL parsing for consistent parameter matching.
     const responsePromise = this.page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/household-items') &&
-        !resp.url().includes('q=') &&
-        resp.request().method() === 'GET',
+      (resp) => {
+        try {
+          const url = new URL(resp.url());
+          return (
+            url.pathname.includes('/api/household-items') &&
+            !url.searchParams.has('q') &&
+            resp.request().method() === 'GET'
+          );
+        } catch {
+          return false;
+        }
+      },
       { timeout: 55000 },
     );
     await this.searchInput.clear();

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -287,11 +287,21 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
 
       // Select 'furniture' category — register response listener BEFORE the
       // action to avoid the networkidle race (can resolve before fetch starts).
+      // Use URL parsing for consistent parameter matching (URLSearchParams
+      // encodes spaces as '+', not '%20').
       const categoryResponsePromise = page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/household-items') &&
-          resp.url().includes('category=furniture') &&
-          resp.request().method() === 'GET',
+        (resp) => {
+          try {
+            const url = new URL(resp.url());
+            return (
+              url.pathname.includes('/api/household-items') &&
+              url.searchParams.get('category') === 'furniture' &&
+              resp.request().method() === 'GET'
+            );
+          } catch {
+            return false;
+          }
+        },
         { timeout: 55000 },
       );
       await listPage.categoryFilter.selectOption('furniture');
@@ -339,11 +349,20 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       // Select 'planned' status — register response listener BEFORE the
       // action to avoid the networkidle race (can resolve before fetch starts).
+      // Use URL parsing for consistent parameter matching.
       const statusResponsePromise = page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/household-items') &&
-          resp.url().includes('status=planned') &&
-          resp.request().method() === 'GET',
+        (resp) => {
+          try {
+            const url = new URL(resp.url());
+            return (
+              url.pathname.includes('/api/household-items') &&
+              url.searchParams.get('status') === 'planned' &&
+              resp.request().method() === 'GET'
+            );
+          } catch {
+            return false;
+          }
+        },
         { timeout: 55000 },
       );
       await listPage.statusFilter.selectOption('planned');


### PR DESCRIPTION
## Summary

Follow-up fix for the E2E test race conditions. The `waitForResponse` URL matching from PR #519 still caused 55s timeouts because of URL encoding differences.

## Root Cause

`URLSearchParams.set()` encodes spaces as `+` but `encodeURIComponent()` produces `%20`. String matching (`resp.url().includes('q=E2E-des0%20HI%20Alpha')`) never matched the actual URL (`q=E2E-des0+HI+Alpha`).

## Fix

Replace string-based URL matching with `new URL(resp.url()).searchParams.get('param')` for consistent encoding handling in:
- `HouseholdItemsPage.ts` POM: `search()` and `clearSearch()`
- `household-items-list.spec.ts`: category and status filter tests

## Test plan

- [ ] All 16 E2E shards pass (especially shards 3, 4 which had the timeouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)