### PR TITLE
fix(budget): require funding source on all budget lines

### DIFF
--- a/client/src/components/budget/BudgetLineForm.tsx
+++ b/client/src/components/budget/BudgetLineForm.tsx
@@ -243,7 +243,6 @@ export function BudgetLineForm({
             onChange={(e) => onFormChange({ budgetSourceId: e.target.value })}
             disabled={isSaving}
           >
-            <option value="">None</option>
             {budgetSources.map((src) => (
               <option key={src.id} value={src.id}>
                 {src.name}

--- a/client/src/hooks/useBudgetSection.ts
+++ b/client/src/hooks/useBudgetSection.ts
@@ -70,6 +70,12 @@ export interface UseBudgetSectionOptions<T extends BaseBudgetLine> {
    * Entity ID (work item or household item)
    */
   entityId: string;
+
+  /**
+   * Default budget source ID to use when opening a new budget form.
+   * If not provided, new forms will have an empty funding source.
+   */
+  defaultBudgetSourceId?: string;
 }
 
 /**
@@ -124,6 +130,7 @@ export function useBudgetSection<T extends BaseBudgetLine>(
     toFormState,
     toPayload,
     entityId,
+    defaultBudgetSourceId,
   } = options;
 
   const emptyForm: BudgetLineFormState = {
@@ -131,7 +138,7 @@ export function useBudgetSection<T extends BaseBudgetLine>(
     plannedAmount: '',
     confidence: 'own_estimate',
     budgetCategoryId: '',
-    budgetSourceId: '',
+    budgetSourceId: defaultBudgetSourceId ?? '',
     vendorId: '',
     pricingMode: 'direct',
     quantity: '',
@@ -156,7 +163,7 @@ export function useBudgetSection<T extends BaseBudgetLine>(
 
   const openAddBudgetForm = () => {
     setEditingBudgetId(null);
-    setBudgetForm(emptyForm);
+    setBudgetForm({ ...emptyForm, budgetSourceId: defaultBudgetSourceId ?? '' });
     setBudgetFormError(null);
     setShowBudgetForm(true);
   };
@@ -171,7 +178,7 @@ export function useBudgetSection<T extends BaseBudgetLine>(
   const closeBudgetForm = () => {
     setShowBudgetForm(false);
     setEditingBudgetId(null);
-    setBudgetForm(emptyForm);
+    setBudgetForm({ ...emptyForm, budgetSourceId: defaultBudgetSourceId ?? '' });
     setBudgetFormError(null);
   };
 

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -200,7 +200,7 @@ export function HouseholdItemDetailPage() {
       description: form.description.trim() || null,
       plannedAmount: parseFloat(form.plannedAmount),
       confidence: form.confidence,
-      budgetSourceId: form.budgetSourceId || null,
+      budgetSourceId: form.budgetSourceId,
       vendorId: form.vendorId || null,
       quantity: form.pricingMode === 'unit' && form.quantity ? parseFloat(form.quantity) : null,
       unit: form.pricingMode === 'unit' && form.unit ? form.unit : null,
@@ -208,6 +208,7 @@ export function HouseholdItemDetailPage() {
       includesVat: form.pricingMode === 'unit' ? form.includesVat : null,
     }),
     entityId: id ?? '',
+    defaultBudgetSourceId: budgetSources.find((s) => s.isDiscretionary)?.id,
   });
 
   useEffect(() => {

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -257,7 +257,7 @@ export default function WorkItemDetailPage() {
       plannedAmount: parseFloat(form.plannedAmount),
       confidence: form.confidence,
       budgetCategoryId: form.budgetCategoryId || null,
-      budgetSourceId: form.budgetSourceId || null,
+      budgetSourceId: form.budgetSourceId,
       vendorId: form.vendorId || null,
       quantity: form.pricingMode === 'unit' && form.quantity ? parseFloat(form.quantity) : null,
       unit: form.pricingMode === 'unit' && form.unit ? form.unit : null,
@@ -265,6 +265,7 @@ export default function WorkItemDetailPage() {
       includesVat: form.pricingMode === 'unit' ? form.includesVat : null,
     }),
     entityId: id ?? '',
+    defaultBudgetSourceId: budgetSources.find((s) => s.isDiscretionary)?.id,
   });
 
   // Local state for duration/constraint inputs (onBlur save pattern to avoid race conditions)

--- a/server/src/db/migrations/0023_require_budget_source.sql
+++ b/server/src/db/migrations/0023_require_budget_source.sql
@@ -1,0 +1,9 @@
+-- Backfill NULL budget_source_id to discretionary-system in work_item_budgets
+UPDATE work_item_budgets
+SET budget_source_id = 'discretionary-system'
+WHERE budget_source_id IS NULL;
+
+-- Backfill NULL budget_source_id to discretionary-system in household_item_budgets
+UPDATE household_item_budgets
+SET budget_source_id = 'discretionary-system'
+WHERE budget_source_id IS NULL;

--- a/server/src/db/migrations/0023_require_budget_source.test.ts
+++ b/server/src/db/migrations/0023_require_budget_source.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Migration integration tests for 0023_require_budget_source.sql
+ *
+ * Tests that:
+ *   1. Fresh DB: all migrations 0001-0023 apply without error
+ *   2. Pre-migration NULL budget_source_id on work_item_budgets rows updated to 'discretionary-system'
+ *   3. Pre-migration NULL budget_source_id on household_item_budgets rows updated to 'discretionary-system'
+ *   4. Rows with non-NULL budget_source_id retain their original value
+ *   5. Post-migration budget_source_id is NOT NULL on all rows
+ *   6. Idempotency: running migrator twice on fresh DB does not error
+ *
+ * Issue #787: Budget lines should not allow 'None' as funding source
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { mkdtempSync, symlinkSync, unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runMigrations } from '../migrate.js';
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// Migrations that must run before 0023
+const PRE_0023_MIGRATIONS = [
+  '0001_create_users_and_sessions.sql',
+  '0002_create_work_items.sql',
+  '0003_create_budget_tables.sql',
+  '0004_add_work_item_budget_fields.sql',
+  '0005_budget_rework.sql',
+  '0006_milestones.sql',
+  '0007_milestone_dependencies.sql',
+  '0008_actual_dates_and_status.sql',
+  '0009_document_links.sql',
+  '0010_household_items.sql',
+  '0011_household_item_invoice_link.sql',
+  '0012_household_item_deps.sql',
+  '0013_drop_hi_dep_cpm_columns.sql',
+  '0014_rename_hi_status_values.sql',
+  '0015_hi_delivery_date_redesign.sql',
+  '0016_household_item_categories.sql',
+  '0017_invoice_budget_lines.sql',
+  '0018_user_preferences.sql',
+  '0019_photos.sql',
+  '0019_unit_pricing_vat.sql',
+  '0020_subsidy_max_amount.sql',
+  '0021_discretionary_budget_source.sql',
+  '0022_security_hygiene.sql',
+];
+
+/**
+ * Apply migrations 0001-0022 to a fresh in-memory DB.
+ */
+function setupPreMigrationDb(db: Database.Database): void {
+  const tempDir = mkdtempSync(join(tmpdir(), 'cs-mig-test-'));
+  const symlinks: string[] = [];
+
+  for (const file of PRE_0023_MIGRATIONS) {
+    const linkPath = join(tempDir, file);
+    symlinkSync(join(MIGRATIONS_DIR, file), linkPath);
+    symlinks.push(linkPath);
+  }
+
+  try {
+    console.warn = () => undefined;
+    runMigrations(db, tempDir);
+  } finally {
+    console.warn = console.error;
+    for (const linkPath of symlinks) {
+      if (existsSync(linkPath)) {
+        unlinkSync(linkPath);
+      }
+    }
+  }
+}
+
+/**
+ * Apply migration 0023 directly on a DB that already has 0001-0022 applied.
+ */
+function runMigration0023(db: Database.Database): void {
+  const sql = readFileSync(join(MIGRATIONS_DIR, '0023_require_budget_source.sql'), 'utf-8');
+  db.exec(sql);
+  db.prepare('INSERT OR IGNORE INTO _migrations (name) VALUES (?)').run(
+    '0023_require_budget_source.sql',
+  );
+}
+
+// ── Helper: insert test data ───────────────────────────────────────────────
+
+function insertUser(db: Database.Database, id: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, display_name, role, auth_provider, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, `${id}@example.com`, `User ${id}`, 'member', 'local', now, now);
+}
+
+function insertBudgetSource(db: Database.Database, id: string, name: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO budget_sources (id, name, source_type, total_amount, created_by, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, name, 'savings', 50000, 'user-001', now, now);
+}
+
+function insertWorkItem(db: Database.Database, id: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO work_items (id, title, status, created_by, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, `Work Item ${id}`, 'not_started', 'user-001', now, now);
+}
+
+function insertHouseholdItem(db: Database.Database, id: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO household_items (id, name, category_id, status, created_by, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, `Item ${id}`, 'hic-other', 'planned', 'user-001', now, now);
+}
+
+describe('Migration 0023: Require budgetSourceId', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.pragma('journal_mode = WAL');
+    sqlite.pragma('foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Test 1: Fresh DB ────────────────────────────────────────────────────
+
+  it('applies all migrations 0001-0023 without error on a fresh DB', () => {
+    console.warn = () => undefined;
+    expect(() => {
+      runMigrations(sqlite);
+    }).not.toThrow();
+    console.warn = console.error;
+  });
+
+  // ─── Test 2-4: Data migration ────────────────────────────────────────────
+
+  describe('data migration', () => {
+    it('backfills NULL budget_source_id to discretionary-system on work_item_budgets', () => {
+      setupPreMigrationDb(sqlite);
+      insertUser(sqlite, 'user-001');
+
+      // Create a work item and insert a budget line with NULL budget_source_id
+      // (using raw SQL since the Drizzle schema now marks it notNull)
+      insertWorkItem(sqlite, 'wi-001');
+      const now = new Date().toISOString();
+      sqlite
+        .prepare(
+          `INSERT INTO work_item_budgets (id, work_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('wib-001', 'wi-001', 1000, 'own_estimate', null, now, now);
+
+      // Verify it's NULL before migration
+      const before = sqlite
+        .prepare('SELECT budget_source_id FROM work_item_budgets WHERE id = ?')
+        .get('wib-001') as any;
+      expect(before.budget_source_id).toBeNull();
+
+      // Apply migration
+      runMigration0023(sqlite);
+
+      // Verify it's now discretionary-system
+      const after = sqlite
+        .prepare('SELECT budget_source_id FROM work_item_budgets WHERE id = ?')
+        .get('wib-001') as any;
+      expect(after.budget_source_id).toBe('discretionary-system');
+    });
+
+    it('backfills NULL budget_source_id to discretionary-system on household_item_budgets', () => {
+      setupPreMigrationDb(sqlite);
+      insertUser(sqlite, 'user-001');
+
+      // Create a household item and insert a budget line with NULL budget_source_id
+      insertHouseholdItem(sqlite, 'hi-001');
+      const now = new Date().toISOString();
+      sqlite
+        .prepare(
+          `INSERT INTO household_item_budgets (id, household_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('hib-001', 'hi-001', 500, 'professional_estimate', null, now, now);
+
+      // Verify it's NULL before migration
+      const before = sqlite
+        .prepare('SELECT budget_source_id FROM household_item_budgets WHERE id = ?')
+        .get('hib-001') as any;
+      expect(before.budget_source_id).toBeNull();
+
+      // Apply migration
+      runMigration0023(sqlite);
+
+      // Verify it's now discretionary-system
+      const after = sqlite
+        .prepare('SELECT budget_source_id FROM household_item_budgets WHERE id = ?')
+        .get('hib-001') as any;
+      expect(after.budget_source_id).toBe('discretionary-system');
+    });
+
+    it('preserves non-NULL budget_source_id on work_item_budgets during migration', () => {
+      setupPreMigrationDb(sqlite);
+      insertUser(sqlite, 'user-001');
+
+      // Create a budget source and a work item with a budget line linked to it
+      insertBudgetSource(sqlite, 'bs-custom', 'Custom Source');
+      insertWorkItem(sqlite, 'wi-002');
+      const now = new Date().toISOString();
+      sqlite
+        .prepare(
+          `INSERT INTO work_item_budgets (id, work_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('wib-002', 'wi-002', 2000, 'quote', 'bs-custom', now, now);
+
+      // Apply migration
+      runMigration0023(sqlite);
+
+      // Verify it still has the original source ID
+      const after = sqlite
+        .prepare('SELECT budget_source_id FROM work_item_budgets WHERE id = ?')
+        .get('wib-002') as any;
+      expect(after.budget_source_id).toBe('bs-custom');
+    });
+
+    it('preserves non-NULL budget_source_id on household_item_budgets during migration', () => {
+      setupPreMigrationDb(sqlite);
+      insertUser(sqlite, 'user-001');
+
+      // Create a budget source and a household item with a budget line linked to it
+      insertBudgetSource(sqlite, 'bs-grant', 'Grant Program');
+      insertHouseholdItem(sqlite, 'hi-002');
+      const now = new Date().toISOString();
+      sqlite
+        .prepare(
+          `INSERT INTO household_item_budgets (id, household_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('hib-002', 'hi-002', 800, 'professional_estimate', 'bs-grant', now, now);
+
+      // Apply migration
+      runMigration0023(sqlite);
+
+      // Verify it still has the original source ID
+      const after = sqlite
+        .prepare('SELECT budget_source_id FROM household_item_budgets WHERE id = ?')
+        .get('hib-002') as any;
+      expect(after.budget_source_id).toBe('bs-grant');
+    });
+
+    it('all rows have non-NULL budget_source_id after migration', () => {
+      setupPreMigrationDb(sqlite);
+      insertUser(sqlite, 'user-001');
+
+      // Create multiple budget lines with mixed NULL and non-NULL sources
+      insertWorkItem(sqlite, 'wi-003');
+      insertHouseholdItem(sqlite, 'hi-003');
+      insertBudgetSource(sqlite, 'bs-test', 'Test Source');
+      const now = new Date().toISOString();
+
+      sqlite
+        .prepare(
+          `INSERT INTO work_item_budgets (id, work_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('wib-null-1', 'wi-003', 100, 'own_estimate', null, now, now);
+      sqlite
+        .prepare(
+          `INSERT INTO work_item_budgets (id, work_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('wib-set-1', 'wi-003', 200, 'own_estimate', 'bs-test', now, now);
+      sqlite
+        .prepare(
+          `INSERT INTO household_item_budgets (id, household_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('hib-null-1', 'hi-003', 300, 'own_estimate', null, now, now);
+      sqlite
+        .prepare(
+          `INSERT INTO household_item_budgets (id, household_item_id, planned_amount, confidence, budget_source_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('hib-set-1', 'hi-003', 400, 'own_estimate', 'bs-test', now, now);
+
+      // Apply migration
+      runMigration0023(sqlite);
+
+      // Verify all rows have non-NULL values
+      const wiRows = sqlite
+        .prepare(
+          `SELECT id, budget_source_id FROM work_item_budgets WHERE work_item_id = ? ORDER BY id`,
+        )
+        .all('wi-003') as any[];
+      const hiRows = sqlite
+        .prepare(
+          `SELECT id, budget_source_id FROM household_item_budgets WHERE household_item_id = ? ORDER BY id`,
+        )
+        .all('hi-003') as any[];
+
+      expect(wiRows).toHaveLength(2);
+      expect(hiRows).toHaveLength(2);
+
+      wiRows.forEach((row: any) => {
+        expect(row.budget_source_id).not.toBeNull();
+        expect(typeof row.budget_source_id).toBe('string');
+      });
+
+      hiRows.forEach((row: any) => {
+        expect(row.budget_source_id).not.toBeNull();
+        expect(typeof row.budget_source_id).toBe('string');
+      });
+    });
+  });
+
+  // ─── Test 5: Idempotency ──────────────────────────────────────────────
+
+  it('migration is idempotent — running twice does not error', () => {
+    setupPreMigrationDb(sqlite);
+
+    // Run migration first time
+    expect(() => {
+      runMigration0023(sqlite);
+    }).not.toThrow();
+
+    // Attempt to run again (should not error even though migration is already recorded)
+    // Typically migrations are recorded in _migrations table to prevent re-runs,
+    // but in this case we're testing the SQL itself is idempotent
+    expect(() => {
+      const sql = readFileSync(join(MIGRATIONS_DIR, '0023_require_budget_source.sql'), 'utf-8');
+      // Only run the SQL, not the migration recording
+      // (it would fail if we tried to insert a duplicate _migrations record)
+      sqlite.exec(sql);
+    }).not.toThrow();
+  });
+});

--- a/server/src/routes/householdItemBudgets.test.ts
+++ b/server/src/routes/householdItemBudgets.test.ts
@@ -153,6 +153,7 @@ describe('Household Item Budget Routes', () => {
           description: 'Initial budget estimate',
           plannedAmount: 500,
           confidence: 'own_estimate',
+          budgetSourceId: 'discretionary-system',
         }),
       });
 
@@ -264,6 +265,7 @@ describe('Household Item Budget Routes', () => {
         headers: { cookie, 'content-type': 'application/json' },
         body: JSON.stringify({
           plannedAmount: 250,
+          budgetSourceId: 'discretionary-system',
         }),
       });
 
@@ -274,7 +276,7 @@ describe('Household Item Budget Routes', () => {
       expect(body.budget.confidence).toBe('own_estimate');
       // budgetCategoryId is auto-assigned to 'bc-household-items' by the service
       expect(body.budget.budgetCategory?.id).toBe('bc-household-items');
-      expect(body.budget.budgetSource).toBeNull();
+      expect(body.budget.budgetSource).not.toBeNull();
       expect(body.budget.vendor).toBeNull();
     });
 
@@ -351,6 +353,7 @@ describe('Household Item Budget Routes', () => {
         headers: { cookie, 'content-type': 'application/json' },
         body: JSON.stringify({
           plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
           extraField: 'should-be-stripped',
           anotherExtra: 'also-stripped',
         }),
@@ -379,7 +382,7 @@ describe('Household Item Budget Routes', () => {
           cookie: `cornerstone_session=${sessionService.createSession(app.db, userId, 3600)}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
 
@@ -408,6 +411,7 @@ describe('Household Item Budget Routes', () => {
         body: JSON.stringify({
           description: 'Original description',
           plannedAmount: 300,
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
@@ -442,6 +446,7 @@ describe('Household Item Budget Routes', () => {
         body: JSON.stringify({
           description: 'Budget line',
           plannedAmount: 300,
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
@@ -515,6 +520,7 @@ describe('Household Item Budget Routes', () => {
         body: JSON.stringify({
           plannedAmount: 300,
           confidence: 'own_estimate',
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
@@ -552,7 +558,7 @@ describe('Household Item Budget Routes', () => {
           cookie: `cornerstone_session=${sessionService.createSession(app.db, userId, 3600)}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
 
@@ -576,7 +582,7 @@ describe('Household Item Budget Routes', () => {
         method: 'POST',
         url: `/api/household-items/${householdItem.id}/budgets`,
         headers: { cookie, 'content-type': 'application/json' },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: HouseholdItemBudgetLine }>().budget.id;
 

--- a/server/src/routes/workItemBudgets.test.ts
+++ b/server/src/routes/workItemBudgets.test.ts
@@ -166,6 +166,7 @@ describe('Work Item Budget Routes', () => {
           description: 'Initial budget estimate',
           plannedAmount: 5000,
           confidence: 'own_estimate',
+          budgetSourceId: 'discretionary-system',
         }),
       });
 
@@ -282,6 +283,7 @@ describe('Work Item Budget Routes', () => {
         headers: { cookie, 'content-type': 'application/json' },
         body: JSON.stringify({
           plannedAmount: 250,
+          budgetSourceId: 'discretionary-system',
         }),
       });
 
@@ -291,7 +293,7 @@ describe('Work Item Budget Routes', () => {
       expect(body.budget.description).toBeNull();
       expect(body.budget.confidence).toBe('own_estimate');
       expect(body.budget.budgetCategory).toBeNull();
-      expect(body.budget.budgetSource).toBeNull();
+      expect(body.budget.budgetSource).not.toBeNull();
       expect(body.budget.vendor).toBeNull();
     });
 
@@ -368,6 +370,7 @@ describe('Work Item Budget Routes', () => {
         headers: { cookie, 'content-type': 'application/json' },
         body: JSON.stringify({
           plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
           extraField: 'should-be-stripped',
           anotherExtra: 'also-stripped',
         }),
@@ -390,6 +393,7 @@ describe('Work Item Budget Routes', () => {
         headers: { cookie, 'content-type': 'application/json' },
         body: JSON.stringify({
           plannedAmount: 0,
+          budgetSourceId: 'discretionary-system',
         }),
       });
 
@@ -418,7 +422,7 @@ describe('Work Item Budget Routes', () => {
           cookie: `cornerstone_session=${sessionService.createSession(app.db, userId, 3600)}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
 
@@ -447,6 +451,7 @@ describe('Work Item Budget Routes', () => {
         body: JSON.stringify({
           description: 'Original description',
           plannedAmount: 3000,
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
@@ -481,6 +486,7 @@ describe('Work Item Budget Routes', () => {
         body: JSON.stringify({
           description: 'Budget line',
           plannedAmount: 3000,
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
@@ -515,6 +521,7 @@ describe('Work Item Budget Routes', () => {
         body: JSON.stringify({
           plannedAmount: 3000,
           confidence: 'own_estimate',
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
@@ -551,6 +558,7 @@ describe('Work Item Budget Routes', () => {
           description: 'Some desc',
           plannedAmount: 1000,
           budgetCategoryId: category.id,
+          budgetSourceId: 'discretionary-system',
         }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
@@ -629,7 +637,7 @@ describe('Work Item Budget Routes', () => {
           cookie: `cornerstone_session=${sessionService.createSession(app.db, userId, 3600)}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
 
@@ -653,7 +661,7 @@ describe('Work Item Budget Routes', () => {
         method: 'POST',
         url: `/api/work-items/${workItem.id}/budgets`,
         headers: { cookie, 'content-type': 'application/json' },
-        body: JSON.stringify({ plannedAmount: 300 }),
+        body: JSON.stringify({ plannedAmount: 300, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
 
@@ -726,7 +734,7 @@ describe('Work Item Budget Routes', () => {
         method: 'POST',
         url: `/api/work-items/${workItem.id}/budgets`,
         headers: { cookie, 'content-type': 'application/json' },
-        body: JSON.stringify({ plannedAmount: 5000 }),
+        body: JSON.stringify({ plannedAmount: 5000, budgetSourceId: 'discretionary-system' }),
       });
       const budgetId = createResp.json<{ budget: WorkItemBudgetLine }>().budget.id;
 

--- a/server/src/services/shared/budgetServiceFactory.test.ts
+++ b/server/src/services/shared/budgetServiceFactory.test.ts
@@ -231,7 +231,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const workItemId = insertWorkItem();
       const hiId = insertHouseholdItem();
 
-      createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+      createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 500,
+        budgetSourceId: 'discretionary-system',
+      });
 
       expect(listWorkItemBudgets(db, workItemId)).toHaveLength(1);
       expect(listHouseholdItemBudgets(db, hiId)).toHaveLength(0);
@@ -253,10 +256,12 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const line1 = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 100,
           description: 'First line',
+          budgetSourceId: 'discretionary-system',
         });
         const line2 = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 200,
           description: 'Second line',
+          budgetSourceId: 'discretionary-system',
         });
 
         const result = listWorkItemBudgets(db, workItemId);
@@ -280,7 +285,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const workItemId1 = insertWorkItem('Item 1');
         const workItemId2 = insertWorkItem('Item 2');
 
-        createWorkItemBudget(db, workItemId2, 'user-001', { plannedAmount: 999 });
+        createWorkItemBudget(db, workItemId2, 'user-001', {
+          plannedAmount: 999,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(listWorkItemBudgets(db, workItemId1)).toHaveLength(0);
       });
@@ -294,10 +302,12 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const lineA = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 300,
           description: 'Line A (paid)',
+          budgetSourceId: 'discretionary-system',
         });
         const lineB = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 200,
           description: 'Line B (pending)',
+          budgetSourceId: 'discretionary-system',
         });
         insertInvoiceForWorkItemBudget(lineA.id, vendorId, { amount: 150, status: 'paid' });
         insertInvoiceForWorkItemBudget(lineB.id, vendorId, { amount: 75, status: 'pending' });
@@ -338,14 +348,20 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const hiId1 = insertHouseholdItem('Sofa');
         const hiId2 = insertHouseholdItem('Fridge');
 
-        createHouseholdItemBudget(db, hiId2, 'user-001', { plannedAmount: 800 });
+        createHouseholdItemBudget(db, hiId2, 'user-001', {
+          plannedAmount: 800,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(listHouseholdItemBudgets(db, hiId1)).toHaveLength(0);
       });
 
       it('does NOT include an invoices list on household item budget lines', () => {
         const hiId = insertHouseholdItem();
-        createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 300 });
+        createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 300,
+          budgetSourceId: 'discretionary-system',
+        });
 
         const result = listHouseholdItemBudgets(db, hiId);
 
@@ -358,7 +374,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const hiId = insertHouseholdItem();
         const vendorId = insertVendor();
 
-        const line = createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 400 });
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 400,
+          budgetSourceId: 'discretionary-system',
+        });
         insertInvoiceForHouseholdItemBudget(line.id, vendorId, { amount: 200, status: 'claimed' });
 
         const result = listHouseholdItemBudgets(db, hiId);
@@ -412,6 +431,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
         const result = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.confidence).toBe('own_estimate');
@@ -423,11 +443,12 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
         const result = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.description).toBeNull();
         expect(result.budgetCategory).toBeNull();
-        expect(result.budgetSource).toBeNull();
+        expect(result.budgetSource).not.toBeNull(); // discretionary-system is always present
         expect(result.vendor).toBeNull();
       });
 
@@ -436,6 +457,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
         const result = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 0,
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.plannedAmount).toBe(0);
@@ -487,6 +509,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const result = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 100,
           description: 'x'.repeat(500),
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.description).toBe('x'.repeat(500));
@@ -519,6 +542,72 @@ describe('budgetServiceFactory — createBudgetService()', () => {
             budgetSourceId: 'non-existent-source',
           });
         }).toThrow(ValidationError);
