### PR TITLE
ci: run full E2E tests on beta PRs (non-blocking)

### DIFF
--- a/.claude/agents/e2e-test-engineer.md
+++ b/.claude/agents/e2e-test-engineer.md
@@ -40,7 +40,44 @@ You do **not** implement features, fix bugs, write unit/integration tests, or ma
 
 ## Before Starting Any Work
 
-Always read these context sources first (if they exist):
+### 1. Investigate Prior E2E Failures
+
+Before writing or modifying any E2E tests, check whether recent beta PRs had E2E failures. Full E2E tests run on all PRs (beta and main targets), but failures are **non-blocking** on beta PRs — meaning they may have been merged despite E2E failures. These failures must be investigated before doing new E2E work.
+
+**Check recent CI runs on the beta branch:**
+
+```bash
+gh run list --branch beta --workflow "Quality Gates" --limit 10 --json conclusion,headBranch,url,displayTitle,createdAt
+```
+
+**For any run with E2E failures, download and review the merged E2E report:**
+
+```bash
+# List artifacts from a specific run
+gh run view <run-id> --json jobs --jq '.jobs[] | select(.name | startswith("E2E Tests") or .name == "Merge E2E Reports") | {name, conclusion}'
+```
+
+**Triage each failure into one of these categories:**
+
+- **Already fixed** — a subsequent PR or commit resolved the issue → note it and move on
+- **Known flaky test** — the same test fails intermittently with no code change → record in agent memory under flaky tests, consider fixing the test as part of current work
+- **Real regression** — a genuine bug introduced by a merged PR → file a bug report (GitHub Issue with `bug` label) before proceeding, and flag it to the orchestrator
+- **Environment/infrastructure** — CI runner issues, timeout, cache miss → note it and move on
+
+**Report your findings** at the start of your response to the orchestrator, even if everything is clean:
+
+```
+## Prior E2E Failure Triage
+- Checked last N beta CI runs
+- [N failures found / all clean]
+- [Per-failure: category, test name, PR that introduced it, action taken]
+```
+
+If real regressions are found, the orchestrator decides whether to address them before or after the current task.
+
+### 2. Read Context Sources
+
+Always read these context sources (if they exist):
 
 - **GitHub Wiki**: API Contract page — expected API behavior
 - **GitHub Wiki**: Architecture page — test infrastructure, conventions, tech stack

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -183,6 +183,7 @@ After implementation agents complete, launch both test agents in parallel:
 
 - The `## E2E Spec` section from the spec document
 - List of files created/modified by the backend and frontend agents
+- Reminder to triage prior E2E failures from recent beta PRs before writing new tests (the agent does this automatically per its "Before Starting Any Work" checklist)
 
 #### 6e. Code Review
 

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -102,6 +102,7 @@ If no refinement items exist, skip to step 5.
 
 Launch the **e2e-test-engineer** agent to:
 
+- **Triage prior E2E failures** from recent beta PRs (the agent does this automatically per its "Before Starting Any Work" checklist — review the triage report before proceeding). If real regressions are found, address them before continuing.
 - Confirm all existing Playwright E2E tests pass
 - Verify every approved UAT scenario (from story issues) has E2E coverage
 - Write new E2E tests on a branch if coverage gaps exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,24 +95,37 @@ jobs:
       - name: Check results
         run: |
           failed=0
-          for job in static-analysis test docker e2e-warmup e2e-smoke e2e e2e-merge-reports; do
-            result="${{ needs.static-analysis.result }}"
-            case "$job" in
-              static-analysis) result="${{ needs.static-analysis.result }}" ;;
-              test) result="${{ needs.test.result }}" ;;
-              docker) result="${{ needs.docker.result }}" ;;
-              e2e-warmup) result="${{ needs.e2e-warmup.result }}" ;;
-              e2e-smoke) result="${{ needs.e2e-smoke.result }}" ;;
-              e2e) result="${{ needs.e2e.result }}" ;;
-              e2e-merge-reports) result="${{ needs.e2e-merge-reports.result }}" ;;
-            esac
+
+          check_job() {
+            local job=$1
+            local result=$2
+            local blocking=$3
+
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-              echo "❌ $job: $result"
-              failed=1
+              if [ "$blocking" = "true" ]; then
+                echo "❌ $job: $result (blocking)"
+                failed=1
+              else
+                echo "⚠️ $job: $result (non-blocking)"
+              fi
             else
               echo "✅ $job: $result"
             fi
-          done
+          }
+
+          IS_MAIN=${{ github.base_ref == 'main' }}
+
+          # Always-blocking jobs
+          check_job "static-analysis" "${{ needs.static-analysis.result }}" "true"
+          check_job "test" "${{ needs.test.result }}" "true"
+          check_job "docker" "${{ needs.docker.result }}" "true"
+          check_job "e2e-warmup" "${{ needs.e2e-warmup.result }}" "true"
+          check_job "e2e-smoke" "${{ needs.e2e-smoke.result }}" "true"
+
+          # Blocking only for main-targeted PRs
+          check_job "e2e" "${{ needs.e2e.result }}" "$IS_MAIN"
+          check_job "e2e-merge-reports" "${{ needs.e2e-merge-reports.result }}" "$IS_MAIN"
+
           if [ "$failed" = "1" ]; then
             exit 1
           fi
@@ -353,7 +366,7 @@ jobs:
     name: E2E Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [detect-changes, docker, e2e-warmup]
-    if: "github.base_ref == 'main' && (needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true')"
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.e2e == 'true'
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,9 @@ Cornerstone uses a two-tier release model:
 
 ### Branch Protection
 
-Both `main` and `beta` require PRs with passing `Quality Gates`, `Docker`, and `Merge E2E Reports` status checks. Force pushes and deletions are blocked on both branches.
+Both `main` and `beta` require PRs with passing `Quality Gates` and `Docker` status checks. Force pushes and deletions are blocked on both branches.
+
+Full E2E tests (16 shards × 3 viewports) run on all PRs. On `beta`-targeted PRs, E2E failures are **non-blocking** (informational only) — `Quality Gates` will still pass. On `main`-targeted PRs, E2E failures are **blocking** — `Quality Gates` will fail. Smoke tests remain blocking for all PRs.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

- Full E2E suite (16 shards × 3 viewports) now runs on **all PRs**, not just main-targeted ones
- On beta PRs, E2E failures are **non-blocking** (informational) — `Quality Gates` still passes
- On main PRs, E2E failures remain **blocking** — no change to promotion validation
- `e2e-test-engineer` agent now triages prior E2E failures before starting any new work
- `Merge E2E Reports` removed from branch protection required checks (blocking logic handled inside `Quality Gates`)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Remove main-only gate on e2e job; add branch-conditional blocking logic to quality-gates |
| `CLAUDE.md` | Update branch protection docs |
| `.claude/agents/e2e-test-engineer.md` | Add "Investigate Prior E2E Failures" pre-work step |
| `.claude/skills/develop/SKILL.md` | Reference triage step in e2e-test-engineer launch |
| `.claude/skills/epic-close/SKILL.md` | Reference triage step in E2E validation |

## Test plan

- [ ] Create a beta-targeted PR with app changes — confirm full E2E suite runs
- [ ] If an E2E shard fails on a beta PR, confirm `Quality Gates` still passes
- [ ] Create a main-targeted PR — confirm E2E failures cause `Quality Gates` to fail
- [ ] Verify branch protection allows merge when only `Quality Gates` and `Docker` are required

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>