### PR TITLE
chore: deduplicate skill files and remove AUTO_MODE

### DIFF
--- a/.claude/skills/batch-develop/SKILL.md
+++ b/.claude/skills/batch-develop/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: batch-develop
-description: 'Reads /tmp/notes.md and runs /develop in AUTO_MODE for each line sequentially. Each line gets its own branch, PR, and full development cycle.'
+description: 'Reads /tmp/notes.md and runs /develop for each line sequentially. Each line gets its own branch, PR, and full development cycle. Skips /develop step 1 (Rebase) since it handles its own baseline reset.'
 ---
 
-# Batch Develop — Sequential AUTO_MODE Development from Notes File
+# Batch Develop — Sequential Development from Notes File
 
-You are the orchestrator running a sequential development pipeline. This skill reads `/tmp/notes.md` and invokes the `/develop` workflow in **AUTO_MODE** for each line, one at a time. Each line gets its own branch, PR, and full development cycle.
+You are the orchestrator running a sequential development pipeline. This skill reads `/tmp/notes.md` and invokes the `/develop` workflow for each line, one at a time. Each line gets its own branch, PR, and full development cycle.
 
-**When to use:** Processing a backlog of issues or bug descriptions listed in `/tmp/notes.md`, where each item should be developed independently with automatic approvals.
+**When to use:** Processing a backlog of issues or bug descriptions listed in `/tmp/notes.md`, where each item should be developed independently.
 **When NOT to use:** When items should be batched into a single PR (use `/develop @/tmp/notes.md` instead). When running a full epic lifecycle (use `/epic-run`).
-
-## AUTO_MODE Declaration
-
-This skill activates **AUTO_MODE** for the session. When AUTO_MODE is active:
-
-- Bug spec approval is auto-approved (PO spec created immediately)
-- PR merge is automatic after CI green + all reviewers approved
-- The only human gate is if retry budget (3) is exhausted for a single item
 
 ## Input
 
@@ -78,13 +70,9 @@ git checkout -B batch-dev-temp origin/beta
 
 #### 3b. Invoke /develop
 
-Invoke the `/develop` skill with the current item as `$ARGUMENTS` and **AUTO_MODE active**. This means:
+Invoke the `/develop` skill with the current item as `$ARGUMENTS`. The `/develop` skill handles the full cycle (steps 1–11): resolve issue → visual spec → branch → move to in progress → implement + test → verify PR → review → fix loop → merge → close.
 
-- Bug descriptions: PO spec is auto-approved, issue created immediately
-- PR merge: Automatic after CI green + all reviewers approved
-- No user approval gates
-
-The `/develop` skill handles the full cycle: resolve issue → branch → implement → test → review → merge → close.
+**Note:** Skip `/develop` step 1 (Rebase) — the baseline reset is already handled by step 3a above. Execute `/develop` steps 2–11 for each item.
 
 #### 3c. Track Result
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -70,21 +70,14 @@ Confirm the issue exists, note its labels (`user-story` or `bug`), and proceed t
   - **Actual behavior**: What currently happens
   - **Reproduction steps**: How to trigger the bug
   - **Acceptance criteria**: Given/When/Then format
-- Present the spec to the user for review and discussion
-- **Only after user approval**: Create a GitHub Issue labeled `bug`, add to Projects board in "Todo", and link as sub-issue of the parent epic if applicable
-
-**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), skip the user approval wait for bug specs. Auto-approve the PO spec and create the GitHub Issue immediately.
-
-**Interactive mode** (default): Do NOT create the GitHub Issue until the user explicitly approves the spec.
+- Create a GitHub Issue labeled `bug`, add to Projects board in "Todo", and link as sub-issue of the parent epic if applicable
 
 #### Multi-item mode
 
 Process each entry in the items list:
 
 1. **Issue numbers**: Resolve each with `gh issue view <number>`. Record title, labels, and acceptance criteria.
-2. **Descriptions**: For each description entry, launch the **product-owner** agent to draft a spec (same format as single-item). Present each spec to the user for approval.
-   - **Approved**: Create a GitHub Issue immediately (labeled `bug` or `user-story`), add to Projects board, link to parent epic if applicable. Record the new issue number in the items list.
-   - **Rejected**: Drop the item from the items list.
+2. **Descriptions**: For each description entry, launch the **product-owner** agent to draft a spec (same format as single-item) and create a GitHub Issue immediately (labeled `bug` or `user-story`), add to Projects board, link to parent epic if applicable. Record the new issue number in the items list.
 
 If all items are rejected, abort the session. If at least one remains, continue.
 
