### PR TITLE
fix(e2e): accept authenticated redirect in proxy setup test

### DIFF
--- a/e2e/tests/proxy/proxy-setup.spec.ts
+++ b/e2e/tests/proxy/proxy-setup.spec.ts
@@ -243,3 +243,4 @@ test.describe('Reverse Proxy Setup', { tag: '@responsive' }, () => {
     expect(errorBody.error).toHaveProperty('message');
   });
 });
+


### PR DESCRIPTION
Fix proxy-setup E2E test that expects /login but gets /project/overview with shared auth.