### PR TITLE
fix(budget): remove double-counting of subsidies in overview and fix …

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -2037,13 +2037,13 @@ describe('CostBreakdownTable', () => {
     // The Net cell (colRemaining) for the item row must contain some currency value.
     // Avg rawCost = resolveProjected(800, 1200, 'avg') = 1000
     // Avg payback = resolveProjected(80, 100, 'avg') = 90
-    // Net (Avg) = 1000 - 90 = 910 → "€910.00"
+    // Net (Avg) = payback - rawCost = 90 - 1000 = -910 → "-€910.00"
     const netCells = container.querySelectorAll('td.colRemaining');
     const nonEmptyNetCells = Array.from(netCells).filter((td) => td.textContent?.trim() !== '');
     expect(nonEmptyNetCells.length).toBeGreaterThan(0);
     // No range format — single value only
     expect(container.textContent).not.toContain('€900.00 – €920.00');
-    expect(container.textContent).toContain('€910.00');
+    expect(container.textContent).toContain('-€910.00');
   });
 
   // Scenario 17: "Sum" label appears AND "Remaining" row also appears
@@ -2088,11 +2088,11 @@ describe('CostBreakdownTable', () => {
   });
 
   // Scenario 19: Sum Net and Remaining Net (perspective-aware)
-  it('Sum Net = totalRawProjected - resolvedPayback; Remaining Net = availableFunds - totalRawProjected + resolvedPayback', () => {
+  it('Sum Net = resolvedPayback - totalRawProjected; Remaining Net = availableFunds - totalRawProjected + resolvedPayback', () => {
     // availableFunds=10000, rawProjectedMin=3000, rawProjectedMax=5000
     // Avg raw = resolveProjected(3000, 5000, 'avg') = 4000
     // minSubsidyPayback=100, subsidyPayback=200 → avgPayback=resolveProjected(100,200,'avg')=150
-    // Sum Net = 4000 - 150 = 3850 → "€3,850.00"
+    // Sum Net = payback - rawCost = 150 - 4000 = -3850 → "-€3,850.00"
     // Remaining Net = 10000 - 4000 + 150 = 6150 → "€6,150.00"
     render(
       <CostBreakdownTable
@@ -2110,9 +2110,9 @@ describe('CostBreakdownTable', () => {
       />,
     );
 
-    // Sum Net = totalRawProjected - resolvedPayback = 4000 - 150 = 3850
+    // Sum Net = payback - rawCost = 150 - 4000 = -3850
     // (may appear multiple times across section rows and Sum row)
-    expect(screen.getAllByText('€3,850.00').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('-€3,850.00').length).toBeGreaterThanOrEqual(1);
     // Remaining Net = availableFunds - totalRawProjected + resolvedPayback = 10000 - 4000 + 150 = 6150
     expect(screen.getByText('€6,150.00')).toBeInTheDocument();
   });

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -52,7 +52,7 @@ function formatPayback(amount: number): string {
 }
 
 /**
- * Renders net value (cost - payback).
+ * Renders net value (payback - cost).
  * At item/category level, uses neutral text color (still an expense).
  * At sum level, uses green/red coloring (surplus vs deficit).
  */
@@ -62,7 +62,7 @@ function renderNet(
   cssStyles: typeof styles,
   colored: boolean = false,
 ): React.ReactNode {
-  const net = rawCost - payback;
+  const net = payback - rawCost;
   if (colored) {
     return (
       <span className={net >= 0 ? cssStyles.valuePositive : cssStyles.valueNegative}>

--- a/server/src/services/budgetOverviewService.test.ts
+++ b/server/src/services/budgetOverviewService.test.ts
@@ -742,9 +742,10 @@ describe('getBudgetOverview', () => {
 
       const result = getBudgetOverview(db);
 
-      // Universal subsidy applies: 10000 * 20% = 2000 reduction; invoice confidence min=max=8000
-      expect(result.minPlanned).toBe(8000);
-      expect(result.maxPlanned).toBe(8000);
+      // Universal subsidy applies: 10000 * 20% = 2000 reduction
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): invoice confidence min=max=10000
+      expect(result.minPlanned).toBe(10000);
+      expect(result.maxPlanned).toBe(10000);
       expect(result.subsidySummary.totalReductions).toBe(2000);
     });
 
@@ -834,10 +835,9 @@ describe('getBudgetOverview', () => {
       const result = getBudgetOverview(db);
 
       // reduction = 10000 * 0.15 = 1500
-      // raw_min = 10000 * 1.0 = 10000; min_planned = 10000 - 1500 = 8500
-      // raw_max = 10000 * 1.0 = 10000; max_planned = 10000 - 1500 = 8500
-      expect(result.minPlanned).toBeCloseTo(8500, 5);
-      expect(result.maxPlanned).toBeCloseTo(8500, 5);
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 10000
+      expect(result.minPlanned).toBeCloseTo(10000, 5);
+      expect(result.maxPlanned).toBeCloseTo(10000, 5);
       expect(result.subsidySummary.totalReductions).toBeCloseTo(1500, 5);
     });
 
@@ -874,9 +874,9 @@ describe('getBudgetOverview', () => {
       const result = getBudgetOverview(db);
 
       // 2 matching lines: 3000 / 2 = 1500 per line
-      // line1: 10000 - 1500 = 8500; line2: 5000 - 1500 = 3500
-      expect(result.minPlanned).toBeCloseTo(12000, 5); // 8500 + 3500
-      expect(result.maxPlanned).toBeCloseTo(12000, 5);
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 10000 + 5000 = 15000
+      expect(result.minPlanned).toBeCloseTo(15000, 5);
+      expect(result.maxPlanned).toBeCloseTo(15000, 5);
       expect(result.subsidySummary.totalReductions).toBeCloseTo(3000, 5);
     });
 
@@ -898,7 +898,8 @@ describe('getBudgetOverview', () => {
       const result = getBudgetOverview(db);
 
       // Only 1 matching line: 2000 / 1 = 2000 reduction
-      expect(result.minPlanned).toBeCloseTo(6000, 5); // 8000 - 2000
+      // minPlanned = raw projected (no subsidy subtraction): 8000
+      expect(result.minPlanned).toBeCloseTo(8000, 5);
       expect(result.subsidySummary.totalReductions).toBeCloseTo(2000, 5);
     });
 
@@ -919,8 +920,9 @@ describe('getBudgetOverview', () => {
 
       const result = getBudgetOverview(db);
 
-      expect(result.minPlanned).toBe(0);
-      expect(result.maxPlanned).toBe(0);
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 500
+      expect(result.minPlanned).toBe(500);
+      expect(result.maxPlanned).toBe(500);
     });
 
     it('subsidy only applies to lines whose category matches (not all lines of work item)', () => {
@@ -959,8 +961,8 @@ describe('getBudgetOverview', () => {
       const result = getBudgetOverview(db);
 
       // Only line1 (10000) gets the 10% reduction = 1000
-      // line1 min/max = 10000 - 1000 = 9000; line2 min/max = 5000 (no reduction)
-      expect(result.minPlanned).toBeCloseTo(14000, 5); // 9000 + 5000
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 10000 + 5000 = 15000
+      expect(result.minPlanned).toBeCloseTo(15000, 5);
       expect(result.subsidySummary.totalReductions).toBeCloseTo(1000, 5);
     });
 
@@ -982,9 +984,9 @@ describe('getBudgetOverview', () => {
       const result = getBudgetOverview(db);
       const cat = result.categorySummaries.find((c) => c.categoryId === catId);
 
-      // 10000 * (1 - 0.20) = 8000
-      expect(cat!.minPlanned).toBeCloseTo(8000, 5);
-      expect(cat!.maxPlanned).toBeCloseTo(8000, 5);
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 10000
+      expect(cat!.minPlanned).toBeCloseTo(10000, 5);
+      expect(cat!.maxPlanned).toBeCloseTo(10000, 5);
     });
 
     it('sums reductions from multiple work item-subsidy category matches', () => {
@@ -1054,8 +1056,7 @@ describe('getBudgetOverview', () => {
       // raw_min = 8000, raw_max = 12000
       // subsidy = 10% percentage on catId
       // reduction = 10000 * 0.10 = 1000
-      // min_planned = max(0, 8000 - 1000) = 7000
-      // max_planned = max(0, 12000 - 1000) = 11000
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 8000 / 12000
       const catId = insertBudgetCategory('Cat Margin + Subsidy');
       const { workItemId } = insertWorkItem({
         plannedAmount: 10000,
@@ -1072,8 +1073,8 @@ describe('getBudgetOverview', () => {
 
       const result = getBudgetOverview(db);
 
-      expect(result.minPlanned).toBeCloseTo(7000, 5);
-      expect(result.maxPlanned).toBeCloseTo(11000, 5);
+      expect(result.minPlanned).toBeCloseTo(8000, 5);
+      expect(result.maxPlanned).toBeCloseTo(12000, 5);
     });
   });
 
@@ -1574,10 +1575,11 @@ describe('getBudgetOverview', () => {
     it('computes remainingVsMinPlannedWithPayback = availableFunds + minPayback - minPlanned', () => {
       // availableFunds = 10000
       // Work item: plannedAmount = 1000, invoice confidence → min=max=1000
-      // Subsidy: fixed 200 → subsidyReduction=200 → totalMinPlanned = 1000 - 200 = 800
-      //                    → minPayback = maxPayback = 200
-      // remainingVsMinPlanned = 10000 - 800 = 9200  (subsidy reduction lowers cost)
-      // remainingVsMinPlannedWithPayback = 10000 + 200 - 800 = 9400  (payback adds on top)
+      // Subsidy: fixed 200 → subsidyReduction=200
+      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 1000
+      // minPayback = maxPayback = 200
+      // remainingVsMinPlanned = 10000 - 1000 = 9000
+      // remainingVsMinPlannedWithPayback = 10000 + 200 - 1000 = 9200
       insertBudgetSource({ totalAmount: 10000 });
       const { workItemId } = insertWorkItem({ plannedAmount: 1000, confidence: 'invoice' });
       const subsidyId = insertSubsidyProgram({ reductionType: 'fixed', reductionValue: 200 });
@@ -1585,9 +1587,9 @@ describe('getBudgetOverview', () => {
 
       const result = getBudgetOverview(db);
 
-      expect(result.remainingVsMinPlanned).toBeCloseTo(9200); // subsidy reduces planned → remaining higher
-      expect(result.remainingVsMinPlannedWithPayback).toBeCloseTo(9400); // payback adds on top
-      expect(result.remainingVsMaxPlannedWithPayback).toBeCloseTo(9400); // fixed: min === max
+      expect(result.remainingVsMinPlanned).toBeCloseTo(9000);
+      expect(result.remainingVsMinPlannedWithPayback).toBeCloseTo(9200); // payback adds on top
+      expect(result.remainingVsMaxPlannedWithPayback).toBeCloseTo(9200); // fixed: min === max
     });
 
     it('equals non-adjusted remaining when no subsidies linked', () => {

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -250,8 +250,8 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
 
     totalReductions += subsidyReduction;
 
-    const rawMinPlanned = Math.max(0, rawMin - subsidyReduction);
-    const rawMaxPlanned = Math.max(0, rawMax - subsidyReduction);
+    const rawMinPlanned = rawMin;
+    const rawMaxPlanned = rawMax;
 
     // If line has invoices, actual cost overrides planned values (the real cost is known)
     const lineActualCost = lineInvoiceMap.get(line.id);


### PR DESCRIPTION
…net column sign

Budget overview was subtracting subsidy reductions from minPlanned/maxPlanned AND adding payback back in remaining calculations, double-counting the subsidy benefit. Now minPlanned/maxPlanned reflect raw projected costs (pre-subsidy), and remaining calculations work correctly.

Cost breakdown Net column was showing positive values (cost - payback) instead of negative values (payback - cost) for normal items where cost exceeds payback.

## Summary

<!-- Brief description of the changes -->

## Related Issues

<!-- Link to GitHub Issues: Fixes #N, Related: #N -->

## Agent Reviews

- [ ] `security-engineer` reviewed
- [ ] `product-architect` reviewed
- [ ] `product-owner` reviewed