+      });
+
+      it('throws ValidationError when budgetSourceId is missing', () => {
+        const workItemId = insertWorkItem();
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('throws ValidationError when budgetSourceId is explicitly null', () => {
+        const workItemId = insertWorkItem();
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('throws ValidationError when budgetSourceId is empty string', () => {
+        const workItemId = insertWorkItem();
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: '',
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createWorkItemBudget(db, workItemId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: '',
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('succeeds with valid budgetSourceId and returns line with budgetSource resolved', () => {
+        const workItemId = insertWorkItem();
+        const sourceId = insertBudgetSource('Primary Funding');
+
+        const result = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 1500,
+          budgetSourceId: sourceId,
+        });
+
+        expect(result.budgetSource).not.toBeNull();
+        expect(result.budgetSource?.id).toBe(sourceId);
+        expect(result.budgetSource?.name).toBe('Primary Funding');
       });
 
       it('throws ValidationError when vendorId does not exist', () => {
@@ -556,7 +645,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('includes invoiceLink field (null) when no invoices linked', () => {
         const workItemId = insertWorkItem();
 
-        const result = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 100 });
+        const result = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(result.invoiceLink).toBeNull();
       });
@@ -571,6 +663,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const result = createHouseholdItemBudget(db, hiId, 'user-001', {
           plannedAmount: 500,
           budgetCategoryId: otherCategoryId,
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.budgetCategory?.id).toBe('bc-household-items');
@@ -581,6 +674,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
         const result = createHouseholdItemBudget(db, hiId, 'user-001', {
           plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
         });
 
         expect(result.budgetCategory?.id).toBe('bc-household-items');
@@ -608,6 +702,83 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         expect(result.budgetCategory?.id).toBe('bc-household-items');
       });
 
+      it('throws ValidationError when budgetSourceId is missing', () => {
+        const hiId = insertHouseholdItem();
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('throws ValidationError when budgetSourceId is explicitly null', () => {
+        const hiId = insertHouseholdItem();
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('throws ValidationError when budgetSourceId is empty string', () => {
+        const hiId = insertHouseholdItem();
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: '',
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: '',
+          });
+        }).toThrow('budgetSourceId is required');
+      });
+
+      it('throws ValidationError when budgetSourceId does not exist', () => {
+        const hiId = insertHouseholdItem();
+
+        expect(() => {
+          createHouseholdItemBudget(db, hiId, 'user-001', {
+            plannedAmount: 100,
+            budgetSourceId: 'non-existent-source',
+          });
+        }).toThrow(ValidationError);
+      });
+
+      it('succeeds with valid budgetSourceId and returns line with budgetSource resolved', () => {
+        const hiId = insertHouseholdItem();
+        const sourceId = insertBudgetSource('Grant Program');
+
+        const result = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 800,
+          budgetSourceId: sourceId,
+        });
+
+        expect(result.budgetSource).not.toBeNull();
+        expect(result.budgetSource?.id).toBe(sourceId);
+        expect(result.budgetSource?.name).toBe('Grant Program');
+      });
+
       it('throws NotFoundError for missing household item', () => {
         expect(() => {
           createHouseholdItemBudget(db, 'non-existent-hi', 'user-001', { plannedAmount: 100 });
@@ -621,7 +792,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('does NOT include invoices field on household item budget lines', () => {
         const hiId = insertHouseholdItem();
 
-        const result = createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 200 });
+        const result = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 200,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect((result as any).invoices).toBeUndefined();
       });
@@ -637,6 +811,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const line = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 500,
           description: 'Original description',
+          budgetSourceId: 'discretionary-system',
         });
 
         const updated = updateWorkItemBudget(db, workItemId, line.id, {
@@ -649,7 +824,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('updates plannedAmount', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
+        });
 
         const updated = updateWorkItemBudget(db, workItemId, line.id, { plannedAmount: 750 });
 
@@ -661,6 +839,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const line = createWorkItemBudget(db, workItemId, 'user-001', {
           plannedAmount: 500,
           confidence: 'own_estimate',
+          budgetSourceId: 'discretionary-system',
         });
 
         const updated = updateWorkItemBudget(db, workItemId, line.id, {
@@ -678,6 +857,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
           plannedAmount: 500,
           description: 'Some description',
           budgetCategoryId: categoryId,
+          budgetSourceId: 'discretionary-system',
         });
 
         const updated = updateWorkItemBudget(db, workItemId, line.id, {
@@ -691,7 +871,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('updates budgetCategoryId, budgetSourceId, vendorId', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
         const categoryId = insertBudgetCategory('Electrical');
         const sourceId = insertBudgetSource('Loan');
         const vendorId = insertVendor('Sparks Inc.');
@@ -727,7 +910,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('throws ValidationError when updating plannedAmount to negative', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(() => {
           updateWorkItemBudget(db, workItemId, line.id, { plannedAmount: -50 });
@@ -736,7 +922,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('throws ValidationError when updating description beyond 500 characters', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(() => {
           updateWorkItemBudget(db, workItemId, line.id, { description: 'x'.repeat(501) });
@@ -745,7 +934,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('throws ValidationError for invalid confidence in update', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(() => {
           updateWorkItemBudget(db, workItemId, line.id, { confidence: 'bad_level' as any });
@@ -754,7 +946,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('throws ValidationError when updating budgetCategoryId to non-existent', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(() => {
           updateWorkItemBudget(db, workItemId, line.id, {
@@ -763,10 +958,87 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         }).toThrow(ValidationError);
       });
 
+      it('throws ValidationError when attempting to remove budgetSourceId (set to null)', () => {
+        const workItemId = insertWorkItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateWorkItemBudget(db, workItemId, line.id, {
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          updateWorkItemBudget(db, workItemId, line.id, {
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow('budgetSourceId cannot be removed');
+      });
+
+      it('throws ValidationError when attempting to set budgetSourceId to empty string', () => {
+        const workItemId = insertWorkItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateWorkItemBudget(db, workItemId, line.id, {
+            budgetSourceId: '',
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          updateWorkItemBudget(db, workItemId, line.id, {
+            budgetSourceId: '',
+          });
+        }).toThrow('budgetSourceId cannot be removed');
+      });
+
+      it('throws ValidationError when updating budgetSourceId to non-existent', () => {
+        const workItemId = insertWorkItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateWorkItemBudget(db, workItemId, line.id, {
+            budgetSourceId: 'non-existent-source',
+          });
+        }).toThrow(ValidationError);
+      });
+
+      it('allows changing budgetSourceId to a different valid source', () => {
+        const workItemId = insertWorkItem();
+        const sourceId1 = insertBudgetSource('Source 1');
+        const sourceId2 = insertBudgetSource('Source 2');
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId1,
+        });
+
+        const updated = updateWorkItemBudget(db, workItemId, line.id, {
+          budgetSourceId: sourceId2,
+        });
+
+        expect(updated.budgetSource?.id).toBe(sourceId2);
+        expect(updated.budgetSource?.name).toBe('Source 2');
+      });
+
       it('cannot update a budget line belonging to a different work item', () => {
         const workItemId1 = insertWorkItem('Item 1');
         const workItemId2 = insertWorkItem('Item 2');
-        const line = createWorkItemBudget(db, workItemId1, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId1, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         // Attempt to update line using workItemId2 — should fail as NotFoundError
         expect(() => {
@@ -781,6 +1053,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
         const line = createHouseholdItemBudget(db, hiId, 'user-001', {
           plannedAmount: 300,
           description: 'Old description',
+          budgetSourceId: 'discretionary-system',
         });
 
         const updated = updateHouseholdItemBudget(db, hiId, line.id, {
@@ -793,7 +1066,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('does NOT update budgetCategoryId even if present in request', () => {
         const hiId = insertHouseholdItem();
         const otherCategoryId = insertBudgetCategory('Plumbing');
-        const line = createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 200 });
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 200,
+          budgetSourceId: 'discretionary-system',
+        });
 
         // bc-household-items should remain even after an update with a different category
         const updated = updateHouseholdItemBudget(db, hiId, line.id, {
@@ -818,6 +1094,80 @@ describe('budgetServiceFactory — createBudgetService()', () => {
           updateHouseholdItemBudget(db, hiId, 'non-existent-budget', { plannedAmount: 100 });
         }).toThrow(NotFoundError);
       });
+
+      it('throws ValidationError when attempting to remove budgetSourceId (set to null)', () => {
+        const hiId = insertHouseholdItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateHouseholdItemBudget(db, hiId, line.id, {
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          updateHouseholdItemBudget(db, hiId, line.id, {
+            budgetSourceId: null as unknown as string,
+          });
+        }).toThrow('budgetSourceId cannot be removed');
+      });
+
+      it('throws ValidationError when attempting to set budgetSourceId to empty string', () => {
+        const hiId = insertHouseholdItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateHouseholdItemBudget(db, hiId, line.id, {
+            budgetSourceId: '',
+          });
+        }).toThrow(ValidationError);
+
+        expect(() => {
+          updateHouseholdItemBudget(db, hiId, line.id, {
+            budgetSourceId: '',
+          });
+        }).toThrow('budgetSourceId cannot be removed');
+      });
+
+      it('throws ValidationError when updating budgetSourceId to non-existent', () => {
+        const hiId = insertHouseholdItem();
+        const sourceId = insertBudgetSource('Original Source');
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId,
+        });
+
+        expect(() => {
+          updateHouseholdItemBudget(db, hiId, line.id, {
+            budgetSourceId: 'non-existent-source',
+          });
+        }).toThrow(ValidationError);
+      });
+
+      it('allows changing budgetSourceId to a different valid source', () => {
+        const hiId = insertHouseholdItem();
+        const sourceId1 = insertBudgetSource('Source 1');
+        const sourceId2 = insertBudgetSource('Source 2');
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: sourceId1,
+        });
+
+        const updated = updateHouseholdItemBudget(db, hiId, line.id, {
+          budgetSourceId: sourceId2,
+        });
+
+        expect(updated.budgetSource?.id).toBe(sourceId2);
+        expect(updated.budgetSource?.name).toBe('Source 2');
+      });
     });
   });
 
@@ -827,7 +1177,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
     describe('work-item configuration (blockDeleteOnInvoices: true)', () => {
       it('deletes a budget line successfully', () => {
         const workItemId = insertWorkItem();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
+        });
 
         deleteWorkItemBudget(db, workItemId, line.id);
 
@@ -855,7 +1208,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('throws BudgetLineInUseError when invoices are linked', () => {
         const workItemId = insertWorkItem();
         const vendorId = insertVendor();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
+        });
         insertInvoiceForWorkItemBudget(line.id, vendorId);
 
         expect(() => {
@@ -870,7 +1226,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('throws BudgetLineInUseError with invoiceCount detail', () => {
         const workItemId = insertWorkItem();
         const vendorId = insertVendor();
-        const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+        const line = createWorkItemBudget(db, workItemId, 'user-001', {
+          plannedAmount: 500,
+          budgetSourceId: 'discretionary-system',
+        });
         // Each budget line can only link to ONE invoice (partial UNIQUE index on work_item_budget_id)
         insertInvoiceForWorkItemBudget(line.id, vendorId);
 
@@ -889,7 +1248,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('cannot delete a budget line belonging to a different work item', () => {
         const workItemId1 = insertWorkItem('Item 1');
         const workItemId2 = insertWorkItem('Item 2');
-        const line = createWorkItemBudget(db, workItemId1, 'user-001', { plannedAmount: 100 });
+        const line = createWorkItemBudget(db, workItemId1, 'user-001', {
+          plannedAmount: 100,
+          budgetSourceId: 'discretionary-system',
+        });
 
         expect(() => {
           deleteWorkItemBudget(db, workItemId2, line.id);
@@ -901,7 +1263,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       it('deletes successfully even when invoices are linked', () => {
         const hiId = insertHouseholdItem();
         const vendorId = insertVendor();
-        const line = createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 300 });
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 300,
+          budgetSourceId: 'discretionary-system',
+        });
         insertInvoiceForHouseholdItemBudget(line.id, vendorId);
 
         // Should NOT throw — HI budget deletion is allowed even with linked invoices
@@ -914,7 +1279,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
       it('deletes a budget line with no invoices successfully', () => {
         const hiId = insertHouseholdItem();
-        const line = createHouseholdItemBudget(db, hiId, 'user-001', { plannedAmount: 300 });
+        const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+          plannedAmount: 300,
+          budgetSourceId: 'discretionary-system',
+        });
 
         deleteHouseholdItemBudget(db, hiId, line.id);
 
@@ -948,14 +1316,17 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const linePending = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 300,
         description: 'Pending line',
+        budgetSourceId: 'discretionary-system',
       });
       const linePaid = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 500,
         description: 'Paid line',
+        budgetSourceId: 'discretionary-system',
       });
       const lineClaimed = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 700,
         description: 'Claimed line',
+        budgetSourceId: 'discretionary-system',
       });
 
       insertInvoiceForWorkItemBudget(linePending.id, vendorId, { amount: 100, status: 'pending' });
@@ -976,7 +1347,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
 
     it('returns 0 for all aggregates when no invoices are linked', () => {
       const workItemId = insertWorkItem();
-      const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+      const line = createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 500,
+        budgetSourceId: 'discretionary-system',
+      });
 
       // Confirm it's not null — already returned from create
       expect(line.actualCost).toBe(0);
@@ -987,7 +1361,10 @@ describe('budgetServiceFactory — createBudgetService()', () => {
     it('work item budget includes invoiceLink when invoice is linked', () => {
       const workItemId = insertWorkItem();
       const vendorId = insertVendor('Concrete Co.');
-      const line = createWorkItemBudget(db, workItemId, 'user-001', { plannedAmount: 500 });
+      const line = createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 500,
+        budgetSourceId: 'discretionary-system',
+      });
       insertInvoiceForWorkItemBudget(line.id, vendorId, { amount: 250, status: 'paid' });
 
       const result = listWorkItemBudgets(db, workItemId);
@@ -1007,6 +1384,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const result = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 100,
         confidence: 'own_estimate',
+        budgetSourceId: 'discretionary-system',
       });
       expect(result.confidenceMargin).toBe(0.2);
     });
@@ -1016,6 +1394,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const result = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 100,
         confidence: 'professional_estimate',
+        budgetSourceId: 'discretionary-system',
       });
       expect(result.confidenceMargin).toBe(0.1);
     });
@@ -1025,6 +1404,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const result = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 100,
         confidence: 'quote',
+        budgetSourceId: 'discretionary-system',
       });
       expect(result.confidenceMargin).toBe(0.05);
     });
@@ -1034,6 +1414,7 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       const result = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 100,
         confidence: 'invoice',
+        budgetSourceId: 'discretionary-system',
       });
       expect(result.confidenceMargin).toBe(0);
     });
