### PR TITLE
fix(db): deduplicate migration 0017 to avoid UNIQUE constraint on upgrade

### DIFF
--- a/server/src/db/migrations/0017_invoice_budget_lines.sql
+++ b/server/src/db/migrations/0017_invoice_budget_lines.sql
@@ -32,6 +32,9 @@ CREATE UNIQUE INDEX idx_invoice_budget_lines_household_item_budget_id
   WHERE household_item_budget_id IS NOT NULL;
 
 -- Step 2: Migrate existing 1:1 FK data into junction rows
+-- Deduplicate: if multiple invoices share the same budget line,
+-- keep only the most recent invoice (by created_at) per budget line.
+
 -- For work_item_budget_id links:
 INSERT INTO invoice_budget_lines (
   id, invoice_id, work_item_budget_id, household_item_budget_id,
@@ -46,14 +49,20 @@ SELECT
     substr(hex(randomblob(2)), 2) || '-' ||
     hex(randomblob(6))
   ) AS id,
-  id AS invoice_id,
-  work_item_budget_id,
+  i1.id AS invoice_id,
+  i1.work_item_budget_id,
   NULL AS household_item_budget_id,
-  amount AS itemized_amount,
-  created_at,
-  updated_at
-FROM invoices
-WHERE work_item_budget_id IS NOT NULL;
+  i1.amount AS itemized_amount,
+  i1.created_at,
+  i1.updated_at
+FROM invoices i1
+WHERE i1.work_item_budget_id IS NOT NULL
+  AND i1.rowid = (
+    SELECT i2.rowid FROM invoices i2
+    WHERE i2.work_item_budget_id = i1.work_item_budget_id
+    ORDER BY i2.created_at DESC
+    LIMIT 1
+  );
 
 -- For household_item_budget_id links:
 INSERT INTO invoice_budget_lines (
@@ -69,14 +78,20 @@ SELECT
     substr(hex(randomblob(2)), 2) || '-' ||
     hex(randomblob(6))
   ) AS id,
-  id AS invoice_id,
+  i1.id AS invoice_id,
   NULL AS work_item_budget_id,
-  household_item_budget_id,
-  amount AS itemized_amount,
-  created_at,
-  updated_at
-FROM invoices
-WHERE household_item_budget_id IS NOT NULL;
+  i1.household_item_budget_id,
+  i1.amount AS itemized_amount,
+  i1.created_at,
+  i1.updated_at
+FROM invoices i1
+WHERE i1.household_item_budget_id IS NOT NULL
+  AND i1.rowid = (
+    SELECT i2.rowid FROM invoices i2
+    WHERE i2.household_item_budget_id = i1.household_item_budget_id
+    ORDER BY i2.created_at DESC
+    LIMIT 1
+  );
 
 -- Step 3: Recreate invoices table without budget FK columns
 CREATE TABLE invoices_new (

--- a/server/src/db/migrations/0017_invoice_budget_lines.test.ts
+++ b/server/src/db/migrations/0017_invoice_budget_lines.test.ts
@@ -764,6 +764,134 @@ describe('Migration 0017: Invoice-Budget-Line Junction Table', () => {
     });
   });
 
