### PR TITLE
fix(e2e): update locators for schedule sub-nav and sidebar changes

### DIFF
--- a/e2e/pages/TimelinePage.ts
+++ b/e2e/pages/TimelinePage.ts
@@ -120,8 +120,8 @@ export class TimelinePage {
     // Toolbar controls
     this.arrowsToggleButton = page.getByLabel(/dependency arrows/i);
     this.zoomToolbar = page.getByRole('toolbar', { name: 'Zoom level' });
-    this.ganttViewButton = page.getByLabel('Gantt view');
-    this.calendarViewButton = page.getByLabel('Calendar view');
+    this.ganttViewButton = page.getByTestId('schedule-view-gantt');
+    this.calendarViewButton = page.getByTestId('schedule-view-calendar');
     this.milestonePanelButton = page.getByTestId('milestones-panel-button');
 
     // Chart area states

--- a/e2e/tests/navigation/sidebar-navigation.spec.ts
+++ b/e2e/tests/navigation/sidebar-navigation.spec.ts
@@ -77,7 +77,7 @@ test.describe('Sidebar Navigation', { tag: '@responsive' }, () => {
     const expectedLinks = ['Project', 'Budget', 'Schedule', 'Settings'];
 
     for (const linkName of expectedLinks) {
-      const link = appShell.sidebar.getByRole('link', { name: linkName });
+      const link = appShell.sidebar.getByRole('link', { name: linkName, exact: true });
       await expect(link).toBeVisible();
     }
   });

--- a/e2e/tests/proxy/proxy-setup.spec.ts
+++ b/e2e/tests/proxy/proxy-setup.spec.ts
@@ -82,8 +82,8 @@ test.describe('Reverse Proxy Setup', { tag: '@responsive' }, () => {
     await page.goto(proxyBaseUrl);
 
     // Then: The application should load correctly
-    // Should redirect to /login since setup is already done via auth-setup
-    await expect(page).toHaveURL(/\/(login)?$/);
+    // Authenticated user is redirected to the default page
+    await expect(page).toHaveURL(/\/project\/overview/);
   });
 
   test('should enforce auth guard through proxy', async ({ browser }) => {


### PR DESCRIPTION
## Summary

Fixes E2E test failures caused by the Schedule page restructuring (PR #591) and sidebar link changes:

- **TimelinePage POM**: Gantt/Calendar view toggle buttons moved from toolbar to `ScheduleSubNav` component — updated locators from `getByLabel('Gantt view')` to `getByTestId('schedule-view-gantt')`
- **sidebar-navigation**: Added `exact: true` to 'Project' link locator to distinguish the nav link from the logo link (both link to `/project`)
- **proxy-setup**: Updated URL expectation — authenticated users redirect to `/project/overview`, not `/login`

## Test plan

- [ ] All 16 E2E shards pass (timeline, navigation, proxy tests were previously failing)
- [ ] Smoke tests still pass