### PR TITLE
fix(e2e): remove stale milestonePanelButton reference from timeline-gantt test

### DIFF
--- a/e2e/tests/timeline/timeline-gantt.spec.ts
+++ b/e2e/tests/timeline/timeline-gantt.spec.ts
@@ -43,7 +43,6 @@ test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
 
     await expect(timelinePage.ganttViewButton).toBeVisible();
     await expect(timelinePage.calendarViewButton).toBeVisible();
-    await expect(timelinePage.milestonePanelButton).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove `milestonePanelButton` reference from `timeline-gantt.spec.ts` that was missed when the milestone panel was moved to its own page

The milestone panel was removed from the Schedule page in PR #644. This reference was missed, causing E2E shards 5/16, 11/16, and 16/16 to fail with "toBeVisible can be only used with Locator object".

## Test plan
- [ ] E2E smoke tests pass
- [ ] E2E shards pass (no more milestonePanelButton errors)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>