### PR TITLE
fix(e2e): replace waitForResponse with networkidle + retry assertions

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -166,46 +166,21 @@ export class HouseholdItemsPage {
    * Type a search query and wait for the DOM to reflect the results.
    *
    * Strategy:
-   * 1. Register a waitForResponse listener BEFORE filling the input so the
-   *    response cannot be missed regardless of timing.
-   * 2. Fill the input.
-   * 3. Wait for URL to update to ?q=<query> — confirms the 300ms debounce
-   *    fired and React set the URL param.
-   * 4. Await the API response that contains the search query parameter.
-   * 5. Wait for DOM to show rows/cards/empty-state.
+   * 1. Fill the search input (triggers 300ms debounce).
+   * 2. Wait for the URL to update to ?q=<query> — confirms debounce fired.
+   * 3. Wait for network to settle (all fetches complete).
+   * 4. Wait for DOM to show rows/cards/empty-state.
    *
-   * Previous approach used networkidle which can resolve before the fetch
-   * starts (between URL update and React effect triggering the API call),
-   * causing waitForLoaded() to see stale DOM.
+   * Callers should wrap assertions in expect.toPass() for retry resilience
+   * under CI load, since networkidle may occasionally resolve before React
+   * re-renders with the new data.
    */
   async search(query: string): Promise<void> {
-    // Step 1: register response listener BEFORE the fill so we never miss it.
-    // Use URL parsing instead of string matching because URLSearchParams
-    // encodes spaces as '+' while encodeURIComponent uses '%20'.
-    const responsePromise = this.page.waitForResponse(
-      (resp) => {
-        try {
-          const url = new URL(resp.url());
-          return (
-            url.pathname.includes('/api/household-items') &&
-            url.searchParams.get('q') === query &&
-            resp.request().method() === 'GET'
-          );
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 55000 },
-    );
-    // Step 2: fill the search input (triggers 300ms debounce)
     await this.searchInput.fill(query);
-    // Step 3: wait for URL to update (debounce complete, React state updated)
     await this.page.waitForURL((url) => url.searchParams.get('q') === query, {
       timeout: 10000,
     });
-    // Step 4: wait for the specific search API response
-    await responsePromise;
-    // Step 5: wait for DOM update
+    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
     await this.waitForLoaded();
   }
 
@@ -213,31 +188,12 @@ export class HouseholdItemsPage {
    * Clear the search input and wait for the DOM to reflect unfiltered results.
    */
   async clearSearch(): Promise<void> {
-    // Register response listener BEFORE clearing so we never miss the refetch.
-    // Use URL parsing for consistent parameter matching.
-    const responsePromise = this.page.waitForResponse(
-      (resp) => {
-        try {
-          const url = new URL(resp.url());
-          return (
-            url.pathname.includes('/api/household-items') &&
-            !url.searchParams.has('q') &&
-            resp.request().method() === 'GET'
-          );
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 55000 },
-    );
     await this.searchInput.clear();
-    // Wait for URL ?q param to clear (debounce complete, React state updated)
     await this.page.waitForURL(
       (url) => !url.searchParams.has('q') || url.searchParams.get('q') === '',
       { timeout: 10000 },
     );
-    // Wait for server response then DOM update
-    await responsePromise;
+    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
     await this.waitForLoaded();
   }
 

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -139,15 +139,17 @@ test.describe('Empty state — filter no match (Scenario 4)', { tag: '@responsiv
 
       await listPage.search('ZZZNOMATCH99999XYZABC');
 
-      await expect(listPage.emptyState).toBeVisible({ timeout: 7000 });
-      const emptyText = await listPage.emptyState.textContent();
-      expect(emptyText?.toLowerCase()).toMatch(/no household items match your filters/);
+      await expect(async () => {
+        await expect(listPage.emptyState).toBeVisible({ timeout: 5000 });
+        const emptyText = await listPage.emptyState.textContent();
+        expect(emptyText?.toLowerCase()).toMatch(/no household items match your filters/);
 
-      // "Clear All Filters" button visible
-      const clearButton = listPage.emptyState.getByRole('button', {
-        name: /Clear All Filters/i,
-      });
-      await expect(clearButton).toBeVisible();
+        // "Clear All Filters" button visible
+        const clearButton = listPage.emptyState.getByRole('button', {
+          name: /Clear All Filters/i,
+        });
+        await expect(clearButton).toBeVisible();
+      }).toPass({ timeout: 30000 });
     } finally {
       if (createdId) await deleteHouseholdItemViaApi(page, createdId);
     }
@@ -178,8 +180,10 @@ test.describe(
 
         await listPage.search(name);
 
-        const names = await listPage.getItemNames();
-        expect(names).toContain(name);
+        await expect(async () => {
+          const names = await listPage.getItemNames();
+          expect(names).toContain(name);
+        }).toPass({ timeout: 30000 });
       } finally {
         if (createdId) await deleteHouseholdItemViaApi(page, createdId);
       }
@@ -206,13 +210,15 @@ test.describe(
         await listPage.waitForLoaded();
         await listPage.search(name);
 
-        await expect(listPage.tableContainer).toBeVisible();
+        await expect(async () => {
+          await expect(listPage.tableContainer).toBeVisible();
 
-        const table = listPage.tableContainer.locator('table');
-        await expect(table.getByRole('columnheader', { name: 'Name' })).toBeVisible();
-        await expect(table.getByRole('columnheader', { name: 'Category' })).toBeVisible();
-        await expect(table.getByRole('columnheader', { name: 'Status' })).toBeVisible();
-        await expect(table.getByRole('columnheader', { name: 'Actions' })).toBeVisible();
+          const table = listPage.tableContainer.locator('table');
+          await expect(table.getByRole('columnheader', { name: 'Name' })).toBeVisible();
+          await expect(table.getByRole('columnheader', { name: 'Category' })).toBeVisible();
+          await expect(table.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+          await expect(table.getByRole('columnheader', { name: 'Actions' })).toBeVisible();
+        }).toPass({ timeout: 30000 });
       } finally {
         if (createdId) await deleteHouseholdItemViaApi(page, createdId);
       }
@@ -243,9 +249,11 @@ test.describe('Search filters (Scenario 6)', { tag: '@responsive' }, () => {
 
       await listPage.search(`${testPrefix} HI Alpha`);
 
-      const names = await listPage.getItemNames();
-      expect(names).toContain(alphaName);
-      expect(names).not.toContain(betaName);
+      await expect(async () => {
+        const names = await listPage.getItemNames();
+        expect(names).toContain(alphaName);
+        expect(names).not.toContain(betaName);
+      }).toPass({ timeout: 30000 });
     } finally {
       for (const id of created) {
         await deleteHouseholdItemViaApi(page, id);
@@ -285,35 +293,19 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
       // First search to narrow to our prefix, then apply category filter
       await listPage.search(`${testPrefix} HI Cat`);
 
-      // Select 'furniture' category — register response listener BEFORE the
-      // action to avoid the networkidle race (can resolve before fetch starts).
-      // Use URL parsing for consistent parameter matching (URLSearchParams
-      // encodes spaces as '+', not '%20').
-      const categoryResponsePromise = page.waitForResponse(
-        (resp) => {
-          try {
-            const url = new URL(resp.url());
-            return (
-              url.pathname.includes('/api/household-items') &&
-              url.searchParams.get('category') === 'furniture' &&
-              resp.request().method() === 'GET'
-            );
-          } catch {
-            return false;
-          }
-        },
-        { timeout: 55000 },
-      );
+      // Select 'furniture' category
       await listPage.categoryFilter.selectOption('furniture');
       await page.waitForURL((url) => url.searchParams.get('category') === 'furniture', {
         timeout: 10000,
       });
-      await categoryResponsePromise;
+      await page.waitForLoadState('networkidle', { timeout: 55000 });
       await listPage.waitForLoaded();
 
-      const names = await listPage.getItemNames();
-      expect(names).toContain(furnitureName);
-      expect(names).not.toContain(applianceName);
+      await expect(async () => {
+        const names = await listPage.getItemNames();
+        expect(names).toContain(furnitureName);
+        expect(names).not.toContain(applianceName);
+      }).toPass({ timeout: 30000 });
     } finally {
       for (const id of created) {
         await deleteHouseholdItemViaApi(page, id);
@@ -347,34 +339,19 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       await listPage.search(`${testPrefix} HI Status`);
 
-      // Select 'planned' status — register response listener BEFORE the
-      // action to avoid the networkidle race (can resolve before fetch starts).
-      // Use URL parsing for consistent parameter matching.
-      const statusResponsePromise = page.waitForResponse(
-        (resp) => {
-          try {
-            const url = new URL(resp.url());
-            return (
-              url.pathname.includes('/api/household-items') &&
-              url.searchParams.get('status') === 'planned' &&
-              resp.request().method() === 'GET'
-            );
-          } catch {
-            return false;
-          }
-        },
-        { timeout: 55000 },
-      );
+      // Select 'planned' status
       await listPage.statusFilter.selectOption('planned');
       await page.waitForURL((url) => url.searchParams.get('status') === 'planned', {
         timeout: 10000,
       });
-      await statusResponsePromise;
+      await page.waitForLoadState('networkidle', { timeout: 55000 });
       await listPage.waitForLoaded();
 
-      const names = await listPage.getItemNames();
-      expect(names).toContain(plannedName);
-      expect(names).not.toContain(purchasedName);
+      await expect(async () => {
+        const names = await listPage.getItemNames();
+        expect(names).toContain(plannedName);
+        expect(names).not.toContain(purchasedName);
+      }).toPass({ timeout: 30000 });
     } finally {
       for (const id of created) {
         await deleteHouseholdItemViaApi(page, id);
@@ -414,11 +391,13 @@ test.describe('Status badge rendering (Scenario 9)', { tag: '@responsive' }, () 
       await listPage.search(`${testPrefix} HI Badge`);
 
       // Each status should have a visible badge in the page
-      for (const status of statuses) {
-        const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
-        const badge = page.locator('[class*="badge"]', { hasText: statusLabel }).first();
-        await expect(badge).toBeVisible();
-      }
+      await expect(async () => {
+        for (const status of statuses) {
+          const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
+          const badge = page.locator('[class*="badge"]', { hasText: statusLabel }).first();
+          await expect(badge).toBeVisible();
+        }
+      }).toPass({ timeout: 30000 });
     } finally {
       for (const id of created) {
         await deleteHouseholdItemViaApi(page, id);
@@ -449,8 +428,10 @@ test.describe('Delete modal — confirm (Scenario 10)', { tag: '@responsive' }, 
     await listPage.waitForLoaded();
 
     await listPage.search(name);
-    const namesBefore = await listPage.getItemNames();
-    expect(namesBefore).toContain(name);
+    await expect(async () => {
+      const namesBefore = await listPage.getItemNames();
+      expect(namesBefore).toContain(name);
+    }).toPass({ timeout: 30000 });
 
     await listPage.openDeleteModal(name);
     await expect(listPage.deleteModal).toBeVisible();
@@ -493,6 +474,11 @@ test.describe('Delete modal — cancel (Scenario 11)', { tag: '@responsive' }, (
       await listPage.goto();
       await listPage.waitForLoaded();
       await listPage.search(name);
+
+      await expect(async () => {
+        const names = await listPage.getItemNames();
+        expect(names).toContain(name);
+      }).toPass({ timeout: 30000 });
 
       await listPage.openDeleteModal(name);
       await listPage.cancelDelete();


### PR DESCRIPTION
## Summary

- Reverts `waitForResponse` approach in `HouseholdItemsPage.search()` and `clearSearch()` back to `networkidle` — `waitForResponse` consistently times out under CI load (16 shards × 2 workers against one SQLite container)
- Replaces `waitForResponse` in category/status filter tests with `networkidle`
- Wraps all post-search/filter assertions in `expect.toPass({ timeout: 30000 })` for retry resilience

## Context

Previous PRs (#519, #521) tried `waitForResponse` with different URL matching strategies but both timed out. This approach uses the simpler `networkidle` wait combined with Playwright's built-in retry mechanism (`expect.toPass()`) to handle the race between network settling and React re-rendering.

## Test plan

- [ ] All 16 E2E shards pass in CI
- [ ] Household items list search/filter tests no longer timeout
- [ ] Category and status filter tests pass on all viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)