@@ -1434,6 +1815,7 @@ describe('resolveRelationsBatch()', () => {
       const line = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: (i + 1) * 100,
         budgetCategoryId: catId,
+        budgetSourceId: 'discretionary-system',
       });
       lines.push({ line, catId });
     }

--- a/server/src/services/shared/budgetServiceFactory.ts
+++ b/server/src/services/shared/budgetServiceFactory.ts
@@ -437,9 +437,10 @@ export function createBudgetService<
       if (data.budgetCategoryId) {
         validateBudgetCategoryId(db, data.budgetCategoryId);
       }
-      if (data.budgetSourceId) {
-        validateBudgetSourceId(db, data.budgetSourceId);
+      if (!data.budgetSourceId) {
+        throw new ValidationError('budgetSourceId is required');
       }
+      validateBudgetSourceId(db, data.budgetSourceId);
       if (data.vendorId) {
         validateVendorId(db, data.vendorId);
       }
@@ -496,10 +497,11 @@ export function createBudgetService<
       }
 
       if ('budgetSourceId' in data) {
-        if (data.budgetSourceId) {
-          validateBudgetSourceId(db, data.budgetSourceId);
+        if (!data.budgetSourceId) {
+          throw new ValidationError('budgetSourceId cannot be removed');
         }
-        updates.budgetSourceId = data.budgetSourceId ?? null;
+        validateBudgetSourceId(db, data.budgetSourceId);
+        updates.budgetSourceId = data.budgetSourceId;
       }
 
       if ('vendorId' in data) {

--- a/server/src/services/shared/budgetServiceFactory.unitPricing.test.ts
+++ b/server/src/services/shared/budgetServiceFactory.unitPricing.test.ts
@@ -100,6 +100,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'm²',
         unitPrice: 100,
         includesVat: true,
+        budgetSourceId: 'discretionary-system',
       });
 
       expect(result.quantity).toBe(2);
