### PR TITLE
fix(e2e): use itemSwatch for category display rows

### DIFF
--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -86,7 +86,7 @@ test.describe('Default categories (Scenario 1 & 2)', { tag: '@responsive' }, () 
     expect(materialsRow).not.toBeNull();
     if (materialsRow) {
       // Color swatch element should be present
-      const swatch = materialsRow.locator('[class*="colorSwatch"]');
+      const swatch = materialsRow.locator('[class*="itemSwatch"]');
       await expect(swatch).toBeVisible();
 
       // Sort order indicator should be present
@@ -1075,7 +1075,7 @@ test.describe('Color field (Scenario 17)', { tag: '@responsive' }, () => {
       expect(row).not.toBeNull();
 
       if (row) {
-        const swatch = row.locator('[class*="colorSwatch"]');
+        const swatch = row.locator('[class*="itemSwatch"]');
         await expect(swatch).toBeVisible();
         // The swatch should have a non-transparent background color
         const bgColor = await swatch.evaluate((el) => (el as HTMLElement).style.backgroundColor);


### PR DESCRIPTION
## Summary
- Fix remaining E2E test failures: colorSwatch → itemSwatch for category display rows in budget-categories tests
- The ManagePage uses `colorSwatch` for create/edit form swatches and `itemSwatch` for display row swatches

Fixes #495

## Test plan
- [ ] E2E shards 7, 12, 13 pass (budget-categories tests 77 and 1057)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>