### PR TITLE
refactor(server): create subsidy and payback service factories

### DIFF
--- a/.claude/agent-memory/qa-integration-tester/MEMORY.md
+++ b/.claude/agent-memory/qa-integration-tester/MEMORY.md
@@ -3,6 +3,13 @@
 > Detailed notes live in topic files. This index links to them.
 > See: `budget-categories-story-142.md`, `e2e-pom-patterns.md`, `e2e-parallel-isolation.md`, `story-358-document-linking.md`, `story-360-document-a11y.md`, `story-epic08-e2e.md`, `story-509-manage-page.md`
 
+## Story #497 Subsidy & Payback Service Factories (2026-03-07)
+
+- **householdItems requires `categoryId`** (NOT NULL FK after migration 0016). Use `categoryId: 'hic-furniture'` in direct DB inserts — seeded by migration 0016.
+- **subsidyPaybackServiceFactory uses raw SQL** (not Drizzle ORM). Configured with plain table/column string names from migrations. `supportsInvoices: false` means HI budget lines always use confidence margins — never actual invoice cost.
+- **ConflictError message for HI**: `'Subsidy program is already linked to this household item'` (lowercase, matches `config.entityLabel.toLowerCase()`).
+- Test files: `shared/subsidyServiceFactory.test.ts` (29), `shared/subsidyPaybackServiceFactory.test.ts` (23), `householdItemSubsidyService.test.ts` (21), `householdItemSubsidyPaybackService.test.ts` (24) — all passing.
+
 ## Running Tests from a Worktree (Critical Pattern)
 
 Worktrees have no `node_modules`. To run tests from a worktree:

--- a/server/src/services/householdItemSubsidyPaybackService.test.ts
+++ b/server/src/services/householdItemSubsidyPaybackService.test.ts
@@ -1,0 +1,570 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import * as schema from '../db/schema.js';
+import { getHouseholdItemSubsidyPayback } from './householdItemSubsidyPaybackService.js';
+import { NotFoundError } from '../errors/AppError.js';
+
+describe('householdItemSubsidyPaybackService', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  function insertTestUser(userId = 'user-001') {
+    const now = new Date().toISOString();
+    db.insert(schema.users)
+      .values({
+        id: userId,
+        email: `${userId}@example.com`,
+        displayName: 'Test User',
+        passwordHash: 'hashed',
+        role: 'member',
+        authProvider: 'local',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return userId;
+  }
+
+  function insertHouseholdItem(name = 'Test Household Item', userId = 'user-001') {
+    const id = `hi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    // hic-furniture is seeded by migration 0016
+    db.insert(schema.householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        status: 'planned',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertBudgetCategory(name?: string) {
+    const id = `cat-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.budgetCategories)
+      .values({
+        id,
+        name: name ?? `Category ${id}`,
+        description: null,
+        color: null,
+        sortOrder: 200 + idCounter,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertBudgetLine(opts: {
+    householdItemId: string;
+    plannedAmount: number;
+    budgetCategoryId?: string | null;
+    confidence?: 'own_estimate' | 'professional_estimate' | 'quote' | 'invoice';
+  }) {
+    const id = `bl-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.householdItemBudgets)
+      .values({
+        id,
+        householdItemId: opts.householdItemId,
+        description: null,
+        plannedAmount: opts.plannedAmount,
+        confidence: opts.confidence ?? 'own_estimate',
+        budgetCategoryId: opts.budgetCategoryId ?? null,
+        budgetSourceId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertSubsidyProgram(
+    opts: {
+      name?: string;
+      reductionType?: 'percentage' | 'fixed';
+      reductionValue?: number;
+      applicationStatus?: 'eligible' | 'applied' | 'approved' | 'received' | 'rejected';
+    } = {},
+  ) {
+    const id = `sp-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.subsidyPrograms)
+      .values({
+        id,
+        name: opts.name ?? `Subsidy ${id}`,
+        description: null,
+        eligibility: null,
+        reductionType: opts.reductionType ?? 'percentage',
+        reductionValue: opts.reductionValue ?? 10,
+        applicationStatus: opts.applicationStatus ?? 'eligible',
+        applicationDeadline: null,
+        notes: null,
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function linkSubsidyToHouseholdItem(householdItemId: string, subsidyProgramId: string) {
+    db.insert(schema.householdItemSubsidies)
+      .values({ householdItemId, subsidyProgramId })
+      .run();
+  }
+
+  function linkCategoryToSubsidy(subsidyProgramId: string, budgetCategoryId: string) {
+    db.insert(schema.subsidyProgramCategories).values({ subsidyProgramId, budgetCategoryId }).run();
+  }
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+    idCounter = 0;
+    insertTestUser();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Error cases ───────────────────────────────────────────────────────────
+
+  describe('error cases', () => {
+    it('throws NotFoundError when household item does not exist', () => {
+      expect(() => {
+        getHouseholdItemSubsidyPayback(db, 'non-existent-hi');
+      }).toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError with message "Household item not found"', () => {
+      expect(() => {
+        getHouseholdItemSubsidyPayback(db, 'non-existent-hi');
+      }).toThrow('Household item not found');
+    });
+  });
+
+  // ─── No linked subsidies ───────────────────────────────────────────────────
+
+  describe('no linked subsidies', () => {
+    it('returns householdItemId, minTotalPayback 0, maxTotalPayback 0 and empty subsidies array', () => {
+      const hiId = insertHouseholdItem();
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.householdItemId).toBe(hiId);
+      expect(result.minTotalPayback).toBe(0);
+      expect(result.maxTotalPayback).toBe(0);
+      expect(result.subsidies).toEqual([]);
+    });
+
+    it('returns 0 totals when all linked subsidies are rejected', () => {
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 20,
+        applicationStatus: 'rejected',
+      });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(0);
+      expect(result.maxTotalPayback).toBe(0);
+      expect(result.subsidies).toHaveLength(0);
+    });
+  });
+
+  // ─── Confidence margin ranges (no invoice support) ─────────────────────────
+
+  describe('confidence margin ranges', () => {
+    it('applies own_estimate margin (±20%) to produce min/max range', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // min: 1000 * 0.80 * 10% = 80, max: 1000 * 1.20 * 10% = 120
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(120);
+      expect(result.subsidies[0].minPayback).toBeCloseTo(80);
+      expect(result.subsidies[0].maxPayback).toBeCloseTo(120);
+    });
+
+    it('applies professional_estimate margin (±10%) to produce min/max range', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        confidence: 'professional_estimate',
+      });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // min: 1000 * 0.90 * 10% = 90, max: 1000 * 1.10 * 10% = 110
+      expect(result.minTotalPayback).toBeCloseTo(90);
+      expect(result.maxTotalPayback).toBeCloseTo(110);
+    });
+
+    it('applies quote margin (±5%) to produce min/max range', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'quote' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // min: 1000 * 0.95 * 10% = 95, max: 1000 * 1.05 * 10% = 105
+      expect(result.minTotalPayback).toBeCloseTo(95);
+      expect(result.maxTotalPayback).toBeCloseTo(105);
+    });
+
+    it('applies invoice confidence (±0%) so min === max === planned amount * rate', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'invoice' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // margin = 0: min = max = 1000 * 10% = 100
+      expect(result.minTotalPayback).toBeCloseTo(100);
+      expect(result.maxTotalPayback).toBeCloseTo(100);
+    });
+
+    it('sums min/max across multiple budget lines with different confidence levels', () => {
+      const hiId = insertHouseholdItem();
+      // own_estimate: min=500*0.8*0.1=40, max=500*1.2*0.1=60
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 500, confidence: 'own_estimate' });
+      // professional_estimate: min=500*0.9*0.1=45, max=500*1.1*0.1=55
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 500,
+        confidence: 'professional_estimate',
+      });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // totals: min=85, max=115
+      expect(result.minTotalPayback).toBeCloseTo(85);
+      expect(result.maxTotalPayback).toBeCloseTo(115);
+    });
+
+    it('confidence margins still apply even without invoice support (no actual cost override)', () => {
+      // This test documents the supportsInvoices: false behavior explicitly.
+      // Even if there were invoices in the DB, household items should use confidence margins.
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 20 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // own_estimate ±20%: min=1000*0.8*20%=160, max=1000*1.2*20%=240
+      // These are NOT collapsed to an actual cost even if invoices existed (supportsInvoices=false)
+      expect(result.minTotalPayback).toBeCloseTo(160);
+      expect(result.maxTotalPayback).toBeCloseTo(240);
+    });
+  });
+
+  // ─── Percentage subsidies ──────────────────────────────────────────────────
+
+  describe('percentage subsidies', () => {
+    it('calculates payback range for universal percentage subsidy (no category filter)', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // own_estimate ±20%: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(120);
+      expect(result.subsidies).toHaveLength(1);
+    });
+
+    it('only applies category-restricted subsidy to matching budget lines', () => {
+      const hiId = insertHouseholdItem();
+      const cat1 = insertBudgetCategory('Electronics');
+      const cat2 = insertBudgetCategory('Furniture');
+      // own_estimate ±20%: matched line min=800, max=1200
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        budgetCategoryId: cat1,
+        confidence: 'own_estimate',
+      });
+      // does not match — excluded
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 500,
+        budgetCategoryId: cat2,
+        confidence: 'own_estimate',
+      });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkCategoryToSubsidy(subsidyId, cat1);
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // Only cat1 line: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(120);
+    });
+
+    it('skips budget lines with no category when subsidy is category-restricted', () => {
+      const hiId = insertHouseholdItem();
+      const cat1 = insertBudgetCategory('Electronics');
+      // no category — excluded
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        budgetCategoryId: null,
+        confidence: 'own_estimate',
+      });
+      // matches
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 500,
+        budgetCategoryId: cat1,
+        confidence: 'own_estimate',
+      });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkCategoryToSubsidy(subsidyId, cat1);
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // Only cat1 line: min=500*0.8*10%=40, max=500*1.2*10%=60
+      expect(result.minTotalPayback).toBeCloseTo(40);
+      expect(result.maxTotalPayback).toBeCloseTo(60);
+    });
+
+    it('returns 0 min/max when no budget lines match the category restriction', () => {
+      const hiId = insertHouseholdItem();
+      const cat1 = insertBudgetCategory('Electronics');
+      const cat2 = insertBudgetCategory('Plumbing');
+      insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        budgetCategoryId: cat2,
+        confidence: 'own_estimate',
+      }); // no match
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkCategoryToSubsidy(subsidyId, cat1);
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(0);
+      expect(result.maxTotalPayback).toBe(0);
+      expect(result.subsidies[0].minPayback).toBe(0);
+      expect(result.subsidies[0].maxPayback).toBe(0);
+    });
+
+    it('returns 0 min/max when household item has no budget lines', () => {
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 15 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(0);
+      expect(result.maxTotalPayback).toBe(0);
+      expect(result.subsidies[0].minPayback).toBe(0);
+      expect(result.subsidies[0].maxPayback).toBe(0);
+    });
+  });
+
+  // ─── Fixed subsidies ───────────────────────────────────────────────────────
+
+  describe('fixed subsidies', () => {
+    it('returns the reductionValue as minPayback and maxPayback (min === max) for a fixed subsidy', () => {
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 5000 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(5000);
+      expect(result.maxTotalPayback).toBe(5000);
+      expect(result.subsidies[0].minPayback).toBe(5000);
+      expect(result.subsidies[0].maxPayback).toBe(5000);
+    });
+
+    it('returns fixed amount even when household item has no budget lines', () => {
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 2000 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(2000);
+      expect(result.maxTotalPayback).toBe(2000);
+    });
+
+    it('returns fixed amount regardless of budget line amounts', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 100000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 3000 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBe(3000);
+      expect(result.maxTotalPayback).toBe(3000);
+    });
+  });
+
+  // ─── Multiple subsidies ────────────────────────────────────────────────────
+
+  describe('multiple subsidies', () => {
+    it('sums min/max payback from multiple subsidies', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+
+      // percentage: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      const sp1 = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      // fixed: min=max=500
+      const sp2 = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 500 });
+      linkSubsidyToHouseholdItem(hiId, sp1);
+      linkSubsidyToHouseholdItem(hiId, sp2);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBeCloseTo(580); // 80 + 500
+      expect(result.maxTotalPayback).toBeCloseTo(620); // 120 + 500
+      expect(result.subsidies).toHaveLength(2);
+    });
+
+    it('excludes rejected subsidies from calculation', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+
+      // approved: min=80, max=120
+      const sp1 = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 10,
+        applicationStatus: 'approved',
+      });
+      // rejected: excluded
+      const sp2 = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 20,
+        applicationStatus: 'rejected',
+      });
+      linkSubsidyToHouseholdItem(hiId, sp1);
+      linkSubsidyToHouseholdItem(hiId, sp2);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(120);
+      expect(result.subsidies).toHaveLength(1);
+    });
+
+    it('includes subsidies with all non-rejected statuses (eligible, applied, approved, received)', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+
+      const statuses = ['eligible', 'applied', 'approved', 'received'] as const;
+      for (const status of statuses) {
+        const sp = insertSubsidyProgram({
+          reductionType: 'fixed',
+          reductionValue: 100,
+          applicationStatus: status,
+        });
+        linkSubsidyToHouseholdItem(hiId, sp);
+      }
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.subsidies).toHaveLength(4);
+      expect(result.minTotalPayback).toBe(400);
+      expect(result.maxTotalPayback).toBe(400);
+    });
+  });
+
+  // ─── Response shape ────────────────────────────────────────────────────────
+
+  describe('response shape', () => {
+    it('returns the correct householdItemId in the response', () => {
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram();
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      expect(result.householdItemId).toBe(hiId);
+    });
+
+    it('returns subsidy entry with all required fields including minPayback and maxPayback', () => {
+      const hiId = insertHouseholdItem();
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({
+        name: 'Solar Rebate',
+        reductionType: 'percentage',
+        reductionValue: 15,
+      });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      const entry = result.subsidies[0];
+      expect(entry.subsidyProgramId).toBe(subsidyId);
+      expect(entry.name).toBe('Solar Rebate');
+      expect(entry.reductionType).toBe('percentage');
+      expect(entry.reductionValue).toBe(15);
+      expect(typeof entry.minPayback).toBe('number');
+      expect(typeof entry.maxPayback).toBe('number');
+      // own_estimate ±20%: min=1000*0.8*15%=120, max=1000*1.2*15%=180
+      expect(entry.minPayback).toBeCloseTo(120);
+      expect(entry.maxPayback).toBeCloseTo(180);
+    });
+
+    it('does not include data from a different household item', () => {
+      const hiId1 = insertHouseholdItem('HI 1');
+      const hiId2 = insertHouseholdItem('HI 2');
+      insertBudgetLine({ householdItemId: hiId1, plannedAmount: 1000, confidence: 'invoice' });
+      insertBudgetLine({ householdItemId: hiId2, plannedAmount: 5000, confidence: 'invoice' });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId1, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId1);
+
+      // invoice confidence: margin=0, so min=max=1000*10%=100
+      expect(result.minTotalPayback).toBeCloseTo(100);
+      expect(result.maxTotalPayback).toBeCloseTo(100);
+    });
+  });
+});