@@ -117,6 +118,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'pcs',
         unitPrice: 100,
         includesVat: false,
+        budgetSourceId: 'discretionary-system',
       });
 
       expect(result.includesVat).toBe(false);
@@ -127,6 +129,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
 
       const result = createWorkItemBudget(db, workItemId, 'user-001', {
         plannedAmount: 500,
+        budgetSourceId: 'discretionary-system',
       });
 
       expect(result.quantity).toBeNull();
@@ -144,6 +147,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'kg',
         unitPrice: 150,
         includesVat: true,
+        budgetSourceId: 'discretionary-system',
       });
 
       const updated = updateWorkItemBudget(db, workItemId, created.id, {
@@ -165,6 +169,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'pcs',
         unitPrice: 100,
         includesVat: false,
+        budgetSourceId: 'discretionary-system',
       });
 
       const updated = updateWorkItemBudget(db, workItemId, created.id, {
@@ -189,6 +194,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'lm',
         unitPrice: 40,
         includesVat: true,
+        budgetSourceId: 'discretionary-system',
       });
 
       // Update only description — unit pricing should be untouched
@@ -215,6 +221,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'pcs',
         unitPrice: 150,
         includesVat: true,
+        budgetSourceId: 'discretionary-system',
       });
 
       expect(result.quantity).toBe(4);
