### PR TITLE
docs: expand screenshot capture and replace placeholders

### DIFF
--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -60,6 +60,4 @@ A summary of each financing source shows:
 
 Approved and disbursed [subsidies](subsidies) are factored into the overview calculations. The dashboard shows how much each subsidy reduces the total cost for its linked category. Pending and rejected subsidies are excluded from calculations.
 
-:::info Screenshot needed
-A screenshot of the budget overview dashboard will be added here.
-:::
+![Budget overview dashboard](/img/screenshots/budget-overview-light.png)

--- a/docs/src/guides/budget/categories.md
+++ b/docs/src/guides/budget/categories.md
@@ -40,6 +40,4 @@ From the categories page you can:
 Deleting a category will fail if any budget lines are still assigned to it. Reassign or remove those budget lines first.
 :::
 
-:::info Screenshot needed
-A screenshot of the budget categories page will be added here.
-:::
+![Budget categories page](/img/screenshots/budget-categories-light.png)

--- a/docs/src/guides/budget/financing-sources.md
+++ b/docs/src/guides/budget/financing-sources.md
@@ -41,6 +41,4 @@ From the financing sources page you can:
 Deleting a financing source will fail if any budget lines reference it. Reassign or remove those budget lines first.
 :::
 
-:::info Screenshot needed
-A screenshot of the financing sources page will be added here.
-:::
+![Financing sources page](/img/screenshots/budget-sources-light.png)

--- a/docs/src/guides/budget/index.md
+++ b/docs/src/guides/budget/index.md
@@ -26,9 +26,7 @@ When a vendor submits an **invoice**, you link invoice line items to the relevan
 
 **Subsidies** reduce the total amount needed from financing sources, applied per budget category.
 
-:::info Screenshot needed
-A screenshot of the budget overview dashboard will be added here.
-:::
+![Budget overview dashboard](/img/screenshots/budget-overview-light.png)
 
 ## Next Steps
 

--- a/docs/src/guides/budget/subsidies.md
+++ b/docs/src/guides/budget/subsidies.md
@@ -44,6 +44,4 @@ Subsidies reduce the total cost shown in the [Budget Overview](budget-overview).
 
 Multiple subsidies can apply to the same category, and their reductions stack.
 
-:::info Screenshot needed
-A screenshot of the subsidies page will be added here.
-:::
+![Subsidies page](/img/screenshots/budget-subsidies-light.png)

--- a/docs/src/guides/budget/vendors-and-invoices.md
+++ b/docs/src/guides/budget/vendors-and-invoices.md
@@ -25,9 +25,7 @@ Click **New Vendor** and provide the vendor's name.
 
 Click a vendor to see their detail page, which shows the vendor's information and all their invoices.
 
-:::info Screenshot needed
-A screenshot of the vendor detail page will be added here.
-:::
+![Vendor detail page](/img/screenshots/budget-vendor-detail-light.png)
 
 ## Invoices
 
@@ -70,6 +68,4 @@ Click an invoice to see its full detail page with all line items, current status
 
 If you have [Paperless-ngx configured](/guides/documents/setup), you can also link documents (invoice PDFs, receipts, supporting files) directly to invoices from the detail page. See [Linking Documents](/guides/documents/linking-documents) for details.
 
-:::info Screenshot needed
-A screenshot of the invoice detail page will be added here.
-:::
+![Invoice detail page](/img/screenshots/budget-invoice-detail-light.png)

--- a/docs/src/guides/documents/browsing-documents.md
+++ b/docs/src/guides/documents/browsing-documents.md
@@ -16,8 +16,8 @@ Documents are displayed as cards in a responsive grid. Each card shows:
 - **Date** -- When the document was created
 - **Tags** -- Paperless-ngx tags displayed as colored chips
 
-:::info Screenshot needed
-A screenshot of the document grid will be added on the next stable release.
+:::note
+Screenshots for the documents feature require a connected Paperless-ngx instance and will be added in a future release.
 :::
 
 ## Searching

