### PR TITLE
fix(diary): add scroll to dashboard recent diary card

### DIFF
--- a/client/src/components/RecentDiaryCard/RecentDiaryCard.module.css
+++ b/client/src/components/RecentDiaryCard/RecentDiaryCard.module.css
@@ -8,6 +8,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
+  max-height: 280px;
+  overflow-y: auto;
 }
 
 .entryItem {


### PR DESCRIPTION
Limits entries list height to ~3 items and adds overflow-y scroll.