### PR TITLE
docs: update documentation for epic #602

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A self-hosted home building project management tool for homeowners. Track work i
 ## Features
 
 - **Work Items** -- CRUD, statuses, dates, assignments, tags, notes, subtasks, dependencies, keyboard shortcuts
-- **Budget Management** -- Budget categories, financing sources, vendor invoices, subsidies, overview dashboard with projections
+- **Budget Management** -- Budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies, overview dashboard with projections
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, and work item linking
@@ -75,6 +75,7 @@ Open `http://localhost:3000` -- the setup wizard will guide you through creating
 - [x] **EPIC-11**: Unified Tag and Category System
 - [x] **EPIC-12**: Codebase Refinement and Consistency
 - [x] **EPIC-14**: Cross-Entity Code Deduplication
+- [x] **EPIC-15**: Budget-Line Invoice Linking Rework
 - [ ] **EPIC-09**: Dashboard and Overview
 - [ ] **EPIC-13**: Construction Diary
 

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,10 +1,15 @@
 ## What's New
 
-This release focuses on internal code quality and accessibility improvements. No new user-facing features were added -- instead, duplicated logic across Work Items and Household Items was consolidated into shared patterns, and UI consistency was improved across all entity detail pages.
+This release reworks the invoice-budget-line relationship from a one-to-one model to a flexible many-to-many design. A single invoice can now be linked to multiple budget lines across work items and household items, each with an itemized amount that attributes a specific portion of the invoice to that budget line.
 
 ### Highlights
 
-- **Improved Accessibility** -- All interactive elements now show `:focus-visible` indicators, status messages use `role="status"` and `role="alert"` attributes, and touch targets meet the 44px minimum for comfortable mobile use
-- **Consistent Error Handling** -- All detail pages now display structured 404 and error states with a uniform layout, instead of each page implementing its own error display
-- **Reduced Code Duplication** -- Budget, subsidy, and payback logic that was duplicated between Work Items and Household Items has been extracted into shared service factories and React components, reducing detail page code by approximately 25%
-- **Harmonized Design Tokens** -- Semantic CSS custom properties are now used consistently across all entity views, with proper dark mode support throughout
+- **Multiple Budget Lines per Invoice** -- Link several budget lines from different work items and household items to a single invoice, each with its own itemized amount. A computed "Remaining" row on the invoice page shows any unallocated portion of the invoice total.
+- **Bidirectional Linking** -- Attach budget lines to invoices from the invoice detail page (two-step picker: select item, then budget line) or directly from a work item or household item's Budget tab.
+- **Invoice Groups on Item Pages** -- When multiple budget lines on the same item share an invoice, they collapse into a grouped view showing the invoice total, each line's planned amount, and its itemized amount.
+- **Accurate Subsidy Calculations** -- Subsidy reductions now use the itemized invoice amount as the cost basis when a budget line is linked to an invoice, instead of the planned estimate.
+- **Accessibility Improvements** -- Focus-visible states, ARIA attributes on invoice groups, keyboard navigation, and 44px touch targets on mobile.
+
+### Breaking Changes
+
+- The old single-budget-line picker on the invoice create/edit modals has been removed. Budget lines are now linked after invoice creation from the invoice detail page or from item detail pages.

--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -24,8 +24,8 @@ Switch between perspectives to understand your financial position from different
 
 The budget overview uses a **blended projection model** that combines estimates and actuals:
 
-- **Budget lines with invoices** use the actual invoice amount (0% margin)
-- **Budget lines without invoices** use the estimated amount with the confidence margin
+- **Budget lines linked to an invoice** use the itemized invoice amount (0% margin)
+- **Budget lines without an invoice link** use the estimated amount with the confidence margin
 
 This means your projections automatically become more accurate as your project progresses and estimates are replaced by real invoices.
 

--- a/docs/src/guides/budget/index.md
+++ b/docs/src/guides/budget/index.md
@@ -22,7 +22,7 @@ The budget system provides:
 
 Each **work item** can have one or more **budget lines**. A budget line connects a work item to a **budget category** and a **financing source** with an estimated amount and confidence level.
 
-When a vendor submits an **invoice**, you link invoice line items to the relevant budget lines. This replaces the estimate with the actual cost and automatically updates the budget overview.
+When a vendor submits an **invoice**, you link the relevant budget lines to the invoice with itemized amounts. A single invoice can be linked to multiple budget lines across different work items and household items, and each link carries a specific amount that attributes a portion of the invoice to that budget line. This replaces the estimate with the actual cost and automatically updates the budget overview.
 
 **Subsidies** reduce the total amount needed from financing sources, applied per budget category.
 

--- a/docs/src/guides/budget/subsidies.md
+++ b/docs/src/guides/budget/subsidies.md
@@ -44,4 +44,8 @@ Subsidies reduce the total cost shown in the [Budget Overview](budget-overview).
 
 Multiple subsidies can apply to the same category, and their reductions stack.
 
