### PR TITLE
fix(e2e): update HI detail page tests for back button navigation

### DIFF
--- a/e2e/pages/HouseholdItemDetailPage.ts
+++ b/e2e/pages/HouseholdItemDetailPage.ts
@@ -49,13 +49,10 @@ export class HouseholdItemDetailPage {
 
     // Back link is a <Link> in the breadcrumb with text "Household Items".
     // NOTE: The AppShell sidebar also has a "Household Items" nav link.
-    // On mobile/tablet, the sidebar is off-screen, so .first() resolves to the
-    // sidebar nav link (outside viewport) and the click times out.
-    // Scope to the breadcrumb container (class*="breadcrumb") to always get the
-    // correct in-page breadcrumb link regardless of viewport.
-    this.backLink = page.locator('[class*="breadcrumb"]').getByRole('link', {
-      name: 'Household Items',
-      exact: true,
+    // The back button is in a navButtons container above the heading.
+    // Scope to the navButtons container to avoid matching sidebar links.
+    this.backLink = page.locator('[class*="navButtons"]').getByRole('button', {
+      name: /back to household items/i,
     });
 
     // Edit button — located in the pageActions area; class="editButton"

--- a/e2e/tests/household-items/household-item-detail.spec.ts
+++ b/e2e/tests/household-items/household-item-detail.spec.ts
@@ -56,8 +56,8 @@ test.describe('Page load (Scenario 1)', { tag: '@responsive' }, () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // Scenario 2: Back link navigates to /project/household-items
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Back breadcrumb navigation (Scenario 2)', { tag: '@responsive' }, () => {
-  test('"Household Items" breadcrumb link navigates to /project/household-items', async ({
+test.describe('Back button navigation (Scenario 2)', { tag: '@responsive' }, () => {
+  test('"Back to Household Items" button navigates to /project/household-items', async ({
     page,
     testPrefix,
   }) => {


### PR DESCRIPTION
## Summary
- Update HouseholdItemDetailPage POM to find back button instead of breadcrumb link
- Update E2E test description to match new back button pattern

Fixes E2E failures in promotion PR #670 (shards 3/16, 9/16, 14/16).

## Test plan
- [x] E2E tests should pass with updated POM locator

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>