### PR TITLE
fix(ui): align page heading font size across all pages

### DIFF
--- a/client/src/pages/DashboardPage/DashboardPage.module.css
+++ b/client/src/pages/DashboardPage/DashboardPage.module.css
@@ -21,7 +21,7 @@
 
 .title {
   margin: 0;
-  font-size: var(--font-size-3xl);
+  font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
 }

--- a/client/src/pages/MilestonesPage/MilestonesPage.module.css
+++ b/client/src/pages/MilestonesPage/MilestonesPage.module.css
@@ -12,8 +12,8 @@
 }
 
 .pageTitle {
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
   margin: 0;
 }

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
@@ -12,8 +12,8 @@
 }
 
 .pageTitle {
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
   margin: 0;
 }


### PR DESCRIPTION
## Summary

- Standardize page headings to use `var(--font-size-4xl)` and `var(--font-weight-bold)` design tokens
- Dashboard was using `--font-size-3xl`, Work Items and Milestones were using hardcoded `2rem`/`700`
- Tab-content spacing already consistent (`var(--spacing-6)`) — no changes needed

Fixes #742

## Test plan
- [ ] Pre-commit hook quality gates pass
- [ ] Visual consistency verified across Dashboard, Work Items, and Milestones pages

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>