### PR TITLE
chore: add test failure diagnostic protocol

### DIFF
--- a/.claude/agents/dev-team-lead.md
+++ b/.claude/agents/dev-team-lead.md
@@ -232,6 +232,57 @@ VERDICT: CHANGES_REQUIRED
 
 Each issue in a `CHANGES_REQUIRED` verdict must include enough detail for the orchestrator to route a targeted fix spec to the appropriate agent.
 
+## Test Failure Diagnostic Protocol (Mode: review)
+
+This protocol activates **only** when test failure reports are included in the review input. When all tests pass, skip this section entirely (zero overhead on the happy path).
+
+### Source-of-Truth Hierarchy
+
+**Spec/Contract > Production code > Test code.** A correct test must never be weakened to accommodate buggy production code. Correct production code must never be broken to satisfy a wrong test.
+
+### Decision Tree
+
+When test failures are present in the review input, walk through these steps for each failure:
+
+1. **Read the spec** — Find the relevant acceptance criterion, API contract endpoint, or schema definition that governs the behavior under test. Record the spec reference.
+2. **Read the test assertion** — Identify exactly what the test expects (expected value, HTTP status, UI state, etc.).
+3. **Read the production code** — Trace the code path that produces the actual result.
+4. **Classify the root cause** — Use the table below:
+
+| Test matches spec? | Code matches spec? | Root cause         | Fix target          |
+|---------------------|---------------------|--------------------|---------------------|
+| Yes                 | No                  | `CODE_BUG`         | Production code     |
+| No                  | Yes                 | `TEST_BUG`         | Test code           |
+| No                  | No                  | `BOTH_WRONG`       | Both (code first)   |
+| Yes                 | Yes                 | `TEST_ENVIRONMENT` | Test setup/config   |
+| Ambiguous           | —                   | `SPEC_AMBIGUOUS`   | Escalate to architect |
+
+5. **Produce diagnosis** — For each failure, emit a structured diagnosis block (see format below).
+
+### Diagnostic Output Format
+
+Extend the standard `CHANGES_REQUIRED` verdict with diagnosis fields for each test-failure issue:
+
+```
+VERDICT: CHANGES_REQUIRED
+
+## Issue 1: <title>
+- **File**: <path>
+- **Line(s)**: <line numbers>
+- **Problem**: <description>
+- **Fix**: <exact change needed>
+- **Agent**: backend-developer | frontend-developer | qa-integration-tester | e2e-test-engineer
+- **Diagnosis**: CODE_BUG | TEST_BUG | BOTH_WRONG | TEST_ENVIRONMENT
+- **Reasoning**: <1-2 sentences explaining why this classification was chosen>
+- **Spec reference**: <link or excerpt from spec/contract/schema that governs this behavior>
+```
+
+### Escalation Rules
+
+- **`SPEC_AMBIGUOUS`** — The spec does not clearly define the expected behavior. Return `VERDICT: ESCALATE_TO_ARCHITECT` instead of `CHANGES_REQUIRED`. Do not produce a fix spec — the product-architect must clarify the spec first, then the review is re-run.
+- **`BOTH_WRONG`** — Produce two fix specs: one for production code (routed to backend-developer or frontend-developer) and one for tests (routed to qa-integration-tester or e2e-test-engineer). The orchestrator applies production code fixes first, then test fixes.
+- **`TEST_ENVIRONMENT`** — The fix spec targets test setup, fixtures, or configuration — not the test assertions or production code.
+
 ## Commit & Push Details (Mode: commit)
 
 1. Stage all changes: `git add <specific-files>` (prefer specific files over `git add -A`)

--- a/.claude/agents/e2e-test-engineer.md
+++ b/.claude/agents/e2e-test-engineer.md
@@ -235,6 +235,28 @@ When you find a defect, report it as a **GitHub Issue** with the `bug` label. Us
 
 ---
 
+## Test Failure Reporting Format
+
+When E2E tests fail, report failures using this structured format. **Do NOT diagnose whether the fault lies in the production code or the test** — that determination belongs to the dev-team-lead's diagnostic protocol. Just report what you observe.
+
+```markdown
+### E2E Failure Report
+
+- **Test file**: <path>
+- **Test name**: <full test name>
+- **Line**: <line number of the failing assertion>
+- **Viewport**: desktop | tablet | mobile
+- **Assertion**: expected `<expected>` but received `<actual>`
+- **Selector(s) used**: <CSS/Playwright selectors involved>
+- **Error output**: <relevant error message or stack trace excerpt>
+- **Tested behavior**: <1 sentence describing what this test validates>
+- **Spec reference**: <acceptance criterion, API contract endpoint, or UX spec this test is based on>
+```
+
+Provide one block per failing test. If multiple assertions fail in the same test, report each assertion separately.
+
+---
+
 ## Strict Boundaries
 
 - Do **NOT** write unit or integration tests — those belong to the `qa-integration-tester`

--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -175,6 +175,26 @@ When you find a defect, report it as a **GitHub Issue** with the `bug` label. Us
 
 ---
 
+## Test Failure Reporting Format
+
+When tests fail, report failures using this structured format. **Do NOT diagnose whether the fault lies in the production code or the test** — that determination belongs to the dev-team-lead's diagnostic protocol. Just report what you observe.
+
+```markdown
+### Failure Report
+
+- **Test file**: <path>
+- **Test name**: <full test name>
+- **Line**: <line number of the failing assertion>
+- **Assertion**: expected `<expected>` but received `<actual>`
+- **Error output**: <relevant error message or stack trace excerpt>
+- **Tested behavior**: <1 sentence describing what this test validates>
+- **Spec reference**: <acceptance criterion, API contract endpoint, or schema definition this test is based on>
+```
+
+Provide one block per failing test. If multiple assertions fail in the same test, report each assertion separately.
+
+---
+
 ## Strict Boundaries
 
 - Do **NOT** implement features or write application code

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -185,6 +185,8 @@ After implementation agents complete, launch both test agents in parallel:
 - List of files created/modified by the backend and frontend agents
 - Reminder to triage prior E2E failures from recent beta PRs before writing new tests (the agent does this automatically per its "Before Starting Any Work" checklist)
 
