### PR TITLE
docs: add dashboard guide for EPIC-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A self-hosted home building project management tool for homeowners. Track work i
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, and work item linking
+- **Project Dashboard** -- At-a-glance project health with budget, timeline, invoice, and subsidy cards, mini Gantt preview, and customizable layout
 - **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices
 - **Authentication** -- Local accounts with setup wizard, OIDC single sign-on
 - **User Management** -- Admin and Member roles, admin panel
@@ -76,7 +77,7 @@ Open `http://localhost:3000` -- the setup wizard will guide you through creating
 - [x] **EPIC-12**: Codebase Refinement and Consistency
 - [x] **EPIC-14**: Cross-Entity Code Deduplication
 - [x] **EPIC-15**: Budget-Line Invoice Linking Rework
-- [ ] **EPIC-09**: Dashboard and Overview
+- [x] **EPIC-09**: Dashboard and Overview
 - [ ] **EPIC-13**: Construction Diary
 
 Track live progress on the [GitHub Projects board](https://github.com/users/steilerDev/projects/4).

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,15 +1,10 @@
 ## What's New
 
-This release reworks the invoice-budget-line relationship from a one-to-one model to a flexible many-to-many design. A single invoice can now be linked to multiple budget lines across work items and household items, each with an itemized amount that attributes a specific portion of the invoice to that budget line.
+Cornerstone now includes a project dashboard that gives you an at-a-glance view of your entire home building project. The dashboard pulls together budget health, timeline progress, invoices, and subsidies into a single page of customizable cards.
 
 ### Highlights
 
-- **Multiple Budget Lines per Invoice** -- Link several budget lines from different work items and household items to a single invoice, each with its own itemized amount. A computed "Remaining" row on the invoice page shows any unallocated portion of the invoice total.
-- **Bidirectional Linking** -- Attach budget lines to invoices from the invoice detail page (two-step picker: select item, then budget line) or directly from a work item or household item's Budget tab.
-- **Invoice Groups on Item Pages** -- When multiple budget lines on the same item share an invoice, they collapse into a grouped view showing the invoice total, each line's planned amount, and its itemized amount.
-- **Accurate Subsidy Calculations** -- Subsidy reductions now use the itemized invoice amount as the cost basis when a budget line is linked to an invoice, instead of the planned estimate.
-- **Accessibility Improvements** -- Focus-visible states, ARIA attributes on invoice groups, keyboard navigation, and 44px touch targets on mobile.
-
-### Breaking Changes
-
-- The old single-budget-line picker on the invoice create/edit modals has been removed. Budget lines are now linked after invoice creation from the invoice detail page or from item detail pages.
+- **Project Dashboard** -- A new overview page at Project > Overview with eight information cards covering budget summary, budget alerts, source utilization, timeline status, a mini Gantt preview, invoice pipeline, subsidy pipeline, and quick actions
+- **Card Customization** -- Dismiss cards you do not need and re-enable them later via the Customize menu; preferences are saved per user
+- **Responsive Layout** -- On mobile, cards are grouped into collapsible sections (Primary, Timeline, Budget Details) with summary lines
+- **Mini Gantt Preview** -- A compact 30-day Gantt chart rendered inline on the dashboard; click it to jump to the full Gantt chart view

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -76,6 +76,7 @@ const sidebars = {
         'guides/household-items/delivery-and-dependencies',
       ],
     },
+    'guides/dashboard/index',
     'guides/appearance/dark-mode',
     'roadmap',
   ],