@@ -340,9 +333,9 @@ If any reviewer identifies blocking issues:
 8. Increment `fixLoopCount` and record the new round's `REVIEW_METRICS`
 9. Repeat until all reviewers approve
 
-### 10. User Approval & Merge
+### 10. Merge
 
-Once all reviews are clean, wait for CI to go green before presenting the PR to the user:
+Once all reviews are clean, wait for CI to go green:
 
 ```
 gh pr checks <pr-number> --watch
@@ -366,16 +359,13 @@ In multi-item mode, present a **per-item summary table**:
 | #61   | Add export button to Gantt     | Resolved |
 ```
 
-**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), skip the user approval wait. Once CI is green and all reviewers have approved, proceed directly to step 10a (persist metrics) and then merge.
+Once CI is green and all reviewers have approved, proceed to step 10a (persist metrics) and then merge.
 
-**Interactive mode** (default): Ask the user to approve the PR for merge. **Do NOT merge until the user explicitly approves.** Wait for explicit confirmation:
-
-- **User approves** → proceed to step 10a (persist metrics), then merge
-- **User reports issues** → take the user's feedback as new input and loop back to **step 6** (Implement + Test) on a new branch to address it
+If the user reports issues with a merged PR, take the user's feedback as new input and start a new `/develop` cycle to address it.
 
 ### 10a. Persist Metrics
 
-After user approval and **before merging**, collect PR metadata and append a record to `.claude/metrics/review-metrics.jsonl`:
+**Before merging**, collect PR metadata and append a record to `.claude/metrics/review-metrics.jsonl`:
 
 1. Fetch PR data:
 

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -5,7 +5,7 @@ description: 'Close an epic: refinement, E2E validation, UAT, documentation, and
 
 # Epic Close — Refinement, UAT & Promotion Workflow
 
-You are the orchestrator running the closing phase for a completed epic. Follow these 12 steps in order. **Do NOT skip steps.** The orchestrator delegates all work — never write production code, tests, or architectural artifacts directly.
+You are the orchestrator running the closing phase for a completed epic. Follow these 13 steps in order. **Do NOT skip steps.** The orchestrator delegates all work — never write production code, tests, or architectural artifacts directly.
 
 **When to use:** After all user stories in an epic have been merged to `beta` and are closed. This skill handles refinement, E2E validation, UAT, documentation, and promotion to `main`.
 **When NOT to use:** Planning a new epic (use `/epic-start`). Implementing a single story or bug fix (use `/develop`).
@@ -114,17 +114,9 @@ This approval is **required** before proceeding to manual UAT validation.
 
 ### 6. UAT Validation
 
-Launch the **product-owner** agent to produce UAT scenarios, then the orchestrator coordinates validation:
+Launch the **product-owner** agent to produce UAT scenarios. The e2e-test-engineer must have already covered these scenarios in step 5. E2E pass + e2e-test-engineer report = sufficient validation. Post the UAT report as a comment on the epic issue and proceed to step 7.
 
-- Produce a UAT Validation Report covering all stories in the epic
-- Provide step-by-step manual validation instructions to the user
-
-**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), treat E2E pass + e2e-test-engineer report as sufficient validation. Post the UAT report as a comment on the epic issue and proceed to step 7 without waiting for user walkthrough.
-
-**Interactive mode** (default): Present the report to the user. The user walks through each scenario:
-
-- **All pass** → proceed to step 7
-- **Any fail** → launch `/develop` for the failing issue(s), then loop back to step 5
+The UAT scenarios are included in the promotion PR (step 9) as a manual validation checklist so the user can spot-check during the promotion gate.
 
 ### 7. Documentation
 
@@ -142,44 +134,88 @@ gh pr create --base beta --title "docs: update documentation for epic #<epic-num
 
 Wait for CI, then squash merge.
 
-### 8. Epic Promotion
+### 8. Branch Sync
 
