### PR TITLE
fix(e2e): update vendor and HI E2E tests for breadcrumb to back button migration

### DIFF
--- a/e2e/pages/HouseholdItemDetailPage.ts
+++ b/e2e/pages/HouseholdItemDetailPage.ts
@@ -47,7 +47,7 @@ export class HouseholdItemDetailPage {
     // h1 heading — the item name (editable)
     this.heading = page.getByRole('heading', { level: 1 });
 
-    // Back link is a <Link> in the breadcrumb with text "Household Items".
+    // Back button navigates to the household items list.
     // NOTE: The AppShell sidebar also has a "Household Items" nav link.
     // The back button is in a navButtons container above the heading.
     // Scope to the navButtons container to avoid matching sidebar links.

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -4,7 +4,7 @@
  * EPIC-04: Household Items & Furniture Management
  *
  * The page renders:
- * - A page header with h1 "Household Items" and a "New Item" button
+ * - A page header with h1 "Household Items" and an "Add new Household Item" button
  * - A search input (aria-label="Search household items") with 300ms debounce
  * - Filter panel (role="search", aria-label="Household item filters") with:
  *   - #category-filter (select)
@@ -20,7 +20,7 @@
  * - An error banner (role="alert", class errorBanner) for API errors
  *
  * Key DOM observations from source code:
- * - "New Item" is a <button> that calls navigate('/project/household-items/new')
+ * - "Add new Household Item" is a <button> that calls navigate('/project/household-items/new')
  * - Delete modal: aria-labelledby="hi-delete-modal-title", confirm button: class confirmDeleteButton
  * - Empty state h2: "No household items yet" or "No household items match your filters"
  * - Table rows are clickable and navigate to detail page
@@ -76,7 +76,7 @@ export class HouseholdItemsPage {
 
     // Page header
     this.heading = page.getByRole('heading', { level: 1, name: 'Project', exact: true });
-    this.newItemButton = page.getByRole('button', { name: /New Item/i });
+    this.newItemButton = page.getByRole('button', { name: /Add new Household Item/i });
 
     // Search and filters
     this.searchInput = page.getByLabel('Search household items');

--- a/e2e/pages/VendorDetailPage.ts
+++ b/e2e/pages/VendorDetailPage.ts
@@ -2,7 +2,7 @@
  * Page Object Model for the Vendor Detail page (/budget/vendors/:id)
  *
  * The page renders:
- * - A breadcrumb navigation (Vendors / <name>)
+ * - A back button navigation ("← Back to Vendors")
  * - A page header with vendor name, specialty subtitle, and Edit/Delete buttons
  * - Stats cards: Total Invoices and Outstanding Balance
  * - An info card (dl/dt/dd list) with all vendor fields — read view
@@ -25,9 +25,8 @@ export interface EditVendorData {
 export class VendorDetailPage {
   readonly page: Page;
 
-  // Breadcrumb
+  // Navigation
   readonly backToVendorsButton: Locator;
-  readonly breadcrumbCurrent: Locator;
 
   // Page header
   readonly pageTitle: Locator;
@@ -71,9 +70,8 @@ export class VendorDetailPage {
   constructor(page: Page) {
     this.page = page;
 
-    // Breadcrumb — the "Vendors" back link is a React Router <Link> (renders <a>)
-    this.backToVendorsButton = page.getByRole('link', { name: 'Vendors', exact: true });
-    this.breadcrumbCurrent = page.locator('[class*="breadcrumbCurrent"]');
+    // Navigation — back button replaces breadcrumb
+    this.backToVendorsButton = page.getByRole('button', { name: /back to vendors/i });
 
     // Page header
     this.pageTitle = page.getByRole('heading', { level: 1 });
@@ -136,7 +134,7 @@ export class VendorDetailPage {
   }
 
   /**
-   * Navigate back to the vendors list using the breadcrumb button.
+   * Navigate back to the vendors list using the back button.
    */
   async goBackToVendors(): Promise<void> {
     await this.backToVendorsButton.click();

--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -417,13 +417,13 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
     }
   });
 
-  test('Detail page heading matches vendor name; breadcrumb shows vendor name', async ({
+  test('Detail page heading matches vendor name and back button is visible', async ({
     page,
     testPrefix,
   }) => {
     const detailPage = new VendorDetailPage(page);
     let createdId: string | null = null;
-    const vendorName = `${testPrefix} Breadcrumb Vendor`;
+    const vendorName = `${testPrefix} Detail Heading Vendor`;
 
     try {
       createdId = await createVendorViaApi(page, {
@@ -434,7 +434,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
       await detailPage.goto(createdId);
 
       await expect(detailPage.pageTitle).toHaveText(vendorName);
-      await expect(detailPage.breadcrumbCurrent).toHaveText(vendorName);
+      await expect(detailPage.backToVendorsButton).toBeVisible();
     } finally {
       if (createdId) await deleteVendorViaApi(page, createdId);
     }
@@ -1054,7 +1054,7 @@ test.describe('List shows key info (Scenario 14)', { tag: '@responsive' }, () =>
 // Navigation tests
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Navigation between list and detail pages', { tag: '@responsive' }, () => {
-  test('Clicking vendor link navigates to detail page; breadcrumb "Vendors" returns to list', async ({
+  test('Clicking vendor link navigates to detail page; back button returns to list', async ({
     page,
     testPrefix,
   }) => {
@@ -1078,10 +1078,10 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
       await vendorsPage.clickView(vendorName);
       await page.waitForURL('**/budget/vendors/*', { timeout: 15000 });
 
-      // Wait for detail page to fully render before interacting with breadcrumb
+      // Wait for detail page to fully render before interacting with back button
       await expect(detailPage.infoCard).toBeVisible({ timeout: 15000 });
 
-      // Navigate back via breadcrumb
+      // Navigate back via back button
       await detailPage.goBackToVendors();
       expect(page.url()).toContain('/budget/vendors');
       await vendorsPage.heading.waitFor({ state: 'visible', timeout: 15000 });


### PR DESCRIPTION
## Summary
- Update VendorDetailPage POM: remove breadcrumbCurrent locator, use back button
- Update vendors.spec.ts: remove breadcrumb text assertions, verify back button instead
- Update HouseholdItemsPage POM: button name from "New Item" to "Add new Household Item"

Fixes E2E failures on promotion PR caused by detail page header rework.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>