### PR TITLE
fix(e2e): update E2E tests for EPIC-14 manage page refactoring

### DIFF
--- a/e2e/pages/TagManagementPage.ts
+++ b/e2e/pages/TagManagementPage.ts
@@ -18,7 +18,7 @@
  * is not usable. The modal is located by [role="dialog"][aria-modal="true"] instead.
  *
  * Note: Edit/Delete buttons in tag rows have no aria-labels — they are plain "Edit" /
- * "Delete" text buttons scoped inside the relevant .tagRow element.
+ * "Delete" text buttons scoped inside the relevant .itemRow element.
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -82,7 +82,7 @@ export class TagManagementPage {
     this.createTagButton = page.getByRole('button', { name: /Create Tag|Creating\.\.\./ });
 
     // Preview row — always rendered below the form fields
-    this.previewRow = page.locator('[class*="previewRow"]');
+    this.previewRow = page.getByText('Preview:').locator('..');
 
     // Create error banner — the alert inside the create card (before the form)
     // Using a broad alert filter here; if the create form card is needed we rely on
@@ -97,7 +97,7 @@ export class TagManagementPage {
     // Use .first() to avoid strict mode: child elements (emptyStateTitle,
     // emptyStateDescription) also contain "emptyState" in their class names.
     this.emptyState = page.locator('[class*="emptyState"]').first();
-    this.tagsList = page.locator('[class*="tagsList"]');
+    this.tagsList = page.locator('[class*="itemsList"]');
 
     // Delete modal — the modal has role="dialog" aria-modal="true" but no aria-labelledby.
     // Locate by attribute selector.
@@ -140,15 +140,15 @@ export class TagManagementPage {
    */
   async getTagNames(): Promise<string[]> {
     // Each tag row in display mode contains a TagPill element whose text is the tag name.
-    // The TagPill renders as a <span> with the name text inside a .tagRow.
-    // We read the text from each .tagRow and strip button labels ("Edit", "Delete").
-    const rows = await this.tagsList.locator('[class*="tagRow"]').all();
+    // The TagPill renders as a <span> with the name text inside a .itemRow.
+    // We read the text from each .itemRow and strip button labels ("Edit", "Delete").
+    const rows = await this.tagsList.locator('[class*="itemRow"]').all();
     const names: string[] = [];
     for (const row of rows) {
       // In display mode the tag name is inside a <span> within the TagPill component.
       // TagPill renders as: <span class="...pill..."><span class="...dot..."></span>name</span>
       // Use the tagInfo div to get only the display-mode name, not edit inputs.
-      const tagInfo = row.locator('[class*="tagInfo"]');
+      const tagInfo = row.locator('[class*="itemInfo"]');
       const infoCount = await tagInfo.count();
       if (infoCount > 0) {
         const text = await tagInfo.textContent();
@@ -164,13 +164,13 @@ export class TagManagementPage {
    */
   async getTagRow(tagName: string): Promise<Locator | null> {
     try {
-      await this.tagsList.locator('[class*="tagRow"]').first().waitFor({ state: 'visible' });
+      await this.tagsList.locator('[class*="itemRow"]').first().waitFor({ state: 'visible' });
     } catch {
       return null;
     }
-    const rows = await this.tagsList.locator('[class*="tagRow"]').all();
+    const rows = await this.tagsList.locator('[class*="itemRow"]').all();
     for (const row of rows) {
-      const tagInfo = row.locator('[class*="tagInfo"]');
+      const tagInfo = row.locator('[class*="itemInfo"]');
       const infoCount = await tagInfo.count();
       if (infoCount === 0) continue; // skip edit-mode rows
       const text = await tagInfo.textContent();
@@ -231,7 +231,7 @@ export class TagManagementPage {
    */
   getEditModeRow(): Locator {
     return this.tagsList
-      .locator('[class*="tagRow"]')
+      .locator('[class*="itemRow"]')
       .filter({ has: this.page.locator('input[type="text"]') })
       .first();
   }
@@ -266,7 +266,7 @@ export class TagManagementPage {
     const saveButton = row.getByRole('button', { name: /^Save$|^Saving\.\.\.$/ });
     await saveButton.click();
     // Wait for the edit form to close (edit inputs disappear)
-    await this.page.locator('[class*="tagRow"] input[type="text"]').waitFor({ state: 'hidden' });
+    await this.page.locator('[class*="itemRow"] input[type="text"]').waitFor({ state: 'hidden' });
   }
 
   /**
@@ -277,7 +277,7 @@ export class TagManagementPage {
     const cancelButton = row.getByRole('button', { name: 'Cancel', exact: true });
     await cancelButton.click();
     // Wait for the edit form to close
-    await this.page.locator('[class*="tagRow"] input[type="text"]').waitFor({ state: 'hidden' });
+    await this.page.locator('[class*="itemRow"] input[type="text"]').waitFor({ state: 'hidden' });
   }
 
   /**
@@ -322,7 +322,7 @@ export class TagManagementPage {
    */
   async waitForTagsLoaded(): Promise<void> {
     await Promise.race([
-      this.tagsList.locator('[class*="tagRow"]').first().waitFor({ state: 'visible' }),
+      this.tagsList.locator('[class*="itemRow"]').first().waitFor({ state: 'visible' }),
       this.emptyState.waitFor({ state: 'visible' }),
     ]);
   }

--- a/e2e/pages/WorkItemDetailPage.ts
+++ b/e2e/pages/WorkItemDetailPage.ts
@@ -167,7 +167,7 @@ export class WorkItemDetailPage {
 
     // Error states
     this.errorBanner = page.locator('[role="alert"][class*="errorBanner"]');
-    this.errorState = page.locator('[class*="error"]').filter({ has: page.getByRole('button') });
+    this.errorState = page.locator('[class*="errorCard"]');
   }
 
   /**

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -86,11 +86,11 @@ test.describe('Default categories (Scenario 1 & 2)', { tag: '@responsive' }, () 
     expect(materialsRow).not.toBeNull();
     if (materialsRow) {
       // Color swatch element should be present
-      const swatch = materialsRow.locator('[class*="categorySwatch"]');
+      const swatch = materialsRow.locator('[class*="colorSwatch"]');
       await expect(swatch).toBeVisible();
 
       // Sort order indicator should be present
-      const sortOrder = materialsRow.locator('[class*="categorySortOrder"]');
+      const sortOrder = materialsRow.locator('[class*="itemSortOrder"]');
       await expect(sortOrder).toBeVisible();
     }
   });
@@ -213,7 +213,7 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
     const rows = await categoriesPage.getCategoryRows();
     let createdId: string | null = null;
     for (const row of rows) {
-      const nameEl = row.locator('[class*="categoryName"]');
+      const nameEl = row.locator('[class*="itemName"]');
       const rowText = await nameEl.textContent();
       if (rowText?.trim() === categoryName) {
         // Get the delete button aria-label to find the category
@@ -801,13 +801,13 @@ test.describe('Empty state (Scenario 18)', { tag: '@responsive' }, () => {
 // Page structure and navigation
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Page structure and accessibility', { tag: '@responsive' }, () => {
-  test('Page has correct h1 heading "Budget"', async ({ page }) => {
+  test('Page has correct h1 heading "Manage"', async ({ page }) => {
     const categoriesPage = new BudgetCategoriesPage(page);
 
     await categoriesPage.goto();
 
     await expect(categoriesPage.heading).toBeVisible();
-    await expect(categoriesPage.heading).toHaveText('Budget');
+    await expect(categoriesPage.heading).toHaveText('Manage');
 
     // Verify the correct sub-page loaded via the h2 section heading
     const sectionHeading = page.getByRole('heading', { level: 2, name: /^Categories \(/ });
@@ -897,7 +897,7 @@ test.describe('Responsive layout (Scenario 9)', { tag: '@responsive' }, () => {
 
     // The first row (Materials) has Edit and Delete buttons
     const firstRow = rows[0];
-    const firstNameEl = firstRow.locator('[class*="categoryName"]');
+    const firstNameEl = firstRow.locator('[class*="itemName"]');
     const firstName = (await firstNameEl.textContent())?.trim() ?? '';
 
     if (firstName) {
@@ -1075,7 +1075,7 @@ test.describe('Color field (Scenario 17)', { tag: '@responsive' }, () => {
       expect(row).not.toBeNull();
 
       if (row) {
-        const swatch = row.locator('[class*="categorySwatch"]');
+        const swatch = row.locator('[class*="colorSwatch"]');
         await expect(swatch).toBeVisible();
         // The swatch should have a non-transparent background color
         const bgColor = await swatch.evaluate((el) => (el as HTMLElement).style.backgroundColor);

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -127,8 +127,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     // Then: The sub-navigation is visible
     await expect(overviewPage.subNav).toBeVisible();
 
-    // And: All five budget tabs are present
-    const expectedTabs = ['Overview', 'Categories', 'Vendors', 'Sources', 'Subsidies'];
+    // And: All four budget tabs are present (Categories moved to Manage page)
+    const expectedTabs = ['Overview', 'Vendors', 'Sources', 'Subsidies'];
     for (const tab of expectedTabs) {
       await expect(
         overviewPage.subNav.getByRole('listitem').filter({ hasText: tab }),

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -63,8 +63,8 @@ async function seedWorkItems(request: Parameters<typeof test>[2], baseUrl: strin
       // Tag already created by another parallel worker — look it up by name
       const listRes = await request.get(`${baseUrl}/api/tags`);
       if (listRes.ok()) {
-        const listBody = (await listRes.json()) as Array<{ id: number; name: string }>;
-        const existing = listBody.find((t) => t.name === tag.name);
+        const listBody = (await listRes.json()) as { tags: Array<{ id: number; name: string }> };
+        const existing = listBody.tags.find((t) => t.name === tag.name);
         if (existing) {
           tagIds.push(existing.id);
         }
@@ -529,7 +529,7 @@ test.describe('Documentation screenshots', () => {
   test('Budget overview', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.budget}`);
     await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { level: 1, name: /budget overview/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /budget/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {
@@ -542,7 +542,7 @@ test.describe('Documentation screenshots', () => {
   test('Budget categories', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.budgetCategories}`);
     await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { level: 1, name: /budget categories/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /manage/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {
@@ -555,7 +555,7 @@ test.describe('Documentation screenshots', () => {
   test('Budget financing sources', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.budgetSources}`);
     await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { level: 1, name: /financing sources/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /budget/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {
@@ -568,7 +568,7 @@ test.describe('Documentation screenshots', () => {
   test('Budget subsidies', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.budgetSubsidies}`);
     await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { level: 1, name: /subsidies/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /budget/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {


### PR DESCRIPTION
## Summary
- Fix E2E test failures caused by EPIC-14's ManagePage refactoring (CSS class renames, heading changes, tab restructuring)
- Update TagManagementPage POM to use correct `itemRow`/`itemInfo`/`itemsList` classes
- Fix WorkItemDetailPage POM `errorState` locator to avoid strict mode violation
- Update budget-overview tab count from 5 to 4 (Categories moved to Manage)
- Fix screenshot test heading assertions and tag API response shape

Fixes #495

## Test plan
- [ ] All 16 E2E shards pass in CI

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>