### PR TITLE
fix(ui): address UAT round 9 feedback (#698, #699, #700)

### DIFF
--- a/client/src/components/GanttChart/GanttChart.tsx
+++ b/client/src/components/GanttChart/GanttChart.tsx
@@ -600,6 +600,30 @@ export function GanttChart({
   }, [data.milestones]);
 
   /**
+   * Map from household item ID → resolved linked items (work items / milestones).
+   * Used to populate the tooltip's "Linked Items" section.
+   */
+  const hiLinkedItemsMap = useMemo(() => {
+    const map = new Map<string, { id: string; title: string; type: 'work_item' | 'milestone' }[]>();
+    for (const hi of data.householdItems ?? []) {
+      if (hi.dependencyIds.length === 0) continue;
+      const linked: { id: string; title: string; type: 'work_item' | 'milestone' }[] = [];
+      for (const dep of hi.dependencyIds) {
+        if (dep.predecessorType === 'work_item') {
+          const title = workItemMap.get(dep.predecessorId)?.title;
+          if (title) linked.push({ id: dep.predecessorId, title, type: 'work_item' });
+        } else {
+          const msId = Number(dep.predecessorId);
+          const title = milestoneTitles.get(msId);
+          if (title) linked.push({ id: dep.predecessorId, title, type: 'milestone' });
+        }
+      }
+      if (linked.length > 0) map.set(hi.id, linked);
+    }
+    return map;
+  }, [data.householdItems, workItemMap, milestoneTitles]);
+
+  /**
    * Map from HI ID to its circle center position in SVG coordinates.
    * Mirrors the positioning logic in GanttHouseholdItems: each HI occupies
    * its own row in the unified row list. The x position uses the best available date.
@@ -994,6 +1018,7 @@ export function GanttChart({
           actualDeliveryDate: tooltipItem.actualDeliveryDate,
           isLate: tooltipItem.isLate,
           householdItemId: hiId,
+          linkedItems: hiLinkedItemsMap.get(hiId),
         });
         setTooltipPosition({
           x: window.innerWidth / 2,
@@ -1008,6 +1033,7 @@ export function GanttChart({
       onHouseholdItemClick,
       showTimerRef,
       hideTimerRef,
+      hiLinkedItemsMap,
     ],
   );
 
@@ -1319,6 +1345,7 @@ export function GanttChart({
                       actualDeliveryDate: hi.actualDeliveryDate,
                       isLate: hi.isLate,
                       householdItemId: hi.id,
+                      linkedItems: hiLinkedItemsMap.get(hi.id),
                     });
                     setTooltipPosition(newPos);
                   }, TOOLTIP_SHOW_DELAY);
@@ -1354,6 +1381,7 @@ export function GanttChart({
                       actualDeliveryDate: hi.actualDeliveryDate,
                       isLate: hi.isLate,
                       householdItemId: hi.id,
+                      linkedItems: hiLinkedItemsMap.get(hi.id),
                     });
                     setTooltipPosition(newPos);
                   }, TOOLTIP_SHOW_DELAY);

--- a/client/src/components/GanttChart/GanttTooltip.tsx
+++ b/client/src/components/GanttChart/GanttTooltip.tsx
@@ -87,6 +87,8 @@ export interface GanttTooltipHouseholdItemData {
   isLate: boolean;
   /** HI ID for "View item" touch link. */
   householdItemId?: string;
+  /** Linked items (work items / milestones) that this household item depends on. */
+  linkedItems?: { id: string; title: string; type: 'work_item' | 'milestone' }[];
 }
 
 /**
@@ -589,6 +591,30 @@ function HouseholdItemTooltipContent({
         <div className={styles.detailRow}>
           <span className={styles.detailValueFloored}>Floored to today</span>
         </div>
+      )}
+
+      {/* Linked items section */}
+      {data.linkedItems && data.linkedItems.length > 0 && (
+        <>
+          <div className={styles.separator} aria-hidden="true" />
+          <div className={styles.linkedItemsSection}>
+            <span className={styles.linkedItemsLabel}>
+              Linked Items ({data.linkedItems.length})
+            </span>
+            <ul className={styles.linkedItemsList} aria-label="Linked items">
+              {data.linkedItems.slice(0, MAX_LINKED_ITEMS_SHOWN).map((item) => (
+                <li key={`${item.type}-${item.id}`} className={styles.linkedItem}>
+                  {item.title}
+                </li>
+              ))}
+              {data.linkedItems.length > MAX_LINKED_ITEMS_SHOWN && (
+                <li className={styles.linkedItemsOverflow}>
+                  +{data.linkedItems.length - MAX_LINKED_ITEMS_SHOWN} more
+                </li>
+              )}
+            </ul>
+          </div>
+        </>
       )}
 
       {/* View item link (touch devices only) */}

