### PR TITLE
chore: add UAT feedback loop to epic-close workflow

### DIFF
--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -49,7 +49,7 @@ Include:
 - Total PRs, average fix loops per PR, % of PRs requiring fix loops
 - Total findings breakdown by severity
 
-Post this report as a comment on the epic GitHub Issue. Include it in the promotion PR body (Step 9).
+Post this report as a comment on the epic GitHub Issue. Include it in the promotion PR body (Step 8).
 
 ### 2b. Lint Health Check
 
@@ -117,29 +117,9 @@ This approval is **required** before proceeding to UAT validation.
 
 Launch the **product-owner** agent to produce UAT scenarios. The e2e-test-engineer must have already covered these scenarios in step 5. E2E pass + e2e-test-engineer report = sufficient validation. Post the UAT report as a comment on the epic issue and proceed to step 7.
 
-The UAT scenarios are included in the promotion PR (step 10) as a manual validation checklist so the user can spot-check during the promotion gate.
+The UAT scenarios are included in the promotion PR (step 8) as a manual validation checklist so the user can spot-check during the promotion gate.
 
-### 7. Documentation & Env Drift Check
-
-Launch the **docs-writer** agent to:
-
-- Update the documentation site (`docs/`) with new feature guides
-- Update `README.md` with newly shipped capabilities
-- Write `RELEASE_SUMMARY.md` for the GitHub Release changelog enrichment
-- **Verify `.env.example` freshness**: Scan server source code for all `process.env.*` references (primarily `server/src/plugins/config.ts`), compare against `.env.example` entries, and fix any drift. Rules:
-  - Optional features (OIDC, Paperless, etc.) must remain **commented out** with example placeholder values
-  - Preserve inline `# Optional: ...` documentation comments
-  - Update the Environment Variables table in `CLAUDE.md` if new vars were added
-
-Commit documentation updates to `beta` via a PR:
-
-```bash
-gh pr create --base beta --title "docs: update documentation for epic #<epic-number>" --body "..."
-```
-
-Wait for CI, then squash merge.
-
-### 8. Branch Sync
+### 7. Branch Sync
 
 Check if `main` has commits that `beta` doesn't (e.g., hotfixes cherry-picked to main):
 
@@ -149,9 +129,9 @@ git log origin/beta..origin/main --oneline
 
 If so, create a sync PR (`main` → `beta`), wait for CI, merge before proceeding. This ensures the promotion PR merges cleanly.
 
-If no divergence, skip to step 9.
+If no divergence, skip to step 8.
 
-### 9. Epic Promotion
+### 8. Epic Promotion
 
 Create a PR from `beta` to `main` using a **merge commit** (not squash). The promotion PR is the single human checkpoint — include a comprehensive summary:
 
@@ -201,7 +181,7 @@ EOF
 )"
 ```
 
-### 10. Post Detailed UAT Criteria
+### 9. Post Detailed UAT Criteria
 
 Post detailed UAT validation criteria as a comment on the promotion PR — step-by-step instructions the user can follow to validate each story:
 
@@ -220,7 +200,7 @@ EOF
 )"
 ```
 
-### 11. CI Gate
+### 10. CI Gate
 
 Wait for all CI checks to pass on the promotion PR, including the full sharded E2E suite (runs on main-targeting PRs):
 
@@ -230,15 +210,101 @@ gh pr checks <pr-number> --watch
 
 If any check fails, investigate and resolve before proceeding.
 
-### 12. User Approval
+### 11. Promotion Approval Loop
 
-**Wait for explicit user approval** before merging. Present the user with:
+Initialize `uatFeedbackRound = 0`. This step loops until the user explicitly approves.
+
+#### 11a. Present for Approval
+
+Present the user with:
 
 1. **Promotion PR link** — with the comprehensive summary, change inventory, and validation checklist
 2. **DockerHub beta image** — `docker pull steilerdev/cornerstone:beta` for manual testing
 3. **E2E + review summary** — confirmation that all automated validation passed
 
