### PR TITLE
refactor(server): extract shared converters and validators

### DIFF
--- a/server/src/services/householdItemBudgetService.ts
+++ b/server/src/services/householdItemBudgetService.ts
@@ -11,6 +11,14 @@ import {
   users,
   invoices,
 } from '../db/schema.js';
+import { toUserSummary, toBudgetCategory, toBudgetSourceSummary, toVendorSummary } from './shared/converters.js';
+import {
+  validateConfidence,
+  validateDescription,
+  validateBudgetCategoryId,
+  validateBudgetSourceId,
+  validateVendorId,
+} from './shared/validators.js';
 import type {
   HouseholdItemBudgetLine,
   BudgetCategory,
@@ -25,75 +33,6 @@ import { CONFIDENCE_MARGINS as confidenceMargins } from '@cornerstone/shared';
 import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/** Valid confidence level values */
-const VALID_CONFIDENCE_LEVELS: ConfidenceLevel[] = [
-  'own_estimate',
-  'professional_estimate',
-  'quote',
-  'invoice',
-];
-
-/** Maximum description length */
-const MAX_DESCRIPTION_LENGTH = 500;
-
-/**
- * Convert a database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null | undefined): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert a database budget category row to BudgetCategory shape.
- */
-function toBudgetCategory(
-  category: typeof budgetCategories.$inferSelect | null | undefined,
-): BudgetCategory | null {
-  if (!category) return null;
-  return {
-    id: category.id,
-    name: category.name,
-    description: category.description,
-    color: category.color,
-    sortOrder: category.sortOrder,
-    createdAt: category.createdAt,
-    updatedAt: category.updatedAt,
-  };
-}
-
-/**
- * Convert a database budget source row to BudgetSourceSummary shape.
- */
-function toBudgetSourceSummary(
-  source: typeof budgetSources.$inferSelect | null | undefined,
-): BudgetSourceSummary | null {
-  if (!source) return null;
-  return {
-    id: source.id,
-    name: source.name,
-    sourceType: source.sourceType,
-  };
-}
-
-/**
- * Convert a database vendor row to VendorSummary shape.
- */
-function toVendorSummary(
-  vendor: typeof vendors.$inferSelect | null | undefined,
-): VendorSummary | null {
-  if (!vendor) return null;
-  return {
-    id: vendor.id,
-    name: vendor.name,
-    specialty: vendor.specialty,
-  };
-}
 
 /**
  * Get total actual amount from invoices linked to a household item budget line.
@@ -195,62 +134,6 @@ function assertHouseholdItemExists(db: DbType, householdItemId: string): void {
   }
 }
 
-/**
- * Validate the description field.
- * @throws ValidationError if description exceeds max length
- */
-function validateDescription(description: string | null | undefined): void {
-  if (description && description.length > MAX_DESCRIPTION_LENGTH) {
-    throw new ValidationError(`Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters`);
-  }
-}
-
-/**
- * Validate that a confidence level value is valid.
- * @throws ValidationError if invalid
- */
-function validateConfidence(confidence: string): void {
-  if (!VALID_CONFIDENCE_LEVELS.includes(confidence as ConfidenceLevel)) {
-    throw new ValidationError(`confidence must be one of: ${VALID_CONFIDENCE_LEVELS.join(', ')}`);
-  }
-}
-
-/**
- * Validate that a budget category ID exists.
- * @throws ValidationError if not found
- */
-function validateBudgetCategoryId(db: DbType, budgetCategoryId: string): void {
-  const cat = db
-    .select()
-    .from(budgetCategories)
-    .where(eq(budgetCategories.id, budgetCategoryId))
-    .get();
-  if (!cat) {
-    throw new ValidationError(`Budget category not found: ${budgetCategoryId}`);
-  }
-}
-
-/**
- * Validate that a budget source ID exists.
- * @throws ValidationError if not found
- */
-function validateBudgetSourceId(db: DbType, budgetSourceId: string): void {
-  const source = db.select().from(budgetSources).where(eq(budgetSources.id, budgetSourceId)).get();
-  if (!source) {
-    throw new ValidationError(`Budget source not found: ${budgetSourceId}`);
-  }
-}
-
-/**
- * Validate that a vendor ID exists.
- * @throws ValidationError if not found
- */
-function validateVendorId(db: DbType, vendorId: string): void {
-  const vendor = db.select().from(vendors).where(eq(vendors.id, vendorId)).get();
-  if (!vendor) {
-    throw new ValidationError(`Vendor not found: ${vendorId}`);
-  }
-}
 
 /**
  * List all budget lines for a household item, ordered by creation time ascending.

--- a/server/src/services/householdItemService.ts
+++ b/server/src/services/householdItemService.ts
@@ -27,10 +27,11 @@ import {
 import { deleteLinksForEntity } from './documentLinkService.js';
 import { listDeps } from './householdItemDepService.js';
 import { autoReschedule } from './schedulingEngine.js';
+import { toUserSummary, toTagResponse, toVendorSummary } from './shared/converters.js';
+import { validateTagIds, validateVendorId } from './shared/validators.js';
 import type {
   HouseholdItemDetail,
   HouseholdItemSummary,
-  HouseholdItemVendorSummary,
   UserSummary,
   TagResponse,
   HouseholdItemCategory,
@@ -46,42 +47,6 @@ import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
-/**
- * Convert database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert database tag row to TagResponse shape.
- */
-function toTagResponse(tag: typeof tags.$inferSelect): TagResponse {
-  return {
-    id: tag.id,
-    name: tag.name,
-    color: tag.color,
-  };
-}
-
-/**
- * Convert database vendor row to HouseholdItemVendorSummary shape.
- */
-function toVendorSummary(
-  vendor: typeof vendors.$inferSelect | null,
-): HouseholdItemVendorSummary | null {
-  if (!vendor) return null;
-  return {
-    id: vendor.id,
-    name: vendor.name,
-    specialty: vendor.specialty,
-  };
-}
 
 /**
  * Fetch tags for a household item.
@@ -294,29 +259,6 @@ function findHouseholdItemById(db: DbType, id: string): typeof householdItems.$i
   return db.select().from(householdItems).where(eq(householdItems.id, id)).get() ?? null;
 }
 
-/**
- * Validate that all tag IDs exist.
- * Throws ValidationError if any tag does not exist.
- */
-function validateTagIds(db: DbType, tagIds: string[]): void {
-  for (const tagId of tagIds) {
-    const tag = db.select().from(tags).where(eq(tags.id, tagId)).get();
-    if (!tag) {
-      throw new ValidationError(`Tag not found: ${tagId}`);
-    }
-  }
-}
-
-/**
- * Validate that vendor ID exists (if provided).
- * Throws ValidationError if vendor does not exist.
- */
-function validateVendorId(db: DbType, vendorId: string): void {
-  const vendor = db.select().from(vendors).where(eq(vendors.id, vendorId)).get();
-  if (!vendor) {
-    throw new ValidationError(`Vendor not found: ${vendorId}`);
-  }
-}
 
 /**
  * Validate that household item category ID exists.

--- a/server/src/services/householdItemSubsidyService.ts
+++ b/server/src/services/householdItemSubsidyService.ts
@@ -9,6 +9,7 @@ import {
   budgetCategories,
   users,
 } from '../db/schema.js';
+import { toUserSummary, toBudgetCategory } from './shared/converters.js';
 import type {
   SubsidyProgram,
   SubsidyReductionType,
@@ -19,33 +20,6 @@ import type {
 import { NotFoundError, ConflictError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/**
- * Convert database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null | undefined): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert database budget category row to BudgetCategory shape.
- */
-function toBudgetCategory(row: typeof budgetCategories.$inferSelect): BudgetCategory {
-  return {
-    id: row.id,
-    name: row.name,
-    description: row.description ?? null,
-    color: row.color ?? null,
-    sortOrder: row.sortOrder,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
 
 /**
  * Load applicable categories for a given subsidy program.
@@ -67,7 +41,7 @@ function loadApplicableCategories(db: DbType, subsidyProgramId: string): BudgetC
     .orderBy(asc(budgetCategories.sortOrder), asc(budgetCategories.name))
     .all();
 
-  return categories.map(toBudgetCategory);
+  return categories.map((row) => toBudgetCategory(row)!);
 }
 
 /**

--- a/server/src/services/shared/converters.test.ts
+++ b/server/src/services/shared/converters.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from '@jest/globals';
+import * as schema from '../../db/schema.js';
+import {
+  toUserSummary,
+  toBudgetCategory,
+  toBudgetSourceSummary,
+  toVendorSummary,
+  toTagResponse,
+} from './converters.js';
+
+// ─── Mock row helpers ───────────────────────────────────────────────────────
+
+function makeUserRow(
+  overrides: Partial<typeof schema.users.$inferSelect> = {},
+): typeof schema.users.$inferSelect {
+  return {
+    id: 'user-1',
+    email: 'alice@example.com',
+    displayName: 'Alice',
+    role: 'member',
+    authProvider: 'local',
+    passwordHash: null,
+    oidcSubject: null,
+    deactivatedAt: null,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeBudgetCategoryRow(
+  overrides: Partial<typeof schema.budgetCategories.$inferSelect> = {},
+): typeof schema.budgetCategories.$inferSelect {
+  return {
+    id: 'bc-1',
+    name: 'Electrical',
+    description: 'Electrical work',
+    color: '#3B82F6',
+    sortOrder: 1,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-02-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeBudgetSourceRow(
+  overrides: Partial<typeof schema.budgetSources.$inferSelect> = {},
+): typeof schema.budgetSources.$inferSelect {
+  return {
+    id: 'bs-1',
+    name: 'Main Loan',
+    sourceType: 'bank_loan',
+    totalAmount: 100000,
+    interestRate: 3.5,
+    terms: '20 years',
+    notes: null,
+    status: 'active',
+    createdBy: null,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeVendorRow(
+  overrides: Partial<typeof schema.vendors.$inferSelect> = {},
+): typeof schema.vendors.$inferSelect {
+  return {
+    id: 'vendor-1',
+    name: 'ACME Contractors',
+    specialty: 'Plumbing',
+    phone: null,
+    email: null,
+    address: null,
+    notes: null,
+    createdBy: null,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeTagRow(
+  overrides: Partial<typeof schema.tags.$inferSelect> = {},
+): typeof schema.tags.$inferSelect {
+  return {
+    id: 'tag-1',
+    name: 'Urgent',
+    color: '#EF4444',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── toUserSummary ──────────────────────────────────────────────────────────
+
+describe('toUserSummary()', () => {
+  it('returns null when passed null', () => {
+    expect(toUserSummary(null)).toBeNull();
+  });
+
+  it('returns null when passed undefined', () => {
+    expect(toUserSummary(undefined)).toBeNull();
+  });
+
+  it('maps id, displayName, and email from user row', () => {
+    const row = makeUserRow({
+      id: 'user-42',
+      displayName: 'Bob Builder',
+      email: 'bob@example.com',
+    });
+
+    const result = toUserSummary(row);
+
+    expect(result).toEqual({
+      id: 'user-42',
+      displayName: 'Bob Builder',
+      email: 'bob@example.com',
+    });
+  });
+
+  it('does not include extra fields like role or authProvider', () => {
+    const row = makeUserRow();
+    const result = toUserSummary(row);
+
+    expect(result).not.toHaveProperty('role');
+    expect(result).not.toHaveProperty('authProvider');
+    expect(result).not.toHaveProperty('passwordHash');
+    expect(result).not.toHaveProperty('createdAt');
+  });
+
+  it('returns only the three summary fields', () => {
+    const row = makeUserRow({ id: 'u1', displayName: 'Carol', email: 'carol@example.com' });
+    const result = toUserSummary(row);
+
+    expect(Object.keys(result!)).toHaveLength(3);
+    expect(Object.keys(result!).sort()).toEqual(['displayName', 'email', 'id']);
+  });
+});
+
+// ─── toBudgetCategory ───────────────────────────────────────────────────────
+
+describe('toBudgetCategory()', () => {
+  it('returns null when passed null', () => {
+    expect(toBudgetCategory(null)).toBeNull();
+  });
+
+  it('returns null when passed undefined', () => {
+    expect(toBudgetCategory(undefined)).toBeNull();
+  });
+
+  it('maps all fields correctly from budget category row', () => {
+    const row = makeBudgetCategoryRow({
+      id: 'bc-99',
+      name: 'Plumbing',
+      description: 'All plumbing work',
+      color: '#10B981',
+      sortOrder: 3,
+      createdAt: '2025-03-01T00:00:00.000Z',
+      updatedAt: '2025-04-01T00:00:00.000Z',
+    });
+
+    const result = toBudgetCategory(row);
+
+    expect(result).toEqual({
+      id: 'bc-99',
+      name: 'Plumbing',
+      description: 'All plumbing work',
+      color: '#10B981',
+      sortOrder: 3,
+      createdAt: '2025-03-01T00:00:00.000Z',
+      updatedAt: '2025-04-01T00:00:00.000Z',
+    });
+  });
+
+  it('passes through null description', () => {
+    const row = makeBudgetCategoryRow({ description: null });
+    const result = toBudgetCategory(row);
+
+    expect(result).not.toBeNull();
+    expect(result!.description).toBeNull();
+  });
+
+  it('passes through null color', () => {
+    const row = makeBudgetCategoryRow({ color: null });
+    const result = toBudgetCategory(row);
+
+    expect(result).not.toBeNull();
+    expect(result!.color).toBeNull();
+  });
+
+  it('passes through null for both description and color simultaneously', () => {
+    const row = makeBudgetCategoryRow({ description: null, color: null });
+    const result = toBudgetCategory(row);
+
+    expect(result).not.toBeNull();
+    expect(result!.description).toBeNull();
+    expect(result!.color).toBeNull();
+  });
+});
+
+// ─── toBudgetSourceSummary ──────────────────────────────────────────────────
+
+describe('toBudgetSourceSummary()', () => {
+  it('returns null when passed null', () => {
+    expect(toBudgetSourceSummary(null)).toBeNull();
+  });
+
+  it('returns null when passed undefined', () => {
+    expect(toBudgetSourceSummary(undefined)).toBeNull();
+  });
+
+  it('maps id, name, and sourceType correctly', () => {
+    const row = makeBudgetSourceRow({
+      id: 'bs-55',
+      name: 'Savings Account',
+      sourceType: 'savings',
+    });
+
+    const result = toBudgetSourceSummary(row);
+
+    expect(result).toEqual({
+      id: 'bs-55',
+      name: 'Savings Account',
+      sourceType: 'savings',
+    });
+  });
+
+  it('does not include extra fields like totalAmount or status', () => {
+    const row = makeBudgetSourceRow();
+    const result = toBudgetSourceSummary(row);
+
+    expect(result).not.toHaveProperty('totalAmount');
+    expect(result).not.toHaveProperty('status');
+    expect(result).not.toHaveProperty('interestRate');
+    expect(result).not.toHaveProperty('createdAt');
+  });
+
+  it('returns only the three summary fields', () => {
+    const row = makeBudgetSourceRow();
+    const result = toBudgetSourceSummary(row);
+
+    expect(Object.keys(result!).sort()).toEqual(['id', 'name', 'sourceType']);
+  });
+
+  it('maps all valid sourceType values correctly', () => {
+    const sourceTypes: Array<typeof schema.budgetSources.$inferSelect['sourceType']> = [
+      'bank_loan',
+      'credit_line',
+      'savings',
+      'other',
+    ];
+
+    for (const sourceType of sourceTypes) {
+      const row = makeBudgetSourceRow({ sourceType });
+      const result = toBudgetSourceSummary(row);
+      expect(result!.sourceType).toBe(sourceType);
+    }
+  });
+});
+
+// ─── toVendorSummary ────────────────────────────────────────────────────────
+
+describe('toVendorSummary()', () => {
+  it('returns null when passed null', () => {
+    expect(toVendorSummary(null)).toBeNull();
+  });
+
+  it('returns null when passed undefined', () => {
+    expect(toVendorSummary(undefined)).toBeNull();
+  });
+
+  it('maps id, name, and specialty correctly', () => {
+    const row = makeVendorRow({
+      id: 'vendor-77',
+      name: 'Best Electric Co.',
+      specialty: 'Electrical',
+    });
+
+    const result = toVendorSummary(row);
+
+    expect(result).toEqual({
+      id: 'vendor-77',
+      name: 'Best Electric Co.',
+      specialty: 'Electrical',
+    });
+  });
+
+  it('passes through null specialty', () => {
+    const row = makeVendorRow({ specialty: null });
+    const result = toVendorSummary(row);
+
+    expect(result).not.toBeNull();
+    expect(result!.specialty).toBeNull();
+  });
+
+  it('does not include extra fields like phone, email, or address', () => {
+    const row = makeVendorRow({ phone: '555-1234', email: 'vendor@test.com', address: '123 St' });
+    const result = toVendorSummary(row);
+
+    expect(result).not.toHaveProperty('phone');
+    expect(result).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('address');
+    expect(result).not.toHaveProperty('notes');
+    expect(result).not.toHaveProperty('createdAt');
+  });
+
+  it('returns only the three summary fields', () => {
+    const row = makeVendorRow();
+    const result = toVendorSummary(row);
+
+    expect(Object.keys(result!).sort()).toEqual(['id', 'name', 'specialty']);
+  });
+});
+
+// ─── toTagResponse ──────────────────────────────────────────────────────────
+
+describe('toTagResponse()', () => {
+  it('maps id, name, and color correctly', () => {
+    const row = makeTagRow({
+      id: 'tag-99',
+      name: 'Structural',
+      color: '#8B5CF6',
+    });
+
+    const result = toTagResponse(row);
+
+    expect(result).toEqual({
+      id: 'tag-99',
+      name: 'Structural',
+      color: '#8B5CF6',
+    });
+  });
+
+  it('passes through null color', () => {
+    const row = makeTagRow({ color: null });
+    const result = toTagResponse(row);
+
+    expect(result.color).toBeNull();
+  });
+
+  it('does not include extra fields like createdAt', () => {
+    const row = makeTagRow();
+    const result = toTagResponse(row);
+
+    expect(result).not.toHaveProperty('createdAt');
+  });
+
+  it('returns only the three response fields', () => {
+    const row = makeTagRow();
+    const result = toTagResponse(row);
+
+    expect(Object.keys(result).sort()).toEqual(['color', 'id', 'name']);
+  });
+});

--- a/server/src/services/shared/converters.ts
+++ b/server/src/services/shared/converters.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared converter functions for service modules.
+ *
+ * These converters transform database rows into API response shapes.
+ * They are extracted from duplicate implementations across multiple service files.
+ */
+
+import { budgetCategories, budgetSources, tags, users, vendors } from '../../db/schema.js';
+import type { BudgetCategory, BudgetSourceSummary, TagResponse, UserSummary, VendorSummary } from '@cornerstone/shared';
+
+/**
+ * Convert a database user row to UserSummary shape.
+ * Returns null if user is null or undefined.
+ */
+export function toUserSummary(
+  user: typeof users.$inferSelect | null | undefined,
+): UserSummary | null {
+  if (!user) return null;
+  return {
+    id: user.id,
+    displayName: user.displayName,
+    email: user.email,
+  };
+}
+
+/**
+ * Convert a database budget category row to BudgetCategory shape.
+ * Returns null if category is null or undefined.
+ */
+export function toBudgetCategory(
+  category: typeof budgetCategories.$inferSelect | null | undefined,
+): BudgetCategory | null {
+  if (!category) return null;
+  return {
+    id: category.id,
+    name: category.name,
+    description: category.description,
+    color: category.color,
+    sortOrder: category.sortOrder,
+    createdAt: category.createdAt,
+    updatedAt: category.updatedAt,
+  };
+}
+
+/**
+ * Convert a database budget source row to BudgetSourceSummary shape.
+ * Returns null if source is null or undefined.
+ */
+export function toBudgetSourceSummary(
+  source: typeof budgetSources.$inferSelect | null | undefined,
+): BudgetSourceSummary | null {
+  if (!source) return null;
+  return {
+    id: source.id,
+    name: source.name,
+    sourceType: source.sourceType,
+  };
+}
+
+/**
+ * Convert a database vendor row to VendorSummary shape.
+ * Returns null if vendor is null or undefined.
+ */
+export function toVendorSummary(
+  vendor: typeof vendors.$inferSelect | null | undefined,
+): VendorSummary | null {
+  if (!vendor) return null;
+  return {
+    id: vendor.id,
+    name: vendor.name,
+    specialty: vendor.specialty,
+  };
+}
+
+/**
+ * Convert a database tag row to TagResponse shape.
+ */
+export function toTagResponse(tag: typeof tags.$inferSelect): TagResponse {
+  return {
+    id: tag.id,
+    name: tag.name,
+    color: tag.color,
+  };
+}

--- a/server/src/services/shared/validators.test.ts
+++ b/server/src/services/shared/validators.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../../db/migrate.js';
+import * as schema from '../../db/schema.js';
+import { ValidationError } from '../../errors/AppError.js';
+import {
+  VALID_CONFIDENCE_LEVELS,
+  MAX_DESCRIPTION_LENGTH,
+  validateTagIds,
+  validateConfidence,
+  validateDescription,
+  validateBudgetCategoryId,
+  validateBudgetSourceId,
+  validateVendorId,
+} from './validators.js';
+
+describe('Shared Validators', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Constants ───────────────────────────────────────────────────────────
+
+  describe('VALID_CONFIDENCE_LEVELS', () => {
+    it('contains exactly the four expected confidence level values', () => {
+      expect(VALID_CONFIDENCE_LEVELS).toHaveLength(4);
+      expect(VALID_CONFIDENCE_LEVELS).toContain('own_estimate');
+      expect(VALID_CONFIDENCE_LEVELS).toContain('professional_estimate');
+      expect(VALID_CONFIDENCE_LEVELS).toContain('quote');
+      expect(VALID_CONFIDENCE_LEVELS).toContain('invoice');
+    });
+
+    it('matches the exact array order', () => {
+      expect(VALID_CONFIDENCE_LEVELS).toEqual([
+        'own_estimate',
+        'professional_estimate',
+        'quote',
+        'invoice',
+      ]);
+    });
+  });
+
+  describe('MAX_DESCRIPTION_LENGTH', () => {
+    it('equals 500', () => {
+      expect(MAX_DESCRIPTION_LENGTH).toBe(500);
+    });
+  });
+
+  // ─── validateTagIds ──────────────────────────────────────────────────────
+
+  describe('validateTagIds()', () => {
+    it('does not throw for an empty array', () => {
+      expect(() => validateTagIds(db, [])).not.toThrow();
+    });
+
+    it('does not throw when all tag IDs exist in the database', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.tags)
+        .values({ id: 'tag-existing-1', name: 'Electrical', color: '#3B82F6', createdAt: now })
+        .run();
+      db.insert(schema.tags)
+        .values({ id: 'tag-existing-2', name: 'Plumbing', color: '#EF4444', createdAt: now })
+        .run();
+
+      expect(() => validateTagIds(db, ['tag-existing-1', 'tag-existing-2'])).not.toThrow();
+    });
+
+    it('does not throw for a single existing tag ID', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.tags)
+        .values({ id: 'tag-single', name: 'Structural', color: null, createdAt: now })
+        .run();
+
+      expect(() => validateTagIds(db, ['tag-single'])).not.toThrow();
+    });
+
+    it('throws ValidationError when a tag ID does not exist', () => {
+      expect(() => validateTagIds(db, ['nonexistent-tag'])).toThrow(ValidationError);
+    });
+
+    it('includes the missing tag ID in the error message', () => {
+      expect(() => validateTagIds(db, ['tag-abc-123'])).toThrow('Tag not found: tag-abc-123');
+    });
+
+    it('throws on the first missing tag ID even when other IDs are valid', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.tags)
+        .values({ id: 'tag-valid', name: 'Valid Tag', color: null, createdAt: now })
+        .run();
+
+      // 'tag-valid' exists but 'tag-missing' does not — should throw for the missing one
+      expect(() => validateTagIds(db, ['tag-valid', 'tag-missing'])).toThrow(ValidationError);
+    });
+
+    it('throws when the only tag in the list does not exist', () => {
+      expect(() => validateTagIds(db, ['does-not-exist'])).toThrow(ValidationError);
+    });
+  });
+
+  // ─── validateConfidence ──────────────────────────────────────────────────
+
+  describe('validateConfidence()', () => {
+    it('does not throw for own_estimate', () => {
+      expect(() => validateConfidence('own_estimate')).not.toThrow();
+    });
+
+    it('does not throw for professional_estimate', () => {
+      expect(() => validateConfidence('professional_estimate')).not.toThrow();
+    });
+
+    it('does not throw for quote', () => {
+      expect(() => validateConfidence('quote')).not.toThrow();
+    });
+
+    it('does not throw for invoice', () => {
+      expect(() => validateConfidence('invoice')).not.toThrow();
+    });
+
+    it('throws ValidationError for an unrecognized value', () => {
+      expect(() => validateConfidence('bad_value')).toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for an empty string', () => {
+      expect(() => validateConfidence('')).toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for a value that is close but not exact', () => {
+      expect(() => validateConfidence('Own_Estimate')).toThrow(ValidationError);
+      expect(() => validateConfidence('OWN_ESTIMATE')).toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for numeric string', () => {
+      expect(() => validateConfidence('1')).toThrow(ValidationError);
+    });
+
+    it('error message lists valid confidence levels', () => {
+      expect(() => validateConfidence('invalid')).toThrow(
+        'confidence must be one of: own_estimate, professional_estimate, quote, invoice',
+      );
+    });
+  });
+
+  // ─── validateDescription ─────────────────────────────────────────────────
+
+  describe('validateDescription()', () => {
+    it('does not throw for null', () => {
+      expect(() => validateDescription(null)).not.toThrow();
+    });
+
+    it('does not throw for undefined', () => {
+      expect(() => validateDescription(undefined)).not.toThrow();
+    });
+
+    it('does not throw for an empty string', () => {
+      expect(() => validateDescription('')).not.toThrow();
+    });
+
+    it('does not throw for a description exactly at the 500-character limit', () => {
+      expect(() => validateDescription('x'.repeat(500))).not.toThrow();
+    });
+
+    it('does not throw for a short description', () => {
+      expect(() => validateDescription('Short description')).not.toThrow();
+    });
+
+    it('throws ValidationError for a description of 501 characters', () => {
+      expect(() => validateDescription('x'.repeat(501))).toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for a very long description', () => {
+      expect(() => validateDescription('a'.repeat(1000))).toThrow(ValidationError);
+    });
+
+    it('error message mentions the max length', () => {
+      expect(() => validateDescription('x'.repeat(501))).toThrow(
+        'Description must not exceed 500 characters',
+      );
+    });
+  });
+
+  // ─── validateBudgetCategoryId ────────────────────────────────────────────
+
+  describe('validateBudgetCategoryId()', () => {
+    it('does not throw when the budget category exists', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.budgetCategories)
+        .values({
+          id: 'bc-test-1',
+          name: 'Test Category',
+          description: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      expect(() => validateBudgetCategoryId(db, 'bc-test-1')).not.toThrow();
+    });
+
+    it('throws ValidationError when the budget category does not exist', () => {
+      expect(() => validateBudgetCategoryId(db, 'bc-missing')).toThrow(ValidationError);
+    });
+
+    it('includes the missing ID in the error message', () => {
+      expect(() => validateBudgetCategoryId(db, 'bc-not-here')).toThrow(
+        'Budget category not found: bc-not-here',
+      );
+    });
+  });
+
+  // ─── validateBudgetSourceId ──────────────────────────────────────────────
+
+  describe('validateBudgetSourceId()', () => {
+    it('does not throw when the budget source exists', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.budgetSources)
+        .values({
+          id: 'bs-test-1',
+          name: 'Test Source',
+          sourceType: 'savings',
+          totalAmount: 50000,
+          interestRate: null,
+          terms: null,
+          notes: null,
+          status: 'active',
+          createdBy: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      expect(() => validateBudgetSourceId(db, 'bs-test-1')).not.toThrow();
+    });
+
+    it('throws ValidationError when the budget source does not exist', () => {
+      expect(() => validateBudgetSourceId(db, 'bs-missing')).toThrow(ValidationError);
+    });
+
+    it('includes the missing ID in the error message', () => {
+      expect(() => validateBudgetSourceId(db, 'bs-not-here')).toThrow(
+        'Budget source not found: bs-not-here',
+      );
+    });
+  });
+
+  // ─── validateVendorId ────────────────────────────────────────────────────
+
+  describe('validateVendorId()', () => {
+    it('does not throw when the vendor exists', () => {
+      const now = new Date().toISOString();
+      db.insert(schema.vendors)
+        .values({
+          id: 'vendor-test-1',
+          name: 'Test Vendor',
+          specialty: null,
+          phone: null,
+          email: null,
+          address: null,
+          notes: null,
+          createdBy: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      expect(() => validateVendorId(db, 'vendor-test-1')).not.toThrow();
+    });
+
+    it('throws ValidationError when the vendor does not exist', () => {
+      expect(() => validateVendorId(db, 'vendor-missing')).toThrow(ValidationError);
+    });
+
+    it('includes the missing ID in the error message', () => {
+      expect(() => validateVendorId(db, 'vendor-not-here')).toThrow(
+        'Vendor not found: vendor-not-here',
+      );
+    });
+  });
+});