-Create a PR from `beta` to `main` using a **merge commit** (not squash):
+Check if `main` has commits that `beta` doesn't (e.g., hotfixes cherry-picked to main):
+
+```bash
+git log origin/beta..origin/main --oneline
+```
+
+If so, create a sync PR (`main` → `beta`), wait for CI, merge before proceeding. This ensures the promotion PR merges cleanly.
+
+If no divergence, skip to step 9.
+
+### 9. Epic Promotion
+
+Create a PR from `beta` to `main` using a **merge commit** (not squash). The promotion PR is the single human checkpoint — include a comprehensive summary:
 
 ```bash
 gh pr create --base main --head beta --title "release: promote epic #<epic-number> to main" --body "$(cat <<'EOF'
-## Summary
+## Epic Summary
 <Epic title and description>
 
-## Stories Included
+### Stories Completed
 - #<story-1> — <title>
 - #<story-2> — <title>
 ...
 
-## UAT Validation
-All UAT scenarios passed. See validation report in comments below.
+### Findings & Fix Loops
+- Total PRs: N | Fix loops: N | Total findings: N (C/H/M/L/I breakdown)
+
+## Change Inventory
+
+### Backend (`server/`, `shared/`)
+<List of changed files grouped by area>
+
+### Frontend (`client/`)
+<List of changed files grouped by area>
+
+### E2E Tests (`e2e/`)
+<List of changed files>
+
+### Docs / Config
+<List of changed files>
+
+## Validation Report
+- E2E test results: <pass/fail summary>
+- Agent review metrics: <summary from epic metrics report>
+- Security findings: <summary of resolved/outstanding>
+
+## Manual Validation Checklist
+<UAT scenarios from step 6, presented as a checklist the user can walk through to spot-check>
+
+- [ ] <Scenario 1: page to visit, action to take, expected result>
+- [ ] <Scenario 2: ...>
+- ...
+
+## Testing
+- **DockerHub beta image**: `docker pull steilerdev/cornerstone:beta`
+- **PR-specific image**: `docker pull steilerdev/cornerstone:pr-<pr-number>`
 EOF
 )"
 ```
 
-### 9. Post UAT Criteria
+### 10. Post Detailed UAT Criteria
 
-Post UAT validation criteria and manual testing steps as comments on the promotion PR — this gives the user a single place to review what was built and how to validate it:
+Post detailed UAT validation criteria as a comment on the promotion PR — step-by-step instructions the user can follow to validate each story:
 
 ```bash
 gh pr comment <pr-number> --body "$(cat <<'EOF'
-## UAT Validation Criteria
+## Detailed UAT Validation
 
-<Copy the UAT validation report from step 6>
+### Story #<N>: <title>
+<Step-by-step manual validation instructions>
 
-## Manual Testing Steps
+### Story #<N>: <title>
+<Step-by-step manual validation instructions>
 
-<Step-by-step instructions for the user>
+...
 EOF
 )"
 ```
 
-### 10. CI Gate
+### 11. CI Gate
 
 Wait for all CI checks to pass on the promotion PR, including the full sharded E2E suite (runs on main-targeting PRs):
 
@@ -189,11 +225,17 @@ gh pr checks <pr-number> --watch
 
 If any check fails, investigate and resolve before proceeding.
 
-### 11. User Approval
+### 12. User Approval
 
-**Wait for explicit user approval** before merging. The user reviews the PR, validates the UAT scenarios, and approves. Do NOT merge without user confirmation.
+**Wait for explicit user approval** before merging. Present the user with:
 
-### 12. Merge & Post-Merge
+1. **Promotion PR link** — with the comprehensive summary, change inventory, and validation checklist
+2. **DockerHub beta image** — `docker pull steilerdev/cornerstone:beta` for manual testing
+3. **E2E + review summary** — confirmation that all automated validation passed
+
+The user reviews the PR, optionally tests with the beta image, and approves. Do NOT merge without user confirmation.
+
+### 13. Merge & Post-Merge
 
 After user approval:
 

--- a/.claude/skills/epic-run/SKILL.md
+++ b/.claude/skills/epic-run/SKILL.md
@@ -5,10 +5,12 @@ description: 'Autonomous end-to-end epic execution: plans stories, develops each
 
 # Epic Run — Autonomous End-to-End Epic Execution
 
-You are the orchestrator running an entire epic lifecycle autonomously. This skill chains planning (`/epic-start`), development (`/develop` per story), and closing (`/epic-close`) into a single session with **AUTO_MODE** enabled. Follow these phases in order. **Do NOT skip phases.**
+You are the orchestrator running an entire epic lifecycle autonomously. This skill chains planning (`/epic-start`), development (`/develop` per story), and closing (`/epic-close`) into a single session. Follow these phases in order. **Do NOT skip phases.**
 
-**When to use:** Executing a complete epic end-to-end without intermediate user approvals. Only pauses for `beta` → `main` promotion.
-**When NOT to use:** Interactive step-by-step work (use `/epic-start`, `/develop`, `/epic-close` individually).
+**When to use:** Executing a complete epic end-to-end in a single session. Only pauses for `beta` → `main` promotion.
+**When NOT to use:** When you want to run individual phases separately (use `/epic-start`, `/develop`, `/epic-close`).
+
+**Delegation principle:** Each phase delegates to the corresponding sub-skill's steps. When this skill says "Execute `/develop` steps 2–11", read and follow those exact steps from the `/develop` skill file (`.claude/skills/develop/SKILL.md`). Do not re-implement or paraphrase them.
 
 ## Input
 