+  // ── 8b. Data migration — deduplication of shared budget lines ─────────────
+
+  describe('data migration: deduplication when multiple invoices share a budget line', () => {
+    it('keeps only the most recent invoice per work_item_budget_id', () => {
+      const db = new Database(':memory:');
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      console.warn = () => undefined;
+      setupPreMigrationDb(db);
+
+      insertVendor(db, 'v-dedup-wi');
+      insertWorkItem(db, 'wi-dedup-1');
+      insertWorkItemBudget(db, 'wib-dedup-1', 'wi-dedup-1');
+
+      // Insert two invoices sharing the same work_item_budget_id with different created_at
+      insertInvoicePre0017(db, 'inv-dedup-old', 'v-dedup-wi', 100.0, {
+        work_item_budget_id: 'wib-dedup-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+      });
+      insertInvoicePre0017(db, 'inv-dedup-new', 'v-dedup-wi', 200.0, {
+        work_item_budget_id: 'wib-dedup-1',
+        created_at: '2026-02-01T00:00:00.000Z',
+      });
+
+      // Migration should not throw a UNIQUE constraint error
+      runMigration0017(db);
+
+      const junctionRows = db
+        .prepare(
+          `SELECT invoice_id, work_item_budget_id, itemized_amount
+           FROM invoice_budget_lines WHERE work_item_budget_id = ?`,
+        )
+        .all('wib-dedup-1') as Array<Record<string, unknown>>;
+
+      expect(junctionRows).toHaveLength(1);
+      expect(junctionRows[0].invoice_id).toBe('inv-dedup-new');
+      expect(junctionRows[0].itemized_amount).toBe(200.0);
+
+      db.close();
+    });
+
+    it('keeps only the most recent invoice per household_item_budget_id', () => {
+      const db = new Database(':memory:');
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      console.warn = () => undefined;
+      setupPreMigrationDb(db);
+
+      insertVendor(db, 'v-dedup-hi');
+      insertHouseholdItem(db, 'hi-dedup-1');
+      insertHouseholdItemBudget(db, 'hib-dedup-1', 'hi-dedup-1');
+
+      // Insert two invoices sharing the same household_item_budget_id
+      insertInvoicePre0017(db, 'inv-dedup-hi-old', 'v-dedup-hi', 300.0, {
+        household_item_budget_id: 'hib-dedup-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+      });
+      insertInvoicePre0017(db, 'inv-dedup-hi-new', 'v-dedup-hi', 400.0, {
+        household_item_budget_id: 'hib-dedup-1',
+        created_at: '2026-02-01T00:00:00.000Z',
+      });
+
+      runMigration0017(db);
+
+      const junctionRows = db
+        .prepare(
+          `SELECT invoice_id, household_item_budget_id, itemized_amount
+           FROM invoice_budget_lines WHERE household_item_budget_id = ?`,
+        )
+        .all('hib-dedup-1') as Array<Record<string, unknown>>;
+
+      expect(junctionRows).toHaveLength(1);
+      expect(junctionRows[0].invoice_id).toBe('inv-dedup-hi-new');
+      expect(junctionRows[0].itemized_amount).toBe(400.0);
+
+      db.close();
+    });
+
+    it('deduplication does not affect budget lines with only one invoice', () => {
+      const db = new Database(':memory:');
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      console.warn = () => undefined;
+      setupPreMigrationDb(db);
+
+      insertVendor(db, 'v-dedup-mix');
+      insertWorkItem(db, 'wi-dedup-mix-1');
+      insertWorkItem(db, 'wi-dedup-mix-2');
+      insertWorkItemBudget(db, 'wib-dedup-mix-1', 'wi-dedup-mix-1');
+      insertWorkItemBudget(db, 'wib-dedup-mix-2', 'wi-dedup-mix-2');
+
+      // Two invoices sharing wib-dedup-mix-1
+      insertInvoicePre0017(db, 'inv-dedup-mix-old', 'v-dedup-mix', 100.0, {
+        work_item_budget_id: 'wib-dedup-mix-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+      });
+      insertInvoicePre0017(db, 'inv-dedup-mix-new', 'v-dedup-mix', 150.0, {
+        work_item_budget_id: 'wib-dedup-mix-1',
+        created_at: '2026-02-01T00:00:00.000Z',
+      });
+      // One invoice with unique wib-dedup-mix-2
+      insertInvoicePre0017(db, 'inv-dedup-mix-solo', 'v-dedup-mix', 250.0, {
+        work_item_budget_id: 'wib-dedup-mix-2',
+      });
+
+      runMigration0017(db);
+
+      const allRows = db
+        .prepare(
+          `SELECT invoice_id, work_item_budget_id, itemized_amount
+           FROM invoice_budget_lines ORDER BY work_item_budget_id`,
+        )
+        .all() as Array<Record<string, unknown>>;
+
+      expect(allRows).toHaveLength(2);
+
+      const deduped = allRows.find((r) => r.work_item_budget_id === 'wib-dedup-mix-1');
+      expect(deduped).toBeDefined();
+      expect(deduped!.invoice_id).toBe('inv-dedup-mix-new');
+
+      const solo = allRows.find((r) => r.work_item_budget_id === 'wib-dedup-mix-2');
+      expect(solo).toBeDefined();
+      expect(solo!.invoice_id).toBe('inv-dedup-mix-solo');
+
+      db.close();
+    });
+  });
+
   // ── 9. XOR CHECK constraint ────────────────────────────────────────────────
 
   describe('XOR CHECK constraint (exactly one FK must be non-null)', () => {


### PR DESCRIPTION
## Summary

- Fixes migration `0017_invoice_budget_lines.sql` failing with `UNIQUE constraint failed: invoice_budget_lines.work_item_budget_id` when upgrading from pre-beta versions where multiple invoices could share the same budget line
- Both INSERT statements (work_item_budget_id and household_item_budget_id) now deduplicate by keeping only the most recent invoice per budget line
- Adds 3 test cases covering deduplication for work item budgets, household item budgets, and mixed scenarios

## Test plan

- [ ] CI passes (migration tests validate deduplication logic)
- [ ] Existing migration tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)