### PR TITLE
fix(e2e): update timeline tests for route-based schedule navigation

### DIFF
--- a/e2e/pages/TimelinePage.ts
+++ b/e2e/pages/TimelinePage.ts
@@ -181,7 +181,7 @@ export class TimelinePage {
 
   /** Navigate to schedule in calendar view. */
   async gotoCalendar(): Promise<void> {
-    await this.page.goto(`${TIMELINE_ROUTE}?view=calendar`);
+    await this.page.goto('/schedule/calendar');
     await this.heading.waitFor({ state: 'visible' });
     await this.calendarView.waitFor({ state: 'visible' });
   }

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -439,7 +439,7 @@ test.describe('Documentation screenshots', () => {
     // Ensure list is populated before screenshotting.
     // Use level: 1 to target only the page h1, not the sidebar nav link which
     // also matches /work items/i and would cause a strict-mode violation.
-    await expect(page.getByRole('heading', { level: 1, name: /work items/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /project/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {
@@ -710,7 +710,7 @@ test.describe('Documentation screenshots', () => {
   test('Household items list', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.householdItems}`);
     await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('heading', { level: 1, name: /household items/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /project/i })).toBeVisible();
     await page.waitForTimeout(500);
 
     for (const theme of ['light', 'dark'] as const) {

--- a/e2e/tests/timeline/timeline-calendar.spec.ts
+++ b/e2e/tests/timeline/timeline-calendar.spec.ts
@@ -39,16 +39,14 @@ test.describe('View toggle (Scenario 1)', { tag: '@responsive' }, () => {
     const timelinePage = new TimelinePage(page);
     await timelinePage.goto();
 
-    // Start in Gantt view (default)
-    await expect(timelinePage.ganttViewButton).toHaveAttribute('aria-pressed', 'true');
-    await expect(timelinePage.calendarViewButton).toHaveAttribute('aria-pressed', 'false');
+    // Start in Gantt view (default) — NavLink sets aria-current="page" on active link
+    await expect(timelinePage.ganttViewButton).toHaveAttribute('aria-current', 'page');
 
     // Switch to calendar
     await timelinePage.switchToCalendar();
 
     await expect(timelinePage.calendarView).toBeVisible();
-    await expect(timelinePage.calendarViewButton).toHaveAttribute('aria-pressed', 'true');
-    await expect(timelinePage.ganttViewButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(timelinePage.calendarViewButton).toHaveAttribute('aria-current', 'page');
   });
 
   test('Switching back to Gantt view hides the calendar', async ({ page }) => {
@@ -60,23 +58,23 @@ test.describe('View toggle (Scenario 1)', { tag: '@responsive' }, () => {
     await timelinePage.switchToGantt();
 
     await expect(timelinePage.calendarView).not.toBeVisible();
-    await expect(timelinePage.ganttViewButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(timelinePage.ganttViewButton).toHaveAttribute('aria-current', 'page');
   });
 
-  test('Calendar view URL param is added/removed when toggling views', async ({ page }) => {
+  test('Calendar view URL changes when toggling views', async ({ page }) => {
     const timelinePage = new TimelinePage(page);
     await timelinePage.goto();
 
-    // Default URL has no ?view param
-    expect(page.url()).not.toContain('view=calendar');
+    // Default URL is /schedule/gantt
+    expect(page.url()).toContain('/schedule/gantt');
 
     // Switch to calendar
     await timelinePage.switchToCalendar();
-    expect(page.url()).toContain('view=calendar');
+    expect(page.url()).toContain('/schedule/calendar');
 
     // Switch back to Gantt
     await timelinePage.switchToGantt();
-    expect(page.url()).not.toContain('view=calendar');
+    expect(page.url()).toContain('/schedule/gantt');
   });
 });
 
@@ -413,7 +411,7 @@ test.describe('Calendar dark mode (Scenario 10)', { tag: '@responsive' }, () => 
   test('Calendar view renders correctly in dark mode', async ({ page }) => {
     const timelinePage = new TimelinePage(page);
 
-    await page.goto(`${TIMELINE_ROUTE}?view=calendar`);
+    await page.goto('/schedule/calendar');
     await page.evaluate(() => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
@@ -435,21 +433,21 @@ test.describe('Calendar dark mode (Scenario 10)', { tag: '@responsive' }, () => 
 // Scenario 11: URL param persistence
 // ─────────────────────────────────────────────────────────────────────────────
 
-test.describe('URL param persistence (Scenario 11)', () => {
-  test('Direct navigation to ?view=calendar renders calendar view', async ({ page }) => {
+test.describe('URL route persistence (Scenario 11)', () => {
+  test('Direct navigation to /schedule/calendar renders calendar view', async ({ page }) => {
     const timelinePage = new TimelinePage(page);
     await timelinePage.gotoCalendar();
 
     await expect(timelinePage.calendarView).toBeVisible();
-    await expect(timelinePage.calendarViewButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(timelinePage.calendarViewButton).toHaveAttribute('aria-current', 'page');
   });
 
-  test('Direct navigation to ?view=calendar&calendarMode=week renders week grid', async ({
+  test('Direct navigation to /schedule/calendar?calendarMode=week renders week grid', async ({
     page,
   }) => {
     const timelinePage = new TimelinePage(page);
 
-    await page.goto(`${TIMELINE_ROUTE}?view=calendar&calendarMode=week`);
+    await page.goto('/schedule/calendar?calendarMode=week');
     await timelinePage.heading.waitFor({ state: 'visible' });
     await timelinePage.calendarView.waitFor({ state: 'visible' });
 

--- a/e2e/tests/timeline/timeline-gantt.spec.ts
+++ b/e2e/tests/timeline/timeline-gantt.spec.ts
@@ -31,10 +31,10 @@ test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
     await expect(timelinePage.heading).toHaveText('Schedule');
   });
 
-  test('Page URL is /schedule', async ({ page }) => {
+  test('Page URL is /schedule/gantt', async ({ page }) => {
     await page.goto(TIMELINE_ROUTE);
-    await page.waitForURL('**/schedule');
-    expect(page.url()).toContain('/schedule');
+    await page.waitForURL('**/schedule/gantt');
+    expect(page.url()).toContain('/schedule/gantt');
   });
 
   test('Toolbar is rendered with view toggle buttons', async ({ page }) => {

--- a/e2e/tests/timeline/timeline-responsive.spec.ts
+++ b/e2e/tests/timeline/timeline-responsive.spec.ts
@@ -474,13 +474,12 @@ test.describe('ARIA roles and labels (Scenario 7)', { tag: '@responsive' }, () =
     await expect(timelinePage.zoomToolbar).toHaveAttribute('aria-label', 'Zoom level');
   });
 
-  test('View toggle toolbar has role=toolbar and accessible label', async ({ page }) => {
+  test('View toggle navigation has accessible label', async ({ page }) => {
     const timelinePage = new TimelinePage(page);
     await timelinePage.goto();
 
-    const viewToolbar = page.getByRole('toolbar', { name: 'View mode' });
-    await expect(viewToolbar).toBeVisible();
-    await expect(viewToolbar).toHaveAttribute('role', 'toolbar');
+    const viewNav = page.getByRole('navigation', { name: 'Schedule view navigation' });
+    await expect(viewNav).toBeVisible();
   });
 
   test('Calendar mode toolbar has role=toolbar', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Updates E2E tests to match the new route-based schedule navigation (`/schedule/gantt`, `/schedule/calendar`) introduced by the ScheduleSubNav rework in #622
- Fixes screenshot test heading assertions for the updated page titles

## Changes
- `TimelinePage.ts`: `gotoCalendar()` uses `/schedule/calendar` route
- `timeline-calendar.spec.ts`: `aria-pressed` → `aria-current`, URL assertions use route paths
- `timeline-responsive.spec.ts`: View toggle assertion uses `navigation` role
- `timeline-gantt.spec.ts`: URL test checks `/schedule/gantt`
- `capture-docs-screenshots.spec.ts`: Heading assertions use "Project"

## Test plan
- [ ] All E2E shards pass in CI

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>