@@ -19,29 +21,13 @@ You are the orchestrator running an entire epic lifecycle autonomously. This ski
 
 If empty, ask the user to describe the epic or provide an issue number before proceeding.
 
-## AUTO_MODE Declaration
-
-This skill activates **AUTO_MODE** for the session. When AUTO_MODE is active:
-
-- Intermediate user approval gates are auto-approved (plan approval, bug specs, PR merges, UAT)
-- The **only mandatory human gate** is promotion from `beta` → `main` (Phase 3, Step 8)
-- Progress updates are posted as comments on the epic GitHub Issue
-
-| Phase   | Gate                | AUTO_MODE Behavior                                 |
-| ------- | ------------------- | -------------------------------------------------- |
-| Phase 1 | Plan approval       | Post plan to epic issue, auto-proceed              |
-| Phase 2 | Bug spec approval   | Auto-approve PO spec, create issue immediately     |
-| Phase 2 | PR merge approval   | Auto-merge after CI green + all reviewers approved |
-| Phase 3 | UAT validation      | E2E pass + e2e-test-engineer report = sufficient   |
-| Phase 3 | Promotion to `main` | **WAIT for user (ALWAYS)** — never auto-approved   |
-
 ## Error Handling: Retry-Then-Pause
 
 Each story has a **retry budget of 3**. The counter increments when:
 
-- Internal code review (step 2.5e) requires re-launching an implementation agent
+- Internal code review (step 6e in `/develop`) requires re-launching an implementation agent
 - CI fails after push and a fix spec must be routed to an agent
-- Review fix loop (step 2.9) requires a full spec→implement→commit cycle
+- Review fix loop (step 9 in `/develop`) requires a full spec→implement→commit cycle
 
 **At 3 failed retries:**
 
@@ -85,30 +71,19 @@ Maintain these variables throughout the session:
 
 ---
 
-## Phase 1: Planning (from `/epic-start`)
+## Phase 1: Planning (delegates to `/epic-start`)
 
-### 1.1 Product Owner
+Execute `/epic-start` steps 3–5 (Product Owner, Product Architect, Present to User). Steps 1–2 (Rebase, Wiki Sync) are already handled by Phase 0.
 
-Launch the **product-owner** agent to:
+Specifically:
 
-- Read `plan/REQUIREMENTS.md` and the existing backlog
-- Create an epic GitHub Issue (labeled `epic`) if one does not already exist
-- Decompose the epic into user stories (labeled `user-story`)
-- Link stories as sub-issues of the epic
-- Set `addBlockedBy` relationships between stories where dependencies exist
-- Set board statuses: **Backlog** for future-sprint stories, **Todo** for first-sprint stories
-- Post acceptance criteria (Given/When/Then format) on each story issue
+1. **Execute `/epic-start` step 3** (Plan: Product Owner) — launches the PO agent to create the epic issue, decompose into stories, link sub-issues, set board statuses, and post acceptance criteria.
 
-### 1.2 Product Architect
+2. **Execute `/epic-start` step 4** (Plan: Product Architect) — launches the architect agent to design schema/API/ADRs and update wiki pages.
 
-Launch the **product-architect** agent to:
+3. **Execute `/epic-start` step 5** (Present to User) — post the plan as a comment on the epic issue and present it to the user. Skip the step 6 handoff instructions (the user is not invoking `/develop` manually — Phase 2 handles it).
 
-- Design schema changes, API contract updates, shared types, and migration files
-- Write or update ADRs for any significant architectural decisions
-- Update wiki pages (`Architecture.md`, `API-Contract.md`, `Schema.md`, `ADR-Index.md`)
-- Commit and push wiki submodule changes
-
-### 1.3 Build Story Queue
+### 1.4 Build Story Queue
 
 After both agents complete:
 
@@ -116,34 +91,11 @@ After both agents complete:
 2. Topologically sort stories by dependencies (unblocked stories first)
 3. Store the sorted list as `storyQueue`
 
