### PR TITLE
fix(e2e): fix 3 E2E test failures blocking EPIC-09 promotion PR #740

### DIFF
--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -342,9 +342,10 @@ export class BudgetSourcesPage {
   }
 
   /**
-   * Get all "amountLabel" spans within a source row to verify presence of Projected/Paid labels.
+   * Get all legend label spans within a source row (the SourceBarChart bar legend labels).
+   * The app renders these with the `barLegendLabel` CSS module class.
    */
   getAmountLabelsInRow(sourceName: string): import('@playwright/test').Locator {
-    return this.getSourceRowByName(sourceName).locator('[class*="amountLabel"]');
+    return this.getSourceRowByName(sourceName).locator('[class*="barLegendLabel"]');
   }
 }

--- a/e2e/pages/UserManagementPage.ts
+++ b/e2e/pages/UserManagementPage.ts
@@ -73,9 +73,14 @@ export class UserManagementPage {
 
   async goto(): Promise<void> {
     await this.page.goto(ROUTES.userManagement);
+    // Wait for heading and search input — on tablet the input may take longer to render
+    await this.heading.waitFor({ state: 'visible' });
+    await this.searchInput.waitFor({ state: 'visible' });
   }
 
   async searchUsers(query: string): Promise<void> {
+    await this.searchInput.waitFor({ state: 'visible' });
+    await this.searchInput.scrollIntoViewIfNeeded();
     await this.searchInput.fill(query);
     await this.page.waitForResponse(
       (resp) => resp.url().includes('/api/users') && resp.status() === 200,

--- a/e2e/tests/admin/search-users.spec.ts
+++ b/e2e/tests/admin/search-users.spec.ts
@@ -100,6 +100,8 @@ test.describe('Search Users', () => {
     await userManagementPage.goto();
 
     // When: User types in search box
+    await userManagementPage.searchInput.waitFor({ state: 'visible' });
+    await userManagementPage.searchInput.scrollIntoViewIfNeeded();
     await userManagementPage.searchInput.fill('Ad');
     await page.waitForTimeout(400); // Wait for debounce
 

--- a/e2e/tests/budget/budget-sources.spec.ts
+++ b/e2e/tests/budget/budget-sources.spec.ts
@@ -820,24 +820,43 @@ test.describe('Discretionary Funding source', () => {
     }
   });
 
-  test('Projected and Paid amount labels are visible on source rows', async ({ page }) => {
+  test('Bar chart and summary row are visible on source rows', async ({ page }) => {
     const sourcesPage = new BudgetSourcesPage(page);
 
     await sourcesPage.goto();
     await sourcesPage.waitForSourcesLoaded();
 
-    // The Discretionary Funding row is always present — verify its amount labels
+    // The Discretionary Funding row is always present — verify its bar chart section renders
     const row = sourcesPage.getSourceRowByName(DISCRETIONARY_NAME);
     await expect(row).toBeVisible();
 
-    const allLabels = sourcesPage.getAmountLabelsInRow(DISCRETIONARY_NAME);
+    // The bar chart section (sourceBarSection) always renders regardless of amounts
+    const barSection = row.locator('[class*="sourceBarSection"]');
+    await expect(barSection).toBeVisible();
 
-    // Collect all label texts
-    const labelTexts = await allLabels.allTextContents();
-    const normalised = labelTexts.map((t) => t.trim());
+    // The summary row (Total / Available / Planned) always renders regardless of amounts
+    const summaryItems = row.locator('[class*="summaryItem"]');
+    const summaryCount = await summaryItems.count();
+    // At minimum: Total, Available, Planned (3 items; Rate only appears when interestRate set)
+    expect(summaryCount).toBeGreaterThanOrEqual(3);
 
-    expect(normalised).toContain('Projected');
-    expect(normalised).toContain('Paid');
+    // Collect all summary item texts and verify they contain expected labels
+    const summaryTexts = await summaryItems.allTextContents();
+    const summaryNormalised = summaryTexts.map((t) => t.trim());
+    expect(summaryNormalised.some((t) => t.includes('Total'))).toBe(true);
+    expect(summaryNormalised.some((t) => t.includes('Available'))).toBe(true);
+    expect(summaryNormalised.some((t) => t.includes('Planned'))).toBe(true);
+
+    // If there are budget lines (non-zero amounts), legend labels should also render
+    const legendLabels = sourcesPage.getAmountLabelsInRow(DISCRETIONARY_NAME);
+    const legendCount = await legendLabels.count();
+    if (legendCount > 0) {
+      const labelTexts = await legendLabels.allTextContents();
+      const normalised = labelTexts.map((t) => t.trim());
+      // Known legend label values from SourceBarChart component
+      const knownLabels = ['Claimed', 'Paid (unclaimed)', 'Projected', 'Allocated (planned)', 'Overflow'];
+      expect(normalised.every((l) => knownLabels.includes(l))).toBe(true);
+    }
   });
 
   test('Discretionary source appears last in the sources list', async ({ page }) => {

--- a/e2e/tests/navigation/dashboard.spec.ts
+++ b/e2e/tests/navigation/dashboard.spec.ts
@@ -509,7 +509,8 @@ test.describe('Card re-enable (Scenario 7)', () => {
       await dashboardPage.waitForCardsLoaded();
 
       // Verify Customize button is NOT visible before dismissing
-      await expect(dashboardPage.customizeButton).toBeHidden();
+      // The button is only rendered when cards are hidden, so it may be absent from the DOM entirely.
+      await expect(dashboardPage.customizeButton).not.toBeVisible();
 
       // Dismiss a card
       await dashboardPage.dismissCard('Quick Actions');
@@ -555,7 +556,8 @@ test.describe('Card re-enable (Scenario 7)', () => {
       await expect(quickActionsCard.first()).toBeVisible();
 
       // Customize button should disappear again (no more hidden cards)
-      await expect(dashboardPage.customizeButton).toBeHidden();
+      // The button is removed from the DOM entirely when all cards are visible.
+      await expect(dashboardPage.customizeButton).not.toBeVisible();
     } finally {
       await uninterceptDashboardApis(page);
     }
@@ -734,9 +736,10 @@ test.describe('Keyboard navigation (Scenario 9)', () => {
       // All dismiss buttons should be focusable
       const dismissButtons = page.getByRole('button', { name: /^Hide .+ card$/ });
       const count = await dismissButtons.count();
-      // We have 10 cards so there should be 10 dismiss buttons (on desktop/tablet grid)
-      // On mobile both grid and mobile sections render cards, so count may be 20
-      expect(count).toBeGreaterThanOrEqual(10);
+      // There are 9 cards defined (CARD_DEFINITIONS). Both the desktop grid and the mobile
+      // sections container render cards simultaneously (CSS controls visibility), so the DOM
+      // may contain up to 18 dismiss buttons. Expect at least 9 (one per card).
+      expect(count).toBeGreaterThanOrEqual(9);
     } finally {
       await uninterceptDashboardApis(page);
     }


### PR DESCRIPTION
## Summary

Fixes 3 E2E test failures that are blocking the EPIC-09 (`beta` → `main`) promotion PR #740.

### Failure 1: Admin Search Users — Tablet viewport (Shard 6)

- **Root cause**: `UserManagementPage.goto()` only waited for the page heading, not the search input. On tablet the input takes longer to render, so `fill()` timed out at 15 s.
- **Fix (POM)**: Added `searchInput.waitFor({ state: 'visible' })` to both `goto()` and `searchUsers()`. Added `scrollIntoViewIfNeeded()` before fill in `searchUsers()`.
- **Fix (test)**: The 'Search updates results dynamically' test called `searchInput.fill()` directly bypassing the POM guard — added an explicit `waitFor` + `scrollIntoViewIfNeeded` before the direct fill.

### Failure 2: Budget Sources Labels — Desktop (Shard 2)

- **Root cause**: PR #791/#792 replaced the numeric grid (which always rendered `amountLabel` spans) with a `SourceBarChart` component using `barLegendLabel` CSS class for legend rows. Legend rows are conditional — they only render when segment values > 0. The POM selector `[class*="amountLabel"]` matched nothing.
- **Fix (POM)**: Updated `getAmountLabelsInRow()` selector from `[class*="amountLabel"]` to `[class*="barLegendLabel"]`.
- **Fix (test)**: Replaced fragile "Projected/Paid label always present" assertion with checks for the always-rendered elements: the `sourceBarSection` container and the `summaryItem` row (Total / Available / Planned). Legend label verification is now conditional on legend rows actually being present (non-zero amounts).

### Failure 3: Dashboard Navigation — Desktop (Shard 4)

**Error 1** (line 739 — dismiss button count):
- **Root cause**: The dashboard renders cards in TWO containers simultaneously (desktop grid + mobile sections div, with CSS controlling visibility). There are 9 cards in `CARD_DEFINITIONS`, not 10. The assertion `>= 10` was wrong on both counts.
- **Fix**: Changed `>= 10` to `>= 9` and updated the comment.

**Error 2** (line 512 — customize button hidden):
- **Root cause**: The Customize button is conditionally rendered (`{hasHiddenCards && (...)}`) — when no cards are hidden it is absent from the DOM entirely. `toBeHidden()` expects the element to exist in DOM (just not visible), so it times out when the element is detached.
- **Fix**: Replaced `toBeHidden()` with `not.toBeVisible()` at both occurrences (initial state check and post-re-enable check).

## Test plan

- [ ] Push to beta and wait for sharded E2E suite to pass
- [ ] Confirm Shard 2 (budget-sources), Shard 4 (dashboard), Shard 6 (search-users) all green
- [ ] Verify promotion PR #740 unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)