### PR TITLE
fix(budget): use actual invoice cost for payback calculations

### DIFF
--- a/server/src/services/budgetOverviewService.test.ts
+++ b/server/src/services/budgetOverviewService.test.ts
@@ -1038,6 +1038,108 @@ describe('getBudgetOverview', () => {
     });
   });
 
+  // ─── totalReductions uses actual invoice cost for invoiced lines ─────────
+
+  describe('totalReductions uses actual invoice cost for invoiced percentage subsidy lines', () => {
+    it('uses actual invoice cost (not plannedAmount) when a budget line has an invoice', () => {
+      // Work item with budget line: plannedAmount=10000, invoice=7000
+      // 20% universal subsidy
+      // Expected: totalReductions = 7000 * 0.20 = 1400 (NOT 10000 * 0.20 = 2000)
+      const { workItemId, budgetLineId } = insertWorkItem({
+        plannedAmount: 10000,
+        confidence: 'own_estimate',
+      });
+      // Insert an invoice for this budget line (actualCost=7000)
+      const vendorId = `vendor-inv-${idCounter++}`;
+      const now = new Date().toISOString();
+      db.insert(schema.vendors)
+        .values({ id: vendorId, name: `Vendor ${vendorId}`, createdAt: now, updatedAt: now })
+        .run();
+      db.insert(schema.invoices)
+        .values({
+          id: `inv-test-${idCounter++}`,
+          vendorId,
+          workItemBudgetId: budgetLineId!,
+          amount: 7000,
+          date: '2026-01-15',
+          status: 'paid',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      const progId = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 20,
+        applicationStatus: 'approved',
+        categoryIds: [], // universal subsidy
+      });
+      linkWorkItemSubsidy(workItemId, progId);
+
+      const result = getBudgetOverview(db);
+
+      // Invoice cost = 7000; 7000 * 20% = 1400 (not 10000 * 20% = 2000)
+      expect(result.subsidySummary.totalReductions).toBeCloseTo(1400, 5);
+    });
+
+    it('uses plannedAmount for uninvoiced lines alongside invoiced lines', () => {
+      // Work item with two budget lines:
+      //   Line A: plannedAmount=10000, invoice=7000
+      //   Line B: plannedAmount=5000, no invoice
+      // 10% universal subsidy
+      // Expected: totalReductions = 7000 * 0.10 + 5000 * 0.10 = 700 + 500 = 1200
+      const { workItemId, budgetLineId: lineAId } = insertWorkItem({
+        plannedAmount: 10000,
+        confidence: 'own_estimate',
+      });
+      // Add second budget line (no invoice)
+      const lineBId = `bud-test-${idCounter++}`;
+      const now = new Date().toISOString();
+      db.insert(schema.workItemBudgets)
+        .values({
+          id: lineBId,
+          workItemId,
+          plannedAmount: 5000,
+          confidence: 'own_estimate',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      // Insert invoice for Line A only
+      const vendorId = `vendor-inv-${idCounter++}`;
+      db.insert(schema.vendors)
+        .values({ id: vendorId, name: `Vendor ${vendorId}`, createdAt: now, updatedAt: now })
+        .run();
+      db.insert(schema.invoices)
+        .values({
+          id: `inv-test-${idCounter++}`,
+          vendorId,
+          workItemBudgetId: lineAId!,
+          amount: 7000,
+          date: '2026-01-15',
+          status: 'paid',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      const progId = insertSubsidyProgram({
+        reductionType: 'percentage',
+        reductionValue: 10,
+        applicationStatus: 'approved',
+        categoryIds: [], // universal subsidy
+      });
+      linkWorkItemSubsidy(workItemId, progId);
+
+      const result = getBudgetOverview(db);
+
+      // Line A (invoiced): 7000 * 10% = 700
+      // Line B (not invoiced): 5000 * 10% = 500
+      // Total: 1200
+      expect(result.subsidySummary.totalReductions).toBeCloseTo(1200, 5);
+    });
+  });
+
   // ─── Confidence margins interact with subsidy reductions ──────────────────
 
   describe('confidence margins interacting with subsidy reductions', () => {
@@ -1249,7 +1351,7 @@ describe('getBudgetOverview', () => {
         applicationStatus: 'approved',
         categoryIds: [catA],
       });
-      linkWorkItemSubsidy(wi1Id, prog); // applies to wi1 (catA, invoice) => 50000 * 0.1 = 5000
+      linkWorkItemSubsidy(wi1Id, prog); // applies to wi1 (catA, actualCost=45000) => 45000 * 0.1 = 4500
 
       const result = getBudgetOverview(db);
 
@@ -1282,8 +1384,9 @@ describe('getBudgetOverview', () => {
       expect(result.remainingVsActualCost).toBe(123000); // 200000 - 77000
       expect(result.remainingVsActualPaid).toBe(155000); // 200000 - 45000
 
-      // Subsidy summary
-      expect(result.subsidySummary.totalReductions).toBeCloseTo(5000, 5);
+      // Subsidy summary — totalReductions uses actual invoice cost (45000), not plannedAmount (50000)
+      // 45000 * 10% = 4500
+      expect(result.subsidySummary.totalReductions).toBeCloseTo(4500, 5);
       expect(result.subsidySummary.activeSubsidyCount).toBe(1);
 
       // Category A: wi1 (has invoice 45000 → min/max=45000) + wi3 (no invoice → 19000/21000)

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -424,7 +424,8 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
       }
 
       if (meta.reductionType === 'percentage') {
-        totalReductions += line.plannedAmount * (meta.reductionValue / 100);
+        const basisAmount = lineInvoiceMap.get(line.id) ?? line.plannedAmount;
+        totalReductions += basisAmount * (meta.reductionValue / 100);
       } else if (meta.reductionType === 'fixed') {
         const cacheKey = `${line.entityId}:${subsidyId}`;
         let matchingLineCount = fixedSubsidyLineCountCacheForTotal.get(cacheKey);

--- a/server/src/services/householdItemSubsidyPaybackService.test.ts
+++ b/server/src/services/householdItemSubsidyPaybackService.test.ts
@@ -191,7 +191,109 @@ describe('householdItemSubsidyPaybackService', () => {
     });
   });
 
-  // ─── Confidence margin ranges (no invoice support) ─────────────────────────
+  // ─── Invoice helper ─────────────────────────────────────────────────────────
+
+  function insertVendor() {
+    const id = `vendor-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.vendors)
+      .values({ id, name: `Vendor ${id}`, createdAt: now, updatedAt: now })
+      .run();
+    return id;
+  }
+
+  function insertHIInvoice(householdItemBudgetId: string, amount: number) {
+    const vendorId = insertVendor();
+    const id = `inv-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.invoices)
+      .values({
+        id,
+        householdItemBudgetId,
+        vendorId,
+        invoiceNumber: null,
+        amount,
+        status: 'pending',
+        date: now.slice(0, 10),
+        dueDate: null,
+        notes: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  // ─── Invoiced lines (actual cost known) ────────────────────────────────────
+
+  describe('invoiced lines (actual cost known)', () => {
+    it('uses actual invoiced cost for min and max when invoices exist (min === max)', () => {
+      const hiId = insertHouseholdItem();
+      const budgetLineId = insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        confidence: 'own_estimate',
+      });
+      insertHIInvoice(budgetLineId, 800); // actual cost = 800
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // Actual cost 800, no margin: min = max = 800 * 10% = 80
+      expect(result.minTotalPayback).toBeCloseTo(80);
+      expect(result.maxTotalPayback).toBeCloseTo(80);
+      expect(result.subsidies[0].minPayback).toBeCloseTo(80);
+      expect(result.subsidies[0].maxPayback).toBeCloseTo(80);
+    });
+
+    it('sums multiple invoices for the same budget line as actual cost (min === max)', () => {
+      const hiId = insertHouseholdItem();
+      const budgetLineId = insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 2000,
+        confidence: 'own_estimate',
+      });
+      insertHIInvoice(budgetLineId, 600);
+      insertHIInvoice(budgetLineId, 400); // total: 1000
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // 1000 × 10% = 100, no margin
+      expect(result.minTotalPayback).toBeCloseTo(100);
+      expect(result.maxTotalPayback).toBeCloseTo(100);
+    });
+
+    it('produces min < max when some lines invoiced and some not (mixed scenario)', () => {
+      const hiId = insertHouseholdItem();
+      // Invoiced line: actual cost 500
+      const invoicedLine = insertBudgetLine({
+        householdItemId: hiId,
+        plannedAmount: 1000,
+        confidence: 'own_estimate',
+      });
+      insertHIInvoice(invoicedLine, 500);
+      // Non-invoiced line: own_estimate, planned 1000
+      insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
+
+      const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 10 });
+      linkSubsidyToHouseholdItem(hiId, subsidyId);
+
+      const result = getHouseholdItemSubsidyPayback(db, hiId);
+
+      // Invoiced: min=max=500*10%=50
+      // Non-invoiced (own_estimate ±20%): min=1000*0.8*10%=80, max=1000*1.2*10%=120
+      // Total: min=130, max=170
+      expect(result.minTotalPayback).toBeCloseTo(130);
+      expect(result.maxTotalPayback).toBeCloseTo(170);
+    });
+  });
+
+  // ─── Confidence margin ranges ───────────────────────────────────────────────
 
   describe('confidence margin ranges', () => {
     it('applies own_estimate margin (±20%) to produce min/max range', () => {
@@ -273,9 +375,9 @@ describe('householdItemSubsidyPaybackService', () => {
       expect(result.maxTotalPayback).toBeCloseTo(115);
     });
 
-    it('confidence margins still apply even without invoice support (no actual cost override)', () => {
-      // This test documents the supportsInvoices: false behavior explicitly.
-      // Even if there were invoices in the DB, household items should use confidence margins.
+    it('confidence margins still apply when no invoices are linked (no actual cost override)', () => {
+      // Without any invoices in the DB, confidence margins are used for the payback range.
+      // This verifies the baseline behavior before invoices are added to a budget line.
       const hiId = insertHouseholdItem();
       insertBudgetLine({ householdItemId: hiId, plannedAmount: 1000, confidence: 'own_estimate' });
       const subsidyId = insertSubsidyProgram({ reductionType: 'percentage', reductionValue: 20 });
@@ -284,7 +386,7 @@ describe('householdItemSubsidyPaybackService', () => {
       const result = getHouseholdItemSubsidyPayback(db, hiId);
 
       // own_estimate ±20%: min=1000*0.8*20%=160, max=1000*1.2*20%=240
-      // These are NOT collapsed to an actual cost even if invoices existed (supportsInvoices=false)
+      // No invoices → confidence margin applies, giving a range (min < max)
       expect(result.minTotalPayback).toBeCloseTo(160);
       expect(result.maxTotalPayback).toBeCloseTo(240);
     });

--- a/server/src/services/householdItemSubsidyPaybackService.ts
+++ b/server/src/services/householdItemSubsidyPaybackService.ts
@@ -12,7 +12,8 @@ const getPayback = createSubsidyPaybackService({
   junctionEntityIdColumn: 'household_item_id',
   budgetLinesTable: 'household_item_budgets',
   budgetLinesEntityIdColumn: 'household_item_id',
-  supportsInvoices: false,
+  supportsInvoices: true,
+  invoiceBudgetIdColumn: 'household_item_budget_id',
   entityLabel: 'Household item',
   entityIdResponseKey: 'householdItemId',
 });
@@ -22,11 +23,13 @@ const getPayback = createSubsidyPaybackService({
  *
  * Rules:
  *   - Only non-rejected subsidies linked to this household item are included.
- *   - Household items never have invoices, so all budget lines use confidence margins.
+ *   - If a budget line HAS invoices: actual cost is known → min = max = actualCost
+ *   - If a budget line has NO invoices: apply confidence margin to plannedAmount:
+ *       minAmount = plannedAmount * (1 - margin)
+ *       maxAmount = plannedAmount * (1 + margin)
  *   - For percentage subsidies: iterate over matching budget lines and compute
- *     min/max amounts using confidence margins.
- *         minAmount = plannedAmount * (1 - margin)
- *         maxAmount = plannedAmount * (1 + margin)
+ *     min/max amounts using confidence margins or actual cost as applicable.
+ *     Payback range per line = [minAmount * rate/100, maxAmount * rate/100]
  *     Payback range per line = [minAmount * rate/100, maxAmount * rate/100]
  *     Sum across all matching lines per subsidy, then across subsidies.
  *   - For fixed subsidies: amount is fixed regardless of budget lines →

--- a/server/src/services/shared/subsidyPaybackServiceFactory.ts
+++ b/server/src/services/shared/subsidyPaybackServiceFactory.ts
@@ -15,6 +15,7 @@ export interface SubsidyPaybackConfig {
   budgetLinesTable: string;
   budgetLinesEntityIdColumn: string;
   supportsInvoices: boolean;
+  invoiceBudgetIdColumn: string;
   entityLabel: string;
   entityIdResponseKey: string;
 }
@@ -82,19 +83,20 @@ export function createSubsidyPaybackService(
 
     const invoiceMap = new Map<string, number>();
     if (config.supportsInvoices) {
-      const invoiceRows = db.all<{ workItemBudgetId: string; actualCost: number }>(
+      const invoiceRows = db.all<{ budgetLineId: string; actualCost: number }>(
         sql`SELECT
-          work_item_budget_id AS workItemBudgetId,
+          ${sql.raw(config.invoiceBudgetIdColumn)} AS budgetLineId,
           COALESCE(SUM(amount), 0) AS actualCost
         FROM invoices
-        WHERE work_item_budget_id IN (
-          SELECT id FROM work_item_budgets WHERE work_item_id = ${entityId}
+        WHERE ${sql.raw(config.invoiceBudgetIdColumn)} IN (
+          SELECT id FROM ${sql.raw(config.budgetLinesTable)}
+          WHERE ${sql.raw(config.budgetLinesEntityIdColumn)} = ${entityId}
         )
-        GROUP BY work_item_budget_id`,
+        GROUP BY ${sql.raw(config.invoiceBudgetIdColumn)}`,
       );
 
       for (const row of invoiceRows) {
-        invoiceMap.set(row.workItemBudgetId, row.actualCost);
+        invoiceMap.set(row.budgetLineId, row.actualCost);
       }
     }
 

--- a/server/src/services/subsidyPaybackService.ts
+++ b/server/src/services/subsidyPaybackService.ts
@@ -13,6 +13,7 @@ const getPayback = createSubsidyPaybackService({
   budgetLinesTable: 'work_item_budgets',
   budgetLinesEntityIdColumn: 'work_item_id',
   supportsInvoices: true,
+  invoiceBudgetIdColumn: 'work_item_budget_id',
   entityLabel: 'Work item',
   entityIdResponseKey: 'workItemId',
 });


### PR DESCRIPTION
## Summary

- **Root cause 1 — HI payback used `supportsInvoices: false`**: `householdItemSubsidyPaybackService.ts` was passing `supportsInvoices: false` to the factory, causing all household item budget lines to always compute payback from projected costs (confidence margins) even when invoices existed. Fixed by enabling invoice support for HI payback.
- **Root cause 2 — factory hardcoded `work_item_budget_id`**: `subsidyPaybackServiceFactory.ts` hardcoded `work_item_budget_id` in its invoice aggregation query. With HI invoice support now enabled, the column must be configurable per entity type. Added an `invoiceBudgetIdColumn` config field and wired the correct column (`household_item_budget_id`) for HI payback.
- **Root cause 3 — `totalReductions` in budget overview used `plannedAmount`**: `budgetOverviewService.ts` always used `plannedAmount` as the base for percentage-subsidy reductions in the `totalReductions` aggregate stat, ignoring actual invoice cost when lines were fully invoiced. Fixed to use `actualCost` when available.

Fixes #592

## Test plan

- [x] Unit tests added for all three root causes (HI payback with invoices, factory column parameterization, budget overview `totalReductions` with invoiced lines)
- [x] Regression tests verify existing WI payback behavior is preserved (AC 2)
- [x] Mixed invoiced/non-invoiced HI lines produce correct split (AC 4)
- [x] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>