-### 1.4 Post Plan (AUTO_MODE)
-
-**AUTO_MODE**: Instead of waiting for user approval, post the complete plan as a comment on the epic GitHub Issue:
-
-```bash
-gh issue comment <epic-number> --body "$(cat <<'EOF'
-## Epic Plan (AUTO_MODE — auto-approved)
-
-### Stories
-<List each story with title, acceptance criteria, and dependencies>
-
-### Architecture
-<Summary of schema changes, new API endpoints, ADRs created>
-
-### Story Queue (execution order)
-<Numbered list of stories in topological order>
-
----
-*This plan was auto-approved in AUTO_MODE. Proceeding to implementation.*
-EOF
-)"
-```
-
-Proceed immediately to Phase 2.
+Post the execution order as a comment on the epic issue and proceed immediately to Phase 2.
 
 ---
 
-## Phase 2: Story Loop (from `/develop`)
+## Phase 2: Story Loop (delegates to `/develop`)
 
 For each story in `storyQueue`:
 
@@ -172,130 +124,24 @@ git fetch origin beta
 git checkout -B feat/<issue-number>-<short-description> origin/beta
 ```
 
-### 2.3 Visual Spec (conditional)
+Note: This replaces `/develop` step 1 (Rebase) and step 4 (Branch). The branch is created directly from `origin/beta` rather than renaming the worktree branch — since `/epic-run` processes multiple stories sequentially, each needs a fresh branch.
 
-If the story touches UI (`client/src/`), launch the **ux-designer** to post a styling specification on the GitHub Issue. Skip for backend-only stories and bug fixes.
+### 2.3–2.11 Execute `/develop` steps 2–11
 
-### 2.4 Move to In Progress
+Execute `/develop` steps 2 through 11 for the current story, using **single-item mode** throughout:
 
-Move the issue to **In Progress** on the Projects board:
+- **Step 2** (Resolve Issues) — resolve the story issue
+- **Step 3** (Visual Spec) — conditional, for UI-touching stories
+- **Step 4** (Branch) — **skip**, already handled in 2.2 above
+- **Step 5** (Move to In Progress) — move issue to In Progress
+- **Step 6** (Implement + Test) — full multi-phase implementation cycle (spec → backend → frontend → QA/E2E → review → fix loop → commit → trailer verification)
+- **Step 7** (Verify PR) — verify or create PR targeting `beta`
+- **Step 8** (Review) — launch 4 reviewer agents in parallel
+- **Step 9** (Fix Loop) — fix loop if reviewers flag blocking issues
+- **Step 10** (Merge) — wait for CI, persist metrics, present summary, squash merge
+- **Step 11** (Close Issues & Clean Up) — close issue, move to Done on board. **Skip the branch cleanup and `/exit`** — the session continues with the next story.
 
-```bash
-ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "296eeabe" } }) { clientMutationId } }'
-```
-
-### 2.5 Implement + Test (Multi-Phase)
-
-Follow the same multi-phase flow as `/develop` step 6:
-
-**2.5a. Spec Generation**: Launch **dev-team-lead** in `[MODE: spec]` with issue number, acceptance criteria, layers affected, UX visual spec reference (if posted in step 2.3), and branch name.
-
-**2.5b. Backend Implementation**: If backend spec present, launch **backend-developer** (Haiku) with the `## Backend Spec` section.
-
-**2.5c. Frontend Implementation**: If frontend spec present, launch **frontend-developer** (Haiku) — in parallel with 2.5b if `Execution Order: parallel`, otherwise sequentially after 2.5b.
-
-**2.5d. QA + E2E Testing**: Launch both test agents in parallel:
-
-- **qa-integration-tester** with the `## QA Spec` section + list of files changed
-- **e2e-test-engineer** (skip if no `## E2E Spec` section) with the `## E2E Spec` section + list of files changed
-
-**2.5e. Code Review**: Launch **dev-team-lead** in `[MODE: review]` with original spec + changed files list. If `VERDICT: CHANGES_REQUIRED`, run fix loop (max 3 iterations — route fixes to appropriate agents, re-review). Each re-launch of an implementation agent counts toward the story's retry budget.
-
-**2.5f. Commit and PR**: Launch **dev-team-lead** in `[MODE: commit]` with contributing agents list, issue number, and branch name. If CI fails, route fix spec to appropriate agent and re-launch `[MODE: commit]`. CI fix attempts also count toward retry budget.
-
-### 2.6 Trailer Verification
-
-Verify commit trailers match the agents launched (same as `/develop` step 6h):
-
-```bash
-git log origin/beta..HEAD --format="%b"
-```
-
-If production files were changed, verify appropriate Co-Authored-By trailers are present. If missing, re-launch `[MODE: commit]` with corrected contributing agents list.
-
-### 2.7 Verify/Create PR
-
-Verify the dev-team-lead has created a PR targeting `beta`. If not, create it:
-
-```bash
-gh pr create --base beta --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points>
-
-Fixes #<issue-number>
-
-## Test plan
-- [ ] Unit tests pass (95%+ coverage)
-- [ ] Integration tests pass
-- [ ] Pre-commit hook quality gates pass
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-EOF
-)"
-```
-
-### 2.8 Review
-
-Launch 4 reviewer agents in parallel:
-
-- `product-architect` — architecture compliance, test coverage, code quality
-- `security-engineer` — OWASP Top 10 review, input validation, auth gaps
-- `product-owner` — requirements coverage, acceptance criteria (stories only)
-- `ux-designer` — token adherence, visual consistency, accessibility (UI PRs only)
-
-### 2.9 Fix Loop
-
-If any reviewer identifies blocking issues:
-
-1. Collect reviewer feedback into a fix request
-2. Launch **dev-team-lead** in `[MODE: spec]` with reviewer feedback to produce targeted fix specs (or write fix specs directly if feedback is clear)
-3. Route fix specs to appropriate implementation agents (backend-developer, frontend-developer, qa-integration-tester, or e2e-test-engineer)
-4. Launch **dev-team-lead** in `[MODE: review]` to verify fixes
-5. Launch **dev-team-lead** in `[MODE: commit]` to commit, push, watch CI
-6. Run trailer verification (step 2.6)
-7. Re-request review from the agent(s) that flagged issues
-8. Track `fixLoopCount` per story — each full spec→implement→commit cycle increments the retry counter
-
-If retry budget (3) is exhausted:
-
-```bash
-gh issue comment <epic-number> --body "**[orchestrator]** Story #<number> failed after 3 retries. Pausing for user guidance."
-```
-
-Ask the user: provide guidance, skip the story, or abort.
-
-### 2.10 Auto-Merge (AUTO_MODE)
-
-Wait for CI to go green:
-
-```
-gh pr checks <pr-number> --watch
-```
-
-**AUTO_MODE**: Once CI is green and all reviewers have approved, persist metrics and merge automatically:
-
-1. Persist metrics to `.claude/metrics/review-metrics.jsonl` (same as `/develop` step 10a)
-2. Commit and push the metrics file
-3. Merge:
-   ```
-   gh pr merge --squash <pr-url>
-   ```
-
-### 2.11 Close Issue
-
-```bash
-gh issue close <issue-number>
-```
-
-Move to **Done** on the Projects board:
-
-```bash
-ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "c558f50d" } }) { clientMutationId } }'
-```
-
-Add the story to `completedStories`.
+After step 11 completes, add the story to `completedStories`.
 
 ### 2.12 Check Newly Unblocked Stories
 
