### PR TITLE
fix(e2e): simplify search/filter sync to URL-only + toPass retry

### DIFF
--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -163,53 +163,29 @@ export class HouseholdItemsPage {
   }
 
   /**
-   * Type a search query and wait for the DOM to reflect the results.
+   * Type a search query and wait for the URL to reflect the query.
    *
-   * Strategy:
-   * 1. Register a waitForResponse listener BEFORE filling the input so the
-   *    response cannot be missed regardless of timing.
-   * 2. Fill the input (triggers 300ms debounce).
-   * 3. Wait for URL to update to ?q=<query> — confirms debounce fired.
-   * 4. Await the API response (proves server has answered).
-   * 5. Wait for DOM to show rows/cards/empty-state.
-   *
-   * The response predicate uses a simple string include check (not URL
-   * parsing) to avoid any encoding mismatches.
+   * After filling the input, we wait for the URL to include ?q=<query> which
+   * proves the 300ms debounce has fired and React will trigger the data fetch.
+   * Callers should wrap DOM assertions in `expect.toPass()` to handle the
+   * asynchronous gap between URL change and React re-render.
    */
   async search(query: string): Promise<void> {
-    const responsePromise = this.page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/household-items') &&
-        resp.request().method() === 'GET' &&
-        resp.status() === 200,
-      { timeout: 55000 },
-    );
     await this.searchInput.fill(query);
     await this.page.waitForURL((url) => url.searchParams.get('q') === query, {
       timeout: 10000,
     });
-    await responsePromise;
-    await this.waitForLoaded();
   }
 
   /**
-   * Clear the search input and wait for the DOM to reflect unfiltered results.
+   * Clear the search input and wait for the URL to reflect the cleared state.
    */
   async clearSearch(): Promise<void> {
-    const responsePromise = this.page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/household-items') &&
-        resp.request().method() === 'GET' &&
-        resp.status() === 200,
-      { timeout: 55000 },
-    );
     await this.searchInput.clear();
     await this.page.waitForURL(
       (url) => !url.searchParams.has('q') || url.searchParams.get('q') === '',
       { timeout: 10000 },
     );
-    await responsePromise;
-    await this.waitForLoaded();
   }
 
   /**

--- a/e2e/tests/household-items/household-items-list.spec.ts
+++ b/e2e/tests/household-items/household-items-list.spec.ts
@@ -293,21 +293,11 @@ test.describe('Category filter (Scenario 7)', { tag: '@responsive' }, () => {
       // First search to narrow to our prefix, then apply category filter
       await listPage.search(`${testPrefix} HI Cat`);
 
-      // Select 'furniture' category — register response listener BEFORE the
-      // action so we never miss the API response.
-      const categoryResponsePromise = page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/household-items') &&
-          resp.request().method() === 'GET' &&
-          resp.status() === 200,
-        { timeout: 55000 },
-      );
+      // Select 'furniture' category and wait for URL to reflect it
       await listPage.categoryFilter.selectOption('furniture');
       await page.waitForURL((url) => url.searchParams.get('category') === 'furniture', {
         timeout: 10000,
       });
-      await categoryResponsePromise;
-      await listPage.waitForLoaded();
 
       await expect(async () => {
         const names = await listPage.getItemNames();
@@ -347,21 +337,11 @@ test.describe('Status filter (Scenario 8)', { tag: '@responsive' }, () => {
 
       await listPage.search(`${testPrefix} HI Status`);
 
-      // Select 'planned' status — register response listener BEFORE the
-      // action so we never miss the API response.
-      const statusResponsePromise = page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/household-items') &&
-          resp.request().method() === 'GET' &&
-          resp.status() === 200,
-        { timeout: 55000 },
-      );
+      // Select 'planned' status and wait for URL to reflect it
       await listPage.statusFilter.selectOption('planned');
       await page.waitForURL((url) => url.searchParams.get('status') === 'planned', {
         timeout: 10000,
       });
-      await statusResponsePromise;
-      await listPage.waitForLoaded();
 
       await expect(async () => {
         const names = await listPage.getItemNames();


### PR DESCRIPTION
## Summary

- Removes `waitForResponse` from `HouseholdItemsPage.search()` and `clearSearch()` — timed out on CI shard 3 because the API response was never caught within 55s
- Simplifies to URL-only sync: fill input → wait for URL update (proves debounce fired)
- All DOM assertions use `expect.toPass({ timeout: 30000 })` which retries until React re-render completes
- Also removes `waitForResponse` from category/status filter tests for consistency

Fixes shard 3 failure: `TimeoutError: page.waitForResponse: Timeout 55000ms exceeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)