### PR TITLE
fix(dashboard): correct budget summary available funds, subsidy sign, and remove percentage

### DIFF
--- a/client/src/components/BudgetSummaryCard/BudgetSummaryCard.module.css
+++ b/client/src/components/BudgetSummaryCard/BudgetSummaryCard.module.css
@@ -34,23 +34,6 @@
   gap: var(--spacing-2);
 }
 
-.remainingPct {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-}
-
-.remainingGreen {
-  color: var(--color-success);
-}
-
-.remainingYellow {
-  color: var(--color-warning);
-}
-
-.remainingRed {
-  color: var(--color-danger);
-}
-
 .metricsGrid {
   display: flex;
   flex-direction: column;

--- a/client/src/components/BudgetSummaryCard/BudgetSummaryCard.test.tsx
+++ b/client/src/components/BudgetSummaryCard/BudgetSummaryCard.test.tsx
@@ -44,13 +44,13 @@ describe('BudgetSummaryCard', () => {
     }
   });
 
-  // ── Test 1: Available Funds ───────────────────────────────────────────────
+  // ── Test 1: Remaining Budget ──────────────────────────────────────────────
 
-  it('renders available funds formatted as EUR currency', () => {
-    renderWithRouter(<BudgetSummaryCard overview={{ ...baseOverview, availableFunds: 100000 }} />);
+  it('renders remaining budget formatted as EUR currency', () => {
+    renderWithRouter(<BudgetSummaryCard overview={{ ...baseOverview, remainingVsActualCost: 50000 }} />);
 
-    const el = screen.getByTestId('available-funds');
-    expect(el).toHaveTextContent('€100,000.00');
+    const el = screen.getByTestId('remaining-budget');
+    expect(el).toHaveTextContent('€50,000.00');
   });
 
   // ── Test 2: Planned Cost Range ────────────────────────────────────────────
@@ -74,84 +74,9 @@ describe('BudgetSummaryCard', () => {
     expect(el).toHaveTextContent('€50,000.00');
   });
 
-  // ── Test 4: Remaining pct — green (> 20%) ─────────────────────────────────
+  // ── Test 4: Subsidy savings shown when totalReductions > 0 ────────────────
 
-  it('shows green remaining percentage when remaining is above 20%', () => {
-    // remainingPct = (100000 - 70000) / 100000 * 100 = 30.0%
-    renderWithRouter(
-      <BudgetSummaryCard
-        overview={{
-          ...baseOverview,
-          availableFunds: 100000,
-          actualCost: 70000,
-          remainingVsActualCost: 30000,
-        }}
-      />,
-    );
-
-    const el = screen.getByTestId('remaining-pct');
-    expect(el).toHaveTextContent('30.0% remaining');
-    expect(el.className).toContain('remainingGreen');
-  });
-
-  // ── Test 5: Remaining pct — yellow (5–20%) ────────────────────────────────
-
-  it('shows yellow remaining percentage when remaining is between 5% and 20%', () => {
-    // remainingPct = (100000 - 88000) / 100000 * 100 = 12.0%
-    renderWithRouter(
-      <BudgetSummaryCard
-        overview={{
-          ...baseOverview,
-          availableFunds: 100000,
-          actualCost: 88000,
-          remainingVsActualCost: 12000,
-        }}
-      />,
-    );
-
-    const el = screen.getByTestId('remaining-pct');
-    expect(el).toHaveTextContent('12.0% remaining');
-    expect(el.className).toContain('remainingYellow');
-  });
-
-  // ── Test 6: Remaining pct — red (< 5%) ────────────────────────────────────
-
-  it('shows red remaining percentage when remaining is below 5%', () => {
-    // remainingPct = (100000 - 97000) / 100000 * 100 = 3.0%
-    renderWithRouter(
-      <BudgetSummaryCard
-        overview={{
-          ...baseOverview,
-          availableFunds: 100000,
-          actualCost: 97000,
-          remainingVsActualCost: 3000,
-        }}
-      />,
-    );
-
-    const el = screen.getByTestId('remaining-pct');
-    expect(el).toHaveTextContent('3.0% remaining');
-    expect(el.className).toContain('remainingRed');
-  });
-
-  // ── Test 7: Remaining pct — red (zero funds) ──────────────────────────────
-
-  it('shows red remaining percentage and 0.0% when availableFunds is zero', () => {
-    // remainingPct defaults to 0 when availableFunds === 0
-    renderWithRouter(
-      <BudgetSummaryCard
-        overview={{ ...baseOverview, availableFunds: 0, actualCost: 0, remainingVsActualCost: 0 }}
-      />,
-    );
-
-    const el = screen.getByTestId('remaining-pct');
-    expect(el).toHaveTextContent('0.0% remaining');
-    expect(el.className).toContain('remainingRed');
-  });
-
-  // ── Test 8: Subsidy impact shown when totalReductions > 0 ────────────────
-
-  it('renders subsidy impact section when totalReductions is greater than zero', () => {
+  it('renders subsidy savings section when totalReductions is greater than zero', () => {
     renderWithRouter(
       <BudgetSummaryCard
         overview={{
@@ -171,7 +96,7 @@ describe('BudgetSummaryCard', () => {
     expect(el).toHaveTextContent('€5,000.00');
   });
 
-  // ── Test 9: Subsidy impact hidden when totalReductions = 0 ───────────────
+  // ── Test 5: Subsidy savings hidden when totalReductions = 0 ───────────────
 
   it('does not render subsidy impact section when totalReductions is zero', () => {
     renderWithRouter(<BudgetSummaryCard overview={baseOverview} />);
@@ -179,7 +104,7 @@ describe('BudgetSummaryCard', () => {
     expect(screen.queryByTestId('subsidy-impact')).toBeNull();
   });
 
-  // ── Test 10: Footer link to /budget/overview ──────────────────────────────
+  // ── Test 6: Footer link to /budget/overview ───────────────────────────────
 
   it('renders a footer link to /budget/overview', () => {
     renderWithRouter(<BudgetSummaryCard overview={baseOverview} />);
@@ -189,7 +114,7 @@ describe('BudgetSummaryCard', () => {
     expect(link).toHaveAttribute('href', '/budget/overview');
   });
 
-  // ── Test 11: BudgetHealthIndicator — On Budget ────────────────────────────
+  // ── Test 7: BudgetHealthIndicator — On Budget ──────────────────────────────
 
   it('renders BudgetHealthIndicator showing On Budget when margin is above 10%', () => {
     // margin = remainingVsMaxPlanned / availableFunds = 15000 / 100000 = 0.15 > 0.10 → On Budget
@@ -202,7 +127,7 @@ describe('BudgetSummaryCard', () => {
     expect(screen.getByRole('status')).toHaveTextContent('On Budget');
   });
 
-  // ── Test 12: BudgetBar renders ────────────────────────────────────────────
+  // ── Test 8: BudgetBar renders ──────────────────────────────────────────────
 
   it('renders BudgetBar with role="img"', () => {
     renderWithRouter(<BudgetSummaryCard overview={baseOverview} />);

--- a/client/src/components/BudgetSummaryCard/BudgetSummaryCard.tsx
+++ b/client/src/components/BudgetSummaryCard/BudgetSummaryCard.tsx
@@ -20,18 +20,6 @@ export function BudgetSummaryCard({ overview }: BudgetSummaryCardProps) {
     subsidySummary,
   } = overview;
 
-  // Calculate remaining percentage
-  const remainingPct =
-    availableFunds > 0 ? ((availableFunds - actualCost) / availableFunds) * 100 : 0;
-
-  // Determine color class based on remaining percentage
-  let remainingColorClass = styles.remainingGreen;
-  if (remainingPct < 5) {
-    remainingColorClass = styles.remainingRed;
-  } else if (remainingPct < 20) {
-    remainingColorClass = styles.remainingYellow;
-  }
-
   // Build budget bar segments
   const segments: BudgetBarSegment[] = [
     {
@@ -58,9 +46,9 @@ export function BudgetSummaryCard({ overview }: BudgetSummaryCardProps) {
     <div className={styles.content}>
       {/* Primary metric */}
       <div className={styles.primaryMetric}>
-        <span className={styles.metricLabel}>Available Funds</span>
-        <span className={styles.metricValue} data-testid="available-funds">
-          {formatCurrency(availableFunds)}
+        <span className={styles.metricLabel}>Remaining Budget</span>
+        <span className={styles.metricValue} data-testid="remaining-budget">
+          {formatCurrency(remainingVsActualCost)}
         </span>
       </div>
 
@@ -79,12 +67,6 @@ export function BudgetSummaryCard({ overview }: BudgetSummaryCardProps) {
           remainingVsProjectedMax={remainingVsMaxPlanned}
           availableFunds={availableFunds}
         />
-        <span
-          className={`${styles.remainingPct} ${remainingColorClass}`}
-          data-testid="remaining-pct"
-        >
-          {remainingPct.toFixed(1)}% remaining
-        </span>
       </div>
 
       {/* Metrics grid */}
@@ -105,9 +87,9 @@ export function BudgetSummaryCard({ overview }: BudgetSummaryCardProps) {
 
         {subsidySummary.totalReductions > 0 && (
           <div className={styles.metricItem}>
-            <dt className={styles.metricItemLabel}>Subsidy Impact</dt>
+            <dt className={styles.metricItemLabel}>Subsidy Savings</dt>
             <dd className={styles.metricItemValue} data-testid="subsidy-impact">
-              −{formatCurrency(subsidySummary.totalReductions)}
+              {formatCurrency(subsidySummary.totalReductions)}
             </dd>
           </div>
         )}

--- a/e2e/tests/navigation/dashboard.spec.ts
+++ b/e2e/tests/navigation/dashboard.spec.ts
@@ -297,7 +297,7 @@ test.describe('All cards render (Scenario 2)', { tag: '@responsive' }, () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 test.describe('Budget Summary card (Scenario 3)', { tag: '@responsive' }, () => {
-  test('Budget Summary card shows available funds amount', async ({ page }) => {
+  test('Budget Summary card shows remaining budget amount', async ({ page }) => {
     // Budget Summary is in the primary section on mobile (always visible), but
     // the card layout and data-testid availability is validated on desktop/tablet grid.
     const viewport = page.viewportSize();
@@ -314,46 +314,20 @@ test.describe('Budget Summary card (Scenario 3)', { tag: '@responsive' }, () => 
       await dashboardPage.goto();
       await dashboardPage.waitForCardsLoaded();
 
-      // Available funds metric is rendered with data-testid="available-funds"
-      const availableFunds = page.getByTestId('available-funds');
-      await expect(availableFunds.first()).toBeVisible();
+      // Remaining budget metric is rendered with data-testid="remaining-budget"
+      const remainingBudget = page.getByTestId('remaining-budget');
+      await expect(remainingBudget.first()).toBeVisible();
 
-      // With our mock data of 300000, it should show the formatted value
-      const text = await availableFunds.first().textContent();
+      // With our mock data, remainingVsActualCost = 115000 (300000 - 185000)
+      const text = await remainingBudget.first().textContent();
       expect(text).toBeTruthy();
       // The value should be a formatted currency amount
-      expect(text?.replace(/\s/g, '')).toMatch(/300[,.]?000/);
+      expect(text?.replace(/\s/g, '')).toMatch(/115[,.]?000/);
     } finally {
       await uninterceptDashboardApis(page);
     }
   });
 
-  test('Budget Summary card shows remaining percentage', async ({ page }) => {
-    // See comment in sibling test above — desktop/tablet grid specific assertion.
-    const viewport = page.viewportSize();
-    if (!viewport || viewport.width < 768) {
-      test.skip();
-      return;
-    }
-
-    const dashboardPage = new DashboardPage(page);
-
-    await interceptDashboardApis(page);
-
-    try {
-      await dashboardPage.goto();
-      await dashboardPage.waitForCardsLoaded();
-
-      // remaining-pct data-testid shows "xx.x% remaining"
-      const remainingPct = page.getByTestId('remaining-pct');
-      await expect(remainingPct.first()).toBeVisible();
-
-      const text = await remainingPct.first().textContent();
-      expect(text).toMatch(/remaining/i);
-    } finally {
-      await uninterceptDashboardApis(page);
-    }
-  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Change primary metric from "Available Funds" (total financing) to "Remaining Budget" (available funds minus actual cost)
- Remove percentage remaining display from health row
- Fix subsidy sign: show as positive "Subsidy Savings" instead of negative "Subsidy Impact"
- Clean up unused CSS classes and update unit/E2E tests

Fixes #744

## Test plan
- [ ] Unit tests pass (updated metric labels, values, removed percentage tests)
- [ ] E2E tests pass (updated dashboard budget summary assertions)
- [ ] Budget Summary card shows correct remaining amount

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>