--- a/server/src/services/shared/validators.ts
+++ b/server/src/services/shared/validators.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared validator functions and constants for service modules.
+ *
+ * These validators enforce business logic constraints across multiple service files.
+ * They are extracted from duplicate implementations.
+ */
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import type * as schemaTypes from '../../db/schema.js';
+import { budgetCategories, budgetSources, tags, users, vendors } from '../../db/schema.js';
+import { ValidationError } from '../../errors/AppError.js';
+import type { ConfidenceLevel } from '@cornerstone/shared';
+
+type DbType = BetterSQLite3Database<typeof schemaTypes>;
+
+/** Valid confidence level values */
+export const VALID_CONFIDENCE_LEVELS: ConfidenceLevel[] = [
+  'own_estimate',
+  'professional_estimate',
+  'quote',
+  'invoice',
+];
+
+/** Maximum description length */
+export const MAX_DESCRIPTION_LENGTH = 500;
+
+/**
+ * Validate that all tag IDs exist.
+ * Throws ValidationError if any tag does not exist.
+ */
+export function validateTagIds(db: DbType, tagIds: string[]): void {
+  for (const tagId of tagIds) {
+    const tag = db.select().from(tags).where(eq(tags.id, tagId)).get();
+    if (!tag) {
+      throw new ValidationError(`Tag not found: ${tagId}`);
+    }
+  }
+}
+
+/**
+ * Validate that a confidence level value is valid.
+ * Throws ValidationError if invalid.
+ */
+export function validateConfidence(confidence: string): void {
+  if (!VALID_CONFIDENCE_LEVELS.includes(confidence as ConfidenceLevel)) {
+    throw new ValidationError(`confidence must be one of: ${VALID_CONFIDENCE_LEVELS.join(', ')}`);
+  }
+}
+
+/**
+ * Validate the description field.
+ * Throws ValidationError if description exceeds max length.
+ */
+export function validateDescription(description: string | null | undefined): void {
+  if (description && description.length > MAX_DESCRIPTION_LENGTH) {
+    throw new ValidationError(`Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters`);
+  }
+}
+
+/**
+ * Validate that a budget category ID exists.
+ * Throws ValidationError if not found.
+ */
+export function validateBudgetCategoryId(db: DbType, budgetCategoryId: string): void {
+  const cat = db
+    .select()
+    .from(budgetCategories)
+    .where(eq(budgetCategories.id, budgetCategoryId))
+    .get();
+  if (!cat) {
+    throw new ValidationError(`Budget category not found: ${budgetCategoryId}`);
+  }
+}
+
+/**
+ * Validate that a budget source ID exists.
+ * Throws ValidationError if not found.
+ */
+export function validateBudgetSourceId(db: DbType, budgetSourceId: string): void {
+  const source = db.select().from(budgetSources).where(eq(budgetSources.id, budgetSourceId)).get();
+  if (!source) {
+    throw new ValidationError(`Budget source not found: ${budgetSourceId}`);
+  }
+}
+
+/**
+ * Validate that a vendor ID exists.
+ * Throws ValidationError if not found.
+ */
+export function validateVendorId(db: DbType, vendorId: string): void {
+  const vendor = db.select().from(vendors).where(eq(vendors.id, vendorId)).get();
+  if (!vendor) {
+    throw new ValidationError(`Vendor not found: ${vendorId}`);
+  }
+}