-The user reviews the PR, optionally tests with the beta image, and approves. Do NOT merge without user confirmation.
+If `uatFeedbackRound > 0`, also include a summary of changes made in the previous feedback round (issues created, PRs merged, what was fixed).
+
+Tell the user:
+- **To approve**: say "approved" (or similar confirmation) → proceed to step 12
+- **To provide feedback**: write feedback to `/tmp/notes.md` and say "feedback in notes" → fixes will be applied autonomously
+
+Do NOT merge without explicit user confirmation.
+
+#### 11b. Await Response
+
+Wait for the user's response. Branch:
+- If the user **approves** → proceed to step 12 (Documentation & Env Drift Check)
+- If the user says **"feedback in notes"** (or similar) → continue to 11c
+
+#### 11c. Read Feedback
+
+Read `/tmp/notes.md` and parse non-empty, non-comment lines. Print a numbered summary of the feedback items for the user to confirm.
+
+#### 11d. PO Grouping
+
+Launch the **product-owner** agent to:
+- Analyze the feedback items
+- Group related items that should be fixed together
+- Create a GitHub Issue for each group, labeled `bug`, linked as a sub-issue of the epic, and added to the Projects board in **Todo** status
+- Return the list of created issue numbers and their groupings
+
+#### 11e. Execute Fixes
+
+For each group of issues from 11d:
+
+1. Create a fresh branch from `origin/beta`: `git checkout -B fix/<issue-number>-<short-description> origin/beta`
+2. Execute `/develop` steps 2–11 (skipping step 1 Rebase and step 4 Branch — branch is already created)
+3. Track success/failure for each group
+
+If any group fails after retry budget exhaustion, report the failure to the user and ask whether to continue with remaining groups or pause.
+
+#### 11f. Update Promotion PR
+
+After all fix groups are merged to `beta`:
+
+1. Close the current promotion PR: `gh pr close <pr-number>`
+2. Re-run Branch Sync (step 7) to ensure `main` and `beta` are aligned
+3. Create a new promotion PR with:
+   - Updated change inventory reflecting all fixes
+   - A **Feedback Rounds** section listing each round's issues and PRs
+   - Reference to the superseded PR: `Supersedes #<old-pr-number>`
+4. Post updated detailed UAT criteria (step 9) on the new PR
+
+#### 11g. CI Gate
+
+Wait for all CI checks to pass on the new promotion PR:
+
+```
+gh pr checks <new-pr-number> --watch
+```
+
+If any check fails, investigate and resolve before proceeding.
+
+#### 11h. Loop
+
+Increment `uatFeedbackRound`. Go to **11a** with the new promotion PR.
+
+### 12. Documentation & Env Drift Check
+
+Launch the **docs-writer** agent to:
+
+- Update the documentation site (`docs/`) with new feature guides
+- Update `README.md` with newly shipped capabilities
+- Write `RELEASE_SUMMARY.md` for the GitHub Release changelog enrichment
+- **Verify `.env.example` freshness**: Scan server source code for all `process.env.*` references (primarily `server/src/plugins/config.ts`), compare against `.env.example` entries, and fix any drift. Rules:
+  - Optional features (OIDC, Paperless, etc.) must remain **commented out** with example placeholder values
+  - Preserve inline `# Optional: ...` documentation comments
+  - Update the Environment Variables table in `CLAUDE.md` if new vars were added
+
+Commit documentation updates to `beta` via a PR:
+
+```bash
+gh pr create --base beta --title "docs: update documentation for epic #<epic-number>" --body "..."
+```
+
+Wait for CI, then squash merge.
+
+**Note:** Documentation runs after user approval (step 11) to ensure docs reflect the final state, including any changes from UAT feedback rounds.
 
 ### 13. Merge & Post-Merge
 

