### PR TITLE
fix(timeline): add HI dependency arrows and critical path milestone connectors

### DIFF
--- a/client/src/components/GanttChart/GanttChart.tsx
+++ b/client/src/components/GanttChart/GanttChart.tsx
@@ -622,16 +622,16 @@ export function GanttChart({
   // ---------------------------------------------------------------------------
 
   /**
-   * For each item (work item or milestone), pre-computes the set of connected
-   * entity IDs (work item string IDs + "milestone:<id>" encoded strings) and
-   * the set of arrow keys for connected dependency arrows.
+   * For each item (work item, milestone, or household item), pre-computes the set of connected
+   * entity IDs and the set of arrow keys for connected dependency arrows.
    *
-   * This allows O(1) lookup when a bar/milestone is hovered without iterating
+   * This allows O(1) lookup when a bar/milestone/HI is hovered without iterating
    * over all dependencies on every render.
    *
    * Entity IDs encoding:
-   *   - Work items:  plain string ID
-   *   - Milestones:  "milestone:<id>"
+   *   - Work items:     plain string ID
+   *   - Milestones:     "milestone:<id>"
+   *   - Household items: "hi:<id>"
    */
   const itemDependencyLookup = useMemo<
     ReadonlyMap<
@@ -730,6 +730,37 @@ export function GanttChart({
       }
     }
 
+    // Household item dependency arrows: work item/milestone → HI delivery date
+    for (const hi of data.householdItems ?? []) {
+      if (!hi.dependencyIds?.length) continue;
+      const hiKey = `hi:${hi.id}`;
+
+      for (const dep of hi.dependencyIds) {
+        let predId = '';
+        let arrowKey = '';
+
+        if (dep.predecessorType === 'work_item') {
+          predId = dep.predecessorId;
+          arrowKey = `hi-dep-wi-${predId}-${hi.id}`;
+        } else if (dep.predecessorType === 'milestone') {
+          predId = `milestone:${dep.predecessorId}`;
+          arrowKey = `hi-dep-ms-${dep.predecessorId}-${hi.id}`;
+        }
+
+        if (!predId) continue;
+
+        // For the predecessor (WI or milestone): HI is connected; arrow is connected
+        const predEntry = getOrCreate(predId);
+        predEntry.connectedEntityIds.add(hiKey);
+        predEntry.arrowKeys.add(arrowKey);
+
+        // For the HI: predecessor is connected; arrow is connected
+        const hiEntry = getOrCreate(hiKey);
+        hiEntry.connectedEntityIds.add(predId);
+        hiEntry.arrowKeys.add(arrowKey);
+      }
+    }
+
     return lookup as ReadonlyMap<
       string,
       {
@@ -738,7 +769,7 @@ export function GanttChart({
         tooltipDeps: ReadonlyArray<GanttTooltipDependencyEntry>;
       }
     >;
-  }, [data.dependencies, data.milestones, data.workItems, workItemMap]);
+  }, [data.dependencies, data.milestones, data.workItems, data.householdItems, workItemMap]);
 
   // ---------------------------------------------------------------------------
   // Arrow hover interaction state — per-bar and per-milestone visual states
@@ -1254,6 +1285,9 @@ export function GanttChart({
                 }}
                 criticalMilestoneIds={criticalMilestoneIds}
                 criticalBorderColor={colors.criticalBorder}
+                criticalConnectorColor={
+                  highlightCriticalPath ? colors.arrowCritical : undefined
+                }
                 onMilestoneClick={onMilestoneClick}
               />
             )}

--- a/client/src/components/GanttChart/GanttMilestones.tsx
+++ b/client/src/components/GanttChart/GanttMilestones.tsx
@@ -72,6 +72,8 @@ export interface GanttMilestonesProps {
   criticalMilestoneIds?: ReadonlySet<number>;
   /** Border color for critical path milestones. */
   criticalBorderColor?: string;
+  /** Stroke color for critical path connectors (late milestone dashed lines). */
+  criticalConnectorColor?: string;
   /** Called when a diamond is hovered (for tooltip). Passes milestone and mouse coords. */
   onMilestoneMouseEnter?: (
     milestone: TimelineMilestone,
@@ -262,6 +264,7 @@ export const GanttMilestones = memo(function GanttMilestones({
   milestoneInteractionStates,
   criticalMilestoneIds,
   criticalBorderColor,
+  criticalConnectorColor,
   onMilestoneMouseEnter,
   onMilestoneMouseLeave,
   onMilestoneMouseMove,
@@ -320,8 +323,12 @@ export const GanttMilestones = memo(function GanttMilestones({
                 y1={y}
                 x2={projectedX}
                 y2={y}
-                stroke={colors.lateStroke}
-                strokeWidth={1.5}
+                stroke={
+                  isCriticalMilestone && criticalConnectorColor
+                    ? criticalConnectorColor
+                    : colors.lateStroke
+                }
+                strokeWidth={isCriticalMilestone ? 2 : 1.5}
                 strokeDasharray="4 3"
                 strokeOpacity={interactionState === 'dimmed' ? 0.2 : 0.6}
                 aria-hidden="true"


### PR DESCRIPTION
## Summary
- Adds household item dependencies to the `itemDependencyLookup` in GanttChart, enabling HI dependency arrow highlighting on hover
- Updates milestone connector rendering to use critical path styling when milestone is on the critical path

Fixes #550, Fixes #551

## Test plan
- [ ] HI dependency arrows render on the Gantt chart
- [ ] Hovering over an HI highlights its dependency arrows
- [ ] Critical path milestones show highlighted connectors

Co-Authored-By: Claude Haiku 4.5 (frontend-developer) <noreply@anthropic.com>