--- a/server/src/services/workItemBudgetService.ts
+++ b/server/src/services/workItemBudgetService.ts
@@ -10,6 +10,14 @@ import {
   vendors,
   users,
 } from '../db/schema.js';
+import { toUserSummary, toBudgetCategory, toBudgetSourceSummary, toVendorSummary } from './shared/converters.js';
+import {
+  validateConfidence,
+  validateDescription,
+  validateBudgetCategoryId,
+  validateBudgetSourceId,
+  validateVendorId,
+} from './shared/validators.js';
 import type {
   WorkItemBudgetLine,
   BudgetCategory,
@@ -25,75 +33,6 @@ import { CONFIDENCE_MARGINS as confidenceMargins } from '@cornerstone/shared';
 import { NotFoundError, ValidationError, BudgetLineInUseError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/** Valid confidence level values */
-const VALID_CONFIDENCE_LEVELS: ConfidenceLevel[] = [
-  'own_estimate',
-  'professional_estimate',
-  'quote',
-  'invoice',
-];
-
-/** Maximum description length */
-const MAX_DESCRIPTION_LENGTH = 500;
-
-/**
- * Convert a database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null | undefined): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert a database budget category row to BudgetCategory shape.
- */
-function toBudgetCategory(
-  category: typeof budgetCategories.$inferSelect | null | undefined,
-): BudgetCategory | null {
-  if (!category) return null;
-  return {
-    id: category.id,
-    name: category.name,
-    description: category.description,
-    color: category.color,
-    sortOrder: category.sortOrder,
-    createdAt: category.createdAt,
-    updatedAt: category.updatedAt,
-  };
-}
-
-/**
- * Convert a database budget source row to BudgetSourceSummary shape.
- */
-function toBudgetSourceSummary(
-  source: typeof budgetSources.$inferSelect | null | undefined,
-): BudgetSourceSummary | null {
-  if (!source) return null;
-  return {
-    id: source.id,
-    name: source.name,
-    sourceType: source.sourceType,
-  };
-}
-
-/**
- * Convert a database vendor row to VendorSummary shape.
- */
-function toVendorSummary(
-  vendor: typeof vendors.$inferSelect | null | undefined,
-): VendorSummary | null {
-  if (!vendor) return null;
-  return {
-    id: vendor.id,
-    name: vendor.name,
-    specialty: vendor.specialty,
-  };
-}
 
 /**
  * Aggregate invoice data for a budget line: actualCost, actualCostPaid, invoiceCount.
@@ -216,62 +155,6 @@ function assertWorkItemExists(db: DbType, workItemId: string): void {
   }
 }
 
-/**
- * Validate the description field.
- * @throws ValidationError if description exceeds max length
- */
-function validateDescription(description: string | null | undefined): void {
-  if (description && description.length > MAX_DESCRIPTION_LENGTH) {
-    throw new ValidationError(`Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters`);
-  }
-}
-
-/**
- * Validate that a confidence level value is valid.
- * @throws ValidationError if invalid
- */
-function validateConfidence(confidence: string): void {
-  if (!VALID_CONFIDENCE_LEVELS.includes(confidence as ConfidenceLevel)) {
-    throw new ValidationError(`confidence must be one of: ${VALID_CONFIDENCE_LEVELS.join(', ')}`);
-  }
-}
-
-/**
- * Validate that a budget category ID exists.
- * @throws ValidationError if not found
- */
-function validateBudgetCategoryId(db: DbType, budgetCategoryId: string): void {
-  const cat = db
-    .select()
-    .from(budgetCategories)
-    .where(eq(budgetCategories.id, budgetCategoryId))
-    .get();
-  if (!cat) {
-    throw new ValidationError(`Budget category not found: ${budgetCategoryId}`);
-  }
-}
-
-/**
- * Validate that a budget source ID exists.
- * @throws ValidationError if not found
- */
-function validateBudgetSourceId(db: DbType, budgetSourceId: string): void {
-  const source = db.select().from(budgetSources).where(eq(budgetSources.id, budgetSourceId)).get();
-  if (!source) {
-    throw new ValidationError(`Budget source not found: ${budgetSourceId}`);
-  }
-}
-
-/**
- * Validate that a vendor ID exists.
- * @throws ValidationError if not found
- */
-function validateVendorId(db: DbType, vendorId: string): void {
-  const vendor = db.select().from(vendors).where(eq(vendors.id, vendorId)).get();
-  if (!vendor) {
-    throw new ValidationError(`Vendor not found: ${vendorId}`);
-  }
-}
 
 /**
  * List all budget lines for a work item, ordered by creation time ascending.

--- a/server/src/services/workItemService.ts
+++ b/server/src/services/workItemService.ts
@@ -14,6 +14,8 @@ import {
 import { listWorkItemBudgets } from './workItemBudgetService.js';
 import { autoReschedule } from './schedulingEngine.js';
 import { deleteLinksForEntity } from './documentLinkService.js';
+import { toUserSummary, toTagResponse } from './shared/converters.js';
+import { validateTagIds } from './shared/validators.js';
 import type {
   WorkItemDetail,
   WorkItemSummary,
@@ -30,29 +32,6 @@ import type {
 import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/**
- * Convert database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert database tag row to TagResponse shape.
- */
-function toTagResponse(tag: typeof tags.$inferSelect): TagResponse {
-  return {
-    id: tag.id,
-    name: tag.name,
-    color: tag.color,
-  };
-}
 
 /**
  * Convert database subtask row to SubtaskResponse shape.
@@ -242,18 +221,6 @@ function validateDateConstraints(data: {
   }
 }
 
-/**
- * Validate that all tag IDs exist.
- * Throws ValidationError if any tag does not exist.
- */
-function validateTagIds(db: DbType, tagIds: string[]): void {
-  for (const tagId of tagIds) {
-    const tag = db.select().from(tags).where(eq(tags.id, tagId)).get();
-    if (!tag) {
-      throw new ValidationError(`Tag not found: ${tagId}`);
-    }
-  }
-}
 
 /**
  * Validate that assigned user ID exists and is active.

--- a/server/src/services/workItemSubsidyService.ts
+++ b/server/src/services/workItemSubsidyService.ts
@@ -9,6 +9,7 @@ import {
   budgetCategories,
   users,
 } from '../db/schema.js';
+import { toUserSummary, toBudgetCategory } from './shared/converters.js';
 import type {
   SubsidyProgram,
   SubsidyReductionType,
@@ -19,33 +20,6 @@ import type {
 import { NotFoundError, ConflictError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/**
- * Convert database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null | undefined): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
-
-/**
- * Convert database budget category row to BudgetCategory shape.
- */
-function toBudgetCategory(row: typeof budgetCategories.$inferSelect): BudgetCategory {
-  return {
-    id: row.id,
-    name: row.name,
-    description: row.description ?? null,
-    color: row.color ?? null,
-    sortOrder: row.sortOrder,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
 
 /**
  * Load applicable categories for a given subsidy program.
@@ -67,7 +41,7 @@ function loadApplicableCategories(db: DbType, subsidyProgramId: string): BudgetC
     .orderBy(asc(budgetCategories.sortOrder), asc(budgetCategories.name))
     .all();
 
-  return categories.map(toBudgetCategory);
+  return categories.map((row) => toBudgetCategory(row)!);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract 5 duplicated converter functions into `server/src/services/shared/converters.ts`
- Extract 6 duplicated validator functions + 2 constants into `server/src/services/shared/validators.ts`
- Refactor 6 service files (workItemService, householdItemService, workItemBudgetService, householdItemBudgetService, workItemSubsidyService, householdItemSubsidyService) to import from shared modules

Fixes #496

## Test plan
- [x] 27 unit tests for converters (converters.test.ts)
- [x] 36 unit tests for validators (validators.test.ts)
- [x] Unit tests pass (95%+ coverage)
- [x] Pre-commit hook quality gates pass (typecheck)
- [x] Pure internal refactoring — no API contract or schema changes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>