### PR TITLE
fix(ui): auto-scroll to top when errors appear

### DIFF
--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
@@ -301,6 +301,13 @@ export function BudgetOverviewPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>('');
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   // Breakdown state
   const [breakdown, setBreakdown] = useState<BudgetBreakdown | null>(null);
   const [isBreakdownLoading, setIsBreakdownLoading] = useState(false);

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -123,6 +123,13 @@ export function HouseholdItemDetailPage() {
   const [dateInlineError, setDateInlineError] = useState<string | null>(null);
   const [isChangingStatus, setIsChangingStatus] = useState(false);
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   // Inline date editing state
   const [localOrderDate, setLocalOrderDate] = useState<string>('');
   const [localActualDeliveryDate, setLocalActualDeliveryDate] = useState<string>('');

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -46,6 +46,13 @@ export function HouseholdItemsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>('');
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);

--- a/client/src/pages/ManagePage/ManagePage.tsx
+++ b/client/src/pages/ManagePage/ManagePage.tsx
@@ -61,6 +61,13 @@ function TagsTab() {
   const [deletingTagId, setDeletingTagId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   useEffect(() => {
     loadTags();
   }, []);

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -191,6 +191,13 @@ export default function WorkItemDetailPage() {
 
   const [inlineError, setInlineError] = useState<string | null>(null);
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   // Shared reload functions for budget-related data
   const reloadBudgetLines = async () => {
     if (!id) return;

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -39,6 +39,13 @@ export function WorkItemsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>('');
 
+  // Auto-scroll to top when error appears
+  useEffect(() => {
+    if (error) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [error]);
+
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);


### PR DESCRIPTION
## Summary
- Adds `useEffect` hooks that auto-scroll to the top of the page when an error state is set
- Ensures error messages are always visible regardless of scroll position
- Applied consistently across 6 pages: BudgetOverviewPage, WorkItemDetailPage, HouseholdItemDetailPage, HouseholdItemsPage, WorkItemsPage, ManagePage

Fixes #548

## Test plan
- [ ] Navigate to a page, scroll down, trigger an error — page should auto-scroll to top
- [ ] Smooth scroll animation should be used
- [ ] Only scrolls when error first appears, not on every render

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Claude Haiku 4.5 (frontend-developer) <noreply@anthropic.com>