--- a/docs/src/guides/dashboard/index.md
+++ b/docs/src/guides/dashboard/index.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 1
+title: Dashboard
+---
+
+# Dashboard
+
+The project dashboard at **Project > Overview** gives you an at-a-glance view of your entire home building project. It pulls together budget health, timeline progress, invoices, and subsidies into a single page of card-based widgets.
+
+## Dashboard Cards
+
+The dashboard is organized into cards, each focused on a specific aspect of your project:
+
+| Card | What It Shows |
+|------|---------------|
+| **Budget Summary** | Available funds and remaining budget across four perspectives (min planned, max planned, actual cost, actual paid) |
+| **Budget Alerts** | Warnings when a budget category's costs exceed its allocated amount |
+| **Source Utilization** | Progress bars showing how much of each financing source has been used |
+| **Timeline Status** | Work item counts by status and milestone progress |
+| **Mini Gantt** | A compact 30-day Gantt chart preview -- click it to open the full [Gantt chart](/guides/timeline/gantt-chart) |
+| **Invoice Pipeline** | Breakdown of invoices by status (pending, paid, claimed) |
+| **Subsidy Pipeline** | Status overview of your [subsidy programs](/guides/budget/subsidies) |
+| **Quick Actions** | Navigation links to frequently used actions like creating work items or viewing the budget |
+
+## Customizing Your Dashboard
+
+You can dismiss any card you do not need by clicking the dismiss button on that card. Dismissed cards are saved to your user preferences and persist across sessions.
+
+To bring back a hidden card:
+
+1. Click the **Customize** button in the page header (this button only appears when at least one card is hidden)
+2. Select the card you want to re-enable from the dropdown menu
+
+Each user's dashboard layout is independent -- dismissing a card only affects your own view.
+
+## Mobile Layout
+
+On smaller screens, the dashboard switches from a flat grid to a sectioned layout:
+
+- **Primary cards** (Budget Summary, Budget Alerts, Invoice Pipeline, Quick Actions) are always visible
+- **Timeline cards** (Timeline Status, Mini Gantt) are grouped under a collapsible "Timeline" section with a summary line
+- **Budget Details cards** (Source Utilization, Subsidy Pipeline) are grouped under a collapsible "Budget Details" section
+
+Tap a section header to expand or collapse it.
+
+## Error Handling
+
+If a data source fails to load, the affected card shows an error message with a **Retry** button. Other cards continue to display normally -- a failure in one area does not block the rest of the dashboard.
+
+Cards that have no data to show (for example, the Invoice Pipeline when no invoices exist yet) display a helpful empty state message with a link to the relevant page where you can add data.
+
+## Accessibility
+
+The dashboard uses ARIA landmarks and live regions so screen readers announce updates as data loads. All cards and controls are fully keyboard-navigable.
+
+:::info Screenshot needed
+Dashboard screenshots will be captured on the next stable release.
+:::

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -39,11 +39,12 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, work item linking, and timeline dependencies
 - **Authentication** -- Local accounts with first-run setup wizard, plus OIDC single sign-on for existing identity providers
 - **User Management** -- Admin and Member roles with a dedicated admin panel
+- **Project Dashboard** -- At-a-glance project health with budget summary, timeline status, invoice and subsidy pipelines, mini Gantt preview, and customizable card layout
 - **Document Integration** -- Browse, search, and link documents from a connected [Paperless-ngx](https://docs.paperless-ngx.com/) instance to work items and invoices
 - **Dark Mode** -- Light, Dark, or System theme with instant switching
 - **Design System** -- Consistent visual language with CSS custom property tokens
 
-See the [Roadmap](roadmap) for upcoming features like reporting and dashboards.
+See the [Roadmap](roadmap) for upcoming features.
 
 ## Quick Links
 
@@ -52,6 +53,7 @@ See the [Roadmap](roadmap) for upcoming features like reporting and dashboards.
 - [Budget Guide](guides/budget) -- Track costs, invoices, and financing sources
 - [Timeline Guide](guides/timeline) -- Gantt chart, calendar view, and milestones
 - [Household Items Guide](guides/household-items) -- Manage furniture, appliances, and fixture purchases
+- [Dashboard Guide](guides/dashboard) -- Project health overview and card customization
 - [Documents Guide](guides/documents) -- Paperless-ngx integration for document linking
 - [OIDC Setup](guides/users/oidc-setup) -- Connect your identity provider
 - [Development](development) -- How Cornerstone is built by an AI agent team

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -25,9 +25,10 @@ Cornerstone is under active development. Here is the current state of planned fe
 - [x] **EPIC-14: Cross-Entity Code Deduplication** ([#495](https://github.com/steilerDev/cornerstone/issues/495)) -- Shared service factories, unified React components for budget and subsidy logic, accessibility improvements, harmonized design tokens
 - [x] **EPIC-15: Budget-Line Invoice Linking Rework** ([#602](https://github.com/steilerDev/cornerstone/issues/602)) -- Many-to-many invoice-budget-line linking with itemized amounts, bidirectional linking UI, invoice groups on item detail pages, subsidy recalculation using itemized amounts
 
+- [x] **EPIC-09: Dashboard and Overview** ([#9](https://github.com/steilerDev/cornerstone/issues/9)) -- Project dashboard with budget summary, timeline status, invoice and subsidy pipelines, mini Gantt preview, and customizable card layout
+
 ## Planned
 
-- [ ] **EPIC-09: Dashboard and Overview** ([#9](https://github.com/steilerDev/cornerstone/issues/9)) -- Project dashboard with budget summary and activity
 - [ ] **EPIC-13: Construction Diary** ([#446](https://github.com/steilerDev/cornerstone/issues/446)) -- Project-level construction diary with automatic system events and manual entries
 
 ## Live Tracking


### PR DESCRIPTION
## Summary

- Add new dashboard guide page (`docs/src/guides/dashboard/index.md`) documenting the project overview page with its eight cards, card customization, responsive layout, error handling, and accessibility
- Update `intro.md` feature list and quick links to include the dashboard
- Mark EPIC-09 as completed in `roadmap.md` and `README.md`
- Update `RELEASE_SUMMARY.md` with EPIC-09 highlights for the next stable release

## Test plan

- [ ] Verify `npm run docs:build` succeeds in CI
- [ ] Verify no broken links (Docusaurus `onBrokenLinks: 'throw'`)
- [ ] Verify new sidebar entry appears correctly
- [ ] Verify README NOTE block is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)