### PR TITLE
fix: quick fixes for HI categories, sidebar budget nav, and budget metrics

### DIFF
--- a/.claude/agent-memory/docs-writer/MEMORY.md
+++ b/.claude/agent-memory/docs-writer/MEMORY.md
@@ -8,8 +8,9 @@
 - Site config: `docs/docusaurus.config.js`
 - Site URL: `https://cornerstone.steiler.dev/` with baseUrl `/`
 - `routeBasePath: '/'` -- docs served at root
-- `onBrokenLinks: 'throw'` -- build fails on broken links
-- `onBrokenMarkdownImages` defaults to `warn` (not configured)
+- `onBrokenLinks: 'throw'`, `onBrokenMarkdownLinks: 'throw'`, `onBrokenAnchors: 'throw'`
+- `markdown.hooks.onBrokenMarkdownImages: 'warn'` -- screenshots don't exist until stable release
+- Note: `onBrokenMarkdownImages` is NOT a top-level config key in Docusaurus 3.9.2; it must go under `markdown.hooks`
 - React 18.3.1 pinned in docs workspace (Docusaurus 3.9.2 incompatible with React 19.x)
 - `blog: false`
 
@@ -18,10 +19,10 @@
 - `npm run docs:build` may fail in worktrees due to node_modules corruption (jiti/babel.js, regenerate.js)
 - Workaround: try building from the base project directory instead of the worktree
 - Clean `npm install` in worktree may not fix it -- sandbox filesystem corruption persists
-- Pre-existing broken screenshot image refs in `work-items/index.md` and `work-items/tags.md`
-- These will resolve when screenshots are captured during stable release
+- Broken screenshot image refs exist across many guide pages (16+ refs) -- all resolve when screenshots are captured during stable release
+- Fixed via `markdown.hooks.onBrokenMarkdownImages: 'warn'` in docusaurus.config.js
 
-## Existing Pages (as of EPIC-06 completion)
+## Existing Pages (as of EPIC-14)
 
 - `intro.md` -- Landing page (slug: /)
 - `roadmap.md` -- Feature roadmap checklist
@@ -29,7 +30,9 @@
 - `guides/work-items/` -- index, creating-work-items, tags, notes-and-subtasks, dependencies, keyboard-shortcuts
 - `guides/users/` -- index, oidc-setup, admin-panel
 - `guides/budget/` -- index, categories, financing-sources, work-item-budgets, vendors-and-invoices, subsidies, budget-overview
-- `guides/timeline/` -- index, gantt-chart, milestones, calendar-view (added EPIC-06)
+- `guides/timeline/` -- index, gantt-chart, milestones, calendar-view
+- `guides/documents/` -- index, setup, browsing-documents, linking-documents
+- `guides/household-items/` -- index, creating-editing-items, budget-and-invoices, work-item-linking, delivery-and-dependencies
 - `guides/appearance/` -- dark-mode
 - `development/` -- index, tech-stack, agentic/overview, agentic/agent-team, agentic/workflow, agentic/setup
 
@@ -44,7 +47,9 @@
 - Double dashes `--` used instead of em dashes in all existing content
 - Footer links in `docusaurus.config.js` should be updated when major features are added
 
-## Roadmap State (post EPIC-06)
+## Roadmap State (post EPIC-14)
 
