### PR TITLE
fix(diary): interleave automatic/manual entries and group invoice filters

### DIFF
--- a/client/src/components/diary/DiaryDateGroup/DiaryDateGroup.module.css
+++ b/client/src/components/diary/DiaryDateGroup/DiaryDateGroup.module.css
@@ -17,38 +17,6 @@
   gap: var(--spacing-3);
 }
 
-.automaticSection {
-  margin-top: var(--spacing-4);
-  border: 1px solid var(--color-border);
-  border-left: 3px solid var(--color-text-muted);
-  border-radius: var(--radius-md);
-  background-color: var(--color-bg-secondary);
-  overflow: hidden;
-}
-
-.automaticHeader {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.automaticIcon {
-  font-size: var(--font-size-base);
-  color: var(--color-text-secondary);
-}
-
-.automaticTitle {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-secondary);
-}
-
-.automaticSection .entriesList {
-  padding: var(--spacing-3);
-}
-
 /* Responsive */
 @media (max-width: 767px) {
   .group {

--- a/client/src/components/diary/DiaryDateGroup/DiaryDateGroup.tsx
+++ b/client/src/components/diary/DiaryDateGroup/DiaryDateGroup.tsx
@@ -19,31 +19,17 @@ function formatDateHeader(dateString: string): string {
 }
 
 export function DiaryDateGroup({ date, entries }: DiaryDateGroupProps) {
-  const manualEntries = entries.filter((e) => !e.isAutomatic);
-  const automaticEntries = entries.filter((e) => e.isAutomatic);
+  // Sort all entries by createdAt descending (newest first)
+  const sortedEntries = [...entries].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
 
   return (
     <section className={styles.group} data-testid={`date-group-${date}`}>
       <h2 className={styles.dateHeader}>{formatDateHeader(date)}</h2>
 
-      {automaticEntries.length > 0 && (
-        <div className={styles.automaticSection} data-testid={`automatic-section-${date}`}>
-          <div className={styles.automaticHeader}>
-            <span className={styles.automaticIcon} aria-hidden="true">
-              ⚙
-            </span>
-            <span className={styles.automaticTitle}>Automated Events</span>
-          </div>
-          <div className={styles.entriesList}>
-            {automaticEntries.map((entry) => (
-              <DiaryEntryCard key={entry.id} entry={entry} />
-            ))}
-          </div>
-        </div>
-      )}
-
       <div className={styles.entriesList}>
-        {manualEntries.map((entry) => (
+        {sortedEntries.map((entry) => (
           <DiaryEntryCard key={entry.id} entry={entry} />
         ))}
       </div>

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.test.tsx
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.test.tsx
@@ -56,7 +56,7 @@ describe('DiaryFilterBar', () => {
     expect(screen.getByTestId('diary-date-to')).toBeInTheDocument();
   });
 
-  it('renders type filter chips for all entry types', () => {
+  it('renders type filter chips for all entry types (invoice_created grouped under invoice_status)', () => {
     renderFilterBar();
     const expectedTypes: DiaryEntryType[] = [
       'daily_log',
@@ -66,7 +66,6 @@ describe('DiaryFilterBar', () => {
       'general_note',
       'work_item_status',
       'invoice_status',
-      'invoice_created',
       'milestone_delay',
       'budget_breach',
       'auto_reschedule',
@@ -75,6 +74,8 @@ describe('DiaryFilterBar', () => {
     for (const type of expectedTypes) {
       expect(screen.getByTestId(`type-filter-${type}`)).toBeInTheDocument();
     }
+    // invoice_created is grouped under invoice_status chip — no separate chip
+    expect(screen.queryByTestId('type-filter-invoice_created')).not.toBeInTheDocument();
   });
 
   // ─── Filter mode chips ─────────────────────────────────────────────────────
@@ -155,12 +156,11 @@ describe('DiaryFilterBar', () => {
     expect(screen.queryByTestId('type-filter-subsidy_status')).not.toBeInTheDocument();
   });
 
-  it('when filterMode="automatic", renders exactly 7 automatic type chips', () => {
+  it('when filterMode="automatic", renders automatic type chips (invoice_created hidden)', () => {
     renderFilterBar({ filterMode: 'automatic' });
     const automaticTypes: DiaryEntryType[] = [
       'work_item_status',
       'invoice_status',
-      'invoice_created',
       'milestone_delay',
       'budget_breach',
       'auto_reschedule',
@@ -169,6 +169,8 @@ describe('DiaryFilterBar', () => {
     for (const type of automaticTypes) {
       expect(screen.getByTestId(`type-filter-${type}`)).toBeInTheDocument();
     }
+    // invoice_created is grouped under invoice_status
+    expect(screen.queryByTestId('type-filter-invoice_created')).not.toBeInTheDocument();
     // Manual types should not be rendered
     expect(screen.queryByTestId('type-filter-daily_log')).not.toBeInTheDocument();
     expect(screen.queryByTestId('type-filter-site_visit')).not.toBeInTheDocument();
@@ -177,9 +179,9 @@ describe('DiaryFilterBar', () => {
     expect(screen.queryByTestId('type-filter-general_note')).not.toBeInTheDocument();
   });
 
-  it('when filterMode="all" (default), all 12 type chips are rendered', () => {
+  it('when filterMode="all" (default), all visible type chips are rendered (invoice_created hidden)', () => {
     renderFilterBar({ filterMode: 'all' });
-    const allTypes: DiaryEntryType[] = [
+    const visibleTypes: DiaryEntryType[] = [
       'daily_log',
       'site_visit',
       'delivery',
@@ -187,15 +189,15 @@ describe('DiaryFilterBar', () => {
       'general_note',
       'work_item_status',
       'invoice_status',
-      'invoice_created',
       'milestone_delay',
       'budget_breach',
       'auto_reschedule',
       'subsidy_status',
     ];
-    for (const type of allTypes) {
+    for (const type of visibleTypes) {
       expect(screen.getByTestId(`type-filter-${type}`)).toBeInTheDocument();
     }
+    expect(screen.queryByTestId('type-filter-invoice_created')).not.toBeInTheDocument();
   });
 
   // ─── Type chip interaction ─────────────────────────────────────────────────

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.tsx
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.tsx
@@ -38,6 +38,14 @@ const AUTOMATIC_ENTRY_TYPES: DiaryEntryType[] = [
   'subsidy_status',
 ];
 
+// invoice_created shares the "Invoice" chip with invoice_status
+const GROUPED_TYPES: Record<string, DiaryEntryType[]> = {
+  invoice_status: ['invoice_status', 'invoice_created'],
+};
+
+// Types to display as chips (invoice_created is hidden — grouped under invoice_status)
+const CHIP_HIDDEN_TYPES: DiaryEntryType[] = ['invoice_created'];
+
 const ALL_ENTRY_TYPES: DiaryEntryType[] = [...MANUAL_ENTRY_TYPES, ...AUTOMATIC_ENTRY_TYPES];
 
 const TYPE_LABELS: Record<DiaryEntryType, string> = {
@@ -76,20 +84,23 @@ export function DiaryFilterBar({
   };
 
   const handleTypeToggle = (type: DiaryEntryType) => {
-    if (activeTypes.includes(type)) {
-      onTypesChange(activeTypes.filter((t) => t !== type));
+    const group = GROUPED_TYPES[type] ?? [type];
+    const isActive = activeTypes.includes(type);
+    if (isActive) {
+      onTypesChange(activeTypes.filter((t) => !group.includes(t)));
     } else {
-      onTypesChange([...activeTypes, type]);
+      onTypesChange([...activeTypes, ...group.filter((t) => !activeTypes.includes(t))]);
     }
   };
 
-  // Determine which types to display based on filter mode
-  const displayedTypes =
+  // Determine which types to display based on filter mode (hide grouped types like invoice_created)
+  const baseTypes =
     filterMode === 'manual'
       ? MANUAL_ENTRY_TYPES
       : filterMode === 'automatic'
         ? AUTOMATIC_ENTRY_TYPES
         : ALL_ENTRY_TYPES;
+  const displayedTypes = baseTypes.filter((t) => !CHIP_HIDDEN_TYPES.includes(t));
 
   const filterCount = [
     searchQuery ? 1 : 0,

--- a/e2e/tests/diary/diary-automatic-events.spec.ts
+++ b/e2e/tests/diary/diary-automatic-events.spec.ts
@@ -83,18 +83,8 @@ test.describe('Automatic entries in diary list (Scenario 1)', { tag: '@responsiv
         await diaryPage.goto();
         await diaryPage.waitForLoaded();
 
-        // UAT R2 fix #868: automatic events are now rendered inside a flat <div> (not a collapsible
-        // details/summary element). The section has data-testid="automatic-section-{date}" and
-        // contains a header with "Automated Events" text. No interaction needed to reveal the cards.
-        const automaticSection = page.getByTestId(
-          `automatic-section-${mockEntry['entryDate'] as string}`,
-        );
-        await automaticSection.waitFor({ state: 'visible' });
-
-        // The section header should contain "Automated Events"
-        await expect(automaticSection).toContainText('Automated Events');
-
-        // The entry card should be directly visible inside the section
+        // UAT R7: automatic entries are now interleaved with manual entries in chronological order
+        // The entry card should be directly visible in the date group
         await expect(diaryPage.entryCard(mockId)).toBeVisible();
       } finally {
         await page.unroute('**/api/diary-entries*');

--- a/e2e/tests/diary/diary-r2-uat.spec.ts
+++ b/e2e/tests/diary/diary-r2-uat.spec.ts
@@ -330,9 +330,9 @@ test.describe('New Entry button text (Scenario 5)', { tag: '@responsive' }, () =
 // ─────────────────────────────────────────────────────────────────────────────
 // Scenario 6: Automatic events section is a flat div, not a collapsible
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Automatic events as flat section (Scenario 6)', { tag: '@responsive' }, () => {
+test.describe('Automatic entries interleaved (Scenario 6)', { tag: '@responsive' }, () => {
   test(
-    'Automatic events section renders as a flat bordered div with "Automated Events" heading',
+    'Automatic and manual entries are interleaved in the same date group',
     { tag: '@smoke' },
     async ({ page }) => {
       const mockDate = '2026-03-16';
@@ -373,23 +373,9 @@ test.describe('Automatic events as flat section (Scenario 6)', { tag: '@responsi
         await diaryPage.heading.waitFor({ state: 'visible' });
         await diaryPage.waitForLoaded();
 
-        // The automatic section is identified by data-testid="automatic-section-{date}"
-        const automaticSection = page.getByTestId(`automatic-section-${mockDate}`);
-        await expect(automaticSection).toBeVisible();
-
-        // It must contain "Automated Events" text
-        await expect(automaticSection).toContainText('Automated Events');
-
-        // It must be a div (NOT a details element — UAT R2 #868 removed the collapsible)
-        const tagName = await automaticSection.evaluate((el) => el.tagName.toLowerCase());
-        expect(tagName).toBe('div');
-
-        // No details/summary element should exist in the automatic section
-        const detailsCount = await automaticSection.locator('details').count();
-        expect(detailsCount).toBe(0);
-
-        // The automatic entry card should be directly visible (no interaction needed)
+        // Both entries should be visible in the same date group (interleaved)
         await expect(diaryPage.entryCard('mock-auto-r2-001')).toBeVisible();
+        await expect(diaryPage.entryCard('mock-manual-r2-001')).toBeVisible();
       } finally {
         await page.unroute('**/api/diary-entries*');
       }

--- a/e2e/tests/diary/diary-uat-fixes.spec.ts
+++ b/e2e/tests/diary/diary-uat-fixes.spec.ts
@@ -169,11 +169,7 @@ test.describe('Source entity title in diary card (Scenario 4)', () => {
       const diaryPage = new DiaryPage(page);
       await diaryPage.heading.waitFor({ state: 'visible' });
 
-      // UAT R2 fix #868: automatic events are now a flat bordered div (not a collapsible).
-      // The section is directly visible — no interaction needed to reveal its contents.
-      const automaticSection = page.getByTestId('automatic-section-2026-03-14');
-      await automaticSection.waitFor({ state: 'visible' });
-
+      // UAT R7: automatic entries are interleaved in chronological order
       // Automatic entries show "Go to related item" as link text (UAT fix #876)
       const sourceLink = page.getByTestId(`source-link-wi-mock-001`);
       await expect(sourceLink).toBeVisible();
@@ -187,11 +183,10 @@ test.describe('Source entity title in diary card (Scenario 4)', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // Scenario 5: Automatic events are in a collapsible section
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Automatic events flat section (Scenario 5)', { tag: '@responsive' }, () => {
-  test('Date group renders automatic events inside a flat "Automated Events" div section', async ({
+test.describe('Automatic events interleaved (Scenario 5)', { tag: '@responsive' }, () => {
+  test('Automatic and manual entries are interleaved in the same date group', async ({
     page,
   }) => {
-    // Mock diary entries: one manual + one automatic on the same date
     await page.route('**/api/diary-entries*', async (route) => {
       if (route.request().method() === 'GET') {
         await route.fulfill({
@@ -246,18 +241,9 @@ test.describe('Automatic events flat section (Scenario 5)', { tag: '@responsive'
       await diaryPage.heading.waitFor({ state: 'visible' });
       await diaryPage.waitForLoaded();
 
-      // UAT R2 fix #868: automatic events are now a flat bordered div (not a collapsible).
-      // The section has data-testid="automatic-section-{date}" and contains a header with
-      // "Automated Events" text.
-      const automaticSection = page.getByTestId('automatic-section-2026-03-14');
-      await expect(automaticSection).toBeVisible();
-
-      // Verify the section contains the "Automated Events" heading text
-      await expect(automaticSection).toContainText('Automated Events');
-
-      // Verify it is a div, not a details element
-      const tagName = await automaticSection.evaluate((el) => el.tagName.toLowerCase());
-      expect(tagName).toBe('div');
+      // Both entries should be visible in the same date group
+      await expect(diaryPage.entryCard('mock-manual-001')).toBeVisible();
+      await expect(diaryPage.entryCard('mock-auto-001')).toBeVisible();
     } finally {
       await page.unroute('**/api/diary-entries*');
     }


### PR DESCRIPTION
## Summary

Two diary UI fixes:

1. **Interleaved entries** — Automatic and manual entries are now displayed in a single chronological list, ordered by `createdAt` timestamp. Automatic entries retain their distinct visual styling (left border, background color).

2. **Grouped invoice filters** — The `invoice_created` type is now grouped under the same "Invoice" filter chip as `invoice_status`. Clicking the chip toggles both types together. The `invoice_created` type is hidden from the individual filter display.

Also removes unused CSS for the separate automatic section container.

## Test plan

- Verify diary date groups show interleaved automatic + manual entries in chronological order
- Verify automatic entries still have distinct styling (left border, background)
- Verify clicking the "Invoice" filter chip toggles both `invoice_status` and `invoice_created` entries
- Verify switching between filter modes (All/Manual/Automatic) works correctly
- Verify the filter chips only show `invoice_status`, not both `invoice_created` separately

🤖 Generated with Claude frontend-developer