--- a/server/src/services/householdItemSubsidyPaybackService.ts
+++ b/server/src/services/householdItemSubsidyPaybackService.ts
@@ -1,16 +1,21 @@
-import { sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import type {
-  HouseholdItemSubsidyPaybackEntry,
-  HouseholdItemSubsidyPaybackResponse,
-} from '@cornerstone/shared';
-import { CONFIDENCE_MARGINS } from '@cornerstone/shared';
-import { NotFoundError } from '../errors/AppError.js';
+import { createSubsidyPaybackService } from './shared/subsidyPaybackServiceFactory.js';
+import type { HouseholdItemSubsidyPaybackResponse } from '@cornerstone/shared';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
-type ConfidenceLevel = keyof typeof CONFIDENCE_MARGINS;
+const getPayback = createSubsidyPaybackService({
+  entityTable: 'household_items',
+  junctionTable: 'household_item_subsidies',
+  junctionAlias: 'his',
+  junctionEntityIdColumn: 'household_item_id',
+  budgetLinesTable: 'household_item_budgets',
+  budgetLinesEntityIdColumn: 'household_item_id',
+  supportsInvoices: false,
+  entityLabel: 'Household item',
+  entityIdResponseKey: 'householdItemId',
+});
 
 /**
  * Calculate the expected subsidy payback range for a single household item.
@@ -34,123 +39,5 @@ export function getHouseholdItemSubsidyPayback(
   db: DbType,
   householdItemId: string,
 ): HouseholdItemSubsidyPaybackResponse {
-  // Verify household item exists
-  const item = db.get<{ id: string }>(
-    sql`SELECT id FROM household_items WHERE id = ${householdItemId}`,
-  );
-  if (!item) {
-    throw new NotFoundError('Household item not found');
-  }
-
-  // Fetch non-rejected subsidies linked to this household item
-  const linkedRows = db.all<{
-    subsidyProgramId: string;
-    name: string;
-    reductionType: string;
-    reductionValue: number;
-  }>(
-    sql`SELECT
-      sp.id              AS subsidyProgramId,
-      sp.name            AS name,
-      sp.reduction_type  AS reductionType,
-      sp.reduction_value AS reductionValue
-    FROM household_item_subsidies his
-    INNER JOIN subsidy_programs sp ON sp.id = his.subsidy_program_id
-    WHERE his.household_item_id = ${householdItemId}
-      AND sp.application_status != 'rejected'`,
-  );
-
-  if (linkedRows.length === 0) {
-    return { householdItemId, minTotalPayback: 0, maxTotalPayback: 0, subsidies: [] };
-  }
-
-  // Fetch all budget lines for this household item, including confidence level
-  const budgetLineRows = db.all<{
-    id: string;
-    plannedAmount: number;
-    confidence: string;
-    budgetCategoryId: string | null;
-  }>(
-    sql`SELECT
-      id                 AS id,
-      planned_amount     AS plannedAmount,
-      confidence         AS confidence,
-      budget_category_id AS budgetCategoryId
-    FROM household_item_budgets
-    WHERE household_item_id = ${householdItemId}`,
-  );
-
-  // Compute per-line min/max effective amounts (household items never have invoices)
-  const budgetLines = budgetLineRows.map((line) => {
-    // Always apply confidence margin (no invoices for household items)
-    const margin =
-      CONFIDENCE_MARGINS[line.confidence as ConfidenceLevel] ?? CONFIDENCE_MARGINS.own_estimate;
-    return {
-      id: line.id,
-      budgetCategoryId: line.budgetCategoryId,
-      minAmount: line.plannedAmount * (1 - margin),
-      maxAmount: line.plannedAmount * (1 + margin),
-    };
-  });
-
-  // Load applicable categories for relevant subsidy programs only
-  const subsidyIds = linkedRows.map((r) => r.subsidyProgramId);
-  const inList = subsidyIds.map((id) => sql`${id}`);
-  const categoryRows = db.all<{ subsidyProgramId: string; budgetCategoryId: string }>(
-    sql`SELECT subsidy_program_id AS subsidyProgramId, budget_category_id AS budgetCategoryId
-    FROM subsidy_program_categories
-    WHERE subsidy_program_id IN (${sql.join(inList, sql`, `)})`,
-  );
-
-  const subsidyCategoryMap = new Map<string, Set<string>>();
-  for (const row of categoryRows) {
-    let cats = subsidyCategoryMap.get(row.subsidyProgramId);
-    if (!cats) {
-      cats = new Set<string>();
-      subsidyCategoryMap.set(row.subsidyProgramId, cats);
-    }
-    cats.add(row.budgetCategoryId);
-  }
-
-  // Calculate min/max payback per subsidy
-  const subsidyEntries: HouseholdItemSubsidyPaybackEntry[] = [];
-  let minTotalPayback = 0;
-  let maxTotalPayback = 0;
-
-  for (const subsidy of linkedRows) {
-    const applicableCategories = subsidyCategoryMap.get(subsidy.subsidyProgramId);
-    const isUniversal = !applicableCategories || applicableCategories.size === 0;
-    let minPayback = 0;
-    let maxPayback = 0;
-
-    if (subsidy.reductionType === 'percentage') {
-      const rate = subsidy.reductionValue / 100;
-      for (const line of budgetLines) {
-        const categoryMatches =
-          isUniversal ||
-          (line.budgetCategoryId !== null && applicableCategories!.has(line.budgetCategoryId));
-        if (categoryMatches) {
-          minPayback += line.minAmount * rate;
-          maxPayback += line.maxAmount * rate;
-        }
-      }
-    } else if (subsidy.reductionType === 'fixed') {
-      // Fixed amount: min === max === reductionValue (not affected by budget line ranges)
-      minPayback = subsidy.reductionValue;
-      maxPayback = subsidy.reductionValue;
-    }
-
-    subsidyEntries.push({
-      subsidyProgramId: subsidy.subsidyProgramId,
-      name: subsidy.name,
-      reductionType: subsidy.reductionType as 'percentage' | 'fixed',
-      reductionValue: subsidy.reductionValue,
-      minPayback,
-      maxPayback,
-    });
-    minTotalPayback += minPayback;
-    maxTotalPayback += maxPayback;
-  }
-
-  return { householdItemId, minTotalPayback, maxTotalPayback, subsidies: subsidyEntries };
+  return getPayback(db, householdItemId) as HouseholdItemSubsidyPaybackResponse;
 }

--- a/server/src/services/householdItemSubsidyService.test.ts
+++ b/server/src/services/householdItemSubsidyService.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import * as schema from '../db/schema.js';
+import * as householdItemSubsidyService from './householdItemSubsidyService.js';
+import { NotFoundError, ConflictError } from '../errors/AppError.js';
+
+describe('householdItemSubsidyService', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  function insertTestUser(id = 'user-001', email = 'test@example.com', displayName = 'Test User') {
+    const now = new Date().toISOString();
+    db.insert(schema.users)
+      .values({
+        id,
+        email,
+        displayName,
+        role: 'member',
+        authProvider: 'local',
+        passwordHash: 'hashed',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  let idCounter = 0;
+
+  function insertTestHouseholdItem(name = 'Test Household Item', userId = 'user-001') {
+    const id = `hi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    // hic-furniture is seeded by migration 0016
+    db.insert(schema.householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        status: 'planned',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertTestSubsidyProgram(
+    name = 'Test Subsidy',
+    options: {
+      reductionType?: 'percentage' | 'fixed';
+      reductionValue?: number;
+      applicationStatus?: 'eligible' | 'applied' | 'approved' | 'received' | 'rejected';
+      createdBy?: string | null;
+    } = {},
+  ) {
+    const id = `subsidy-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.subsidyPrograms)
+      .values({
+        id,
+        name,
+        description: null,
+        eligibility: null,
+        reductionType: options.reductionType ?? 'percentage',
+        reductionValue: options.reductionValue ?? 10,
+        applicationStatus: options.applicationStatus ?? 'eligible',
+        applicationDeadline: null,
+        notes: null,
+        createdBy: options.createdBy ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+    idCounter = 0;
+    insertTestUser();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── listHouseholdItemSubsidies() ─────────────────────────────────────────
+
+  describe('listHouseholdItemSubsidies()', () => {
+    it('returns empty array when no subsidy programs are linked', () => {
+      const householdItemId = insertTestHouseholdItem();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns linked subsidy program with all fields', () => {
+      const householdItemId = insertTestHouseholdItem('Living Room Sofa');
+      const subsidyId = insertTestSubsidyProgram('Appliance Energy Rebate', {
+        reductionType: 'percentage',
+        reductionValue: 15,
+        applicationStatus: 'eligible',
+        createdBy: 'user-001',
+      });
+
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(subsidyId);
+      expect(result[0].name).toBe('Appliance Energy Rebate');
+      expect(result[0].reductionType).toBe('percentage');
+      expect(result[0].reductionValue).toBe(15);
+      expect(result[0].applicationStatus).toBe('eligible');
+      expect(result[0].createdBy?.id).toBe('user-001');
+    });
+
+    it('returns multiple linked subsidy programs', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId1 = insertTestSubsidyProgram('Subsidy A');
+      const subsidyId2 = insertTestSubsidyProgram('Subsidy B');
+
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId1 })
+        .run();
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId2 })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+
+      expect(result).toHaveLength(2);
+      const names = result.map((s) => s.name);
+      expect(names).toContain('Subsidy A');
+      expect(names).toContain('Subsidy B');
+    });
+
+    it('does not return subsidies linked to a different household item', () => {
+      const hiId1 = insertTestHouseholdItem('Household Item 1');
+      const hiId2 = insertTestHouseholdItem('Household Item 2');
+      const subsidyId = insertTestSubsidyProgram('Exclusive Subsidy');
+
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId2, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, hiId1);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns subsidy with applicableCategories field', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Category Subsidy');
+
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+
+      expect(result[0].applicableCategories).toBeDefined();
+      expect(Array.isArray(result[0].applicableCategories)).toBe(true);
+    });
+
+    it('returns subsidy with null createdBy when createdBy is null', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Anonymous Subsidy', { createdBy: null });
+
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].createdBy).toBeNull();
+    });
+
+    it('throws NotFoundError when household item does not exist', () => {
+      expect(() => {
+        householdItemSubsidyService.listHouseholdItemSubsidies(db, 'non-existent-hi');
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.listHouseholdItemSubsidies(db, 'non-existent-hi');
+      }).toThrow('Household item not found');
+    });
+  });
+
+  // ─── linkSubsidyToHouseholdItem() ─────────────────────────────────────────
+
+  describe('linkSubsidyToHouseholdItem()', () => {
+    it('links a subsidy program to a household item and returns the program', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Energy Efficiency Rebate', {
+        reductionType: 'fixed',
+        reductionValue: 3000,
+      });
+
+      const result = householdItemSubsidyService.linkSubsidyToHouseholdItem(
+        db,
+        householdItemId,
+        subsidyId,
+      );
+
+      expect(result.id).toBe(subsidyId);
+      expect(result.name).toBe('Energy Efficiency Rebate');
+      expect(result.reductionType).toBe('fixed');
+      expect(result.reductionValue).toBe(3000);
+    });
+
+    it('persists the link (verify via listHouseholdItemSubsidies)', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Persistent Subsidy');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId);
+
+      const listed = householdItemSubsidyService.listHouseholdItemSubsidies(
+        db,
+        householdItemId,
+      );
+      expect(listed).toHaveLength(1);
+      expect(listed[0].id).toBe(subsidyId);
+    });
+
+    it('allows linking the same subsidy to multiple household items', () => {
+      const hiId1 = insertTestHouseholdItem('Household Item 1');
+      const hiId2 = insertTestHouseholdItem('Household Item 2');
+      const subsidyId = insertTestSubsidyProgram('Shared Subsidy');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, hiId1, subsidyId);
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, hiId2, subsidyId);
+
+      const result1 = householdItemSubsidyService.listHouseholdItemSubsidies(db, hiId1);
+      const result2 = householdItemSubsidyService.listHouseholdItemSubsidies(db, hiId2);
+
+      expect(result1).toHaveLength(1);
+      expect(result2).toHaveLength(1);
+    });
+
+    it('allows linking multiple subsidies to the same household item', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId1 = insertTestSubsidyProgram('Subsidy X');
+      const subsidyId2 = insertTestSubsidyProgram('Subsidy Y');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId1);
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId2);
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns subsidy with populated applicableCategories', () => {
+      const categories = db.select().from(schema.budgetCategories).limit(1).all();
+      if (categories.length === 0) return;
+
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('With Categories');
+
+      db.insert(schema.subsidyProgramCategories)
+        .values({ subsidyProgramId: subsidyId, budgetCategoryId: categories[0].id })
+        .run();
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+      expect(result[0].applicableCategories).toHaveLength(1);
+      expect(result[0].applicableCategories[0].id).toBe(categories[0].id);
+    });
+
+    it('throws NotFoundError when household item does not exist', () => {
+      const subsidyId = insertTestSubsidyProgram('Some Subsidy');
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(
+          db,
+          'non-existent-hi',
+          subsidyId,
+        );
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(
+          db,
+          'non-existent-hi',
+          subsidyId,
+        );
+      }).toThrow('Household item not found');
+    });
+
+    it('throws NotFoundError when subsidy program does not exist', () => {
+      const householdItemId = insertTestHouseholdItem();
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(
+          db,
+          householdItemId,
+          'non-existent-subsidy',
+        );
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(
+          db,
+          householdItemId,
+          'non-existent-subsidy',
+        );
+      }).toThrow('Subsidy program not found');
+    });
+
+    it('throws ConflictError when subsidy is already linked to the household item', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Duplicate Subsidy');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId);
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId);
+      }).toThrow(ConflictError);
+
+      expect(() => {
+        householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId);
+      }).toThrow('Subsidy program is already linked to this household item');
+    });
+  });
+
+  // ─── unlinkSubsidyFromHouseholdItem() ──────────────────────────────────────
+
+  describe('unlinkSubsidyFromHouseholdItem()', () => {
+    it('removes the subsidy link from a household item', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Linked Subsidy');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId);
+      householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(db, householdItemId, subsidyId);
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+      expect(result).toEqual([]);
+    });
+
+    it('only removes the specific subsidy link, not others', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId1 = insertTestSubsidyProgram('Subsidy To Remove');
+      const subsidyId2 = insertTestSubsidyProgram('Subsidy To Keep');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId1);
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, householdItemId, subsidyId2);
+
+      householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(db, householdItemId, subsidyId1);
+
+      const result = householdItemSubsidyService.listHouseholdItemSubsidies(db, householdItemId);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(subsidyId2);
+    });
+
+    it('throws NotFoundError when household item does not exist', () => {
+      const subsidyId = insertTestSubsidyProgram('Some Subsidy');
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          'non-existent-hi',
+          subsidyId,
+        );
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          'non-existent-hi',
+          subsidyId,
+        );
+      }).toThrow('Household item not found');
+    });
+
+    it('throws NotFoundError when subsidy is not linked to the household item', () => {
+      const householdItemId = insertTestHouseholdItem();
+      const subsidyId = insertTestSubsidyProgram('Unlinked Subsidy');
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          householdItemId,
+          subsidyId,
+        );
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          householdItemId,
+          subsidyId,
+        );
+      }).toThrow('Subsidy program is not linked to this household item');
+    });
+
+    it('throws NotFoundError when trying to unlink from a different household item', () => {
+      const hiId1 = insertTestHouseholdItem('HI 1');
+      const hiId2 = insertTestHouseholdItem('HI 2');
+      const subsidyId = insertTestSubsidyProgram('HI1 Subsidy');
+
+      householdItemSubsidyService.linkSubsidyToHouseholdItem(db, hiId1, subsidyId);
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(db, hiId2, subsidyId);
+      }).toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError for a non-existent subsidyProgramId on an existing household item', () => {
+      const householdItemId = insertTestHouseholdItem();
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          householdItemId,
+          'non-existent-subsidy',
+        );
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        householdItemSubsidyService.unlinkSubsidyFromHouseholdItem(
+          db,
+          householdItemId,
+          'non-existent-subsidy',
+        );
+      }).toThrow('Subsidy program is not linked to this household item');
+    });
+  });
+});

--- a/server/src/services/householdItemSubsidyService.ts
+++ b/server/src/services/householdItemSubsidyService.ts
@@ -1,102 +1,27 @@
-import { eq, and, inArray, asc } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import {
-  householdItems,
-  householdItemSubsidies,
-  subsidyPrograms,
-  subsidyProgramCategories,
-  budgetCategories,
-  users,
-} from '../db/schema.js';
-import { toUserSummary, toBudgetCategory } from './shared/converters.js';
-import type {
-  SubsidyProgram,
-  SubsidyReductionType,
-  SubsidyApplicationStatus,
-  BudgetCategory,
-  UserSummary,
-} from '@cornerstone/shared';
-import { NotFoundError, ConflictError } from '../errors/AppError.js';
+import { householdItems, householdItemSubsidies } from '../db/schema.js';
+import { createSubsidyService } from './shared/subsidyServiceFactory.js';
+import type { SubsidyProgram } from '@cornerstone/shared';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
-/**
- * Load applicable categories for a given subsidy program.
- */
-function loadApplicableCategories(db: DbType, subsidyProgramId: string): BudgetCategory[] {
-  const links = db
-    .select()
-    .from(subsidyProgramCategories)
-    .where(eq(subsidyProgramCategories.subsidyProgramId, subsidyProgramId))
-    .all();
-
-  if (links.length === 0) return [];
-
-  const categoryIds = links.map((l) => l.budgetCategoryId);
-  const categories = db
-    .select()
-    .from(budgetCategories)
-    .where(inArray(budgetCategories.id, categoryIds))
-    .orderBy(asc(budgetCategories.sortOrder), asc(budgetCategories.name))
-    .all();
-
-  return categories.map((row) => toBudgetCategory(row)!);
-}
-
-/**
- * Convert database subsidy program row to SubsidyProgram shape.
- */
-function toSubsidyProgram(db: DbType, row: typeof subsidyPrograms.$inferSelect): SubsidyProgram {
-  const createdByUser = row.createdBy
-    ? db.select().from(users).where(eq(users.id, row.createdBy)).get()
-    : null;
-
-  const applicableCategories = loadApplicableCategories(db, row.id);
-
-  return {
-    id: row.id,
-    name: row.name,
-    description: row.description ?? null,
-    eligibility: row.eligibility ?? null,
-    reductionType: row.reductionType as SubsidyReductionType,
-    reductionValue: row.reductionValue,
-    applicationStatus: row.applicationStatus as SubsidyApplicationStatus,
-    applicationDeadline: row.applicationDeadline ?? null,
-    notes: row.notes ?? null,
-    applicableCategories,
-    createdBy: toUserSummary(createdByUser),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
-
-/**
- * Ensure a household item exists.
- * @throws NotFoundError if not found
- */
-function assertHouseholdItemExists(db: DbType, householdItemId: string): void {
-  const item = db.select().from(householdItems).where(eq(householdItems.id, householdItemId)).get();
-  if (!item) {
-    throw new NotFoundError('Household item not found');
-  }
-}
+const service = createSubsidyService({
+  entityTable: householdItems,
+  entityIdColumn: householdItems.id,
+  junctionTable: householdItemSubsidies,
+  junctionEntityIdColumn: householdItemSubsidies.householdItemId,
+  junctionSubsidyProgramIdColumn: householdItemSubsidies.subsidyProgramId,
+  entityLabel: 'Household item',
+  makeInsertValues: (householdItemId, subsidyProgramId) => ({ householdItemId, subsidyProgramId }),
+});
 
 /**
  * List all subsidy programs linked to a household item.
  * @throws NotFoundError if household item does not exist
  */
 export function listHouseholdItemSubsidies(db: DbType, householdItemId: string): SubsidyProgram[] {
-  assertHouseholdItemExists(db, householdItemId);
-
-  const rows = db
-    .select({ program: subsidyPrograms })
-    .from(householdItemSubsidies)
-    .innerJoin(subsidyPrograms, eq(subsidyPrograms.id, householdItemSubsidies.subsidyProgramId))
-    .where(eq(householdItemSubsidies.householdItemId, householdItemId))
-    .all();
-
-  return rows.map((row) => toSubsidyProgram(db, row.program));
+  return service.list(db, householdItemId);
 }
 
 /**
@@ -109,39 +34,7 @@ export function linkSubsidyToHouseholdItem(
   householdItemId: string,
   subsidyProgramId: string,
 ): SubsidyProgram {
-  assertHouseholdItemExists(db, householdItemId);
-
-  // Validate subsidy program exists
-  const program = db
-    .select()
-    .from(subsidyPrograms)
-    .where(eq(subsidyPrograms.id, subsidyProgramId))
-    .get();
-
-  if (!program) {
-    throw new NotFoundError('Subsidy program not found');
-  }
-
-  // Check for existing link
-  const existing = db
-    .select()
-    .from(householdItemSubsidies)
-    .where(
-      and(
-        eq(householdItemSubsidies.householdItemId, householdItemId),
-        eq(householdItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .get();
-
-  if (existing) {
-    throw new ConflictError('Subsidy program is already linked to this household item');
-  }
-
-  // Create the link
-  db.insert(householdItemSubsidies).values({ householdItemId, subsidyProgramId }).run();
-
-  return toSubsidyProgram(db, program);
+  return service.link(db, householdItemId, subsidyProgramId);
 }
 
 /**
@@ -153,29 +46,5 @@ export function unlinkSubsidyFromHouseholdItem(
   householdItemId: string,
   subsidyProgramId: string,
 ): void {
-  assertHouseholdItemExists(db, householdItemId);
-
-  const existing = db
-    .select()
-    .from(householdItemSubsidies)
-    .where(
-      and(
-        eq(householdItemSubsidies.householdItemId, householdItemId),
-        eq(householdItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .get();
-
-  if (!existing) {
-    throw new NotFoundError('Subsidy program is not linked to this household item');
-  }
-
-  db.delete(householdItemSubsidies)
-    .where(
-      and(
-        eq(householdItemSubsidies.householdItemId, householdItemId),
-        eq(householdItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .run();
+  return service.unlink(db, householdItemId, subsidyProgramId);
 }

--- a/server/src/services/shared/subsidyPaybackServiceFactory.test.ts
+++ b/server/src/services/shared/subsidyPaybackServiceFactory.test.ts
@@ -1,0 +1,652 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../../db/migrate.js';
+import * as schema from '../../db/schema.js';
+import { createSubsidyPaybackService } from './subsidyPaybackServiceFactory.js';
+import { NotFoundError } from '../../errors/AppError.js';
+
+// ─── Factory configurations used in tests ─────────────────────────────────────
+
+const workItemConfig = {
+  entityTable: 'work_items',
+  junctionTable: 'work_item_subsidies',
+  junctionAlias: 'wis',
+  junctionEntityIdColumn: 'work_item_id',
+  budgetLinesTable: 'work_item_budgets',
+  budgetLinesEntityIdColumn: 'work_item_id',
+  supportsInvoices: true,
+  entityLabel: 'Work item',
+  entityIdResponseKey: 'workItemId',
+} as const;
+
+const householdItemConfig = {
+  entityTable: 'household_items',
+  junctionTable: 'household_item_subsidies',
+  junctionAlias: 'his',
+  junctionEntityIdColumn: 'household_item_id',
+  budgetLinesTable: 'household_item_budgets',
+  budgetLinesEntityIdColumn: 'household_item_id',
+  supportsInvoices: false,
+  entityLabel: 'Household item',
+  entityIdResponseKey: 'householdItemId',
+} as const;
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+describe('subsidyPaybackServiceFactory — createSubsidyPaybackService()', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  function insertTestUser(userId = 'user-001') {
+    const now = new Date().toISOString();
+    db.insert(schema.users)
+      .values({
+        id: userId,
+        email: `${userId}@example.com`,
+        displayName: 'Test User',
+        passwordHash: 'hashed',
+        role: 'member',
+        authProvider: 'local',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return userId;
+  }
+
+  function insertWorkItem(title = 'Test Work Item', userId = 'user-001') {
+    const id = `wi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.workItems)
+      .values({
+        id,
+        title,
+        status: 'not_started',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertHouseholdItem(name = 'Test Item', userId = 'user-001') {
+    const id = `hi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        status: 'planned',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertSubsidyProgram(
+    opts: {
+      name?: string;
+      reductionType?: 'percentage' | 'fixed';
+      reductionValue?: number;
+      applicationStatus?: 'eligible' | 'applied' | 'approved' | 'received' | 'rejected';
+    } = {},
+  ) {
+    const id = `sp-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.subsidyPrograms)
+      .values({
+        id,
+        name: opts.name ?? `Subsidy ${id}`,
+        description: null,
+        eligibility: null,
+        reductionType: opts.reductionType ?? 'percentage',
+        reductionValue: opts.reductionValue ?? 10,
+        applicationStatus: opts.applicationStatus ?? 'eligible',
+        applicationDeadline: null,
+        notes: null,
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertBudgetCategory(name?: string) {
+    const id = `cat-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.budgetCategories)
+      .values({
+        id,
+        name: name ?? `Category ${id}`,
+        description: null,
+        color: null,
+        sortOrder: 200 + idCounter,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertWiBudgetLine(opts: {
+    workItemId: string;
+    plannedAmount: number;
+    budgetCategoryId?: string | null;
+    confidence?: 'own_estimate' | 'professional_estimate' | 'quote' | 'invoice';
+  }) {
+    const id = `bl-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.workItemBudgets)
+      .values({
+        id,
+        workItemId: opts.workItemId,
+        description: null,
+        plannedAmount: opts.plannedAmount,
+        confidence: opts.confidence ?? 'own_estimate',
+        budgetCategoryId: opts.budgetCategoryId ?? null,
+        budgetSourceId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertHiBudgetLine(opts: {
+    householdItemId: string;
+    plannedAmount: number;
+    budgetCategoryId?: string | null;
+    confidence?: 'own_estimate' | 'professional_estimate' | 'quote' | 'invoice';
+  }) {
+    const id = `hibl-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.householdItemBudgets)
+      .values({
+        id,
+        householdItemId: opts.householdItemId,
+        description: null,
+        plannedAmount: opts.plannedAmount,
+        confidence: opts.confidence ?? 'own_estimate',
+        budgetCategoryId: opts.budgetCategoryId ?? null,
+        budgetSourceId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertVendor() {
+    const id = `vendor-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.vendors)
+      .values({ id, name: `Vendor ${id}`, createdAt: now, updatedAt: now })
+      .run();
+    return id;
+  }
+
+  function insertInvoice(budgetLineId: string, amount: number) {
+    const vendorId = insertVendor();
+    const id = `inv-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.invoices)
+      .values({
+        id,
+        workItemBudgetId: budgetLineId,
+        vendorId,
+        invoiceNumber: null,
+        amount,
+        status: 'pending',
+        date: now.slice(0, 10),
+        dueDate: null,
+        notes: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+    idCounter = 0;
+    insertTestUser();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Factory shape ─────────────────────────────────────────────────────────
+
+  describe('factory shape', () => {
+    it('returns a callable function', () => {
+      const fn = createSubsidyPaybackService(workItemConfig);
+      expect(typeof fn).toBe('function');
+    });
+  });
+
+  // ─── Error cases ───────────────────────────────────────────────────────────
+
+  describe('error cases', () => {
+    it('throws NotFoundError when work item does not exist (supportsInvoices: true)', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      expect(() => getPayback(db, 'non-existent-wi')).toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError with entityLabel message for work item', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      expect(() => getPayback(db, 'non-existent-wi')).toThrow('Work item not found');
+    });
+
+    it('throws NotFoundError when household item does not exist (supportsInvoices: false)', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      expect(() => getPayback(db, 'non-existent-hi')).toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError with entityLabel message for household item', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      expect(() => getPayback(db, 'non-existent-hi')).toThrow('Household item not found');
+    });
+  });
+
+  // ─── No linked subsidies ───────────────────────────────────────────────────
+
+  describe('no linked subsidies', () => {
+    it('returns zero totals and empty subsidies array for work item with no subsidies', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      expect(result['workItemId']).toBe(workItemId);
+      expect(result['minTotalPayback']).toBe(0);
+      expect(result['maxTotalPayback']).toBe(0);
+      expect(result['subsidies']).toEqual([]);
+    });
+
+    it('returns zero totals and empty subsidies array for household item with no subsidies', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      expect(result['householdItemId']).toBe(hiId);
+      expect(result['minTotalPayback']).toBe(0);
+      expect(result['maxTotalPayback']).toBe(0);
+      expect(result['subsidies']).toEqual([]);
+    });
+
+    it('returns 0 totals when all linked subsidies are rejected', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      const subsidyId = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 20,
+        applicationStatus: 'rejected',
+      });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      expect(result['minTotalPayback']).toBe(0);
+      expect(result['maxTotalPayback']).toBe(0);
+      expect(result['subsidies']).toHaveLength(0);
+    });
+  });
+
+  // ─── entityIdResponseKey ───────────────────────────────────────────────────
+
+  describe('entityIdResponseKey', () => {
+    it('uses workItemId as response key for work-item config', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 100 });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      expect(result['workItemId']).toBe(workItemId);
+      expect(result['householdItemId']).toBeUndefined();
+    });
+
+    it('uses householdItemId as response key for household-item config', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 100 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      expect(result['householdItemId']).toBe(hiId);
+      expect(result['workItemId']).toBeUndefined();
+    });
+  });
+
+  // ─── supportsInvoices: false — always uses confidence margins ──────────────
+
+  describe('supportsInvoices: false', () => {
+    it('applies confidence margin even when no invoice records exist for the entity', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      insertHiBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // own_estimate ±20%: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result['minTotalPayback']).toBeCloseTo(80);
+      expect(result['maxTotalPayback']).toBeCloseTo(120);
+    });
+
+    it('applies professional_estimate margin (±10%) for household item', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      insertHiBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        confidence: 'professional_estimate',
+      });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // min=1000*0.9*10%=90, max=1000*1.1*10%=110
+      expect(result['minTotalPayback']).toBeCloseTo(90);
+      expect(result['maxTotalPayback']).toBeCloseTo(110);
+    });
+
+    it('applies quote margin (±5%) for household item', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      insertHiBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'quote' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // min=1000*0.95*10%=95, max=1000*1.05*10%=105
+      expect(result['minTotalPayback']).toBeCloseTo(95);
+      expect(result['maxTotalPayback']).toBeCloseTo(105);
+    });
+
+    it('applies invoice confidence (±0%) so min === max === planned amount * rate', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      insertHiBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'invoice' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // margin=0: min = max = 1000 * 10% = 100
+      expect(result['minTotalPayback']).toBeCloseTo(100);
+      expect(result['maxTotalPayback']).toBeCloseTo(100);
+    });
+  });
+
+  // ─── supportsInvoices: true — uses actual cost when invoices exist ──────────
+
+  describe('supportsInvoices: true', () => {
+    it('uses actual invoiced cost for min and max when invoices exist (min === max)', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      const budgetLineId = insertWiBudgetLine({
+        workItemId,
+        plannedAmount: 1000,
+        confidence: 'own_estimate',
+      });
+      insertInvoice(budgetLineId, 800); // actual cost = 800
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      // Actual cost 800, no margin: min = max = 800 * 10% = 80
+      expect(result['minTotalPayback']).toBeCloseTo(80);
+      expect(result['maxTotalPayback']).toBeCloseTo(80);
+    });
+
+    it('applies confidence margin when no invoices exist for the budget line', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      insertWiBudgetLine({ workItemId, plannedAmount: 1000, confidence: 'own_estimate' });
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      // own_estimate ±20%: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result['minTotalPayback']).toBeCloseTo(80);
+      expect(result['maxTotalPayback']).toBeCloseTo(120);
+    });
+
+    it('sums multiple invoices for the same budget line as actual cost', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      const budgetLineId = insertWiBudgetLine({
+        workItemId,
+        plannedAmount: 2000,
+        confidence: 'own_estimate',
+      });
+      insertInvoice(budgetLineId, 600);
+      insertInvoice(budgetLineId, 400); // total: 1000
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as Record<string, unknown>;
+
+      // 1000 × 10% = 100
+      expect(result['minTotalPayback']).toBeCloseTo(100);
+      expect(result['maxTotalPayback']).toBeCloseTo(100);
+    });
+  });
+
+  // ─── Fixed subsidies ───────────────────────────────────────────────────────
+
+  describe('fixed subsidies', () => {
+    it('returns reductionValue as min === max for fixed subsidy on work item', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 5000 });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, workItemId) as {
+        minTotalPayback: number;
+        maxTotalPayback: number;
+        subsidies: Array<{ minPayback: number; maxPayback: number }>;
+      };
+
+      expect(result.minTotalPayback).toBe(5000);
+      expect(result.maxTotalPayback).toBe(5000);
+      expect(result.subsidies[0].minPayback).toBe(5000);
+      expect(result.subsidies[0].maxPayback).toBe(5000);
+    });
+
+    it('returns reductionValue as min === max for fixed subsidy on household item', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 2500 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as {
+        minTotalPayback: number;
+        maxTotalPayback: number;
+        subsidies: Array<{ minPayback: number; maxPayback: number }>;
+      };
+
+      expect(result.minTotalPayback).toBe(2500);
+      expect(result.maxTotalPayback).toBe(2500);
+      expect(result.subsidies[0].minPayback).toBe(2500);
+      expect(result.subsidies[0].maxPayback).toBe(2500);
+    });
+
+    it('returns fixed amount even with no budget lines', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 3000 });
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      expect(result['minTotalPayback']).toBe(3000);
+      expect(result['maxTotalPayback']).toBe(3000);
+    });
+  });
+
+  // ─── Rejected subsidies excluded ──────────────────────────────────────────
+
+  describe('rejected subsidies', () => {
+    it('excludes rejected subsidies from calculation', () => {
+      const getPayback = createSubsidyPaybackService(workItemConfig);
+      const workItemId = insertWorkItem();
+      insertWiBudgetLine({ workItemId, plannedAmount: 1000, confidence: 'own_estimate' });
+
+      const approved = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 10,
+        applicationStatus: 'approved',
+      });
+      const rejected = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 50,
+        applicationStatus: 'rejected',
+      });
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: approved })
+        .run();
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: rejected })
+        .run();
+
+      const result = getPayback(db, workItemId) as {
+        subsidies: unknown[];
+        minTotalPayback: number;
+        maxTotalPayback: number;
+      };
+
+      expect(result.subsidies).toHaveLength(1);
+      // Only approved: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(120);
+    });
+  });
+
+  // ─── Category-restricted subsidies ────────────────────────────────────────
+
+  describe('category-restricted subsidies', () => {
+    it('only applies subsidy to budget lines matching the category restriction', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      const cat1 = insertBudgetCategory('Electronics');
+      const cat2 = insertBudgetCategory('Furniture');
+
+      insertHiBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        budgetCategoryId: cat1,
+        confidence: 'own_estimate',
+      }); // matches
+      insertHiBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 500,
+        budgetCategoryId: cat2,
+        confidence: 'own_estimate',
+      }); // excluded
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      db.insert(schema.subsidyProgramCategories)
+        .values({ subsidyProgramId: subsidyId, budgetCategoryId: cat1 })
+        .run();
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // Only cat1 line: min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      expect(result['minTotalPayback']).toBeCloseTo(80);
+      expect(result['maxTotalPayback']).toBeCloseTo(120);
+    });
+
+    it('universal subsidy (no category link) matches all budget lines', () => {
+      const getPayback = createSubsidyPaybackService(householdItemConfig);
+      const hiId = insertHouseholdItem();
+      const cat1 = insertBudgetCategory('Electronics');
+      const cat2 = insertBudgetCategory('Decor');
+
+      insertHiBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        budgetCategoryId: cat1,
+        confidence: 'invoice',
+      });
+      insertHiBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 500,
+        budgetCategoryId: cat2,
+        confidence: 'invoice',
+      });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      // No subsidyProgramCategories link — it's universal
+      db.insert(schema.householdItemSubsidies)
+        .values({ householdItemId: hiId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = getPayback(db, hiId) as Record<string, unknown>;
+
+      // All lines (invoice margin=0): (1000+500)*10% = 150
+      expect(result['minTotalPayback']).toBeCloseTo(150);
+      expect(result['maxTotalPayback']).toBeCloseTo(150);
+    });
+  });
+});

--- a/server/src/services/shared/subsidyPaybackServiceFactory.ts
+++ b/server/src/services/shared/subsidyPaybackServiceFactory.ts
@@ -1,0 +1,185 @@
+import { sql } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type * as schemaTypes from '../../db/schema.js';
+import { CONFIDENCE_MARGINS } from '@cornerstone/shared';
+import { NotFoundError } from '../../errors/AppError.js';
+
+type DbType = BetterSQLite3Database<typeof schemaTypes>;
+type ConfidenceLevel = keyof typeof CONFIDENCE_MARGINS;
+
+export interface SubsidyPaybackConfig {
+  entityTable: string;
+  junctionTable: string;
+  junctionAlias: string;
+  junctionEntityIdColumn: string;
+  budgetLinesTable: string;
+  budgetLinesEntityIdColumn: string;
+  supportsInvoices: boolean;
+  entityLabel: string;
+  entityIdResponseKey: string;
+}
+
+export interface SubsidyPaybackEntry {
+  subsidyProgramId: string;
+  name: string;
+  reductionType: 'percentage' | 'fixed';
+  reductionValue: number;
+  minPayback: number;
+  maxPayback: number;
+}
+
+export function createSubsidyPaybackService(
+  config: SubsidyPaybackConfig,
+): (db: DbType, entityId: string) => unknown {
+  return function getPayback(db: DbType, entityId: string): unknown {
+    const item = db.get<{ id: string }>(
+      sql`SELECT id FROM ${sql.raw(config.entityTable)} WHERE id = ${entityId}`,
+    );
+    if (!item) {
+      throw new NotFoundError(`${config.entityLabel} not found`);
+    }
+
+    const linkedRows = db.all<{
+      subsidyProgramId: string;
+      name: string;
+      reductionType: string;
+      reductionValue: number;
+    }>(
+      sql`SELECT
+        sp.id              AS subsidyProgramId,
+        sp.name            AS name,
+        sp.reduction_type  AS reductionType,
+        sp.reduction_value AS reductionValue
+      FROM ${sql.raw(config.junctionTable)} ${sql.raw(config.junctionAlias)}
+      INNER JOIN subsidy_programs sp ON sp.id = ${sql.raw(`${config.junctionAlias}.subsidy_program_id`)}
+      WHERE ${sql.raw(`${config.junctionAlias}.${config.junctionEntityIdColumn}`)} = ${entityId}
+        AND sp.application_status != 'rejected'`,
+    );
+
+    if (linkedRows.length === 0) {
+      return {
+        [config.entityIdResponseKey]: entityId,
+        minTotalPayback: 0,
+        maxTotalPayback: 0,
+        subsidies: [],
+      };
+    }
+
+    const budgetLineRows = db.all<{
+      id: string;
+      plannedAmount: number;
+      confidence: string;
+      budgetCategoryId: string | null;
+    }>(
+      sql`SELECT
+        id                 AS id,
+        planned_amount     AS plannedAmount,
+        confidence         AS confidence,
+        budget_category_id AS budgetCategoryId
+      FROM ${sql.raw(config.budgetLinesTable)}
+      WHERE ${sql.raw(config.budgetLinesEntityIdColumn)} = ${entityId}`,
+    );
+
+    const invoiceMap = new Map<string, number>();
+    if (config.supportsInvoices) {
+      const invoiceRows = db.all<{ workItemBudgetId: string; actualCost: number }>(
+        sql`SELECT
+          work_item_budget_id AS workItemBudgetId,
+          COALESCE(SUM(amount), 0) AS actualCost
+        FROM invoices
+        WHERE work_item_budget_id IN (
+          SELECT id FROM work_item_budgets WHERE work_item_id = ${entityId}
+        )
+        GROUP BY work_item_budget_id`,
+      );
+
+      for (const row of invoiceRows) {
+        invoiceMap.set(row.workItemBudgetId, row.actualCost);
+      }
+    }
+
+    const budgetLines = budgetLineRows.map((line) => {
+      if (config.supportsInvoices && invoiceMap.has(line.id)) {
+        const actualCost = invoiceMap.get(line.id) ?? 0;
+        return {
+          id: line.id,
+          budgetCategoryId: line.budgetCategoryId,
+          minAmount: actualCost,
+          maxAmount: actualCost,
+        };
+      } else {
+        const margin =
+          CONFIDENCE_MARGINS[line.confidence as ConfidenceLevel] ?? CONFIDENCE_MARGINS.own_estimate;
+        return {
+          id: line.id,
+          budgetCategoryId: line.budgetCategoryId,
+          minAmount: line.plannedAmount * (1 - margin),
+          maxAmount: line.plannedAmount * (1 + margin),
+        };
+      }
+    });
+
+    const subsidyIds = linkedRows.map((r) => r.subsidyProgramId);
+    const inList = subsidyIds.map((id) => sql`${id}`);
+    const categoryRows = db.all<{ subsidyProgramId: string; budgetCategoryId: string }>(
+      sql`SELECT subsidy_program_id AS subsidyProgramId, budget_category_id AS budgetCategoryId
+      FROM subsidy_program_categories
+      WHERE subsidy_program_id IN (${sql.join(inList, sql`, `)})`,
+    );
+
+    const subsidyCategoryMap = new Map<string, Set<string>>();
+    for (const row of categoryRows) {
+      let cats = subsidyCategoryMap.get(row.subsidyProgramId);
+      if (!cats) {
+        cats = new Set<string>();
+        subsidyCategoryMap.set(row.subsidyProgramId, cats);
+      }
+      cats.add(row.budgetCategoryId);
+    }
+
+    const subsidyEntries: SubsidyPaybackEntry[] = [];
+    let minTotalPayback = 0;
+    let maxTotalPayback = 0;
+
+    for (const subsidy of linkedRows) {
+      const applicableCategories = subsidyCategoryMap.get(subsidy.subsidyProgramId);
+      const isUniversal = !applicableCategories || applicableCategories.size === 0;
+      let minPayback = 0;
+      let maxPayback = 0;
+
+      if (subsidy.reductionType === 'percentage') {
+        const rate = subsidy.reductionValue / 100;
+        for (const line of budgetLines) {
+          const categoryMatches =
+            isUniversal ||
+            (line.budgetCategoryId !== null && applicableCategories!.has(line.budgetCategoryId));
+          if (categoryMatches) {
+            minPayback += line.minAmount * rate;
+            maxPayback += line.maxAmount * rate;
+          }
+        }
+      } else if (subsidy.reductionType === 'fixed') {
+        minPayback = subsidy.reductionValue;
+        maxPayback = subsidy.reductionValue;
+      }
+
+      subsidyEntries.push({
+        subsidyProgramId: subsidy.subsidyProgramId,
+        name: subsidy.name,
+        reductionType: subsidy.reductionType as 'percentage' | 'fixed',
+        reductionValue: subsidy.reductionValue,
+        minPayback,
+        maxPayback,
+      });
+      minTotalPayback += minPayback;
+      maxTotalPayback += maxPayback;
+    }
+
+    return {
+      [config.entityIdResponseKey]: entityId,
+      minTotalPayback,
+      maxTotalPayback,
+      subsidies: subsidyEntries,
+    };
+  };
+}

--- a/server/src/services/shared/subsidyServiceFactory.test.ts
+++ b/server/src/services/shared/subsidyServiceFactory.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../../db/migrate.js';
+import * as schema from '../../db/schema.js';
+import { createSubsidyService } from './subsidyServiceFactory.js';
+import { NotFoundError, ConflictError } from '../../errors/AppError.js';
+
+// ─── Factory configurations under test ────────────────────────────────────────
+
+function makeWorkItemService(db: BetterSQLite3Database<typeof schema>) {
+  return createSubsidyService({
+    entityTable: schema.workItems,
+    entityIdColumn: schema.workItems.id,
+    junctionTable: schema.workItemSubsidies,
+    junctionEntityIdColumn: schema.workItemSubsidies.workItemId,
+    junctionSubsidyProgramIdColumn: schema.workItemSubsidies.subsidyProgramId,
+    entityLabel: 'Work item',
+    makeInsertValues: (workItemId, subsidyProgramId) => ({ workItemId, subsidyProgramId }),
+  });
+}
+
+function makeHouseholdItemService(db: BetterSQLite3Database<typeof schema>) {
+  return createSubsidyService({
+    entityTable: schema.householdItems,
+    entityIdColumn: schema.householdItems.id,
+    junctionTable: schema.householdItemSubsidies,
+    junctionEntityIdColumn: schema.householdItemSubsidies.householdItemId,
+    junctionSubsidyProgramIdColumn: schema.householdItemSubsidies.subsidyProgramId,
+    entityLabel: 'Household item',
+    makeInsertValues: (householdItemId, subsidyProgramId) => ({ householdItemId, subsidyProgramId }),
+  });
+}
+
+// ─── Test database helpers ─────────────────────────────────────────────────────
+
+describe('subsidyServiceFactory — createSubsidyService()', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  function insertTestUser(id = 'user-001') {
+    const now = new Date().toISOString();
+    db.insert(schema.users)
+      .values({
+        id,
+        email: `${id}@example.com`,
+        displayName: 'Test User',
+        role: 'member',
+        authProvider: 'local',
+        passwordHash: 'hashed',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertWorkItem(title = 'Test Work Item', userId = 'user-001') {
+    const id = `wi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.workItems)
+      .values({
+        id,
+        title,
+        status: 'not_started',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertHouseholdItem(name = 'Test Household Item', userId = 'user-001') {
+    const id = `hi-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    // hic-furniture is seeded by migration 0016
+    db.insert(schema.householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        status: 'planned',
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertSubsidyProgram(
+    name = 'Test Subsidy',
+    opts: {
+      reductionType?: 'percentage' | 'fixed';
+      reductionValue?: number;
+      applicationStatus?: 'eligible' | 'applied' | 'approved' | 'received' | 'rejected';
+      createdBy?: string | null;
+    } = {},
+  ) {
+    const id = `sp-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.subsidyPrograms)
+      .values({
+        id,
+        name,
+        description: null,
+        eligibility: null,
+        reductionType: opts.reductionType ?? 'percentage',
+        reductionValue: opts.reductionValue ?? 10,
+        applicationStatus: opts.applicationStatus ?? 'eligible',
+        applicationDeadline: null,
+        notes: null,
+        createdBy: opts.createdBy ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+    idCounter = 0;
+    insertTestUser();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Factory shape ────────────────────────────────────────────────────────
+
+  describe('factory shape', () => {
+    it('returns a service object with list, link, and unlink methods', () => {
+      const service = makeWorkItemService(db);
+
+      expect(typeof service.list).toBe('function');
+      expect(typeof service.link).toBe('function');
+      expect(typeof service.unlink).toBe('function');
+    });
+
+    it('two factory instances created with different configs are independent', () => {
+      const wiService = makeWorkItemService(db);
+      const hiService = makeHouseholdItemService(db);
+
+      const workItemId = insertWorkItem();
+      const hiId = insertHouseholdItem();
+      const subsidyId = insertSubsidyProgram('Shared Program');
+
+      // Link subsidy only to work item
+      wiService.link(db, workItemId, subsidyId);
+
+      // Work item has the link
+      expect(wiService.list(db, workItemId)).toHaveLength(1);
+      // Household item does NOT have it
+      expect(hiService.list(db, hiId)).toHaveLength(0);
+    });
+  });
+
+  // ─── list() ───────────────────────────────────────────────────────────────
+
+  describe('list()', () => {
+    describe('work-item configuration', () => {
+      it('returns empty array when no subsidies are linked', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+
+        expect(service.list(db, workItemId)).toEqual([]);
+      });
+
+      it('returns linked subsidy program with full shape', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem('Foundation Work');
+        const subsidyId = insertSubsidyProgram('Green Energy Rebate', {
+          reductionType: 'percentage',
+          reductionValue: 15,
+          applicationStatus: 'eligible',
+          createdBy: 'user-001',
+        });
+        db.insert(schema.workItemSubsidies)
+          .values({ workItemId, subsidyProgramId: subsidyId })
+          .run();
+
+        const result = service.list(db, workItemId);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe(subsidyId);
+        expect(result[0].name).toBe('Green Energy Rebate');
+        expect(result[0].reductionType).toBe('percentage');
+        expect(result[0].reductionValue).toBe(15);
+        expect(result[0].applicationStatus).toBe('eligible');
+        expect(result[0].applicableCategories).toBeDefined();
+        expect(Array.isArray(result[0].applicableCategories)).toBe(true);
+        expect(result[0].createdBy?.id).toBe('user-001');
+      });
+
+      it('returns multiple linked subsidy programs', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId1 = insertSubsidyProgram('Subsidy A');
+        const subsidyId2 = insertSubsidyProgram('Subsidy B');
+        db.insert(schema.workItemSubsidies)
+          .values({ workItemId, subsidyProgramId: subsidyId1 })
+          .run();
+        db.insert(schema.workItemSubsidies)
+          .values({ workItemId, subsidyProgramId: subsidyId2 })
+          .run();
+
+        const result = service.list(db, workItemId);
+
+        expect(result).toHaveLength(2);
+        const names = result.map((s) => s.name);
+        expect(names).toContain('Subsidy A');
+        expect(names).toContain('Subsidy B');
+      });
+
+      it('returns subsidy with null createdBy when createdBy is null', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Anonymous Subsidy', { createdBy: null });
+        db.insert(schema.workItemSubsidies)
+          .values({ workItemId, subsidyProgramId: subsidyId })
+          .run();
+
+        const result = service.list(db, workItemId);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].createdBy).toBeNull();
+      });
+
+      it('throws NotFoundError when work item does not exist', () => {
+        const service = makeWorkItemService(db);
+
+        expect(() => {
+          service.list(db, 'non-existent-wi');
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.list(db, 'non-existent-wi');
+        }).toThrow('Work item not found');
+      });
+    });
+
+    describe('household-item configuration', () => {
+      it('returns empty array when no subsidies are linked', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+
+        expect(service.list(db, hiId)).toEqual([]);
+      });
+
+      it('throws NotFoundError when household item does not exist', () => {
+        const service = makeHouseholdItemService(db);
+
+        expect(() => {
+          service.list(db, 'non-existent-hi');
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.list(db, 'non-existent-hi');
+        }).toThrow('Household item not found');
+      });
+
+      it('does not return subsidies linked to a different household item', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId1 = insertHouseholdItem('Sofa');
+        const hiId2 = insertHouseholdItem('Fridge');
+        const subsidyId = insertSubsidyProgram('Exclusive Subsidy');
+        db.insert(schema.householdItemSubsidies)
+          .values({ householdItemId: hiId2, subsidyProgramId: subsidyId })
+          .run();
+
+        expect(service.list(db, hiId1)).toHaveLength(0);
+      });
+    });
+  });
+
+  // ─── link() ───────────────────────────────────────────────────────────────
+
+  describe('link()', () => {
+    describe('work-item configuration', () => {
+      it('creates junction row and returns the subsidy program', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Solar Panel Rebate', {
+          reductionType: 'fixed',
+          reductionValue: 5000,
+        });
+
+        const result = service.link(db, workItemId, subsidyId);
+
+        expect(result.id).toBe(subsidyId);
+        expect(result.name).toBe('Solar Panel Rebate');
+        expect(result.reductionType).toBe('fixed');
+        expect(result.reductionValue).toBe(5000);
+      });
+
+      it('persists the link so list() returns it', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Persistent Subsidy');
+
+        service.link(db, workItemId, subsidyId);
+
+        const listed = service.list(db, workItemId);
+        expect(listed).toHaveLength(1);
+        expect(listed[0].id).toBe(subsidyId);
+      });
+
+      it('throws NotFoundError when work item does not exist', () => {
+        const service = makeWorkItemService(db);
+        const subsidyId = insertSubsidyProgram('Some Subsidy');
+
+        expect(() => {
+          service.link(db, 'non-existent-wi', subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.link(db, 'non-existent-wi', subsidyId);
+        }).toThrow('Work item not found');
+      });
+
+      it('throws NotFoundError when subsidy program does not exist', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+
+        expect(() => {
+          service.link(db, workItemId, 'non-existent-subsidy');
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.link(db, workItemId, 'non-existent-subsidy');
+        }).toThrow('Subsidy program not found');
+      });
+
+      it('throws ConflictError when subsidy is already linked', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Duplicate Subsidy');
+
+        service.link(db, workItemId, subsidyId);
+
+        expect(() => {
+          service.link(db, workItemId, subsidyId);
+        }).toThrow(ConflictError);
+
+        expect(() => {
+          service.link(db, workItemId, subsidyId);
+        }).toThrow('Subsidy program is already linked to this work item');
+      });
+
+      it('allows linking the same subsidy to multiple work items', () => {
+        const service = makeWorkItemService(db);
+        const workItemId1 = insertWorkItem('Work Item 1');
+        const workItemId2 = insertWorkItem('Work Item 2');
+        const subsidyId = insertSubsidyProgram('Shared Subsidy');
+
+        service.link(db, workItemId1, subsidyId);
+        service.link(db, workItemId2, subsidyId);
+
+        expect(service.list(db, workItemId1)).toHaveLength(1);
+        expect(service.list(db, workItemId2)).toHaveLength(1);
+      });
+    });
+
+    describe('household-item configuration', () => {
+      it('creates junction row and returns the subsidy program', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+        const subsidyId = insertSubsidyProgram('Appliance Rebate', {
+          reductionType: 'percentage',
+          reductionValue: 20,
+        });
+
+        const result = service.link(db, hiId, subsidyId);
+
+        expect(result.id).toBe(subsidyId);
+        expect(result.name).toBe('Appliance Rebate');
+        expect(result.reductionType).toBe('percentage');
+        expect(result.reductionValue).toBe(20);
+      });
+
+      it('throws NotFoundError when household item does not exist', () => {
+        const service = makeHouseholdItemService(db);
+        const subsidyId = insertSubsidyProgram('Some Subsidy');
+
+        expect(() => {
+          service.link(db, 'non-existent-hi', subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.link(db, 'non-existent-hi', subsidyId);
+        }).toThrow('Household item not found');
+      });
+
+      it('throws NotFoundError when subsidy program does not exist', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+
+        expect(() => {
+          service.link(db, hiId, 'non-existent-subsidy');
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.link(db, hiId, 'non-existent-subsidy');
+        }).toThrow('Subsidy program not found');
+      });
+
+      it('throws ConflictError when subsidy is already linked to the household item', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+        const subsidyId = insertSubsidyProgram('Duplicate Subsidy');
+
+        service.link(db, hiId, subsidyId);
+
+        expect(() => {
+          service.link(db, hiId, subsidyId);
+        }).toThrow(ConflictError);
+
+        expect(() => {
+          service.link(db, hiId, subsidyId);
+        }).toThrow('Subsidy program is already linked to this household item');
+      });
+    });
+  });
+
+  // ─── unlink() ─────────────────────────────────────────────────────────────
+
+  describe('unlink()', () => {
+    describe('work-item configuration', () => {
+      it('removes the junction row', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Linked Subsidy');
+
+        service.link(db, workItemId, subsidyId);
+        service.unlink(db, workItemId, subsidyId);
+
+        expect(service.list(db, workItemId)).toEqual([]);
+      });
+
+      it('only removes the specified link, not others on the same entity', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId1 = insertSubsidyProgram('Subsidy To Remove');
+        const subsidyId2 = insertSubsidyProgram('Subsidy To Keep');
+
+        service.link(db, workItemId, subsidyId1);
+        service.link(db, workItemId, subsidyId2);
+        service.unlink(db, workItemId, subsidyId1);
+
+        const result = service.list(db, workItemId);
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe(subsidyId2);
+      });
+
+      it('throws NotFoundError when work item does not exist', () => {
+        const service = makeWorkItemService(db);
+        const subsidyId = insertSubsidyProgram('Some Subsidy');
+
+        expect(() => {
+          service.unlink(db, 'non-existent-wi', subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.unlink(db, 'non-existent-wi', subsidyId);
+        }).toThrow('Work item not found');
+      });
+
+      it('throws NotFoundError when subsidy is not linked to the work item', () => {
+        const service = makeWorkItemService(db);
+        const workItemId = insertWorkItem();
+        const subsidyId = insertSubsidyProgram('Unlinked Subsidy');
+
+        expect(() => {
+          service.unlink(db, workItemId, subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.unlink(db, workItemId, subsidyId);
+        }).toThrow('Subsidy program is not linked to this work item');
+      });
+    });
+
+    describe('household-item configuration', () => {
+      it('removes the junction row', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+        const subsidyId = insertSubsidyProgram('Linked Subsidy');
+
+        service.link(db, hiId, subsidyId);
+        service.unlink(db, hiId, subsidyId);
+
+        expect(service.list(db, hiId)).toEqual([]);
+      });
+
+      it('throws NotFoundError when household item does not exist', () => {
+        const service = makeHouseholdItemService(db);
+        const subsidyId = insertSubsidyProgram('Some Subsidy');
+
+        expect(() => {
+          service.unlink(db, 'non-existent-hi', subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.unlink(db, 'non-existent-hi', subsidyId);
+        }).toThrow('Household item not found');
+      });
+
+      it('throws NotFoundError when subsidy is not linked to the household item', () => {
+        const service = makeHouseholdItemService(db);
+        const hiId = insertHouseholdItem();
+        const subsidyId = insertSubsidyProgram('Unlinked Subsidy');
+
+        expect(() => {
+          service.unlink(db, hiId, subsidyId);
+        }).toThrow(NotFoundError);
+
+        expect(() => {
+          service.unlink(db, hiId, subsidyId);
+        }).toThrow('Subsidy program is not linked to this household item');
+      });
+    });
+  });
+
+  // ─── Applicable categories loaded correctly ────────────────────────────────
+
+  describe('applicableCategories', () => {
+    it('loads applicable categories linked to the subsidy program', () => {
+      const service = makeWorkItemService(db);
+      const workItemId = insertWorkItem();
+      const subsidyId = insertSubsidyProgram('Category Subsidy');
+
+      // Get a real seeded budget category
+      const categories = db.select().from(schema.budgetCategories).limit(1).all();
+      if (categories.length === 0) return; // guard: skip if no categories seeded
+
+      db.insert(schema.subsidyProgramCategories)
+        .values({ subsidyProgramId: subsidyId, budgetCategoryId: categories[0].id })
+        .run();
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = service.list(db, workItemId);
+
+      expect(result[0].applicableCategories).toHaveLength(1);
+      expect(result[0].applicableCategories[0].id).toBe(categories[0].id);
+    });
+
+    it('returns empty applicableCategories when none are linked to the subsidy', () => {
+      const service = makeWorkItemService(db);
+      const workItemId = insertWorkItem();
+      const subsidyId = insertSubsidyProgram('Uncategorized Subsidy');
+      db.insert(schema.workItemSubsidies)
+        .values({ workItemId, subsidyProgramId: subsidyId })
+        .run();
+
+      const result = service.list(db, workItemId);
+
+      expect(result[0].applicableCategories).toEqual([]);
+    });
+  });
+});

--- a/server/src/services/shared/subsidyServiceFactory.ts
+++ b/server/src/services/shared/subsidyServiceFactory.ts
@@ -1,0 +1,166 @@
+import { eq, and, inArray, asc } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { SQLiteColumn, SQLiteTable } from 'drizzle-orm/sqlite-core';
+import type * as schemaTypes from '../../db/schema.js';
+import {
+  subsidyPrograms,
+  subsidyProgramCategories,
+  budgetCategories,
+  users,
+} from '../../db/schema.js';
+import { toUserSummary, toBudgetCategory } from './converters.js';
+import type {
+  SubsidyProgram,
+  SubsidyReductionType,
+  SubsidyApplicationStatus,
+  BudgetCategory,
+} from '@cornerstone/shared';
+import { NotFoundError, ConflictError } from '../../errors/AppError.js';
+
+type DbType = BetterSQLite3Database<typeof schemaTypes>;
+
+export interface SubsidyServiceConfig {
+  entityTable: SQLiteTable;
+  entityIdColumn: SQLiteColumn;
+  junctionTable: SQLiteTable;
+  junctionEntityIdColumn: SQLiteColumn;
+  junctionSubsidyProgramIdColumn: SQLiteColumn;
+  entityLabel: string;
+  makeInsertValues: (entityId: string, subsidyProgramId: string) => Record<string, string>;
+}
+
+export interface SubsidyService {
+  list: (db: DbType, entityId: string) => SubsidyProgram[];
+  link: (db: DbType, entityId: string, subsidyProgramId: string) => SubsidyProgram;
+  unlink: (db: DbType, entityId: string, subsidyProgramId: string) => void;
+}
+
+function loadApplicableCategories(db: DbType, subsidyProgramId: string): BudgetCategory[] {
+  const links = db
+    .select()
+    .from(subsidyProgramCategories)
+    .where(eq(subsidyProgramCategories.subsidyProgramId, subsidyProgramId))
+    .all();
+
+  if (links.length === 0) return [];
+
+  const categoryIds = links.map((l) => l.budgetCategoryId);
+  const categories = db
+    .select()
+    .from(budgetCategories)
+    .where(inArray(budgetCategories.id, categoryIds))
+    .orderBy(asc(budgetCategories.sortOrder), asc(budgetCategories.name))
+    .all();
+
+  return categories.map((row) => toBudgetCategory(row)!);
+}
+
+function toSubsidyProgram(db: DbType, row: typeof subsidyPrograms.$inferSelect): SubsidyProgram {
+  const createdByUser = row.createdBy
+    ? db.select().from(users).where(eq(users.id, row.createdBy)).get()
+    : null;
+
+  const applicableCategories = loadApplicableCategories(db, row.id);
+
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? null,
+    eligibility: row.eligibility ?? null,
+    reductionType: row.reductionType as SubsidyReductionType,
+    reductionValue: row.reductionValue,
+    applicationStatus: row.applicationStatus as SubsidyApplicationStatus,
+    applicationDeadline: row.applicationDeadline ?? null,
+    notes: row.notes ?? null,
+    applicableCategories,
+    createdBy: toUserSummary(createdByUser),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createSubsidyService(config: SubsidyServiceConfig): SubsidyService {
+  function assertEntityExists(db: DbType, entityId: string): void {
+    const item = db.select().from(config.entityTable).where(eq(config.entityIdColumn, entityId)).get();
+    if (!item) {
+      throw new NotFoundError(`${config.entityLabel} not found`);
+    }
+  }
+
+  function list(db: DbType, entityId: string): SubsidyProgram[] {
+    assertEntityExists(db, entityId);
+
+    const rows = db
+      .select({ program: subsidyPrograms })
+      .from(config.junctionTable)
+      .innerJoin(subsidyPrograms, eq(subsidyPrograms.id, config.junctionSubsidyProgramIdColumn))
+      .where(eq(config.junctionEntityIdColumn, entityId))
+      .all();
+
+    return rows.map((row) => toSubsidyProgram(db, row.program));
+  }
+
+  function link(db: DbType, entityId: string, subsidyProgramId: string): SubsidyProgram {
+    assertEntityExists(db, entityId);
+
+    const program = db
+      .select()
+      .from(subsidyPrograms)
+      .where(eq(subsidyPrograms.id, subsidyProgramId))
+      .get();
+
+    if (!program) {
+      throw new NotFoundError('Subsidy program not found');
+    }
+
+    const existing = db
+      .select()
+      .from(config.junctionTable)
+      .where(
+        and(
+          eq(config.junctionEntityIdColumn, entityId),
+          eq(config.junctionSubsidyProgramIdColumn, subsidyProgramId),
+        ),
+      )
+      .get();
+
+    if (existing) {
+      throw new ConflictError(`Subsidy program is already linked to this ${config.entityLabel.toLowerCase()}`);
+    }
+
+    const insertValues = config.makeInsertValues(entityId, subsidyProgramId);
+    db.insert(config.junctionTable).values(insertValues).run();
+
+    return toSubsidyProgram(db, program);
+  }
+
+  function unlink(db: DbType, entityId: string, subsidyProgramId: string): void {
+    assertEntityExists(db, entityId);
+
+    const existing = db
+      .select()
+      .from(config.junctionTable)
+      .where(
+        and(
+          eq(config.junctionEntityIdColumn, entityId),
+          eq(config.junctionSubsidyProgramIdColumn, subsidyProgramId),
+        ),
+      )
+      .get();
+
+    if (!existing) {
+      throw new NotFoundError(`Subsidy program is not linked to this ${config.entityLabel.toLowerCase()}`);
+    }
+
+    db.delete(config.junctionTable)
+      .where(
+        and(
+          eq(config.junctionEntityIdColumn, entityId),
+          eq(config.junctionSubsidyProgramIdColumn, subsidyProgramId),
+        ),
+      )
+      .run();
+  }
+
+  return { list, link, unlink };
+}

--- a/server/src/services/subsidyPaybackService.ts
+++ b/server/src/services/subsidyPaybackService.ts
@@ -1,16 +1,21 @@
-import { sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import type {
-  WorkItemSubsidyPaybackEntry,
-  WorkItemSubsidyPaybackResponse,
-} from '@cornerstone/shared';
-import { CONFIDENCE_MARGINS } from '@cornerstone/shared';
-import { NotFoundError } from '../errors/AppError.js';
+import { createSubsidyPaybackService } from './shared/subsidyPaybackServiceFactory.js';
+import type { WorkItemSubsidyPaybackResponse } from '@cornerstone/shared';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
-type ConfidenceLevel = keyof typeof CONFIDENCE_MARGINS;
+const getPayback = createSubsidyPaybackService({
+  entityTable: 'work_items',
+  junctionTable: 'work_item_subsidies',
+  junctionAlias: 'wis',
+  junctionEntityIdColumn: 'work_item_id',
+  budgetLinesTable: 'work_item_budgets',
+  budgetLinesEntityIdColumn: 'work_item_id',
+  supportsInvoices: true,
+  entityLabel: 'Work item',
+  entityIdResponseKey: 'workItemId',
+});
 
 /**
  * Calculate the expected subsidy payback range for a single work item.
@@ -35,149 +40,5 @@ export function getWorkItemSubsidyPayback(
   db: DbType,
   workItemId: string,
 ): WorkItemSubsidyPaybackResponse {
-  // Verify work item exists
-  const item = db.get<{ id: string }>(sql`SELECT id FROM work_items WHERE id = ${workItemId}`);
-  if (!item) {
-    throw new NotFoundError('Work item not found');
-  }
-
-  // Fetch non-rejected subsidies linked to this work item
-  const linkedRows = db.all<{
-    subsidyProgramId: string;
-    name: string;
-    reductionType: string;
-    reductionValue: number;
-  }>(
-    sql`SELECT
-      sp.id              AS subsidyProgramId,
-      sp.name            AS name,
-      sp.reduction_type  AS reductionType,
-      sp.reduction_value AS reductionValue
-    FROM work_item_subsidies wis
-    INNER JOIN subsidy_programs sp ON sp.id = wis.subsidy_program_id
-    WHERE wis.work_item_id = ${workItemId}
-      AND sp.application_status != 'rejected'`,
-  );
-
-  if (linkedRows.length === 0) {
-    return { workItemId, minTotalPayback: 0, maxTotalPayback: 0, subsidies: [] };
-  }
-
-  // Fetch all budget lines for this work item, including confidence level
-  const budgetLineRows = db.all<{
-    id: string;
-    plannedAmount: number;
-    confidence: string;
-    budgetCategoryId: string | null;
-  }>(
-    sql`SELECT
-      id                 AS id,
-      planned_amount     AS plannedAmount,
-      confidence         AS confidence,
-      budget_category_id AS budgetCategoryId
-    FROM work_item_budgets
-    WHERE work_item_id = ${workItemId}`,
-  );
-
-  // Fetch actual invoice costs per budget line (SUM of invoice amounts)
-  const invoiceRows = db.all<{ workItemBudgetId: string; actualCost: number }>(
-    sql`SELECT
-      work_item_budget_id AS workItemBudgetId,
-      COALESCE(SUM(amount), 0) AS actualCost
-    FROM invoices
-    WHERE work_item_budget_id IN (
-      SELECT id FROM work_item_budgets WHERE work_item_id = ${workItemId}
-    )
-    GROUP BY work_item_budget_id`,
-  );
-
-  const invoiceMap = new Map<string, number>();
-  for (const row of invoiceRows) {
-    invoiceMap.set(row.workItemBudgetId, row.actualCost);
-  }
-
-  // Compute per-line min/max effective amounts
-  const budgetLines = budgetLineRows.map((line) => {
-    if (invoiceMap.has(line.id)) {
-      // Actual cost known: min === max === actual invoiced cost
-      const actualCost = invoiceMap.get(line.id) ?? 0;
-      return {
-        id: line.id,
-        budgetCategoryId: line.budgetCategoryId,
-        minAmount: actualCost,
-        maxAmount: actualCost,
-      };
-    } else {
-      // No invoices: apply confidence margin
-      const margin =
-        CONFIDENCE_MARGINS[line.confidence as ConfidenceLevel] ?? CONFIDENCE_MARGINS.own_estimate;
-      return {
-        id: line.id,
-        budgetCategoryId: line.budgetCategoryId,
-        minAmount: line.plannedAmount * (1 - margin),
-        maxAmount: line.plannedAmount * (1 + margin),
-      };
-    }
-  });
-
-  // Load applicable categories for relevant subsidy programs only
-  const subsidyIds = linkedRows.map((r) => r.subsidyProgramId);
-  const inList = subsidyIds.map((id) => sql`${id}`);
-  const categoryRows = db.all<{ subsidyProgramId: string; budgetCategoryId: string }>(
-    sql`SELECT subsidy_program_id AS subsidyProgramId, budget_category_id AS budgetCategoryId
-    FROM subsidy_program_categories
-    WHERE subsidy_program_id IN (${sql.join(inList, sql`, `)})`,
-  );
-
-  const subsidyCategoryMap = new Map<string, Set<string>>();
-  for (const row of categoryRows) {
-    let cats = subsidyCategoryMap.get(row.subsidyProgramId);
-    if (!cats) {
-      cats = new Set<string>();
-      subsidyCategoryMap.set(row.subsidyProgramId, cats);
-    }
-    cats.add(row.budgetCategoryId);
-  }
-
-  // Calculate min/max payback per subsidy
-  const subsidyEntries: WorkItemSubsidyPaybackEntry[] = [];
-  let minTotalPayback = 0;
-  let maxTotalPayback = 0;
-
-  for (const subsidy of linkedRows) {
-    const applicableCategories = subsidyCategoryMap.get(subsidy.subsidyProgramId);
-    const isUniversal = !applicableCategories || applicableCategories.size === 0;
-    let minPayback = 0;
-    let maxPayback = 0;
-
-    if (subsidy.reductionType === 'percentage') {
-      const rate = subsidy.reductionValue / 100;
-      for (const line of budgetLines) {
-        const categoryMatches =
-          isUniversal ||
-          (line.budgetCategoryId !== null && applicableCategories!.has(line.budgetCategoryId));
-        if (categoryMatches) {
-          minPayback += line.minAmount * rate;
-          maxPayback += line.maxAmount * rate;
-        }
-      }
-    } else if (subsidy.reductionType === 'fixed') {
-      // Fixed amount: min === max === reductionValue (not affected by budget line ranges)
-      minPayback = subsidy.reductionValue;
-      maxPayback = subsidy.reductionValue;
-    }
-
-    subsidyEntries.push({
-      subsidyProgramId: subsidy.subsidyProgramId,
-      name: subsidy.name,
-      reductionType: subsidy.reductionType as 'percentage' | 'fixed',
-      reductionValue: subsidy.reductionValue,
-      minPayback,
-      maxPayback,
-    });
-    minTotalPayback += minPayback;
-    maxTotalPayback += maxPayback;
-  }
-
-  return { workItemId, minTotalPayback, maxTotalPayback, subsidies: subsidyEntries };
+  return getPayback(db, workItemId) as WorkItemSubsidyPaybackResponse;
 }

--- a/server/src/services/workItemSubsidyService.ts
+++ b/server/src/services/workItemSubsidyService.ts
@@ -1,102 +1,27 @@
-import { eq, and, inArray, asc } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import {
-  workItems,
-  workItemSubsidies,
-  subsidyPrograms,
-  subsidyProgramCategories,
-  budgetCategories,
-  users,
-} from '../db/schema.js';
-import { toUserSummary, toBudgetCategory } from './shared/converters.js';
-import type {
-  SubsidyProgram,
-  SubsidyReductionType,
-  SubsidyApplicationStatus,
-  BudgetCategory,
-  UserSummary,
-} from '@cornerstone/shared';
-import { NotFoundError, ConflictError } from '../errors/AppError.js';
+import { workItems, workItemSubsidies } from '../db/schema.js';
+import { createSubsidyService } from './shared/subsidyServiceFactory.js';
+import type { SubsidyProgram } from '@cornerstone/shared';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
-/**
- * Load applicable categories for a given subsidy program.
- */
-function loadApplicableCategories(db: DbType, subsidyProgramId: string): BudgetCategory[] {
-  const links = db
-    .select()
-    .from(subsidyProgramCategories)
-    .where(eq(subsidyProgramCategories.subsidyProgramId, subsidyProgramId))
-    .all();
-
-  if (links.length === 0) return [];
-
-  const categoryIds = links.map((l) => l.budgetCategoryId);
-  const categories = db
-    .select()
-    .from(budgetCategories)
-    .where(inArray(budgetCategories.id, categoryIds))
-    .orderBy(asc(budgetCategories.sortOrder), asc(budgetCategories.name))
-    .all();
-
-  return categories.map((row) => toBudgetCategory(row)!);
-}
-
-/**
- * Convert database subsidy program row to SubsidyProgram shape.
- */
-function toSubsidyProgram(db: DbType, row: typeof subsidyPrograms.$inferSelect): SubsidyProgram {
-  const createdByUser = row.createdBy
-    ? db.select().from(users).where(eq(users.id, row.createdBy)).get()
-    : null;
-
-  const applicableCategories = loadApplicableCategories(db, row.id);
-
-  return {
-    id: row.id,
-    name: row.name,
-    description: row.description ?? null,
-    eligibility: row.eligibility ?? null,
-    reductionType: row.reductionType as SubsidyReductionType,
-    reductionValue: row.reductionValue,
-    applicationStatus: row.applicationStatus as SubsidyApplicationStatus,
-    applicationDeadline: row.applicationDeadline ?? null,
-    notes: row.notes ?? null,
-    applicableCategories,
-    createdBy: toUserSummary(createdByUser),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
-
-/**
- * Ensure a work item exists.
- * @throws NotFoundError if not found
- */
-function assertWorkItemExists(db: DbType, workItemId: string): void {
-  const item = db.select().from(workItems).where(eq(workItems.id, workItemId)).get();
-  if (!item) {
-    throw new NotFoundError('Work item not found');
-  }
-}
+const service = createSubsidyService({
+  entityTable: workItems,
+  entityIdColumn: workItems.id,
+  junctionTable: workItemSubsidies,
+  junctionEntityIdColumn: workItemSubsidies.workItemId,
+  junctionSubsidyProgramIdColumn: workItemSubsidies.subsidyProgramId,
+  entityLabel: 'Work item',
+  makeInsertValues: (workItemId, subsidyProgramId) => ({ workItemId, subsidyProgramId }),
+});
 
 /**
  * List all subsidy programs linked to a work item.
  * @throws NotFoundError if work item does not exist
  */
 export function listWorkItemSubsidies(db: DbType, workItemId: string): SubsidyProgram[] {
-  assertWorkItemExists(db, workItemId);
-
-  const rows = db
-    .select({ program: subsidyPrograms })
-    .from(workItemSubsidies)
-    .innerJoin(subsidyPrograms, eq(subsidyPrograms.id, workItemSubsidies.subsidyProgramId))
-    .where(eq(workItemSubsidies.workItemId, workItemId))
-    .all();
-
-  return rows.map((row) => toSubsidyProgram(db, row.program));
+  return service.list(db, workItemId);
 }
 
 /**
@@ -109,39 +34,7 @@ export function linkSubsidyToWorkItem(
   workItemId: string,
   subsidyProgramId: string,
 ): SubsidyProgram {
-  assertWorkItemExists(db, workItemId);
-
-  // Validate subsidy program exists
-  const program = db
-    .select()
-    .from(subsidyPrograms)
-    .where(eq(subsidyPrograms.id, subsidyProgramId))
-    .get();
-
-  if (!program) {
-    throw new NotFoundError('Subsidy program not found');
-  }
-
-  // Check for existing link
-  const existing = db
-    .select()
-    .from(workItemSubsidies)
-    .where(
-      and(
-        eq(workItemSubsidies.workItemId, workItemId),
-        eq(workItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .get();
-
-  if (existing) {
-    throw new ConflictError('Subsidy program is already linked to this work item');
-  }
-
-  // Create the link
-  db.insert(workItemSubsidies).values({ workItemId, subsidyProgramId }).run();
-
-  return toSubsidyProgram(db, program);
+  return service.link(db, workItemId, subsidyProgramId);
 }
 
 /**
@@ -153,29 +46,5 @@ export function unlinkSubsidyFromWorkItem(
   workItemId: string,
   subsidyProgramId: string,
 ): void {
-  assertWorkItemExists(db, workItemId);
-
-  const existing = db
-    .select()
-    .from(workItemSubsidies)
-    .where(
-      and(
-        eq(workItemSubsidies.workItemId, workItemId),
-        eq(workItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .get();
-
-  if (!existing) {
-    throw new NotFoundError('Subsidy program is not linked to this work item');
-  }
-
-  db.delete(workItemSubsidies)
-    .where(
-      and(
-        eq(workItemSubsidies.workItemId, workItemId),
-        eq(workItemSubsidies.subsidyProgramId, subsidyProgramId),
-      ),
-    )
-    .run();
+  return service.unlink(db, workItemId, subsidyProgramId);
 }


### PR DESCRIPTION
## Summary
- Extract duplicated subsidy CRUD logic into generic `subsidyServiceFactory` (list/link/unlink operations)
- Extract duplicated payback calculation logic into generic `subsidyPaybackServiceFactory` (configurable raw SQL calculator)
- Refactor 4 service files (`workItemSubsidyService`, `householdItemSubsidyService`, `subsidyPaybackService`, `householdItemSubsidyPaybackService`) into thin wrappers — 705 → 539 total lines, identical API behavior

Fixes #497

## Test plan
- [x] Unit tests pass (97 tests across 4 test files, 95%+ coverage on factory modules and wrappers)
- [x] Integration tests pass (factory modules tested with Fastify inject pattern)
- [x] Pre-commit hook quality gates pass (typecheck clean)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>