### PR TITLE
fix(diary): move button to header and improve form spacing

### DIFF
--- a/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.module.css
+++ b/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.module.css
@@ -147,6 +147,7 @@
   flex-wrap: wrap;
   gap: var(--spacing-2);
   margin-bottom: var(--spacing-3);
+  margin-top: var(--spacing-2);
 }
 
 .materialChip {
@@ -188,6 +189,7 @@
 .materialInputForm {
   display: flex;
   gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
 }
 
 .materialInputForm .input {

--- a/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
+++ b/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
@@ -435,7 +435,7 @@ export function DiaryEntryForm({
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>Description</label>
+            <label className={styles.label}>Items</label>
             {(deliveryMaterials?.length ?? 0) > 0 && (
               <div className={styles.materialsList}>
                 {deliveryMaterials!.map((material, index) => (

--- a/client/src/pages/DiaryPage/DiaryPage.module.css
+++ b/client/src/pages/DiaryPage/DiaryPage.module.css
@@ -11,6 +11,13 @@
   margin-bottom: var(--spacing-2);
 }
 
+.headerTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
 .title {
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
@@ -22,6 +29,11 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   margin: var(--spacing-2) 0 0 0;
+}
+
+.createButton {
+  flex-shrink: 0;
+  align-self: center;
 }
 
 .controls {
@@ -83,8 +95,19 @@
     gap: var(--spacing-4);
   }
 
+  .headerTop {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .title {
     font-size: var(--font-size-2xl);
+  }
+
+  .createButton {
+    width: 100%;
+    min-height: 44px;
+    align-self: stretch;
   }
 
   .controls {
@@ -97,8 +120,7 @@
     gap: var(--spacing-2);
   }
 
-  .exportButton,
-  .createButton {
+  .exportButton {
     width: 100%;
     min-height: 44px;
   }

--- a/client/src/pages/DiaryPage/DiaryPage.tsx
+++ b/client/src/pages/DiaryPage/DiaryPage.tsx
@@ -205,10 +205,21 @@ export default function DiaryPage() {
   return (
     <div className={styles.page}>
       <header className={styles.header}>
-        <h1 className={styles.title}>Construction Diary</h1>
-        <p className={styles.subtitle}>
-          {totalItems} {totalItems === 1 ? 'entry' : 'entries'}
-        </p>
+        <div className={styles.headerTop}>
+          <div>
+            <h1 className={styles.title}>Construction Diary</h1>
+            <p className={styles.subtitle}>
+              {totalItems} {totalItems === 1 ? 'entry' : 'entries'}
+            </p>
+          </div>
+          <Link
+            to="/diary/new"
+            className={`${shared.btnPrimary} ${styles.createButton}`}
+            style={{ textDecoration: 'none' }}
+          >
+            New Entry
+          </Link>
+        </div>
       </header>
 
       {error && <div className={shared.bannerError}>{error}</div>}
@@ -226,16 +237,6 @@ export default function DiaryPage() {
         filterMode={filterMode}
         onFilterModeChange={handleFilterModeChange}
       />
-
-      <div className={styles.controls}>
-        <Link
-          to="/diary/new"
-          className={`${shared.btnPrimary} ${styles.createButton}`}
-          style={{ textDecoration: 'none' }}
-        >
-          New Entry
-        </Link>
-      </div>
 
       {isLoading && <div className={shared.loading}>Loading entries...</div>}
 


### PR DESCRIPTION
## Summary

Two small frontend polish fixes for the diary feature:

1. **Header Button Positioning**: Move 'New Entry' button from controls section to top-right of page header, matching the pattern used on work items, household items, and vendors pages
2. **Form Label & Spacing**: Update delivery section label from "Description" to "Items" (matching the detail view fix from R5) and add appropriate vertical spacing around the materials list

## Changes

- DiaryPage.tsx: Move link into header with flex layout
- DiaryPage.module.css: Add headerTop flex layout, update responsive styles
- DiaryEntryForm.tsx: Change label text from "Description" to "Items"
- DiaryEntryForm.module.css: Add margin-top to materials list and input form

## Test Plan

- [x] Diary overview page button position matches other list pages
- [x] Button wraps to full width on mobile
- [x] Delivery form label displays as "Items" when editing
- [x] Spacing between label, chips, and input form is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)