@@ -311,149 +157,29 @@ gh issue comment <epic-number> --body "**[orchestrator]** Progress: <N>/<total> 
 
 ---
 
-## Phase 3: Closing (from `/epic-close`)
+## Phase 3: Closing (delegates to `/epic-close`)
 
-### 3.1 Verify All Stories Merged
+### 3.0 Pre-Check
 
-```bash
-gh issue view <epic-number>
-# Check the sub-issues section — all should be closed
-```
+If `failedStories` is non-empty, ask the user: proceed with completed stories only, retry failures, or abort. Note excluded stories for inclusion in the promotion PR body.
 
-If `failedStories` is non-empty, ask the user: proceed with completed stories only, retry failures, or abort. Note excluded stories in the promotion PR body.
+### 3.1 Execute `/epic-close` steps 2–12
 
-### 3.2 Epic Metrics Report
+Execute `/epic-close` steps 2 through 12 in order. Step 1 (Rebase) is skipped — the worktree is already on the latest beta from the story loop.
 
-Read `.claude/metrics/review-metrics.jsonl` and generate a summary for the epic. Post as a comment on the epic issue.
+- **Step 2** (Verify All Stories Merged)
+- **Step 2a** (Generate Epic Metrics Report)
+- **Step 2b** (Lint Health Check)
+- **Step 3** (Collect Refinement Items)
+- **Step 4** (Refinement PR)
+- **Step 5** (E2E Validation)
+- **Step 6** (UAT Validation)
+- **Step 7** (Documentation)
+- **Step 8** (Branch Sync)
+- **Step 9** (Epic Promotion)
+- **Step 10** (Post Detailed UAT Criteria)
+- **Step 11** (CI Gate)
+- **Step 12** (User Approval) — **mandatory human gate**
+- **Step 13** (Merge & Post-Merge)
 