--- a/docs/src/guides/documents/index.md
+++ b/docs/src/guides/documents/index.md
@@ -27,8 +27,8 @@ Browser  -->  Cornerstone Server  -->  Paperless-ngx
                (proxy layer)            (document store)
 ```
 
-:::info Screenshot needed
-A screenshot of the Documents page showing the document browser will be added on the next stable release.
+:::note
+Screenshots for the documents feature require a connected Paperless-ngx instance and will be added in a future release.
 :::
 
 ## Prerequisites

--- a/docs/src/guides/documents/linking-documents.md
+++ b/docs/src/guides/documents/linking-documents.md
@@ -17,8 +17,8 @@ A **Documents** section appears on:
 
 Each section shows the number of linked documents as a badge next to the heading.
 
-:::info Screenshot needed
-A screenshot of the linked documents section on a work item detail page will be added on the next stable release.
+:::note
+Screenshots for the documents feature require a connected Paperless-ngx instance and will be added in a future release.
 :::
 
 ## Linking a Document

--- a/docs/src/guides/household-items/index.md
+++ b/docs/src/guides/household-items/index.md
@@ -59,17 +59,13 @@ The household items list page provides:
 
 All filter and sort settings are synced to the URL, so your view is bookmarkable and shareable.
 
-:::info Screenshot needed
-A screenshot of the household items list page will be added on the next stable release.
-:::
+![Household items list page](/img/screenshots/household-items-list-light.png)
 
 ## Detail View
 
 Click any household item to see its full detail page with all fields, budget lines, notes, dependencies, linked work items, linked documents, and applied subsidies. Fields can be edited inline by clicking on them.
 
-:::info Screenshot needed
-A screenshot of the household item detail page will be added on the next stable release.
-:::
+![Household item detail page](/img/screenshots/household-item-detail-light.png)
 
 ## Next Steps
 

--- a/docs/src/guides/timeline/calendar-view.md
+++ b/docs/src/guides/timeline/calendar-view.md
@@ -78,6 +78,4 @@ Both the view mode (Gantt vs Calendar) and the calendar sub-mode (Month vs Week)
 
 This means your view preferences are preserved when bookmarking, sharing links, or using browser back/forward navigation.
 
-:::info Screenshot needed
-A screenshot of the calendar monthly view will be added on the next stable release.
-:::
+![Calendar monthly view](/img/screenshots/timeline-calendar-light.png)

--- a/docs/src/guides/timeline/gantt-chart.md
+++ b/docs/src/guides/timeline/gantt-chart.md
@@ -155,6 +155,4 @@ The engine uses the **Critical Path Method (CPM)** and respects:
 Only work items with status **Not Started** are rescheduled automatically. In-progress and completed items keep their actual dates.
 :::
 
-:::info Screenshot needed
-A screenshot of the Gantt chart with dependency arrows and critical path highlighting will be added on the next stable release.
-:::
+![Gantt chart with dependency arrows and critical path](/img/screenshots/timeline-gantt-dependencies-light.png)

--- a/docs/src/guides/timeline/index.md
+++ b/docs/src/guides/timeline/index.md
@@ -25,9 +25,7 @@ Work items that have **start and end dates** appear on both the Gantt chart and 
 
 The **scheduling engine** uses the Critical Path Method (CPM) to calculate optimal dates for your work items, respecting all dependency relationships and constraints. When you trigger auto-schedule, it adjusts dates for not-started items to ensure dependencies are satisfied.
 
-:::info Screenshot needed
-A screenshot of the timeline page showing the Gantt chart view will be added on the next stable release.
-:::
+![Timeline Gantt chart view](/img/screenshots/timeline-gantt-light.png)
 
 ## Next Steps
 

--- a/docs/src/guides/timeline/milestones.md
+++ b/docs/src/guides/timeline/milestones.md
@@ -88,6 +88,4 @@ The milestone panel is a slide-over dialog accessible from the toolbar. It provi
 
 Use **Escape** to close the panel or navigate back from a sub-view.
 
-:::info Screenshot needed
-A screenshot of the milestone panel will be added on the next stable release.
-:::
+![Milestone panel](/img/screenshots/timeline-milestones-light.png)

--- a/docs/src/guides/work-items/index.md
+++ b/docs/src/guides/work-items/index.md
@@ -32,17 +32,13 @@ The work items list page provides:
 
 All filter and sort settings are synced to the URL, so your view is bookmarkable and shareable.
 
-:::info Screenshot needed
-A screenshot of the work items list page will be added on the next stable release.
-:::
+![Work items list page](/img/screenshots/work-items-list-light.png)
 
 ## Detail View
 
 Click any work item to see its full detail page with all fields, notes, subtasks, dependencies, and linked documents.
 
-:::info Screenshot needed
-A screenshot of the work item detail page will be added on the next stable release.
-:::
+![Work item detail page](/img/screenshots/work-item-detail-light.png)
 
 ## Next Steps
 

--- a/docs/src/guides/work-items/tags.md
+++ b/docs/src/guides/work-items/tags.md
@@ -25,6 +25,4 @@ From the tag management page you can:
 - **Edit** a tag's name or color
 - **Delete** a tag (this removes it from all work items that use it)
 
-:::info Screenshot needed
-A screenshot of the tag management interface will be added on the next stable release.
-:::
+![Tag management page](/img/screenshots/tags-light.png)

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -14,7 +14,7 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { test, expect } from '@playwright/test';
-import { ROUTES } from '../../fixtures/testData.js';
+import { ROUTES, API } from '../../fixtures/testData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCREENSHOTS_DIR = path.resolve(__dirname, '../../../docs/static/img/screenshots');
@@ -150,11 +150,266 @@ async function seedWorkItems(request: Parameters<typeof test>[2], baseUrl: strin
   return createdIds;
 }
 
+async function seedBudgetData(
+  request: Parameters<typeof test>[2],
+  baseUrl: string,
+  workItemIds: number[],
+) {
+  // Create budget categories
+  const categories = [
+    { name: 'Electrical', description: 'All electrical work and materials' },
+    { name: 'Plumbing', description: 'Water supply, drainage, and fixtures' },
+    { name: 'Windows & Doors', description: 'Exterior and interior openings' },
+    { name: 'Structural', description: 'Foundation, framing, and load-bearing elements' },
+  ];
+  const categoryIds: number[] = [];
+  for (const cat of categories) {
+    const res = await request.post(`${baseUrl}${API.budgetCategories}`, { data: cat });
+    if (res.ok()) {
+      const body = (await res.json()) as { id: number };
+      categoryIds.push(body.id);
+    }
+  }
+
+  // Create financing sources
+  const sources = [
+    { name: 'Construction Loan', totalAmount: 250000 },
+    { name: 'Savings', totalAmount: 50000 },
+  ];
+  const sourceIds: number[] = [];
+  for (const src of sources) {
+    const res = await request.post(`${baseUrl}${API.budgetSources}`, { data: src });
+    if (res.ok()) {
+      const body = (await res.json()) as { id: number };
+      sourceIds.push(body.id);
+    }
+  }
+
+  // Create a subsidy program
+  await request.post(`${baseUrl}${API.subsidyPrograms}`, {
+    data: {
+      name: 'Energy Efficiency Rebate',
+      type: 'percentage',
+      rate: 15,
+      budgetCategoryId: categoryIds[0],
+      status: 'approved',
+    },
+  });
+
+  // Create vendors
+  const vendors = [
+    { name: 'Sparky Electric Co.' },
+    { name: 'ProPlumb Solutions' },
+    { name: 'ClearView Windows' },
+  ];
+  const vendorIds: number[] = [];
+  for (const v of vendors) {
+    const res = await request.post(`${baseUrl}${API.vendors}`, { data: v });
+    if (res.ok()) {
+      const body = (await res.json()) as { id: number };
+      vendorIds.push(body.id);
+    }
+  }
+
+  // Add budget lines to work items
+  if (workItemIds.length >= 5 && categoryIds.length >= 4 && sourceIds.length >= 2) {
+    const budgetLines = [
+      {
+        workItemId: workItemIds[1],
+        categoryId: categoryIds[0],
+        sourceId: sourceIds[0],
+        amount: 18500,
+        confidence: 'professional_estimate',
+      },
+      {
+        workItemId: workItemIds[2],
+        categoryId: categoryIds[1],
+        sourceId: sourceIds[0],
+        amount: 12000,
+        confidence: 'quote',
+      },
+      {
+        workItemId: workItemIds[4],
+        categoryId: categoryIds[2],
+        sourceId: sourceIds[1],
+        amount: 22000,
+        confidence: 'own_estimate',
+      },
+      {
+        workItemId: workItemIds[3],
+        categoryId: categoryIds[3],
+        sourceId: sourceIds[0],
+        amount: 35000,
+        confidence: 'invoice',
+      },
+    ];
+    for (const line of budgetLines) {
+      await request.post(`${baseUrl}/api/work-items/${line.workItemId}/budgets`, {
+        data: {
+          budgetCategoryId: line.categoryId,
+          budgetSourceId: line.sourceId,
+          estimatedAmount: line.amount,
+          confidence: line.confidence,
+        },
+      });
+    }
+  }
+
+  // Create invoices on vendors
+  const invoiceIds: number[] = [];
+  if (vendorIds.length >= 2) {
+    const invoices = [
+      {
+        vendorId: vendorIds[0],
+        invoiceNumber: 'INV-2026-001',
+        date: '2026-02-15',
+        status: 'paid',
+        lineItems: [{ description: 'First fix wiring labor', amount: 9500 }],
+      },
+      {
+        vendorId: vendorIds[0],
+        invoiceNumber: 'INV-2026-002',
+        date: '2026-02-28',
+        status: 'pending',
+        lineItems: [{ description: 'Electrical materials', amount: 4200 }],
+      },
+      {
+        vendorId: vendorIds[1],
+        invoiceNumber: 'PP-4401',
+        date: '2026-02-20',
+        status: 'paid',
+        lineItems: [
+          { description: 'Pipe fittings and connectors', amount: 3100 },
+          { description: 'Plumbing labor - bathrooms', amount: 6800 },
+        ],
+      },
+    ];
+    for (const inv of invoices) {
+      const res = await request.post(`${baseUrl}${API.vendors}/${inv.vendorId}/invoices`, {
+        data: {
+          invoiceNumber: inv.invoiceNumber,
+          date: inv.date,
+          status: inv.status,
+          lineItems: inv.lineItems,
+        },
+      });
+      if (res.ok()) {
+        const body = (await res.json()) as { id: number };
+        invoiceIds.push(body.id);
+      }
+    }
+  }
+
+  return { vendorIds, invoiceIds };
+}
+
+async function seedTimelineData(
+  request: Parameters<typeof test>[2],
+  baseUrl: string,
+  workItemIds: number[],
+) {
+  // Create dependencies between work items
+  if (workItemIds.length >= 7) {
+    // Foundation -> Plumbing rough-in (FS)
+    await request.post(`${baseUrl}/api/work-items/${workItemIds[2]}/dependencies`, {
+      data: { predecessorId: workItemIds[3], type: 'finish_to_start' },
+    });
+    // Foundation -> Electrical rough-in (FS)
+    await request.post(`${baseUrl}/api/work-items/${workItemIds[1]}/dependencies`, {
+      data: { predecessorId: workItemIds[3], type: 'finish_to_start' },
+    });
+    // Electrical -> Drywall (FS)
+    await request.post(`${baseUrl}/api/work-items/${workItemIds[5]}/dependencies`, {
+      data: { predecessorId: workItemIds[1], type: 'finish_to_start' },
+    });
+    // Drywall -> Paint (FS)
+    await request.post(`${baseUrl}/api/work-items/${workItemIds[6]}/dependencies`, {
+      data: { predecessorId: workItemIds[5], type: 'finish_to_start' },
+    });
+  }
+
+  // Create milestones
+  const milestones = [
+    { title: 'Foundation Complete', targetDate: '2026-01-25' },
+    { title: 'Rough-ins Complete', targetDate: '2026-02-28' },
+    { title: 'Final Inspection', targetDate: '2026-06-30' },
+  ];
+  for (const ms of milestones) {
+    await request.post(`${baseUrl}${API.milestones}`, { data: ms });
+  }
+
+  // Trigger auto-schedule
+  await request.post(`${baseUrl}${API.schedule}/auto`);
+}
+
+async function seedHouseholdItems(request: Parameters<typeof test>[2], baseUrl: string) {
+  const items = [
+    {
+      name: 'Kitchen island pendant lights',
+      category: 'fixtures',
+      status: 'purchased',
+      room: 'Kitchen',
+      quantity: 3,
+      description: 'Brass pendant lights for above the kitchen island.',
+    },
+    {
+      name: 'Dishwasher',
+      category: 'appliances',
+      status: 'scheduled',
+      room: 'Kitchen',
+      quantity: 1,
+      description: 'Energy Star rated built-in dishwasher.',
+    },
+    {
+      name: 'Living room sofa',
+      category: 'furniture',
+      status: 'planned',
+      room: 'Living Room',
+      quantity: 1,
+      description: 'L-shaped sectional sofa in charcoal grey.',
+    },
+    {
+      name: 'Smart thermostat',
+      category: 'electronics',
+      status: 'arrived',
+      room: 'Hallway',
+      quantity: 1,
+      description: 'Wi-Fi connected programmable thermostat.',
+    },
+    {
+      name: 'Bathroom vanity mirror',
+      category: 'fixtures',
+      status: 'planned',
+      room: 'Bathroom',
+      quantity: 2,
+      description: 'LED backlit vanity mirrors with anti-fog.',
+    },
+  ];
+
+  const householdItemIds: number[] = [];
+  for (const item of items) {
+    const res = await request.post(`${baseUrl}${API.householdItems}`, { data: item });
+    if (res.ok()) {
+      const body = (await res.json()) as { id: number };
+      householdItemIds.push(body.id);
+    }
+  }
+  return householdItemIds;
+}
+
 test.describe('Documentation screenshots', () => {
   const baseUrl = process.env.APP_BASE_URL || 'http://localhost:3000';
 
+  let workItemIds: number[] = [];
+  let vendorIds: number[] = [];
+  let householdItemIds: number[] = [];
+
   test.beforeAll(async ({ request }) => {
-    await seedWorkItems(request, baseUrl);
+    workItemIds = await seedWorkItems(request, baseUrl);
+    const budgetResult = await seedBudgetData(request, baseUrl, workItemIds);
+    vendorIds = budgetResult.vendorIds;
+    await seedTimelineData(request, baseUrl, workItemIds);
+    householdItemIds = await seedHouseholdItems(request, baseUrl);
   });
 
   test.describe('Unauthenticated screenshots', () => {
@@ -266,6 +521,227 @@ test.describe('Documentation screenshots', () => {
       await setTheme(page, theme);
       await page.waitForTimeout(300);
       await saveScreenshot(page, 'admin-users', theme);
+    }
+  });
+
+  // Budget screenshots
+
+  test('Budget overview', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.budget}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: /budget overview/i })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'budget-overview', theme);
+    }
+  });
+
+  test('Budget categories', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.budgetCategories}`);
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.getByRole('heading', { level: 1, name: /budget categories/i }),
+    ).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'budget-categories', theme);
+    }
+  });
+
+  test('Budget financing sources', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.budgetSources}`);
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.getByRole('heading', { level: 1, name: /financing sources/i }),
+    ).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'budget-sources', theme);
+    }
+  });
+
+  test('Budget subsidies', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.budgetSubsidies}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: /subsidies/i })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'budget-subsidies', theme);
+    }
+  });
+
+  test('Vendor detail', async ({ page }) => {
+    const vendorId = vendorIds[0];
+    if (!vendorId) {
+      test.skip(true, 'No vendors available');
+      return;
+    }
+
+    await page.goto(`${baseUrl}${ROUTES.budgetVendors}/${vendorId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'budget-vendor-detail', theme);
+    }
+  });
+
+  test('Invoice detail', async ({ page }) => {
+    const vendorId = vendorIds[0];
+    if (!vendorId) {
+      test.skip(true, 'No vendors available');
+      return;
+    }
+
+    await page.goto(`${baseUrl}${ROUTES.budgetVendors}/${vendorId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    // Click the first invoice row to navigate to invoice detail
+    const invoiceLink = page.getByRole('link', { name: /INV-2026-001/i });
+    if ((await invoiceLink.count()) > 0) {
+      await invoiceLink.click();
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+      await page.waitForTimeout(500);
+
+      for (const theme of ['light', 'dark'] as const) {
+        await setTheme(page, theme);
+        await page.waitForTimeout(300);
+        await saveScreenshot(page, 'budget-invoice-detail', theme);
+      }
+    }
+  });
+
+  // Timeline screenshots
+
+  test('Timeline Gantt chart', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.timeline}`);
+    await page.waitForLoadState('networkidle');
+    // Wait for SVG bars to render
+    await expect(page.locator('svg rect').first()).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'timeline-gantt', theme);
+    }
+  });
+
+  test('Timeline Gantt dependencies', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.timeline}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('svg rect').first()).toBeVisible({ timeout: 10000 });
+
+    // Ensure dependency arrows are visible (toggle on if needed)
+    const arrowPath = page.locator('svg path.dependency-arrow, svg path[marker-end]').first();
+    if ((await arrowPath.count()) === 0) {
+      // Try toggling the dependency arrows button
+      const toggleBtn = page.locator('[aria-label*="dependencies"], [aria-label*="arrows"]');
+      if ((await toggleBtn.count()) > 0) {
+        await toggleBtn.first().click();
+        await page.waitForTimeout(500);
+      }
+    }
+
+    // Also toggle critical path on if available
+    const criticalPathBtn = page.locator(
+      '[aria-label*="critical path"], [aria-label*="Critical path"]',
+    );
+    if ((await criticalPathBtn.count()) > 0) {
+      await criticalPathBtn.first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.waitForTimeout(300);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'timeline-gantt-dependencies', theme);
+    }
+  });
+
+  test('Timeline calendar view', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.timeline}?view=calendar`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'timeline-calendar', theme);
+    }
+  });
+
+  test('Timeline milestones panel', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.timeline}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('svg rect').first()).toBeVisible({ timeout: 10000 });
+
+    // Open milestones panel
+    const milestonesBtn = page.locator('[data-testid="milestones-panel-button"]');
+    if ((await milestonesBtn.count()) > 0) {
+      await milestonesBtn.click();
+      await page.waitForTimeout(500);
+    }
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'timeline-milestones', theme);
+    }
+  });
+
+  // Household items screenshots
+
+  test('Household items list', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.householdItems}`);
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.getByRole('heading', { level: 1, name: /household items/i }),
+    ).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'household-items-list', theme);
+    }
+  });
+
+  test('Household item detail', async ({ page }) => {
+    const itemId = householdItemIds[0];
+    if (!itemId) {
+      test.skip(true, 'No household items available');
+      return;
+    }
+
+    await page.goto(`${baseUrl}${ROUTES.householdItems}/${itemId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'household-item-detail', theme);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Expand the screenshot capture test (`e2e/tests/screenshots/capture-docs-screenshots.spec.ts`) from 6 to 18 pages (36 screenshots with light/dark themes)
- Add 3 new seed functions: `seedBudgetData`, `seedTimelineData`, `seedHouseholdItems` for populated page screenshots
- Replace all 20 `:::info Screenshot needed` placeholder blocks across docs pages:
  - 17 blocks → `![alt](/img/screenshots/name-light.png)` image references
  - 3 blocks (documents pages) → `:::note` explaining Paperless-ngx dependency

## Test plan

- [ ] Pre-commit typecheck passes (shared/server/client workspaces)
- [ ] CI Quality Gates pass
- [ ] CI E2E suite passes (screenshot tests compile and run)
- [ ] `npm run docs:build` succeeds (broken image refs are OK — they resolve on next stable release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)