@@ -228,6 +235,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
 
       const result = createHouseholdItemBudget(db, hiId, 'user-001', {
         plannedAmount: 250,
+        budgetSourceId: 'discretionary-system',
       });
 
       expect(result.quantity).toBeNull();
@@ -245,6 +253,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'm²',
         unitPrice: 400,
         includesVat: false,
+        budgetSourceId: 'discretionary-system',
       });
 
       const updated = updateHouseholdItemBudget(db, hiId, created.id, {
@@ -266,6 +275,7 @@ describe('budgetServiceFactory — unit pricing fields', () => {
         unit: 'pcs',
         unitPrice: 100,
         includesVat: true,
+        budgetSourceId: 'discretionary-system',
       });
 
       const updated = updateHouseholdItemBudget(db, hiId, created.id, {


### PR DESCRIPTION
## Summary

- Migration 0023 backfills NULL `budget_source_id` to discretionary source in both `work_item_budgets` and `household_item_budgets`
- Schema marks `budgetSourceId` as `notNull` with `onDelete: 'restrict'`
- Backend validation rejects missing/null `budgetSourceId` on create and update
- Shared types updated: `budgetSourceId` required on create, non-nullable on update
- Frontend removes "None" option from funding source dropdown
- New budget lines default to discretionary source

Fixes #787

## Test plan
- [ ] Migration test verifies backfill of NULL values
- [ ] Budget service factory tests validate required budgetSourceId on create/update
- [ ] Unit tests for shared type changes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>