### PR TITLE
ci: add env drift guardrail for server env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ LOG_LEVEL=info
 NODE_ENV=production
 
 # Set to true when running behind a reverse proxy (e.g., nginx)
-# TRUST_PROXY=false
+TRUST_PROXY=false
 
 # ─── Database ──────────────────────────────────────────
 DATABASE_URL=/app/data/cornerstone.db
@@ -15,13 +15,13 @@ SESSION_DURATION=604800
 SECURE_COOKIES=true
 
 # ─── OIDC ──────────────────────────────────────────────
-# OIDC_ISSUER=https://auth.example.com/realms/main
-# OIDC_CLIENT_ID=cornerstone
-# OIDC_CLIENT_SECRET=your-client-secret
-# OIDC_REDIRECT_URI=https://cornerstone.example.com/api/auth/oidc/callback  # Optional: auto-derived from request if not set
+OIDC_ISSUER=https://auth.example.com/realms/main
+OIDC_CLIENT_ID=cornerstone
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_REDIRECT_URI=https://cornerstone.example.com/api/auth/oidc/callback
 
 # ─── Paperless-ngx ─────────────────────────────────────
-# PAPERLESS_URL=http://paperless-ngx:8000
-# PAPERLESS_API_TOKEN=your-paperless-api-token
-# PAPERLESS_EXTERNAL_URL=https://paperless.example.com  # Optional: browser-accessible URL for "View in Paperless-ngx" links
-# PAPERLESS_FILTER_TAG=cornerstone                      # Optional: only show documents with this Paperless-ngx tag
+PAPERLESS_URL=http://paperless-ngx:8000
+PAPERLESS_API_TOKEN=your-paperless-api-token
+PAPERLESS_EXTERNAL_URL=https://paperless.example.com
+PAPERLESS_FILTER_TAG=cornerstone

--- a/.github/workflows/envdrift.yml
+++ b/.github/workflows/envdrift.yml
@@ -1,0 +1,20 @@
+name: Env Drift
+
+on:
+  pull_request:
+    branches: [main, beta]
+  push:
+    branches: [main]
+
+jobs:
+  envdrift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Check .env.example drift (server)
+        run: npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include server


### PR DESCRIPTION
## Summary
This PR adds an automated env drift check and converts key optional env entries in `.env.example` into parseable example assignments.

## Why
Issue #421 showed how easy it is for `.env.example` to drift behind runtime configuration.

## Changes
- Add `.github/workflows/envdrift.yml`
  - Runs env drift check against server code:
  - `npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include server`
- Normalize env example declarations so drift checks can parse them reliably:
  - `TRUST_PROXY`
  - OIDC keys (`OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`)
  - Paperless keys (`PAPERLESS_URL`, `PAPERLESS_API_TOKEN`, `PAPERLESS_EXTERNAL_URL`, `PAPERLESS_FILTER_TAG`)

## Result
Future additions of server env keys are automatically checked against `.env.example` in CI, reducing config regressions.
