### PR TITLE
fix(dashboard): add aria-live to mobile sections container

### DIFF
--- a/client/src/pages/DashboardPage/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage/DashboardPage.tsx
@@ -433,7 +433,7 @@ export function DashboardPage() {
       </div>
 
       {/* Mobile: sectioned layout */}
-      <div className={styles.mobileSections} role="region" aria-label="Dashboard overview">
+      <div className={styles.mobileSections} role="region" aria-label="Dashboard overview" aria-live="polite" aria-atomic="false">
         {/* Primary section — always expanded */}
         <div className={styles.mobileSection}>
           {visibleCards.filter((c) => c.section === 'primary').map((card) => renderCard(card))}


### PR DESCRIPTION
## Summary
- Adds `aria-live="polite"` and `aria-atomic="false"` to the mobile sections container to match the desktop grid's ARIA attributes
- Ensures screen reader users on mobile viewports receive state change announcements

Fixes review finding from product-owner on PR #718.

Fixes #478

## Test plan
- [ ] CI passes (no functional changes, only ARIA attribute addition)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>