-Completed: EPIC-02, EPIC-11, EPIC-01, EPIC-03, EPIC-12, EPIC-05, EPIC-06
-Planned: EPIC-04, EPIC-07, EPIC-08, EPIC-09, EPIC-10
+Completed: EPIC-02, EPIC-11(#12), EPIC-01, EPIC-03, EPIC-12(#115), EPIC-05, EPIC-06, EPIC-08, EPIC-04, EPIC-07, EPIC-10, EPIC-11(#444 tags), EPIC-12(#445 refinement), EPIC-14(#495)
+Planned: EPIC-09(#9 dashboard), EPIC-13(#446 construction diary)
+
+Note: EPIC-11 and EPIC-12 each have two issues -- original (#12/#115) and new (#444/#445). Both pairs are completed.

--- a/.claude/agent-memory/qa-integration-tester/epic14-e2e-validation.md
+++ b/.claude/agent-memory/qa-integration-tester/epic14-e2e-validation.md
@@ -1,0 +1,94 @@
+# EPIC-14 E2E Validation Notes (2026-03-07)
+
+## EPIC-14 Summary
+Refactoring epic (no new features). 5 PRs merged to beta:
+- PR #534: `subsidyServiceFactory` + `subsidyPaybackServiceFactory` (server)
+- PR #535: `budgetServiceFactory` (server)
+- PR #536: Shared base types in `shared/src/types/budget.ts`
+- PR #537: `budgetApiFactory.ts`, `budgetConstants.ts`, `useBudgetSection.ts` (client)
+- PR #538: UI harmonization (CSS tokens, dark mode, error/loading state patterns)
+
+All PRs had Quality Gates + E2E Smoke Tests pass before merge.
+
+## Coverage Gap Found & Fixed
+
+The shared budget components (`BudgetLineForm`, `BudgetLineCard`, `SubsidyLinkSection`)
+had NO E2E-level CRUD tests — only the presence of the "Add Line" button was checked.
+
+New test file: `e2e/tests/budget/budget-lines.spec.ts` (PR #539, branch `chore/495-e2e-validation`)
+
+## API Response Shapes (Critical)
+
+- `POST /api/work-items/:id/budgets` → `{ budget: { id, plannedAmount, ... } }`
+  NOT `{ workItemBudget: ... }` — the route returns `reply.send({ budget })` for both WI and HI.
+- `POST /api/household-items/:id/budgets` → `{ budget: { id, plannedAmount, ... } }`
+- `POST /api/subsidy-programs` → `{ subsidyProgram: { id, ... } }`
+- `POST /api/budget-sources` → `{ budgetSource: { id, ... } }`
+
+## BudgetLineCard Component Selectors
+
+- Edit button: `getByRole('button', { name: /^Edit$/i })`
+- Delete button: `getByRole('button', { name: /^Delete$/i })`
+- Inline confirm (after delete click): `getByRole('button', { name: 'Confirm', exact: true })`
+- Inline cancel (after delete click): `getByRole('button', { name: 'Cancel', exact: true })`
+
+## BudgetLineForm Component Selectors
+
+- Form appears after clicking "Add budget line" button
+- Submit button text: `'Add Line'` (not editing) or `'Save Changes'` (editing)
+- Cancel: `getByRole('button', { name: 'Cancel', exact: true })`
+- Planned amount input: `page.locator('#budget-planned-amount')`
+- Description input: `page.locator('#budget-description')`
+- Confidence select: `page.locator('#budget-confidence')`
+- Category select: `page.locator('#budget-category')` (WI only; HI uses static label)
+- Vendor select: `page.locator('#budget-vendor')`
+- Source select: `page.locator('#budget-source')`
+- Submit disabled when `plannedAmount` is empty
+
+## SubsidyLinkSection Component Selectors
+
+- Picker select: `getByLabel('Select subsidy program to link')`
+- Link button: `getByRole('button', { name: /Add Subsidy/i })`
+- Link button disabled until a subsidy is selected in the picker
+- Linked item name: `locator('[class*="linkedItemName"]').filter({ hasText: subsidyName })`
+- Unlink button: `getByRole('button', { name: 'Unlink subsidy <name>' })`
+- Empty state: `getByText('No subsidies linked')`
+
+## Confidence Labels & Margins (budgetConstants.ts)
+
+- `own_estimate` → "Own Estimate" with "+20%" margin
+- `professional_estimate` → "Professional Estimate" with "+10%" margin
+- `quote` → "Quote" with "+5%" margin
+- `invoice` → "Invoice" with "+0%" margin (no margin shown in card)
+
+## Work Item Budget Section Locator Pattern
+
+```typescript
+const budgetSection = page
+  .locator('section')
+  .filter({ has: page.getByRole('heading', { level: 2, name: 'Budget', exact: true }) });
+```
+
+## Household Item Budget Section Locator Pattern
+
+The HI detail page uses a `getByRole('heading', { name: /budget/i, level: 2 })` pattern
+(no section wrapper like WI). Use the button directly on the page:
+```typescript
+const addButton = page.getByRole('button', { name: /add budget line|add line/i }).first();
+```
+
+## HI Budget Category
+
+`householdItemBudgetService` forces `budgetCategoryId = 'bc-household-items'` regardless
+of what is sent in the request. The form renders a static category label instead of a dropdown.
+
+## TypeScript Check for E2E Tests
+
+Pre-existing type errors exist in:
+- `e2e/containers/cornerstoneContainer.ts` (testcontainers API mismatch)
+- `e2e/containers/setup.ts` (same)
+- `e2e/tests/screenshots/capture-docs-screenshots.spec.ts` (Playwright API mismatch)
+
+These are NOT new — they exist in the base repo and do not affect test execution.
+The `tsc --noEmit --project e2e/tsconfig.json` command using the main repo's tsc works:
+`/Users/franksteiler/Documents/Sandboxes/cornerstone/node_modules/.bin/tsc`

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -47,7 +47,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </NavLink>
         <NavLink
           to="/budget"
-          end
           className={({ isActive }) => `${styles.navLink} ${isActive ? styles.active : ''}`}
           onClick={onClose}
         >

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
@@ -586,6 +586,29 @@ export function BudgetOverviewPage() {
               </span>
             </div>
 
+            {/* Expected Payback (only when hasPayback) */}
+            {hasPayback && (
+              <div className={styles.metricGroup}>
+                <span className={styles.metricLabel}>Expected Payback</span>
+                <span
+                  className={`${styles.metricValue} ${styles.metricPaybackValue}`}
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  <span className={styles.metricRange}>
+                    {formatShort(overview.subsidySummary.minTotalPayback)}
+                    {overview.subsidySummary.minTotalPayback !==
+                    overview.subsidySummary.maxTotalPayback ? (
+                      <>
+                        <span className={styles.metricRangeSep}>&ndash;</span>
+                        {formatShort(overview.subsidySummary.maxTotalPayback)}
+                      </>
+                    ) : null}
+                  </span>
+                </span>
+              </div>
+            )}
+
             {/* Remaining (best/worst) — with detail on hover/tap */}
             <div className={styles.metricGroup}>
               <span className={styles.metricLabel}>Remaining</span>
@@ -621,29 +644,6 @@ export function BudgetOverviewPage() {
                 <RemainingDetailPanel items={remainingDetailItems} />
               </div>
             </div>
-
-            {/* Expected Payback (only when hasPayback) */}
-            {hasPayback && (
-              <div className={styles.metricGroup}>
-                <span className={styles.metricLabel}>Expected Payback</span>
-                <span
-                  className={`${styles.metricValue} ${styles.metricPaybackValue}`}
-                  aria-live="polite"
-                  aria-atomic="true"
-                >
-                  <span className={styles.metricRange}>
-                    {formatShort(overview.subsidySummary.minTotalPayback)}
-                    {overview.subsidySummary.minTotalPayback !==
-                    overview.subsidySummary.maxTotalPayback ? (
-                      <>
-                        <span className={styles.metricRangeSep}>&ndash;</span>
-                        {formatShort(overview.subsidySummary.maxTotalPayback)}
-                      </>
-                    ) : null}
-                  </span>
-                </span>
-              </div>
-            )}
           </div>
 
           {/* Stacked bar */}

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -95,6 +95,15 @@ export function HouseholdItemsPage() {
   const deleteTriggerRef = useRef<HTMLButtonElement | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
+  // Category name lookup map
+  const categoryNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const cat of categories) {
+      map.set(cat.id, cat.name);
+    }
+    return map;
+  }, [categories]);
+
   // Load vendors and categories on mount
   useEffect(() => {
     const loadData = async () => {
@@ -708,7 +717,7 @@ export function HouseholdItemsPage() {
                     onClick={() => handleRowClick(item.id)}
                   >
                     <td className={styles.titleCell}>{item.name}</td>
-                    <td>{item.category.charAt(0).toUpperCase() + item.category.slice(1)}</td>
+                    <td>{categoryNameMap.get(item.category) ?? item.category}</td>
                     <td>
                       <HouseholdItemStatusBadge status={item.status} />
                     </td>
@@ -842,7 +851,7 @@ export function HouseholdItemsPage() {
                 <div className={styles.cardBody}>
                   <div className={styles.cardRow}>
                     <span className={styles.cardLabel}>Category:</span>
-                    <span>{item.category.charAt(0).toUpperCase() + item.category.slice(1)}</span>
+                    <span>{categoryNameMap.get(item.category) ?? item.category}</span>
                   </div>
                   <div className={styles.cardRow}>
                     <span className={styles.cardLabel}>Status:</span>


### PR DESCRIPTION
## Summary

Three quick fixes addressing household item category display, sidebar navigation, and budget health metric ordering.

- **Fix #545**: Household item categories displayed with 'Hic-' prefix instead of proper category names. Now uses a category name lookup map.
- **Fix #555 part 1**: Budget sidebar NavLink had `end` prop causing sub-pages to lose highlight. Removed the prop to allow prefix matching.
- **Fix #555 part 2**: Reordered budget health metrics to show: Available Funds → Projected Cost Range → Expected Payback → Remaining (Expected Payback moved before Remaining).

## Changes

1. **HouseholdItemsPage.tsx**: Added `categoryNameMap` useMemo to map category IDs to names, replacing naive capitalization with actual lookup in both table and card views.
2. **Sidebar.tsx**: Removed `end` prop from Budget NavLink (line 50).
3. **BudgetOverviewPage.tsx**: Moved Expected Payback block before Remaining block in metrics row to match required order.

## Test plan

- View household items page; verify category names display properly (e.g., "Furniture" not "Hic-furniture")
- Navigate to /budget/vendors and /budget/sources; verify Budget nav link is highlighted
- View Budget overview page; verify metric order is: Available Funds → Projected Cost Range → Expected Payback → Remaining

🤖 Generated by frontend-developer