### PR TITLE
ci(release): register GitHub deployments for Docker Hub pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,12 @@ jobs:
 
     permissions:
       contents: read
+      deployments: write
       id-token: write
+
+    environment:
+      name: ${{ needs.release.outputs.is-prerelease == 'true' && 'dockerhub-beta' || 'dockerhub-production' }}
+      url: https://hub.docker.com/r/steilerdev/cornerstone/tags?name=${{ needs.release.outputs.new-release-version }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `environment` block to the `docker` job in the release workflow so each Docker Hub push registers a GitHub deployment
- Beta releases create a `dockerhub-beta` deployment, stable releases create `dockerhub-production`
- Each deployment links to the Docker Hub tags page filtered to the specific version
- Adds `deployments: write` permission to the `docker` job

## Test plan

- [ ] Push a commit to `beta` that triggers a version bump — verify `dockerhub-beta` deployment appears in the repo's Deployments tab
- [ ] Promote to `main` — verify `dockerhub-production` deployment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)