-### 3.3 Collect + Address Refinement Items
-
-Review all story PRs for non-blocking review comments. If refinement items exist:
-
-1. Create a branch: `git checkout -B chore/<epic-number>-refinement origin/beta`
-2. Launch **dev-team-lead** in `[MODE: spec]` with refinement observations
-3. Route fix specs to appropriate implementation agents (backend-developer, frontend-developer, qa-integration-tester, e2e-test-engineer)
-4. Launch **dev-team-lead** in `[MODE: review]` to verify fixes
-5. Launch **dev-team-lead** in `[MODE: commit]` with contributing agents list
-6. Create PR targeting `beta`, wait for CI, auto-merge
-
-### 3.4 E2E Validation
-
-Launch the **e2e-test-engineer** agent to:
-
-- Confirm all existing Playwright E2E tests pass
-- Verify every UAT scenario has E2E coverage
-- Write new E2E tests if coverage gaps exist
-- Ensure dependent system containers are included in the E2E environment
-- Expand smoke tests if the epic introduced new major capabilities
-- Open a PR targeting `beta` to trigger the full sharded E2E suite
-- Wait for the full E2E suite to pass
-
-### 3.5 UAT Validation (AUTO_MODE)
-
-Launch the **product-owner** agent to produce UAT scenarios, then the orchestrator coordinates validation and produces a UAT Validation Report.
-
-**AUTO_MODE**: E2E pass + e2e-test-engineer report = sufficient. Do NOT wait for user walkthrough. Post the UAT report as a comment on the epic issue and proceed.
-
-### 3.6 Documentation
-
-Launch the **docs-writer** agent to:
-
-- Update the documentation site (`docs/`) with new feature guides
-- Update `README.md` with newly shipped capabilities
-- Write `RELEASE_SUMMARY.md`
-
-Commit documentation updates to `beta` via a PR, wait for CI, auto-merge.
-
-### 3.7 Branch Sync
-
-Check if `main` has commits that `beta` doesn't:
-
-```bash
-git log origin/beta..origin/main --oneline
-```
-
-If so, create a sync PR (`main` → `beta`), wait for CI, merge before proceeding.
-
-### 3.8 Promotion PR
-
-Create a PR from `beta` to `main` using a **merge commit** (not squash):
-
-```bash
-gh pr create --base main --head beta --title "release: promote epic #<epic-number> to main" --body "$(cat <<'EOF'
-## Summary
-<Epic title and description>
-
-## Stories Included
-- #<story-1> — <title>
-- #<story-2> — <title>
-...
-
-## Excluded Stories (if any)
-<List any failed/skipped stories>
-
-## Epic Metrics
-<Paste metrics report from step 3.2>
-
-## UAT Validation
-All UAT scenarios passed (AUTO_MODE: E2E + e2e-test-engineer report).
-See validation report in comments.
-
-## Review Summary
-<Total PRs, fix loops, findings breakdown>
-EOF
-)"
-```
-
-### 3.9 Post UAT Criteria on PR
-
-Post UAT validation criteria and manual testing steps as comments on the promotion PR (same as `/epic-close` step 9).
-
-### 3.10 CI Gate
-
-```
-gh pr checks <pr-number> --watch
-```
-
-### 3.11 HARD GATE: User Approval
-
-**This is the ONLY mandatory human gate in AUTO_MODE.**
-
-Present the user with:
-
-1. **Promotion PR link**
-2. **Epic summary**: stories completed, stories excluded (if any), total findings, fix loops
-3. **UAT report**: summary of validation results
-4. **DockerHub beta image**: `docker pull steilerdev/cornerstone:beta` for manual testing
-
-**Wait for explicit user confirmation.** Do NOT merge without user approval.
-
-### 3.12 Merge & Post-Merge
-
-After user approval:
-
-1. Merge with a merge commit:
-   ```
-   gh pr merge --merge <pr-url>
-   ```
-2. Verify the merge-back job succeeded (automated by `release.yml`). If it fails:
-   ```bash
-   git checkout beta && git pull && git merge origin/main && git push
-   ```
-3. Close the epic issue:
-   ```
-   gh issue close <epic-number>
-   ```
-4. Move the epic to **Done** on the Projects board:
-   ```bash
-   ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <epic-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-   gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "c558f50d" } }) { clientMutationId } }'
-   ```
-5. Post final summary on the epic issue:
-   ```bash
-   gh issue comment <epic-number> --body "**[orchestrator]** Epic complete. Promoted to main. Release will be created by semantic-release."
-   ```
-6. Exit the session:
-   ```
-   /exit
-   ```
+If any step in `/epic-close` references "failed stories" or "excluded stories", use the `failedStories` list from Phase 2.

