### PR TITLE
fix(milestones): use same badge class for HI as WI in milestone detail

### DIFF
--- a/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.tsx
+++ b/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.tsx
@@ -597,7 +597,7 @@ export function MilestoneDetailPage() {
                   ))}
                   {linkedHouseholdItems.map((item) => (
                     <li key={`hi-${item.id}`} className={styles.linkedWorkItem}>
-                      <span className={styles.itemTypeBadgeHI}>Household Item</span>
+                      <span className={styles.itemTypeBadge}>Household Item</span>
                       <Link
                         to={`/project/household-items/${item.id}`}
                         className={styles.workItemLink}
@@ -666,7 +666,7 @@ export function MilestoneDetailPage() {
                           onClick={() => handleQuickLinkHouseholdItem(item.id)}
                           disabled={isLinkingItem}
                         >
-                          <span className={styles.itemTypeBadgeHI}>Household</span>
+                          <span className={styles.itemTypeBadge}>Household Item</span>
                           <span>{item.name}</span>
                         </button>
                       ))}


### PR DESCRIPTION
## Summary
- Change HI indicator from `itemTypeBadgeHI` (green) to `itemTypeBadge` (blue/primary) to match WI indicator styling
- Normalize search dropdown label from "Household" to "Household Item"

## Test plan
- [ ] Milestone detail page HI badge matches WI badge styling (blue, same class)
- [ ] Search dropdown shows "Household Item" badge for HI results

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>