### PR TITLE
fix: replace gh pr checks --watch with CI gate polling pattern

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -133,7 +133,7 @@ For each piece of work, follow this order:
 Before considering any task complete, verify:
 
 - [ ] Pre-commit hook passes (triggers on commit: selective tests, typecheck, build, audit)
-- [ ] CI checks pass after push (wait with `gh pr checks <pr-number> --watch`)
+- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`)
 - [ ] New code is structured for testability (clear interfaces, injectable dependencies)
 - [ ] API responses match the contract shapes exactly
 - [ ] Error responses use correct HTTP status codes and error shapes from the contract
@@ -169,7 +169,7 @@ Before considering any task complete, verify:
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI: `gh pr checks <pr-number> --watch`
+6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-architect` and `security-engineer` to review the PR. Both must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/dev-team-lead.md
+++ b/.claude/agents/dev-team-lead.md
@@ -335,11 +335,7 @@ For multi-item batches, include per-item summary bullets and one `Fixes #N` line
 
 ### CI Monitoring
 
-Watch CI checks after pushing:
-
-```bash
-gh pr checks <pr-number> --watch
-```
+Watch CI checks after pushing using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
 
 If CI fails:
 
@@ -403,7 +399,7 @@ In `[MODE: commit]`:
 2. Stage specific files and commit with conventional message + all contributing agent trailers
 3. Push: `git push -u origin <branch-name>`
 4. Create PR targeting `beta` (if not already created)
-5. Watch CI: `gh pr checks <pr-number> --watch`
+5. Watch CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 6. If CI fails, return a fix spec (do NOT fix directly)
 7. Return PR URL with CI status to orchestrator
 

--- a/.claude/agents/e2e-test-engineer.md
+++ b/.claude/agents/e2e-test-engineer.md
@@ -273,7 +273,7 @@ If you discover something that requires a fix, write a bug report. If you need c
 
 ## E2E Smoke Tests
 
-E2E smoke tests run automatically in CI (see `e2e-smoke` job in `.github/workflows/ci.yml`) — **do not run them locally**. After pushing your branch and creating a PR, wait for CI to report results: `gh pr checks <pr-number> --watch`. If CI E2E smoke tests fail, investigate and fix before proceeding.
+E2E smoke tests run automatically in CI (see `e2e-smoke` job in `.github/workflows/ci.yml`) — **do not run them locally**. After pushing your branch and creating a PR, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant). If CI E2E smoke tests fail, investigate and fix before proceeding.
 
 ## Quality Assurance Self-Checks
 
@@ -291,7 +291,7 @@ Before considering your work complete, verify:
 - [ ] Dependent systems are tested via real containers (not only mocked)
 - [ ] Smoke tests expanded if new major capabilities were added
 - [ ] Bug reports have complete reproduction steps
-- [ ] CI checks pass after push (wait with `gh pr checks <pr-number> --watch`) — includes E2E smoke tests
+- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`) — includes E2E smoke tests
 
 ---
 

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -130,7 +130,7 @@ Follow this workflow for every task:
 Before considering any task complete:
 
 1. **Commit** your changes — the pre-commit hook runs all quality gates (lint, format, tests, typecheck, build, audit)
-2. **Wait for CI** after pushing (`gh pr checks <pr-number> --watch`) — do not proceed until green
+2. **Wait for CI** after pushing (use the **CI Gate Polling** pattern from `CLAUDE.md`) — do not proceed until green
 3. **Verify** that all new components handle loading, error, and empty states
 4. **Check** that TypeScript types are properly defined (no `any` types without justification)
 5. **Ensure** new API client functions match the contract on the GitHub Wiki API Contract page
@@ -170,7 +170,7 @@ Before considering any task complete:
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI: `gh pr checks <pr-number> --watch`
+6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-architect` and `security-engineer` to review the PR. Both must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/product-architect.md
+++ b/.claude/agents/product-architect.md
@@ -225,7 +225,7 @@ When launched to review a pull request, follow this process:
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI: `gh pr checks <pr-number> --watch`
+6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-owner`, `product-architect`, and `security-engineer` to review the PR. All must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -222,7 +222,7 @@ Before considering your work complete, verify:
 - [ ] Bug reports have complete reproduction steps
 - [ ] Performance metrics validated against baselines (bundle size, load time, API response time)
 - [ ] Docker deployment tested if applicable
-- [ ] CI checks pass after push (wait with `gh pr checks <pr-number> --watch`)
+- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`)
 
 ---
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -347,9 +347,7 @@ If any reviewer identifies blocking issues:
 
 Once all reviews are clean, wait for CI to go green:
 
-```
-gh pr checks <pr-number> --watch
-```
+Use the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` only).
 
 After CI is green, present the user with:
 

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -93,7 +93,7 @@ If there are refinement items to address:
    ```
    gh pr create --base beta --title "chore: address refinement items for epic #<epic-number>" --body "..."
    ```
-8. Wait for CI: `gh pr checks <pr-number> --watch`
+8. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` only)
 9. Squash merge: `gh pr merge --squash <pr-url>`
 
 If no refinement items exist, skip to step 5.
@@ -204,13 +204,9 @@ EOF
 
 ### 10. CI Gate
 