--- a/.claude/skills/epic-run/SKILL.md
+++ b/.claude/skills/epic-run/SKILL.md
@@ -174,12 +174,12 @@ Execute `/epic-close` steps 2 through 13 in order. Step 1 (Rebase) is skipped �
 - **Step 4** (Refinement PR)
 - **Step 5** (E2E Validation)
 - **Step 6** (UAT Validation)
-- **Step 7** (Documentation)
-- **Step 8** (Branch Sync)
-- **Step 9** (Epic Promotion)
-- **Step 10** (Post Detailed UAT Criteria)
-- **Step 11** (CI Gate)
-- **Step 12** (User Approval) — **mandatory human gate**
+- **Step 7** (Branch Sync)
+- **Step 8** (Epic Promotion)
+- **Step 9** (Post Detailed UAT Criteria)
+- **Step 10** (CI Gate)
+- **Step 11** (Promotion Approval Loop) — **mandatory human gate** with autonomous feedback fix loop
+- **Step 12** (Documentation & Env Drift Check) — runs after user approval
 - **Step 13** (Merge & Post-Merge)
 
 If any step in `/epic-close` references "failed stories" or "excluded stories", use the `failedStories` list from Phase 2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,13 +97,13 @@ The orchestrator uses four skills to drive work. Each skill contains the full op
 
 ## Acceptance & Validation
 
-Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story/bug PR — PRs auto-merge after CI green + all reviewers approved. **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT scenarios fed to e2e-test-engineer, docs update, promotion. Use `/epic-run` to execute the entire lifecycle in a single session. The only human gate is promotion from `beta` → `main`, where the user reviews a comprehensive summary with change inventory, validation report, and manual validation checklist.
+Every epic follows a two-phase validation lifecycle. **Development phase** (`/develop`): PO defines acceptance criteria, QA + E2E + security review each story/bug PR — PRs auto-merge after CI green + all reviewers approved. **Epic validation phase** (`/epic-close`): refinement, E2E coverage confirmation, UAT scenarios fed to e2e-test-engineer, promotion, then docs update. Use `/epic-run` to execute the entire lifecycle in a single session. The only human gate is promotion from `beta` → `main`, where the user reviews a comprehensive summary with change inventory, validation report, and manual validation checklist. If the user provides feedback via `/tmp/notes.md`, fixes are applied autonomously (PO groups items into issues, `/develop` fixes each group) and the promotion PR is re-created — looping until the user approves. Documentation runs after approval to reflect the final state.
 
 ### Key Rules
 
 - **User approval required for promotion** — the user is the final authority on `beta` → `main` promotion
 - **Automated before manual** — all automated tests must be green before the user validates
-- **Iterate until right** — failed validation triggers a fix-and-revalidate loop
+- **Iterate until right** — failed validation triggers a fix-and-revalidate loop (user writes feedback to `/tmp/notes.md`, system fixes autonomously and re-presents)
 - **Acceptance criteria live on GitHub Issues** — stored on story issues, summarized on promotion PRs
 - **Security review required** — the `security-engineer` must review every story PR
 - **Test agents own all tests** — `qa-integration-tester` owns unit and integration tests; `e2e-test-engineer` owns Playwright E2E browser tests. Developer agents do not write tests.


### PR DESCRIPTION
## Summary

- Reorder epic-close steps 7-12: move Documentation & Env Drift Check after user approval (new step 12) so docs reflect the final state including any UAT feedback fixes
- Add Promotion Approval Loop (step 11) with sub-steps 11a-11h that lets users write feedback to `/tmp/notes.md` for autonomous fix cycles — PO groups items into issues, `/develop` fixes each group, promotion PR is re-created and re-presented
- Update epic-run Phase 3 step list to match new ordering
- Update CLAUDE.md Acceptance & Validation section to document the feedback loop

Fixes #821

## Test plan

- [ ] Read epic-close/SKILL.md end-to-end — verify step numbering is sequential and cross-references are correct
- [ ] Read epic-run/SKILL.md Phase 3 — verify step list matches epic-close
- [ ] Verify CLAUDE.md Acceptance & Validation text is consistent with the new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)