--- a/.claude/skills/epic-start/SKILL.md
+++ b/.claude/skills/epic-start/SKILL.md
@@ -90,9 +90,7 @@ Present the complete epic plan to the user:
 - **Architecture**: Summary of schema changes, new API endpoints, ADRs created
 - **Sprint plan**: Which stories are in the first sprint (Todo) vs backlog
 
-**AUTO_MODE override**: If AUTO_MODE is active (set by `/epic-run`), skip the user approval wait. Instead, post the plan as a comment on the epic GitHub Issue with the header "Epic Plan (AUTO_MODE — auto-approved)" and proceed immediately to step 6.
-
-**Interactive mode** (default): Wait for user approval. If the user requests changes, re-launch the appropriate agent (PO or architect) to address feedback and present again.
+Post the plan as a comment on the epic GitHub Issue and proceed immediately to step 6.
 
 ### 6. Handoff
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,21 +95,9 @@ The orchestrator uses four skills to drive work. Each skill contains the full op
 | `/epic-close` | Refinement, E2E validation, UAT, docs, promotion to `main`                 | Epic issue number                                               |
 | `/epic-run`   | Autonomous end-to-end epic: plan, develop all stories, close               | Epic description or issue number                                |
 
-### AUTO_MODE Convention
-
-`/epic-run` activates **AUTO_MODE** for the session. When AUTO_MODE is active, intermediate user approval gates are auto-approved. The existing skills (`/epic-start`, `/develop`, `/epic-close`) each contain `AUTO_MODE override` blocks that describe the alternate behavior. AUTO_MODE is never active when skills are invoked directly — only when chained by `/epic-run`.
-
-| Skill         | Gate                | Interactive (default) | AUTO_MODE                                          |
-| ------------- | ------------------- | --------------------- | -------------------------------------------------- |
-| `/epic-start` | Plan approval       | Wait for user         | Post plan to epic issue, auto-proceed              |
-| `/develop`    | Bug spec approval   | Wait for user         | Auto-approve PO spec, create issue immediately     |
-| `/develop`    | PR merge approval   | Wait for user         | Auto-merge after CI green + all reviewers approved |
-| `/epic-close` | UAT validation      | User walkthrough      | E2E pass + e2e-test-engineer report = sufficient   |
-| `/epic-close` | Promotion to `main` | **Wait for user**     | **Wait for user (ALWAYS)** — never auto-approved   |
-
 ## Acceptance & Validation
 
-Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story/bug PR (single items or batched). **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT with user, docs update, promotion. Alternatively, use `/epic-run` to execute the entire lifecycle autonomously in a single session (only pauses for promotion approval).
+Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story/bug PR — PRs auto-merge after CI green + all reviewers approved. **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT scenarios fed to e2e-test-engineer, docs update, promotion. Use `/epic-run` to execute the entire lifecycle in a single session. The only human gate is promotion from `beta` → `main`, where the user reviews a comprehensive summary with change inventory, validation report, and manual validation checklist.
 
 ### Key Rules
 
@@ -189,7 +177,7 @@ Production files: any file under `server/`, `client/`, or `shared/`.
 
 **NEVER `cd` to the base project directory to modify files.** All file edits, git operations, and commands must be performed from within the git worktree assigned at session start. The base project directory may have other sessions' uncommitted changes. This applies to subagents too — all file reads, writes, and exploration must use the worktree path.
 
-See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story, or batched for multiple small items) → `/epic-close` (once per epic after all stories merged). Alternatively, `/epic-run` chains all three phases autonomously (only pauses for promotion approval).
+See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story, or batched for multiple small items) → `/epic-close` (once per epic after all stories merged). Alternatively, `/epic-run` chains all three phases in a single session (only pauses for promotion approval).
 
 Note: Dependabot auto-merge (`.github/workflows/dependabot-auto-merge.yml`) targets `beta` — it handles automated dependency updates, not agent work.
 


### PR DESCRIPTION
## Summary

- Rewrites `/epic-run` to delegate to sub-skills (`/epic-start`, `/develop`, `/epic-close`) instead of re-implementing their steps inline, reducing from 457 to 185 lines
- Adds Branch Sync step to `/epic-close` (step 8) before promotion PR creation
- Removes AUTO_MODE convention from all skills and CLAUDE.md — PRs auto-merge after CI green + all reviewers approved; only human gate is `beta` → `main` promotion

## Test plan
- [ ] Read each skill file end-to-end for coherence
- [ ] Verify `/epic-run` references specific step numbers from sub-skills
- [ ] Confirm no duplicated GraphQL option IDs in `/epic-run`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)