### PR TITLE
refactor(invoices): remove old budget-line pickers (#608)

### DIFF
--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -8,12 +8,7 @@ import type {
 } from '@cornerstone/shared';
 import { fetchAllInvoices, createInvoice } from '../../lib/invoicesApi.js';
 import { fetchVendors } from '../../lib/vendorsApi.js';
-import { fetchWorkItemBudgets } from '../../lib/workItemBudgetsApi.js';
-import { fetchHouseholdItemBudgets } from '../../lib/householdItemBudgetsApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
-import { WorkItemPicker } from '../../components/WorkItemPicker/WorkItemPicker.js';
-import { HouseholdItemPicker } from '../../components/HouseholdItemPicker/HouseholdItemPicker.js';
-import type { WorkItemBudgetLine, HouseholdItemBudgetLine } from '@cornerstone/shared';
 import { formatDate, formatCurrency } from '../../lib/formatters.js';
 import { BudgetSubNav } from '../../components/BudgetSubNav/BudgetSubNav.js';
 import styles from './InvoicesPage.module.css';
@@ -32,10 +27,6 @@ interface InvoiceFormState {
   dueDate: string;
   status: InvoiceStatus;
   notes: string;
-  selectedWorkItemId: string;
-  workItemBudgetId: string;
-  selectedHouseholdItemId: string;
-  householdItemBudgetId: string;
 }
 
 const EMPTY_FORM: InvoiceFormState = {
@@ -46,10 +37,6 @@ const EMPTY_FORM: InvoiceFormState = {
   dueDate: '',
   status: 'pending',
   notes: '',
-  selectedWorkItemId: '',
-  workItemBudgetId: '',
-  selectedHouseholdItemId: '',
-  householdItemBudgetId: '',
 };
 
 export function InvoicesPage() {
@@ -88,12 +75,6 @@ export function InvoicesPage() {
   const [createForm, setCreateForm] = useState<InvoiceFormState>(EMPTY_FORM);
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState('');
-  const [budgetLines, setBudgetLines] = useState<WorkItemBudgetLine[]>([]);
-  const [budgetLinesLoading, setBudgetLinesLoading] = useState(false);
-  const [householdItemBudgetLines, setHouseholdItemBudgetLines] = useState<
-    HouseholdItemBudgetLine[]
-  >([]);
-  const [householdItemBudgetLinesLoading, setHouseholdItemBudgetLinesLoading] = useState(false);
 
   useEffect(() => {
     if (urlPage !== currentPage) setCurrentPage(urlPage);
@@ -178,7 +159,6 @@ export function InvoicesPage() {
   const openCreateModal = () => {
     setCreateForm(EMPTY_FORM);
     setCreateError('');
-    setBudgetLines([]);
     setShowCreateModal(true);
   };
 
@@ -761,114 +741,6 @@ export function InvoicesPage() {
                   <option value="claimed">Claimed</option>
                 </select>
               </div>
-
-              <div className={styles.field}>
-                <span className={styles.label}>Link to Work Item</span>
-                <WorkItemPicker
-                  value={createForm.selectedWorkItemId}
-                  onChange={(workItemId) => {
-                    setCreateForm({
-                      ...createForm,
-                      selectedWorkItemId: workItemId,
-                      workItemBudgetId: '',
-                      selectedHouseholdItemId: '',
-                      householdItemBudgetId: '',
-                    });
-                    if (workItemId) {
-                      setBudgetLinesLoading(true);
-                      void fetchWorkItemBudgets(workItemId)
-                        .then((lines) => setBudgetLines(lines))
-                        .catch(() => setBudgetLines([]))
-                        .finally(() => setBudgetLinesLoading(false));
-                    } else {
-                      setBudgetLines([]);
-                    }
-                  }}
-                  excludeIds={[]}
-                  disabled={isCreating}
-                  placeholder="Search work items..."
-                  showItemsOnFocus
-                />
-              </div>
-
-              {createForm.selectedWorkItemId && (
-                <div className={styles.field}>
-                  <label htmlFor="create-budget-line" className={styles.label}>
-                    Budget Line
-                  </label>
-                  <select
-                    id="create-budget-line"
-                    value={createForm.workItemBudgetId}
-                    onChange={(e) =>
-                      setCreateForm({ ...createForm, workItemBudgetId: e.target.value })
-                    }
-                    className={styles.select}
-                    disabled={isCreating || budgetLinesLoading}
-                  >
-                    <option value="">None</option>
-                    {budgetLines.map((bl) => (
-                      <option key={bl.id} value={bl.id}>
-                        {bl.description || `${formatCurrency(bl.plannedAmount)} (${bl.confidence})`}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-
-              <div className={styles.separator}>— or —</div>
-
-              <div className={styles.field}>
-                <span className={styles.label}>Link to Household Item</span>
-                <HouseholdItemPicker
-                  value={createForm.selectedHouseholdItemId}
-                  onChange={(householdItemId) => {
-                    setCreateForm({
-                      ...createForm,
-                      selectedHouseholdItemId: householdItemId,
-                      householdItemBudgetId: '',
-                      selectedWorkItemId: '',
-                      workItemBudgetId: '',
-                    });
-                    if (householdItemId) {
-                      setHouseholdItemBudgetLinesLoading(true);
-                      void fetchHouseholdItemBudgets(householdItemId)
-                        .then((lines) => setHouseholdItemBudgetLines(lines))
-                        .catch(() => setHouseholdItemBudgetLines([]))
-                        .finally(() => setHouseholdItemBudgetLinesLoading(false));
-                    } else {
-                      setHouseholdItemBudgetLines([]);
-                    }
-                  }}
-                  excludeIds={[]}
-                  disabled={isCreating}
-                  placeholder="Search household items..."
-                  showItemsOnFocus
-                />
-              </div>
-
-              {createForm.selectedHouseholdItemId && (
-                <div className={styles.field}>
-                  <label htmlFor="create-household-budget-line" className={styles.label}>
-                    Budget Line
-                  </label>
-                  <select
-                    id="create-household-budget-line"
-                    value={createForm.householdItemBudgetId}
-                    onChange={(e) =>
-                      setCreateForm({ ...createForm, householdItemBudgetId: e.target.value })
-                    }
-                    className={styles.select}
-                    disabled={isCreating || householdItemBudgetLinesLoading}
-                  >
-                    <option value="">None</option>
-                    {householdItemBudgetLines.map((bl) => (
-                      <option key={bl.id} value={bl.id}>
-                        {bl.description || `${formatCurrency(bl.plannedAmount)} (${bl.confidence})`}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
 
               <div className={styles.field}>
                 <label htmlFor="create-notes" className={styles.label}>

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
@@ -7,14 +7,10 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type * as VendorsApiTypes from '../../lib/vendorsApi.js';
 import type * as InvoicesApiTypes from '../../lib/invoicesApi.js';
-import type * as WorkItemsApiTypes from '../../lib/workItemsApi.js';
-import type * as WorkItemBudgetsApiTypes from '../../lib/workItemBudgetsApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import type {
   VendorDetail,
   Invoice,
-  WorkItemSummary,
-  WorkItemBudgetLine,
 } from '@cornerstone/shared';
 
 // Mock the vendor API module BEFORE importing the component
@@ -43,68 +39,10 @@ jest.unstable_mockModule('../../lib/invoicesApi.js', () => ({
   deleteInvoice: mockDeleteInvoice,
 }));
 
-// Mock the work items API module BEFORE importing the component
-const mockListWorkItems = jest.fn<typeof WorkItemsApiTypes.listWorkItems>();
-
-jest.unstable_mockModule('../../lib/workItemsApi.js', () => ({
-  listWorkItems: mockListWorkItems,
-  getWorkItem: jest.fn(),
-  createWorkItem: jest.fn(),
-  updateWorkItem: jest.fn(),
-  deleteWorkItem: jest.fn(),
-  fetchWorkItemSubsidies: jest.fn(),
-  linkWorkItemSubsidy: jest.fn(),
-  unlinkWorkItemSubsidy: jest.fn(),
-}));
-
-// Mock the work item budgets API module BEFORE importing the component
-const mockFetchWorkItemBudgets = jest.fn<typeof WorkItemBudgetsApiTypes.fetchWorkItemBudgets>();
-
-jest.unstable_mockModule('../../lib/workItemBudgetsApi.js', () => ({
-  fetchWorkItemBudgets: mockFetchWorkItemBudgets,
-  createWorkItemBudget: jest.fn(),
-  updateWorkItemBudget: jest.fn(),
-  deleteWorkItemBudget: jest.fn(),
-}));
-
 describe('VendorDetailPage', () => {
   let VendorDetailPage: React.ComponentType;
 
   // ─── Sample Data ─────────────────────────────────────────────────────────
-
-  const sampleWorkItem: WorkItemSummary = {
-    id: 'work-item-1',
-    title: 'Foundation Work',
-    status: 'in_progress',
-    startDate: '2026-01-01',
-    endDate: '2026-03-01',
-    durationDays: 59,
-    actualStartDate: null,
-    actualEndDate: null,
-    assignedUser: null,
-    tags: [],
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  };
-
-  const sampleBudgetLine: WorkItemBudgetLine = {
-    id: 'budget-line-1',
-    workItemId: 'work-item-1',
-    description: 'Concrete pour',
-    plannedAmount: 15000,
-    confidence: 'quote',
-    confidenceMargin: 0.05,
-    budgetCategory: null,
-    budgetSource: null,
-    vendor: null,
-    actualCost: 0,
-    actualCostPaid: 0,
-    invoiceCount: 0,
-    invoiceLink: null,
-    createdBy: null,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  };
 
   const sampleVendor: VendorDetail = {
     id: 'vendor-1',
@@ -201,18 +139,9 @@ describe('VendorDetailPage', () => {
     mockCreateInvoice.mockReset();
     mockUpdateInvoice.mockReset();
     mockDeleteInvoice.mockReset();
-    mockListWorkItems.mockReset();
-    mockFetchWorkItemBudgets.mockReset();
 
     // Default: invoices load successfully (empty list) unless overridden
     mockFetchInvoices.mockResolvedValue([]);
-    // Default: work items load as empty list (no work items to link) unless overridden
-    mockListWorkItems.mockResolvedValue({
-      items: [],
-      pagination: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
-    });
-    // Default: no budget lines (fetchWorkItemBudgets only called when user selects a work item)
-    mockFetchWorkItemBudgets.mockResolvedValue([]);
   });
 
   /**
@@ -1408,164 +1337,6 @@ describe('VendorDetailPage', () => {
       // Modal should still be open
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-
-    it('renders "Link to Work Item" dropdown in create modal', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([]);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add invoice/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add invoice/i }));
-
-      const dialog = screen.getByRole('dialog');
-      expect(within(dialog).getByLabelText(/link to work item/i)).toBeInTheDocument();
-    });
-
-    it('loads work items into the "Link to Work Item" dropdown', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add invoice/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add invoice/i }));
-
-      const dialog = screen.getByRole('dialog');
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      // The work item title should be visible as an option
-      expect(workItemSelect).toHaveTextContent('Foundation Work');
-    });
-
-    it('shows budget line dropdown after selecting a work item in create modal', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-      mockFetchWorkItemBudgets.mockResolvedValueOnce([sampleBudgetLine]);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add invoice/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add invoice/i }));
-
-      const dialog = screen.getByRole('dialog');
-
-      // Budget line dropdown should not exist before a work item is selected
-      expect(within(dialog).queryByLabelText(/budget line/i)).not.toBeInTheDocument();
-
-      // Select the work item
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      await user.selectOptions(workItemSelect, 'work-item-1');
-
-      // Budget line dropdown should now appear
-      await waitFor(() => {
-        expect(within(dialog).getByLabelText(/budget line/i)).toBeInTheDocument();
-      });
-    });
-
-    it('populates budget line dropdown with lines fetched for the selected work item', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-      mockFetchWorkItemBudgets.mockResolvedValueOnce([sampleBudgetLine]);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add invoice/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add invoice/i }));
-
-      const dialog = screen.getByRole('dialog');
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      await user.selectOptions(workItemSelect, 'work-item-1');
-
-      await waitFor(() => {
-        expect(mockFetchWorkItemBudgets).toHaveBeenCalledWith('work-item-1');
-      });
-
-      await waitFor(() => {
-        const budgetLineSelect = within(dialog).getByLabelText(/budget line/i);
-        expect(budgetLineSelect).toHaveTextContent('Concrete pour');
-      });
-    });
-
-    it('submits workItemBudgetId when a budget line is selected in create modal', async () => {
-      const newInvoice: Invoice = {
-        ...sampleInvoice,
-        id: 'invoice-new',
-      };
-
-      mockFetchVendor.mockResolvedValue(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-      mockFetchWorkItemBudgets.mockResolvedValueOnce([sampleBudgetLine]);
-      mockCreateInvoice.mockResolvedValueOnce(newInvoice);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add invoice/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add invoice/i }));
-
-      const dialog = screen.getByRole('dialog');
-
-      // Fill required fields
-      fireEvent.change(within(dialog).getByLabelText(/amount/i), { target: { value: '1500' } });
-      fireEvent.change(within(dialog).getByLabelText(/invoice date/i), {
-        target: { value: '2026-02-01' },
-      });
-
-      // Select work item then budget line
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      await user.selectOptions(workItemSelect, 'work-item-1');
-
-      await waitFor(() => {
-        expect(within(dialog).getByLabelText(/budget line/i)).toBeInTheDocument();
-      });
-
-      const budgetLineSelect = within(dialog).getByLabelText(/budget line/i);
-      await user.selectOptions(budgetLineSelect, 'budget-line-1');
-
-      await user.click(within(dialog).getByRole('button', { name: /^add invoice$/i }));
-
-      await waitFor(() => {
-        expect(mockCreateInvoice).toHaveBeenCalledWith(
-          'vendor-1',
-          expect.objectContaining({ amount: 1500, date: '2026-02-01' }),
-        );
-      });
-    });
   });
 
   // ─── Edit invoice modal ───────────────────────────────────────────────────
@@ -1742,131 +1513,6 @@ describe('VendorDetailPage', () => {
 
       await waitFor(() => {
         expect(within(dialog).getByText(/failed to update invoice/i)).toBeInTheDocument();
-      });
-    });
-
-    it('renders "Link to Work Item" dropdown in edit modal', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([sampleInvoice]);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /edit invoice INV-001/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /edit invoice INV-001/i }));
-
-      const dialog = screen.getByRole('dialog');
-      expect(within(dialog).getByLabelText(/link to work item/i)).toBeInTheDocument();
-    });
-
-    it('shows budget line dropdown after selecting a work item in edit modal', async () => {
-      mockFetchVendor.mockResolvedValueOnce(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([sampleInvoice]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-      mockFetchWorkItemBudgets.mockResolvedValueOnce([sampleBudgetLine]);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /edit invoice INV-001/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /edit invoice INV-001/i }));
-
-      const dialog = screen.getByRole('dialog');
-
-      // Budget line dropdown should not be visible before a work item is chosen
-      expect(within(dialog).queryByLabelText(/budget line/i)).not.toBeInTheDocument();
-
-      // Select a work item
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      await user.selectOptions(workItemSelect, 'work-item-1');
-
-      // Budget line dropdown should now appear
-      await waitFor(() => {
-        expect(within(dialog).getByLabelText(/budget line/i)).toBeInTheDocument();
-      });
-    });
-
-    it('sends workItemBudgetId when budget link is touched in edit modal', async () => {
-      const updatedInvoice: Invoice = {
-        ...sampleInvoice,
-      };
-
-      mockFetchVendor.mockResolvedValue(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([sampleInvoice]);
-      mockListWorkItems.mockResolvedValue({
-        items: [sampleWorkItem],
-        pagination: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
-      });
-      mockFetchWorkItemBudgets.mockResolvedValueOnce([sampleBudgetLine]);
-      mockUpdateInvoice.mockResolvedValueOnce(updatedInvoice);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /edit invoice INV-001/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /edit invoice INV-001/i }));
-
-      const dialog = screen.getByRole('dialog');
-
-      // Select work item — this "touches" the budget link
-      const workItemSelect = within(dialog).getByLabelText(/link to work item/i);
-      await user.selectOptions(workItemSelect, 'work-item-1');
-
-      await waitFor(() => {
-        expect(within(dialog).getByLabelText(/budget line/i)).toBeInTheDocument();
-      });
-
-      const budgetLineSelect = within(dialog).getByLabelText(/budget line/i);
-      await user.selectOptions(budgetLineSelect, 'budget-line-1');
-
-      await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
-
-      await waitFor(() => {
-        expect(mockUpdateInvoice).toHaveBeenCalledWith('vendor-1', 'invoice-1', expect.any(Object));
-      });
-    });
-
-    it('does NOT send workItemBudgetId when budget link is not touched in edit modal', async () => {
-      const updatedInvoice: Invoice = { ...sampleInvoice, status: 'paid' };
-
-      mockFetchVendor.mockResolvedValue(sampleVendor);
-      mockFetchInvoices.mockResolvedValueOnce([sampleInvoice]);
-      mockUpdateInvoice.mockResolvedValueOnce(updatedInvoice);
-
-      const user = userEvent.setup();
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /edit invoice INV-001/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /edit invoice INV-001/i }));
-
-      const dialog = screen.getByRole('dialog');
-      const statusSelect = within(dialog).getByLabelText(/status/i);
-      await user.selectOptions(statusSelect, 'paid');
-
-      await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
-
-      await waitFor(() => {
-        expect(mockUpdateInvoice).toHaveBeenCalledWith(
-          'vendor-1',
-          'invoice-1',
-          // only the changed field (status) should be in the payload
-          expect.objectContaining({ status: 'paid' }),
-        );
       });
     });
   });

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
@@ -5,8 +5,6 @@ import type {
   UpdateVendorRequest,
   Invoice,
   InvoiceStatus,
-  WorkItemSummary,
-  WorkItemBudgetLine,
 } from '@cornerstone/shared';
 import { fetchVendor, updateVendor, deleteVendor } from '../../lib/vendorsApi.js';
 import {
@@ -15,8 +13,6 @@ import {
   updateInvoice,
   deleteInvoice,
 } from '../../lib/invoicesApi.js';
-import { listWorkItems } from '../../lib/workItemsApi.js';
-import { fetchWorkItemBudgets } from '../../lib/workItemBudgetsApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import { formatDate } from '../../lib/formatters.js';
 import styles from './VendorDetailPage.module.css';
@@ -44,8 +40,6 @@ interface InvoiceFormState {
   dueDate: string;
   status: InvoiceStatus;
   notes: string;
-  selectedWorkItemId: string;
-  workItemBudgetId: string;
 }
 
 const EMPTY_INVOICE_FORM: InvoiceFormState = {
@@ -55,8 +49,6 @@ const EMPTY_INVOICE_FORM: InvoiceFormState = {
   dueDate: '',
   status: 'pending',
   notes: '',
-  selectedWorkItemId: '',
-  workItemBudgetId: '',
 };
 
 export function VendorDetailPage() {
@@ -100,22 +92,11 @@ export function VendorDetailPage() {
   const [isDeletingInvoice, setIsDeletingInvoice] = useState(false);
   const [deleteInvoiceError, setDeleteInvoiceError] = useState<string>('');
 
-  // Work item + budget line linking state (for invoice create/edit modals)
-  const [workItems, setWorkItems] = useState<WorkItemSummary[]>([]);
-  const [budgetLines, setBudgetLines] = useState<WorkItemBudgetLine[]>([]);
-  const [budgetLinesLoading, setBudgetLinesLoading] = useState(false);
-  // Tracks whether the user interacted with the budget link dropdowns during edit
-  const [budgetLinkTouched, setBudgetLinkTouched] = useState(false);
-
   useEffect(() => {
     if (!id) return;
     void loadVendor();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
-
-  useEffect(() => {
-    void listWorkItems({ pageSize: 100 }).then((res) => setWorkItems(res.items));
-  }, []);
 
   const loadVendor = async () => {
     if (!id) return;
@@ -270,7 +251,6 @@ export function VendorDetailPage() {
   const openCreateModal = () => {
     setCreateForm(EMPTY_INVOICE_FORM);
     setCreateError('');
-    setBudgetLines([]);
     setShowCreateModal(true);
   };
 
@@ -331,11 +311,7 @@ export function VendorDetailPage() {
       dueDate: invoice.dueDate ? invoice.dueDate.slice(0, 10) : '',
       status: invoice.status,
       notes: invoice.notes ?? '',
-      selectedWorkItemId: '',
-      workItemBudgetId: '',
     });
-    setBudgetLines([]);
-    setBudgetLinkTouched(false);
     setEditInvoiceError('');
   };
 
@@ -1005,72 +981,6 @@ export function VendorDetailPage() {
               </div>
 
               <div className={styles.field}>
-                <label htmlFor="create-work-item" className={styles.label}>
-                  Link to Work Item
-                </label>
-                <select
-                  id="create-work-item"
-                  value={createForm.selectedWorkItemId}
-                  onChange={(e) => {
-                    const workItemId = e.target.value;
-                    setCreateForm({
-                      ...createForm,
-                      selectedWorkItemId: workItemId,
-                      workItemBudgetId: '',
-                    });
-                    if (workItemId) {
-                      setBudgetLinesLoading(true);
-                      void fetchWorkItemBudgets(workItemId)
-                        .then((lines) => {
-                          setBudgetLines(lines);
-                        })
-                        .catch(() => {
-                          setBudgetLines([]);
-                        })
-                        .finally(() => {
-                          setBudgetLinesLoading(false);
-                        });
-                    } else {
-                      setBudgetLines([]);
-                    }
-                  }}
-                  className={styles.select}
-                  disabled={isCreating}
-                >
-                  <option value="">None</option>
-                  {workItems.map((wi) => (
-                    <option key={wi.id} value={wi.id}>
-                      {wi.title}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {createForm.selectedWorkItemId && (
-                <div className={styles.field}>
-                  <label htmlFor="create-budget-line" className={styles.label}>
-                    Budget Line
-                  </label>
-                  <select
-                    id="create-budget-line"
-                    value={createForm.workItemBudgetId}
-                    onChange={(e) =>
-                      setCreateForm({ ...createForm, workItemBudgetId: e.target.value })
-                    }
-                    className={styles.select}
-                    disabled={isCreating || budgetLinesLoading}
-                  >
-                    <option value="">None</option>
-                    {budgetLines.map((bl) => (
-                      <option key={bl.id} value={bl.id}>
-                        {bl.description || `${formatCurrency(bl.plannedAmount)} (${bl.confidence})`}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-
-              <div className={styles.field}>
                 <label htmlFor="create-notes" className={styles.label}>
                   Notes
                 </label>
@@ -1221,73 +1131,6 @@ export function VendorDetailPage() {
                   <option value="claimed">Claimed</option>
                 </select>
               </div>
-
-              <div className={styles.field}>
-                <label htmlFor="edit-work-item" className={styles.label}>
-                  Link to Work Item
-                </label>
-                <select
-                  id="edit-work-item"
-                  value={editInvoiceForm.selectedWorkItemId}
-                  onChange={(e) => {
-                    const workItemId = e.target.value;
-                    setBudgetLinkTouched(true);
-                    setEditInvoiceForm({
-                      ...editInvoiceForm,
-                      selectedWorkItemId: workItemId,
-                      workItemBudgetId: '',
-                    });
-                    if (workItemId) {
-                      setBudgetLinesLoading(true);
-                      void fetchWorkItemBudgets(workItemId)
-                        .then((lines) => {
-                          setBudgetLines(lines);
-                        })
-                        .catch(() => {
-                          setBudgetLines([]);
-                        })
-                        .finally(() => {
-                          setBudgetLinesLoading(false);
-                        });
-                    } else {
-                      setBudgetLines([]);
-                    }
-                  }}
-                  className={styles.select}
-                  disabled={isUpdatingInvoice}
-                >
-                  <option value="">None</option>
-                  {workItems.map((wi) => (
-                    <option key={wi.id} value={wi.id}>
-                      {wi.title}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {editInvoiceForm.selectedWorkItemId && (
-                <div className={styles.field}>
-                  <label htmlFor="edit-budget-line" className={styles.label}>
-                    Budget Line
-                  </label>
-                  <select
-                    id="edit-budget-line"
-                    value={editInvoiceForm.workItemBudgetId}
-                    onChange={(e) =>
-                      setEditInvoiceForm({ ...editInvoiceForm, workItemBudgetId: e.target.value })
-                    }
-                    className={styles.select}
-                    disabled={isUpdatingInvoice || budgetLinesLoading}
-                  >
-                    <option value="">None</option>
-                    {budgetLines.map((bl) => (
-                      <option key={bl.id} value={bl.id}>
-                        {bl.description || `${formatCurrency(bl.plannedAmount)} (${bl.confidence})`}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
 
               <div className={styles.field}>
                 <label htmlFor="edit-invoice-notes" className={styles.label}>


### PR DESCRIPTION
## Summary

- Remove old single-budget-line picker fields from VendorDetailPage and InvoicesPage invoice create/edit forms
- Budget lines are now linked via dedicated InvoiceBudgetLinesSection (Story #606) and item detail pages (Story #607)
- All backend aggregation queries were already updated in Stories #603 and #605

Fixes #608

## Test plan
- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>