-Wait for all CI checks to pass on the promotion PR, including the full sharded E2E suite (runs on main-targeting PRs):
+Wait for all required CI gates to pass on the promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
 
-```
-gh pr checks <pr-number> --watch
-```
-
-If any check fails, investigate and resolve before proceeding.
+If any gate fails, investigate and resolve before proceeding.
 
 ### 11. Promotion Approval Loop
 
@@ -277,13 +273,9 @@ After all fix groups are merged to `beta`:
 
 #### 11g. CI Gate
 
-Wait for all CI checks to pass on the new promotion PR:
+Wait for all required CI gates to pass on the new promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
 
-```
-gh pr checks <new-pr-number> --watch
-```
-
-If any check fails, investigate and resolve before proceeding.
+If any gate fails, investigate and resolve before proceeding.
 
 #### 11h. Loop
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -129,11 +129,7 @@ Present the blocking findings to the user. **Do NOT wait for CI.**
 
 Post a consolidated `gh pr review --approve` comment on the PR summarizing the review outcome.
 
-Wait for CI to complete:
-
-```bash
-gh pr checks <pr-number> --watch
-```
+Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
 
 If CI fails, report the specific failures to the user. **Do NOT merge.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,35 @@ All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 - CI auto-fix bot: `npm run lint:fix` + `npm run format` + `npm audit fix` (runs on `beta` push, creates PR if changes needed)
 - CI Quality Gates: typecheck + test + build (runs on every PR)
 
-To validate your work: **commit and push**. After pushing, **only wait for the branch protection required checks to pass** — never wait for the full CI suite to finish. For beta PRs, wait only for `Quality Gates`. For main PRs, wait for `Quality Gates` + `E2E Gates`. Use `gh pr checks <pr-number> --watch` and proceed as soon as all required checks are green, even if optional checks (E2E shards, Docker PR Release, etc.) are still running.
+To validate your work: **commit and push**. After pushing, **always wait for the required CI gates to pass** before proceeding to the next step.
+
+#### CI Gate Polling (canonical pattern)
+
+`gh pr checks --watch` does not support GitHub Rulesets (only legacy branch protection). Use the polling loops below to watch the required gate checks by name.
+
+**Step 1 — Check for merge conflicts.** CI may not run (or silently hang) if the PR has conflicts. Always verify mergeability first:
+
+```bash
+state=$(gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'); if [ "$state" != "MERGEABLE" ]; then echo "PR is not mergeable (state: $state) — resolve conflicts before waiting for CI"; exit 1; fi
+```
+
+If the state is `CONFLICTING`, rebase onto the target branch, force-push, and re-check. If the state is `UNKNOWN`, wait a few seconds and retry — GitHub may still be computing mergeability.
+
+**Step 2 — Poll for required gate checks.**
+
+**Beta PRs** (require `Quality Gates` only):
+
+```bash
+echo "Waiting for Quality Gates..."; while true; do bucket=$(gh pr checks <PR> --repo steilerDev/cornerstone --json name,bucket -q '.[] | select(.name == "Quality Gates") | .bucket' 2>/dev/null); case "$bucket" in pass) echo "Quality Gates passed"; break ;; fail) echo "Quality Gates FAILED"; exit 1 ;; *) sleep 30 ;; esac; done
+```
+
+**Main PRs** (require `Quality Gates` + `E2E Gates`):
+
+```bash
+echo "Waiting for Quality Gates + E2E Gates..."; while true; do qg=$(gh pr checks <PR> --repo steilerDev/cornerstone --json name,bucket -q '.[] | select(.name == "Quality Gates") | .bucket' 2>/dev/null); e2e=$(gh pr checks <PR> --repo steilerDev/cornerstone --json name,bucket -q '.[] | select(.name == "E2E Gates") | .bucket' 2>/dev/null); if [ "$qg" = "fail" ] || [ "$e2e" = "fail" ]; then echo "CI FAILED (QG=$qg, E2E=$e2e)"; exit 1; fi; if [ "$qg" = "pass" ] && [ "$e2e" = "pass" ]; then echo "All gates passed"; break; fi; sleep 30; done
+```
+
+Replace `<PR>` with the PR number. The polling loop handles the "checks not yet reported" edge case — an empty bucket means we retry after 30s.
 
 The only exception is the QA agent running a specific test file it just wrote (e.g., `npx jest path/to/new.test.ts`) to verify correctness before committing — but never `npm test` (the full suite).
 


### PR DESCRIPTION
## Summary

- `gh pr checks --watch` (and `--watch --required`) does not support GitHub Rulesets — only legacy branch protection ([cli/cli#5573](https://github.com/cli/cli/issues/5573))
- Added a canonical **CI Gate Polling** section to `CLAUDE.md` with a 2-step process: (1) check PR mergeability to catch conflicts before waiting, (2) poll specific gate check names via `--json` + jq filtering
- Replaced all 15 inline `gh pr checks --watch` references across 6 agent definitions, 3 skills, and the project guide with pointers to the centralized definition

## Test plan

- [x] Push a beta-targeting PR and verify merge conflict check catches `CONFLICTING` state before entering the polling loop
- [ ] Confirm beta polling loop exits when `Quality Gates` resolves without waiting for E2E shards
- [ ] Verify grep finds no remaining `gh pr checks.*--watch` outside the explanatory note in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)