### PR TITLE
fix(security): remove upgrade-insecure-requests CSP and HSTS

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -86,13 +86,13 @@ export default defineConfig({
       name: 'tablet',
       dependencies: ['auth-setup'],
       grep: /@responsive/,
-      timeout: 60_000, // WebKit is significantly slower than Chromium; multi-step tests need 40-50s
-      expect: { timeout: 15_000 }, // WebKit expect assertions need more time
+      timeout: 30_000, // 2x desktop — WebKit is slightly slower than Chromium
+      expect: { timeout: 10_000 }, // 2x desktop expect timeout
       use: {
         ...devices['iPad (gen 7)'],
         storageState: 'test-results/.auth/admin.json',
-        actionTimeout: 15_000, // WebKit click/fill actions need more time
-        navigationTimeout: 15_000, // WebKit page loads need more time
+        actionTimeout: 10_000, // 2x desktop action timeout
+        navigationTimeout: 10_000, // matches desktop navigation timeout
       },
     },
 
@@ -101,13 +101,13 @@ export default defineConfig({
       name: 'mobile',
       dependencies: ['auth-setup'],
       grep: /@responsive/,
-      timeout: 60_000, // WebKit is significantly slower than Chromium; multi-step tests need 40-50s
-      expect: { timeout: 15_000 }, // WebKit expect assertions need more time
+      timeout: 30_000, // 2x desktop — WebKit is slightly slower than Chromium
+      expect: { timeout: 10_000 }, // 2x desktop expect timeout
       use: {
         ...devices['iPhone 13'],
         storageState: 'test-results/.auth/admin.json',
-        actionTimeout: 15_000, // WebKit click/fill actions need more time
-        navigationTimeout: 15_000, // WebKit page loads need more time
+        actionTimeout: 10_000, // 2x desktop action timeout
+        navigationTimeout: 10_000, // matches desktop navigation timeout
       },
     },
   ],

--- a/e2e/tests/admin/deactivate-user.spec.ts
+++ b/e2e/tests/admin/deactivate-user.spec.ts
@@ -6,17 +6,6 @@ import { test, expect } from '../../fixtures/auth.js';
 import { UserManagementPage } from '../../pages/UserManagementPage.js';
 import { TEST_ADMIN } from '../../fixtures/testData.js';
 
-// The User Management page does not render reliably on the tablet WebKit
-// viewport (iPad gen 7, 810px) within the 15s actionTimeout. The deactivation
-// functionality works on desktop; skip on tablet to prevent false-positive
-// shard failures (same pattern as search-users.spec.ts).
-test.beforeEach(async ({ page }) => {
-  const viewport = page.viewportSize();
-  if (viewport && viewport.width < 1200) {
-    test.skip();
-  }
-});
-
 test.describe('Deactivate User', () => {
   // Serialize tests within this describe block — they all interact with the shared
   // admin user's deactivation modal and must not run in parallel with each other.

--- a/e2e/tests/admin/edit-user.spec.ts
+++ b/e2e/tests/admin/edit-user.spec.ts
@@ -6,17 +6,6 @@ import { test, expect } from '../../fixtures/auth.js';
 import { UserManagementPage } from '../../pages/UserManagementPage.js';
 import { TEST_ADMIN } from '../../fixtures/testData.js';
 
-// The User Management page does not render reliably on the tablet WebKit
-// viewport (iPad gen 7, 810px) within the 15s actionTimeout. The edit
-// functionality works on desktop; skip on tablet to prevent false-positive
-// shard failures (same pattern as search-users.spec.ts).
-test.beforeEach(async ({ page }) => {
-  const viewport = page.viewportSize();
-  if (viewport && viewport.width < 1200) {
-    test.skip();
-  }
-});
-
 test.describe('Edit User', () => {
   // Serialize tests within this describe block — they all modify the shared admin
   // user record and must not run in parallel with each other.

--- a/e2e/tests/admin/search-users.spec.ts
+++ b/e2e/tests/admin/search-users.spec.ts
@@ -6,19 +6,6 @@ import { test, expect } from '../../fixtures/auth.js';
 import { UserManagementPage } from '../../pages/UserManagementPage.js';
 import { TEST_ADMIN } from '../../fixtures/testData.js';
 
-// The user-management search input does not render reliably on the tablet
-// WebKit viewport (iPad gen 7, 810px) within the 15s actionTimeout. The
-// search feature works on desktop; tablet users are served the same layout
-// but the test environment cannot guarantee the input is interactive in time.
-// Skip this entire spec on tablet to prevent false-positive shard failures.
-test.beforeEach(async ({ page }) => {
-  const viewport = page.viewportSize();
-  // iPad gen 7 is 810px wide; iPhone 13 is 390px. Skip on any non-desktop viewport.
-  if (viewport && viewport.width < 1200) {
-    test.skip();
-  }
-});
-
 test.describe('Search Users', () => {
   test('Search filters by name', async ({ page }) => {
     const userManagementPage = new UserManagementPage(page);

--- a/e2e/tests/budget/budget-sources.spec.ts
+++ b/e2e/tests/budget/budget-sources.spec.ts
@@ -817,7 +817,6 @@ test.describe('Discretionary Funding source', () => {
       // Register response listener BEFORE clicking save (per waitForResponse-before-action pattern).
       const saveResponse = page.waitForResponse(
         (resp) => resp.url().includes('/api/budget-sources') && resp.status() === 200,
-        { timeout: 15000 },
       );
       await sourcesPage.saveEdit(DISCRETIONARY_NAME);
       await saveResponse;

--- a/server/src/plugins/helmetPlugin.test.ts
+++ b/server/src/plugins/helmetPlugin.test.ts
@@ -41,19 +41,19 @@ describe('Helmet Plugin — security headers', () => {
     expect(response.headers['content-security-policy']).toBeDefined();
     expect(typeof response.headers['content-security-policy']).toBe('string');
     expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+    // upgrade-insecure-requests must NOT be present (app never terminates TLS)
+    expect(response.headers['content-security-policy']).not.toContain('upgrade-insecure-requests');
   });
 
-  it('API response includes strict-transport-security header', async () => {
+  it('API response does not include strict-transport-security header (TLS terminates at proxy)', async () => {
     // When: Any API request is made
     const response = await app.inject({
       method: 'GET',
       url: '/api/health',
     });
 
-    // Then: HSTS header is present
-    expect(response.headers['strict-transport-security']).toBeDefined();
-    expect(response.headers['strict-transport-security']).toContain('max-age=');
-    expect(response.headers['strict-transport-security']).toContain('includeSubDomains');
+    // Then: HSTS header is NOT present (app runs behind TLS-terminating proxy)
+    expect(response.headers['strict-transport-security']).toBeUndefined();
   });
 
   it('API response includes x-frame-options header with value SAMEORIGIN', async () => {

--- a/server/src/plugins/helmetPlugin.ts
+++ b/server/src/plugins/helmetPlugin.ts
@@ -16,13 +16,10 @@ export default fp(
           objectSrc: ["'none'"],
           baseUri: ["'self'"],
           formAction: ["'self'"],
+          upgradeInsecureRequests: null, // Remove — app never terminates TLS
         },
       },
-      hsts: {
-        maxAge: 31536000,
-        includeSubDomains: true,
-        preload: false,
-      },
+      hsts: false, // App runs behind TLS-terminating proxy; HSTS belongs there
       frameguard: { action: 'sameorigin' },
       noSniff: true,
       xssFilter: true,


### PR DESCRIPTION
## Summary

- Remove `upgrade-insecure-requests` from CSP — the app never terminates TLS, so this directive caused WebKit to fetch JS/CSS over HTTPS on the HTTP-only port, resulting in blank pages on tablet/mobile E2E shards
- Disable HSTS header (RFC 6797 §7.2: must not be sent over HTTP)
- Reset WebKit timeouts to 2x desktop (from inflated 3-4x workaround values)
- Revert viewport-based `test.skip()` workarounds in admin E2E specs
- Remove explicit `waitForResponse` timeout in budget-sources spec

## Test plan

- [ ] Shards 7-16 (tablet/mobile WebKit) pass — pages render instead of blank white
- [ ] Shards 1-6 (desktop Chromium) still pass
- [ ] Response headers no longer include `upgrade-insecure-requests` or `Strict-Transport-Security`
- [ ] Admin specs (deactivate-user, edit-user, search-users) run on tablet viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)