### PR TITLE
fix(e2e): uncheck hide-linked toggle in duplicate document linking test

### DIFF
--- a/e2e/tests/documents/document-linking.spec.ts
+++ b/e2e/tests/documents/document-linking.spec.ts
@@ -274,6 +274,12 @@ test.describe('Document Linking — Duplicate (Scenario 5)', { tag: '@responsive
       await addDocButton.click();
       pickerModal = page.getByRole('dialog', { name: 'Add Document' });
       await expect(pickerModal).toBeVisible();
+
+      // Uncheck "Hide linked" toggle so the already-linked document is visible
+      const hideLinkedCheckbox = pickerModal.getByRole('checkbox', { name: /hide linked/i });
+      await expect(hideLinkedCheckbox).toBeVisible({ timeout: 5000 });
+      await hideLinkedCheckbox.uncheck();
+
       await expect(
         pickerModal.getByRole('list', { name: 'Documents' }).getByRole('listitem'),
       ).toHaveCount(1, { timeout: 10000 });


### PR DESCRIPTION
## Summary
- The hide-linked toggle (#562) defaults to ON, filtering already-linked documents from the picker
- The duplicate-link E2E test needs to uncheck this toggle before attempting to re-link
- Fixes failing E2E shards 3/16, 9/16, 14/16 on promotion PR #541

## Test plan
- [ ] E2E document-linking duplicate test passes on all viewports (desktop, tablet, mobile)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>