+### Cost Basis for Subsidy Calculations
+
+When a budget line is linked to an invoice with an itemized amount, the subsidy calculation uses the **itemized invoice amount** as the cost basis instead of the planned amount. This ensures subsidy reductions reflect the actual cost attribution from invoices, not the original estimate.
+
 ![Subsidies page](/img/screenshots/budget-subsidies-light.png)

--- a/docs/src/guides/budget/vendors-and-invoices.md
+++ b/docs/src/guides/budget/vendors-and-invoices.md
@@ -5,7 +5,7 @@ title: Vendors & Invoices
 
 # Vendors & Invoices
 
-Vendors are the companies and contractors that provide services or materials for your project. Each vendor can have multiple invoices, and each invoice can have line items linked to budget lines on your work items.
+Vendors are the companies and contractors that provide services or materials for your project. Each vendor can have multiple invoices, and each invoice can be linked to multiple budget lines across your work items and household items.
 
 ## Vendors
 
@@ -44,7 +44,9 @@ From a vendor's detail page, click **New Invoice** and provide:
 
 - **Invoice Number** -- The vendor's invoice reference number
 - **Date** -- The invoice date
-- **Line Items** -- One or more line items, each with a description, amount, and optional link to a budget line
+- **Amount** -- The total invoice amount
+
+Budget lines are linked to the invoice after creation from the invoice detail page (see [Linking Budget Lines](#linking-budget-lines-to-an-invoice) below).
 
 ### Invoice Statuses
 
@@ -56,16 +58,49 @@ Invoices progress through three statuses:
 | **Paid** | Invoice has been paid to the vendor |
 | **Claimed** | Payment has been claimed from / reimbursed by the financing source |
 
-### Invoice Line Items
-
-Each invoice contains one or more line items. A line item can be linked to a **budget line** on a work item. When linked, the invoice amount replaces the budget line's estimate and the confidence level is set to "Invoice" automatically.
-
-This is how estimates transition to actual costs -- as invoices arrive, your budget projections become more accurate.
-
 ### Invoice Detail
 
-Click an invoice to see its full detail page with all line items, current status, and linked budget lines.
+Click an invoice to see its full detail page with the invoice amount, current status, and the **Linked Budget Lines** section.
 
 If you have [Paperless-ngx configured](/guides/documents/setup), you can also link documents (invoice PDFs, receipts, supporting files) directly to invoices from the detail page. See [Linking Documents](/guides/documents/linking-documents) for details.
 
 ![Invoice detail page](/img/screenshots/budget-invoice-detail-light.png)
+
+## Linking Budget Lines to an Invoice
+
+A single invoice often covers multiple cost items -- for example, one contractor invoice might include materials, labor, and equipment hire across different budget categories. Cornerstone supports linking **multiple budget lines** from work items and household items to a single invoice, each with an itemized amount.
+
+### How to Link from the Invoice Page
+
+On the invoice detail page, the **Linked Budget Lines** section lets you add budget line links using a two-step picker:
+
+1. **Select an item** -- Choose a work item or household item from the picker
+2. **Select a budget line** -- Pick which budget line on that item to link
+
+Once linked, enter the **itemized amount** for each budget line -- the portion of the invoice total that applies to that specific line. All itemized amounts are shown alongside a computed **Remaining** row that displays the unallocated portion of the invoice total.
+
+:::tip
+The Remaining row helps you ensure the full invoice amount is allocated. If the remaining amount is zero, the invoice is fully distributed across budget lines.
+:::
+
+### How to Link from an Item Detail Page
+
+You can also link budget lines to invoices directly from the work item or household item detail page. On the **Budget** tab, each budget line that is not yet linked to an invoice shows a link action that lets you select an existing invoice.
+
+This bidirectional linking means you can work from whichever direction makes sense -- start with the invoice and find the budget lines, or start with a budget line and attach it to an invoice.
+
+### Invoice Groups on Item Detail Pages
+
+When multiple budget lines on a work item or household item share the same invoice, they are visually grouped into an **Invoice Group**. The group is collapsible and shows:
+
+- The **invoice total** amount
+- Each budget line's **planned amount** and **itemized amount** (the portion allocated from that invoice)
+- The invoice status and date
+
+This grouped view helps you see at a glance how a single invoice is distributed across the item's budget lines.
+
+### Rules and Constraints
+
+- A budget line can be linked to **at most one invoice** -- each budget line is exclusive to a single invoice
+- An invoice can be linked to **many budget lines** across different work items and household items
+- Itemized amounts are independent of the planned amount on the budget line -- they represent the actual cost attribution from the invoice

--- a/docs/src/guides/budget/work-item-budgets.md
+++ b/docs/src/guides/budget/work-item-budgets.md
@@ -31,13 +31,14 @@ Higher confidence levels produce tighter budget projections. As your project pro
 
 ## Linking to Invoices
 
-When a vendor invoice arrives for work covered by a budget line, you can link the invoice line item to the budget line. This automatically:
+When a vendor invoice arrives for work covered by a budget line, you can link the budget line to an invoice. You can do this from either direction:
 
-- Sets the confidence level to **Invoice**
-- Uses the actual invoice amount instead of the estimate
-- Updates the budget overview with the real cost
+- From the **invoice detail page** -- use the two-step picker to select a work item and then a budget line, and specify the itemized amount
+- From the **work item Budget tab** -- click the link action on an unlinked budget line to attach it to an existing invoice
 
-See [Vendors & Invoices](vendors-and-invoices) for details on managing invoices.
+When multiple budget lines on the same work item share an invoice, they collapse into an **Invoice Group** showing the invoice total alongside each line's planned and itemized amounts.
+
+See [Vendors & Invoices](vendors-and-invoices) for details on managing invoices and the linking workflow.
 
 ## Multiple Budget Lines per Work Item
 

--- a/docs/src/guides/household-items/budget-and-invoices.md
+++ b/docs/src/guides/household-items/budget-and-invoices.md
@@ -32,13 +32,14 @@ A single household item can have multiple budget lines. For example, a kitchen a
 
 ## Invoice Linking
 
-When a vendor invoice arrives for a household item purchase, you can link invoice line items to the item's budget lines. This replaces the estimate with the actual cost:
+When a vendor invoice arrives for a household item purchase, you can link the item's budget lines to the invoice. You can do this from either direction:
 
-1. Navigate to the vendor's invoice detail page (via **Budget > Invoices**)
-2. On an invoice line item, select the household item's budget line as the linked budget
-3. The actual cost updates automatically
+- **From the invoice detail page** -- use the two-step picker to select the household item and then a budget line, and specify the itemized amount
+- **From the household item Budget tab** -- click the link action on an unlinked budget line to attach it to an existing invoice
 
-See [Vendors & Invoices](/guides/budget/vendors-and-invoices) for details on creating invoices.
+A single invoice can cover multiple budget lines across different items. When multiple budget lines on the same household item share an invoice, they collapse into an **Invoice Group** showing the invoice total alongside each line's planned and itemized amounts.
+
+See [Vendors & Invoices](/guides/budget/vendors-and-invoices) for details on managing invoices and the full linking workflow.
 
 ## Subsidies
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -32,7 +32,7 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 ## Key Features
 
 - **Work Items** -- Create and manage construction tasks with statuses, dates, assignments, tags, notes, subtasks, and dependencies
-- **Budget Management** -- Track costs with budget categories, financing sources, vendor invoices, subsidies, and a dashboard with multiple projection perspectives
+- **Budget Management** -- Track costs with budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies, and a dashboard with multiple projection perspectives
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path highlighting, zoom controls, milestones, and automatic scheduling via the Critical Path Method
 - **Calendar View** -- Monthly and weekly calendar grids showing work items and milestones
 - **Milestones** -- Track major project checkpoints with target dates, projected completion, and late detection

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -23,6 +23,7 @@ Cornerstone is under active development. Here is the current state of planned fe
 - [x] **EPIC-11: Unified Tag and Category System** ([#444](https://github.com/steilerDev/cornerstone/issues/444)) -- Consolidated tagging and categorization across work items, budget lines, and household items
 - [x] **EPIC-12: Codebase Refinement and Consistency** ([#445](https://github.com/steilerDev/cornerstone/issues/445)) -- Shared route factories, standardized API clients, consolidated error handling, reusable modal component
 - [x] **EPIC-14: Cross-Entity Code Deduplication** ([#495](https://github.com/steilerDev/cornerstone/issues/495)) -- Shared service factories, unified React components for budget and subsidy logic, accessibility improvements, harmonized design tokens
+- [x] **EPIC-15: Budget-Line Invoice Linking Rework** ([#602](https://github.com/steilerDev/cornerstone/issues/602)) -- Many-to-many invoice-budget-line linking with itemized amounts, bidirectional linking UI, invoice groups on item detail pages, subsidy recalculation using itemized amounts
 
 ## Planned
 


### PR DESCRIPTION
## Summary
- Updated budget, invoice, and subsidy documentation to reflect the new many-to-many invoice-budget-line linking model
- Updated README.md features and roadmap
- Wrote RELEASE_SUMMARY.md for EPIC-15

Fixes #602 (partial — documentation only)

## Test plan
- [ ] `docs:build` passes (verified locally)
- [ ] No broken links in docs site

Co-Authored-By: Claude docs-writer (Opus 4.6) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)