+**If test agents report failures**: Collect structured failure reports (see the agents' "Test Failure Reporting Format" sections) and include them verbatim in the review input for step 6e. This triggers the dev-team-lead's diagnostic protocol.
+
 #### 6e. Code Review
 
 Launch the **dev-team-lead** in `[MODE: review]` with:
@@ -197,16 +199,23 @@ Launch the **dev-team-lead** in `[MODE: review]` with:
 
 **If `VERDICT: CHANGES_REQUIRED`** → proceed to step 6f
 
+**If `VERDICT: ESCALATE_TO_ARCHITECT`** → The spec is ambiguous. Launch the **product-architect** agent to clarify the spec (provide the ambiguous spec reference and the dev-team-lead's reasoning). After the architect clarifies, re-launch the **dev-team-lead** in `[MODE: review]` with the clarified spec. Then proceed based on the new verdict.
+
 #### 6f. Fix Loop (max 3 iterations)
 
 Track `internalFixCount` (starts at 0). For each iteration:
 
-1. Parse the fix specs from the review verdict — each fix specifies which agent should handle it
-2. Re-launch the appropriate agent(s) with targeted fix specs:
-   - Backend fixes → **backend-developer** (Haiku)
-   - Frontend fixes → **frontend-developer** (Haiku)
-   - Unit/integration test fixes → **qa-integration-tester**
-   - E2E test fixes → **e2e-test-engineer**
+1. Parse the fix specs from the review verdict — each fix specifies which agent should handle it and includes a `Diagnosis` classification when test failures are involved
+2. Route fixes based on diagnosis:
+   - `CODE_BUG` → production code fix to **backend-developer** or **frontend-developer** (Haiku)
+   - `TEST_BUG` → test fix to **qa-integration-tester** or **e2e-test-engineer**
+   - `BOTH_WRONG` → apply production code fixes **first**, then test fixes (two sequential rounds)
+   - `TEST_ENVIRONMENT` → test setup fix to **qa-integration-tester** or **e2e-test-engineer**
+   - Non-test issues (no diagnosis) → route as before:
+     - Backend fixes → **backend-developer** (Haiku)
+     - Frontend fixes → **frontend-developer** (Haiku)
+     - Unit/integration test fixes → **qa-integration-tester**
+     - E2E test fixes → **e2e-test-engineer**
 3. After fixes complete, re-launch **dev-team-lead** in `[MODE: review]` with updated file list
 4. Increment `internalFixCount`
 5. If `VERDICT: APPROVED` → proceed to step 6g

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -111,6 +111,8 @@ Launch the **e2e-test-engineer** agent to:
 - Open a PR targeting `beta` to trigger the full sharded E2E suite in CI (if it does not yet exist)
 - Wait for the full E2E suite to pass (not just smoke tests)
 
+**If the e2e-test-engineer reports failures**: Collect the structured E2E failure reports and launch the **dev-team-lead** in `[MODE: review]` with the failure reports and the relevant spec/acceptance criteria. The dev-team-lead's diagnostic protocol will classify each failure and produce targeted fix specs. Route fixes based on the diagnosis (same routing as `/develop` step 6f).
+
 This approval is **required** before proceeding to UAT validation.
 
 ### 6. UAT Validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,15 @@ Any agent making a decision that affects other agents (e.g., a new naming conven
 
 When a code change invalidates information in agent memory (e.g., fixing a bug documented in memory, changing a public API, updating routes), the implementing agent must update the relevant agent memory files.
 
+### Test Failure Debugging Protocol
+
+When tests fail during development, a structured diagnostic protocol determines whether the failure is in the test, the production code, or the spec — preventing wasted fix loops (e.g., weakening a correct test to make broken code pass).
+
+- **Source-of-truth hierarchy**: Spec/Contract > Production code > Test code
+- **Rule**: Correct tests must not be weakened to accommodate buggy code; correct code must not be broken to satisfy a wrong test
+- **Protocol owner**: The `dev-team-lead` runs the diagnostic decision tree during `[MODE: review]` when test failures are present in the review input. See the dev-team-lead agent definition for the full classification table and escalation rules.
+- **Test agents report, not diagnose**: `qa-integration-tester` and `e2e-test-engineer` submit structured failure reports but do not determine whether the fault lies in code or tests — that judgment belongs to the dev-team-lead.
+
 ### Review Metrics
 
 All reviewing agents (product-architect, security-engineer, product-owner, ux-designer) must append a structured metrics block as an HTML comment at the end of every PR review body. This is invisible to GitHub readers but parsed by the orchestrator for performance tracking.


### PR DESCRIPTION
## Summary

- Add structured diagnostic protocol for test failures across 6 agent/skill files
- Dev-team-lead classifies failures using a decision tree (CODE_BUG, TEST_BUG, BOTH_WRONG, TEST_ENVIRONMENT, SPEC_AMBIGUOUS)
- Test agents report failures in structured format without diagnosing root cause
- Orchestrator routes fixes based on classification, with escalation path to product-architect for ambiguous specs

## Test plan
- [ ] Documentation-only change — no runtime impact
- [ ] Verify internal consistency of protocol across all 6 files

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>