### PR TITLE
fix(a11y): responsive, dark mode & accessibility polish (#609)

### DIFF
--- a/client/src/components/budget/BudgetSection.module.css
+++ b/client/src/components/budget/BudgetSection.module.css
@@ -92,9 +92,9 @@
   background: var(--color-primary-hover);
 }
 
-.linkInvoiceBtn:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 1px;
+.linkInvoiceBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 
 .linkInvoiceBtn:disabled {
@@ -103,8 +103,14 @@
 }
 
 @media (max-width: 767px) {
+  .addButton {
+    min-height: 44px;
+    padding: 0.75rem 1rem;
+  }
+
   .linkInvoiceBtn {
     min-height: 44px;
+    min-width: 44px;
     padding: 0.5rem 1rem;
     width: 100%;
   }

--- a/client/src/components/budget/InvoiceGroup.module.css
+++ b/client/src/components/budget/InvoiceGroup.module.css
@@ -30,9 +30,9 @@
   background: var(--color-bg-tertiary);
 }
 
-.toggleBtn:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: -1px;
+.toggleBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 
 .toggleBtn:active {
@@ -192,6 +192,11 @@
   background: var(--color-danger-bg);
   color: var(--color-danger-active);
   border-color: var(--color-danger-border);
+}
+
+.unlinkBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 
 .unlinkBtn:disabled {

--- a/client/src/components/budget/InvoiceGroup.tsx
+++ b/client/src/components/budget/InvoiceGroup.tsx
@@ -59,9 +59,10 @@ export function InvoiceGroup<T extends BaseBudgetLine>({
   }, [isExpanded]);
 
   const statusBadgeClass = `${styles.statusBadge} ${styles[`status_${invoiceStatus}`] || ''}`;
+  const ariaLabel = `Invoice ${invoiceNumber || 'unknown'}: ${lines.length} budget lines, ${formatCurrency(itemizedTotal)} invoiced`;
 
   return (
-    <div className={styles.group}>
+    <div className={styles.group} role="group" aria-label={ariaLabel}>
       {/* Header with toggle button */}
       <button
         ref={toggleButtonRef}

--- a/client/src/components/budget/InvoiceLinkModal.module.css
+++ b/client/src/components/budget/InvoiceLinkModal.module.css
@@ -76,9 +76,9 @@
   color: var(--color-text-primary);
 }
 
-.closeButton:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: -1px;
+.closeButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 
 /* ─── Error Banner ───────────────────────────────────────────────────────── */
@@ -127,11 +127,11 @@
   transition: var(--transition-button);
 }
 
-.select:focus,
-.input:focus {
+.select:focus-visible,
+.input:focus-visible {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: inset 0 0 0 2px var(--color-primary-focus-subtle);
+  box-shadow: inset 0 0 0 2px var(--color-focus-ring-subtle);
 }
 
 .select:disabled,
@@ -144,9 +144,9 @@
   border-color: var(--color-danger-border);
 }
 
-.inputError:focus {
+.inputError:focus-visible {
   border-color: var(--color-danger-active);
-  box-shadow: inset 0 0 0 2px var(--color-danger-bg);
+  box-shadow: inset 0 0 0 2px var(--color-focus-ring-danger);
 }
 
 /* ─── Field Error ─────────────────────────────────────────────────────────── */

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
@@ -67,6 +67,8 @@ export function InvoiceBudgetLinesSection({
   // Focus management
   const addButtonRef = useRef<HTMLButtonElement>(null);
   const pickerModalRef = useRef<HTMLDivElement>(null);
+  const remainingAmountRef = useRef<HTMLTableCellElement>(null);
+  const newLineRowRef = useRef<HTMLTableRowElement>(null);
 
   // Load budget lines on mount
   useEffect(() => {
@@ -185,9 +187,15 @@ export function InvoiceBudgetLinesSection({
       const response = await createInvoiceBudgetLine(invoiceId, createData);
 
       // Update state with new line and remaining amount
-      setBudgetLines([...budgetLines, response.budgetLine]);
+      const newBudgetLines = [...budgetLines, response.budgetLine];
+      setBudgetLines(newBudgetLines);
       setRemainingAmount(response.remainingAmount);
       closePicker();
+
+      // Focus the newly added row after a short delay
+      setTimeout(() => {
+        newLineRowRef.current?.focus();
+      }, 100);
     } catch (err) {
       let errorMsg = 'Failed to link budget line. Please try again.';
 
@@ -271,6 +279,7 @@ export function InvoiceBudgetLinesSection({
    */
   const handleDeleteLine = async (lineId: string) => {
     setIsDeleting(true);
+    const deletedIndex = budgetLines.findIndex((line) => line.id === lineId);
 
     try {
       await deleteInvoiceBudgetLine(invoiceId, lineId);
@@ -278,6 +287,21 @@ export function InvoiceBudgetLinesSection({
       // Re-fetch budget lines to get updated remaining amount
       await loadBudgetLines();
       setDeletingLineId(null);
+
+      // Focus management: move focus to the next row or the Add button
+      setTimeout(() => {
+        // If there are remaining lines, focus the next one; otherwise focus the Add button
+        if (budgetLines.length > 1) {
+          // Focus the next row if available, or the previous one
+          const focusIndex = deletedIndex < budgetLines.length - 1 ? deletedIndex : deletedIndex - 1;
+          const rows = document.querySelectorAll('[data-row-id]');
+          if (rows[focusIndex]) {
+            (rows[focusIndex] as HTMLElement).focus();
+          }
+        } else {
+          addButtonRef.current?.focus();
+        }
+      }, 50);
     } catch (err) {
       if (err instanceof ApiClientError) {
         setError(err.error.message);
@@ -368,8 +392,14 @@ export function InvoiceBudgetLinesSection({
               </tr>
             </thead>
             <tbody>
-              {budgetLines.map((line) => (
-                <tr key={line.id} className={styles.tr}>
+              {budgetLines.map((line, index) => (
+                <tr
+                  key={line.id}
+                  className={styles.tr}
+                  ref={index === budgetLines.length - 1 ? newLineRowRef : null}
+                  data-row-id={line.id}
+                  tabIndex={-1}
+                >
                   <td className={styles.tdDescription}>{line.budgetLineDescription || '\u2014'}</td>
                   <td className={styles.tdCategory}>{line.categoryName || '\u2014'}</td>
                   <td className={styles.tdPlanned}>{formatCurrency(line.plannedAmount)}</td>
@@ -444,7 +474,14 @@ export function InvoiceBudgetLinesSection({
                 <td colSpan={3} className={styles.tdRemainingLabel}>
                   Remaining
                 </td>
-                <td className={styles.tdRemaining}>{formatCurrency(remainingAmount)}</td>
+                <td
+                  ref={remainingAmountRef}
+                  className={styles.tdRemaining}
+                  aria-live="polite"
+                  aria-label={`Remaining amount: ${formatCurrency(remainingAmount)}`}
+                >
+                  {formatCurrency(remainingAmount)}
+                </td>
                 <td />
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary

- Add aria-live="polite" to Remaining amount for screen reader announcements
- Add role="group" and descriptive aria-label to InvoiceGroup component
- Add focus management: focus moves to new row after add, next row after delete
- Update all focus states to :focus-visible with design system tokens
- Ensure 44px minimum touch targets on mobile for all interactive elements

Fixes #609

## Test plan
- [ ] Unit tests pass (95%+ coverage)
- [ ] Pre-commit hook quality gates pass
- [ ] No hardcoded hex colors in CSS

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>