--- a/client/src/components/calendar/CalendarView.tsx
+++ b/client/src/components/calendar/CalendarView.tsx
@@ -188,6 +188,32 @@ export function CalendarView({
 
   const milestoneById = useMemo(() => new Map(milestones.map((m) => [m.id, m])), [milestones]);
 
+  const householdItemById = useMemo(
+    () => new Map(householdItems.map((hi) => [hi.id, hi])),
+    [householdItems],
+  );
+
+  // Build per-HI linked items (resolved from dependencyIds)
+  const hiLinkedItemsMap = useMemo(() => {
+    const map = new Map<string, { id: string; title: string; type: 'work_item' | 'milestone' }[]>();
+    for (const hi of householdItems) {
+      if (hi.dependencyIds.length === 0) continue;
+      const linked: { id: string; title: string; type: 'work_item' | 'milestone' }[] = [];
+      for (const dep of hi.dependencyIds) {
+        if (dep.predecessorType === 'work_item') {
+          const wi = workItemById.get(dep.predecessorId);
+          if (wi) linked.push({ id: dep.predecessorId, title: wi.title, type: 'work_item' });
+        } else {
+          const msId = Number(dep.predecessorId);
+          const ms = milestoneById.get(msId);
+          if (ms) linked.push({ id: dep.predecessorId, title: ms.title, type: 'milestone' });
+        }
+      }
+      if (linked.length > 0) map.set(hi.id, linked);
+    }
+    return map;
+  }, [householdItems, workItemById, milestoneById]);
+
   // Build per-item dependency tooltip entries (predecessors + successors)
   const itemTooltipDepsMap = useMemo(() => {
     const map = new Map<string, GanttTooltipDependencyEntry[]>();
@@ -241,28 +267,47 @@ export function CalendarView({
     return map;
   }, [workItems]);
 
-  // When a first touch-tap occurs on a work item, show its tooltip and register for two-tap
+  // When a first touch-tap occurs on a work/household item, show its tooltip and register for two-tap
   const handleCalendarItemTouchTap = useCallback(
     (itemId: string, onNavigate: () => void) => {
-      const item = workItemById.get(itemId);
-      if (item && activeTouchId !== itemId) {
+      if (activeTouchId !== itemId) {
         // First tap: build tooltip data and show it
-        const today = new Date();
-        const effectiveStart = item.actualStartDate ?? item.startDate;
-        const effectiveEnd = item.actualEndDate ?? item.endDate;
-        const actualDurationDays = computeActualDuration(effectiveStart, effectiveEnd, today);
-        setTooltipData({
-          kind: 'work-item',
-          title: item.title,
-          status: item.status,
-          startDate: item.startDate,
-          endDate: item.endDate,
-          durationDays: item.durationDays,
-          assignedUserName: item.assignedUser?.displayName ?? null,
-          plannedDurationDays: item.durationDays,
-          actualDurationDays,
-          dependencies: itemTooltipDepsMap.get(itemId),
-        });
+        const item = workItemById.get(itemId);
+        if (item) {
+          const today = new Date();
+          const effectiveStart = item.actualStartDate ?? item.startDate;
+          const effectiveEnd = item.actualEndDate ?? item.endDate;
+          const actualDurationDays = computeActualDuration(effectiveStart, effectiveEnd, today);
+          setTooltipData({
+            kind: 'work-item',
+            title: item.title,
+            status: item.status,
+            startDate: item.startDate,
+            endDate: item.endDate,
+            durationDays: item.durationDays,
+            assignedUserName: item.assignedUser?.displayName ?? null,
+            plannedDurationDays: item.durationDays,
+            actualDurationDays,
+            dependencies: itemTooltipDepsMap.get(itemId),
+          });
+        } else {
+          const hi = householdItemById.get(itemId);
+          if (hi) {
+            setTooltipData({
+              kind: 'household-item',
+              name: hi.name,
+              category: hi.category,
+              status: hi.status,
+              earliestDeliveryDate: hi.earliestDeliveryDate,
+              latestDeliveryDate: hi.latestDeliveryDate,
+              targetDeliveryDate: hi.targetDeliveryDate,
+              actualDeliveryDate: hi.actualDeliveryDate,
+              isLate: hi.isLate,
+              householdItemId: hi.id,
+              linkedItems: hiLinkedItemsMap.get(hi.id),
+            });
+          }
+        }
         // Position tooltip at viewport center as a safe default for touch
         setTooltipPosition({
           x: typeof window !== 'undefined' ? window.innerWidth / 2 : 300,
@@ -277,37 +322,61 @@ export function CalendarView({
         onNavigate();
       });
     },
-    [workItemById, activeTouchId, itemTooltipDepsMap, handleTouchTap],
+    [workItemById, householdItemById, activeTouchId, itemTooltipDepsMap, hiLinkedItemsMap, handleTouchTap],
   );
 
-  const handleWorkItemMouseEnter = useCallback(
+  const handleItemMouseEnter = useCallback(
     (itemId: string, mouseX: number, mouseY: number) => {
       clearTooltipTimers();
       handleItemHoverStart(itemId);
+
+      // Check work items first
       const item = workItemById.get(itemId);
-      if (!item) return;
-      tooltipShowTimerRef.current = setTimeout(() => {
-        // Compute actual duration from actual/scheduled dates
-        const today = new Date();
-        const effectiveStart = item.actualStartDate ?? item.startDate;
-        const effectiveEnd = item.actualEndDate ?? item.endDate;
-        const actualDurationDays = computeActualDuration(effectiveStart, effectiveEnd, today);
-        setTooltipData({
-          kind: 'work-item',
-          title: item.title,
-          status: item.status,
-          startDate: item.startDate,
-          endDate: item.endDate,
-          durationDays: item.durationDays,
-          assignedUserName: item.assignedUser?.displayName ?? null,
-          plannedDurationDays: item.durationDays,
-          actualDurationDays,
-          dependencies: itemTooltipDepsMap.get(itemId),
-        });
-        setTooltipPosition({ x: mouseX, y: mouseY });
-      }, TOOLTIP_SHOW_DELAY);
+      if (item) {
+        tooltipShowTimerRef.current = setTimeout(() => {
+          const today = new Date();
+          const effectiveStart = item.actualStartDate ?? item.startDate;
+          const effectiveEnd = item.actualEndDate ?? item.endDate;
+          const actualDurationDays = computeActualDuration(effectiveStart, effectiveEnd, today);
+          setTooltipData({
+            kind: 'work-item',
+            title: item.title,
+            status: item.status,
+            startDate: item.startDate,
+            endDate: item.endDate,
+            durationDays: item.durationDays,
+            assignedUserName: item.assignedUser?.displayName ?? null,
+            plannedDurationDays: item.durationDays,
+            actualDurationDays,
+            dependencies: itemTooltipDepsMap.get(itemId),
+          });
+          setTooltipPosition({ x: mouseX, y: mouseY });
+        }, TOOLTIP_SHOW_DELAY);
+        return;
+      }
+
+      // Check household items
+      const hi = householdItemById.get(itemId);
+      if (hi) {
+        tooltipShowTimerRef.current = setTimeout(() => {
+          setTooltipData({
+            kind: 'household-item',
+            name: hi.name,
+            category: hi.category,
+            status: hi.status,
+            earliestDeliveryDate: hi.earliestDeliveryDate,
+            latestDeliveryDate: hi.latestDeliveryDate,
+            targetDeliveryDate: hi.targetDeliveryDate,
+            actualDeliveryDate: hi.actualDeliveryDate,
+            isLate: hi.isLate,
+            householdItemId: hi.id,
+            linkedItems: hiLinkedItemsMap.get(hi.id),
+          });
+          setTooltipPosition({ x: mouseX, y: mouseY });
+        }, TOOLTIP_SHOW_DELAY);
+      }
     },
-    [workItemById, handleItemHoverStart, itemTooltipDepsMap],
+    [workItemById, householdItemById, handleItemHoverStart, itemTooltipDepsMap, hiLinkedItemsMap],
   );
 
   const handleWorkItemMouseLeave = useCallback(() => {
@@ -543,7 +612,7 @@ export function CalendarView({
             householdItems={householdItems}
             onMilestoneClick={onMilestoneClick}
             hoveredItemId={hoveredItemId}
-            onItemMouseEnter={handleWorkItemMouseEnter}
+            onItemMouseEnter={handleItemMouseEnter}
             onItemMouseLeave={handleWorkItemMouseLeave}
             onItemMouseMove={handleWorkItemMouseMove}
             onMilestoneMouseEnter={handleMilestoneMouseEnter}
@@ -561,7 +630,7 @@ export function CalendarView({
             householdItems={householdItems}
             onMilestoneClick={onMilestoneClick}
             hoveredItemId={hoveredItemId}
-            onItemMouseEnter={handleWorkItemMouseEnter}
+            onItemMouseEnter={handleItemMouseEnter}
             onItemMouseLeave={handleWorkItemMouseLeave}
             onItemMouseMove={handleWorkItemMouseMove}
             onMilestoneMouseEnter={handleMilestoneMouseEnter}

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.test.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.test.tsx
@@ -135,13 +135,13 @@ describe('HouseholdItemsPage', () => {
       });
     });
 
-    it('renders "Add new Household Item" button in header', async () => {
+    it('renders "New Household Item" button in header', async () => {
       mockListHouseholdItems.mockResolvedValueOnce(emptyResponse);
 
       renderPage();
 
       await waitFor(() => {
-        const buttons = screen.getAllByRole('button', { name: /add new household item/i });
+        const buttons = screen.getAllByRole('button', { name: /new household item/i });
         expect(buttons[0]).toBeInTheDocument();
       });
     });
@@ -330,7 +330,7 @@ describe('HouseholdItemsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add new household item/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new household item/i })).toBeInTheDocument();
       });
 
       // Open the actions menu for the first item by clicking the first menu button
@@ -358,7 +358,7 @@ describe('HouseholdItemsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add new household item/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new household item/i })).toBeInTheDocument();
       });
 
       // Open the actions menu for the first item
@@ -384,7 +384,7 @@ describe('HouseholdItemsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add new household item/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new household item/i })).toBeInTheDocument();
       });
 
       // Open the actions menu for the first item
@@ -412,7 +412,7 @@ describe('HouseholdItemsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add new household item/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new household item/i })).toBeInTheDocument();
       });
 
       // Open the actions menu for the first item
@@ -441,7 +441,7 @@ describe('HouseholdItemsPage', () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /add new household item/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new household item/i })).toBeInTheDocument();
       });
 
       // Open the actions menu for the first item

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -450,7 +450,7 @@ export function HouseholdItemsPage() {
           className={styles.primaryButton}
           onClick={() => navigate('/project/household-items/new')}
         >
-          Add new Household Item
+          New Household Item
         </button>
       </div>
       <ProjectSubNav />

--- a/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.tsx
+++ b/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.tsx
@@ -597,13 +597,13 @@ export function MilestoneDetailPage() {
                   ))}
                   {linkedHouseholdItems.map((item) => (
                     <li key={`hi-${item.id}`} className={styles.linkedWorkItem}>
+                      <span className={styles.itemTypeBadgeHI}>Household Item</span>
                       <Link
                         to={`/project/household-items/${item.id}`}
                         className={styles.workItemLink}
                       >
                         {item.name}
                       </Link>
-                      <span className={styles.itemTypeBadgeHI}>Household</span>
                       <button
                         type="button"
                         className={styles.unlinkButton}

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -76,7 +76,7 @@ export class HouseholdItemsPage {
 
     // Page header
     this.heading = page.getByRole('heading', { level: 1, name: 'Project', exact: true });
-    this.newItemButton = page.getByRole('button', { name: /Add new Household Item/i });
+    this.newItemButton = page.getByRole('button', { name: /New Household Item/i });
 
     // Search and filters
     this.searchInput = page.getByLabel('Search household items');


### PR DESCRIPTION
## Summary
- Move HI type badge to left of name in milestone detail view, matching WI pattern (#698)
- Change button text to "New Household Item" on HI list page (#699)
- Add household item tooltip support to Calendar view and show linked items in HI tooltips for both Gantt and Calendar views (#700)

Fixes #698
Fixes #699
Fixes #700

## Test plan
- [ ] Milestone detail page shows HI badge left of name
- [ ] HI list page button says "New Household Item"
- [ ] Calendar view shows tooltip on HI hover with delivery dates and linked items
- [ ] Gantt chart HI tooltip also shows linked items
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>