### PR TITLE
fix(e2e): use waitForResponse with simple predicate + fix create redirect

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -166,21 +166,29 @@ export class HouseholdItemsPage {
    * Type a search query and wait for the DOM to reflect the results.
    *
    * Strategy:
-   * 1. Fill the search input (triggers 300ms debounce).
-   * 2. Wait for the URL to update to ?q=<query> — confirms debounce fired.
-   * 3. Wait for network to settle (all fetches complete).
-   * 4. Wait for DOM to show rows/cards/empty-state.
+   * 1. Register a waitForResponse listener BEFORE filling the input so the
+   *    response cannot be missed regardless of timing.
+   * 2. Fill the input (triggers 300ms debounce).
+   * 3. Wait for URL to update to ?q=<query> — confirms debounce fired.
+   * 4. Await the API response (proves server has answered).
+   * 5. Wait for DOM to show rows/cards/empty-state.
    *
-   * Callers should wrap assertions in expect.toPass() for retry resilience
-   * under CI load, since networkidle may occasionally resolve before React
-   * re-renders with the new data.
+   * The response predicate uses a simple string include check (not URL
+   * parsing) to avoid any encoding mismatches.
    */
   async search(query: string): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/household-items') &&
+        resp.request().method() === 'GET' &&
+        resp.status() === 200,
+      { timeout: 55000 },
+    );
     await this.searchInput.fill(query);
     await this.page.waitForURL((url) => url.searchParams.get('q') === query, {
       timeout: 10000,
     });
-    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
+    await responsePromise;
     await this.waitForLoaded();
   }
 
@@ -188,12 +196,19 @@ export class HouseholdItemsPage {
    * Clear the search input and wait for the DOM to reflect unfiltered results.
    */
   async clearSearch(): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/household-items') &&
+        resp.request().method() === 'GET' &&
+        resp.status() === 200,
+      { timeout: 55000 },
+    );
     await this.searchInput.clear();
     await this.page.waitForURL(
       (url) => !url.searchParams.has('q') || url.searchParams.get('q') === '',
       { timeout: 10000 },
     );
-    await this.page.waitForLoadState('networkidle', { timeout: 55000 });
+    await responsePromise;
     await this.waitForLoaded();
   }
 

--- a/e2e/tests/household-items/household-item-create.spec.ts
+++ b/e2e/tests/household-items/household-item-create.spec.ts
@@ -101,11 +101,15 @@ test.describe('Create with name only — happy path (Scenario 4)', { tag: '@resp
         expect(page.url()).not.toContain('/new');
         expect(createdId).toBeTruthy();
 
-        // Detail page heading should show the item name
-        const heading = page.getByRole('heading', { level: 1 });
-        await expect(heading).toBeVisible();
-        const headingText = await heading.textContent();
-        expect(headingText?.trim()).toContain(name);
+        // Detail page heading should show the item name — wrap in toPass()
+        // because on mobile WebKit the URL may change before React renders
+        // the detail page component.
+        await expect(async () => {
+          const heading = page.getByRole('heading', { level: 1 });
+          await expect(heading).toBeVisible();
+          const headingText = await heading.textContent();
+          expect(headingText?.trim()).toContain(name);
+        }).toPass({ timeout: 15000 });
       } finally {
         if (createdId) await deleteHouseholdItemViaApi(page, createdId);
       }

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -293,12 +293,20 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
       // First search to narrow to our prefix, then apply category filter
       await listPage.search(`${testPrefix} HI Cat`);
 
-      // Select 'furniture' category
+      // Select 'furniture' category — register response listener BEFORE the
+      // action so we never miss the API response.
+      const categoryResponsePromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/household-items') &&
+          resp.request().method() === 'GET' &&
+          resp.status() === 200,
+        { timeout: 55000 },
+      );
       await listPage.categoryFilter.selectOption('furniture');
       await page.waitForURL((url) => url.searchParams.get('category') === 'furniture', {
         timeout: 10000,
       });
-      await page.waitForLoadState('networkidle', { timeout: 55000 });
+      await categoryResponsePromise;
       await listPage.waitForLoaded();
 
       await expect(async () => {
@@ -339,12 +347,20 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       await listPage.search(`${testPrefix} HI Status`);
 
-      // Select 'planned' status
+      // Select 'planned' status — register response listener BEFORE the
+      // action so we never miss the API response.
+      const statusResponsePromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/household-items') &&
+          resp.request().method() === 'GET' &&
+          resp.status() === 200,
+        { timeout: 55000 },
+      );
       await listPage.statusFilter.selectOption('planned');
       await page.waitForURL((url) => url.searchParams.get('status') === 'planned', {
         timeout: 10000,
       });
-      await page.waitForLoadState('networkidle', { timeout: 55000 });
+      await statusResponsePromise;
       await listPage.waitForLoaded();
 
       await expect(async () => {


### PR DESCRIPTION
## Summary

- Reverts `networkidle` back to `waitForResponse` in `HouseholdItemsPage.search()` and `clearSearch()`, using a **simple string-includes predicate** (not URL parsing) registered BEFORE the user action
- Applies the same `waitForResponse` pattern to category/status filter tests
- Fixes mobile WebKit create redirect test by wrapping heading assertion in `expect.toPass()`

## Context

Three iterations of fixes:
1. PR #521: `waitForResponse` with URL parsing → timed out (55s)
2. PR #522: `networkidle` + `expect.toPass()` → `networkidle` resolves before React's useEffect fires the fetch, DOM never updates
3. **This PR**: `waitForResponse` with simple predicate (`resp.url().includes(...)` + `resp.status() === 200`) — avoids any URL encoding issues while ensuring we wait for the actual API response

## Test plan

- [ ] All 16 E2E shards pass in CI
- [ ] Household items list search/filter/badge tests pass on all viewports
- [ ] Household item create redirect test passes on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)