### PR TITLE
docs: add EPIC-13 diary documentation and task tracking to skills

### DIFF
--- a/.claude/agent-memory/docs-writer/MEMORY.md
+++ b/.claude/agent-memory/docs-writer/MEMORY.md
@@ -22,7 +22,7 @@
 - Broken screenshot image refs exist across many guide pages (16+ refs) -- all resolve when screenshots are captured during stable release
 - Fixed via `markdown.hooks.onBrokenMarkdownImages: 'warn'` in docusaurus.config.js
 
-## Existing Pages (as of EPIC-14)
+## Existing Pages (as of EPIC-13)
 
 - `intro.md` -- Landing page (slug: /)
 - `roadmap.md` -- Feature roadmap checklist
@@ -33,6 +33,8 @@
 - `guides/timeline/` -- index, gantt-chart, milestones, calendar-view
 - `guides/documents/` -- index, setup, browsing-documents, linking-documents
 - `guides/household-items/` -- index, creating-editing-items, budget-and-invoices, work-item-linking, delivery-and-dependencies
+- `guides/diary/` -- index, manual-entries, automatic-events, signatures
+- `guides/dashboard/` -- index
 - `guides/appearance/` -- dark-mode
 - `development/` -- index, tech-stack, agentic/overview, agentic/agent-team, agentic/workflow, agentic/setup
 
@@ -47,10 +49,10 @@
 - Double dashes `--` used instead of em dashes in all existing content
 - Footer links in `docusaurus.config.js` should be updated when major features are added
 
-## Roadmap State (post EPIC-15)
+## Roadmap State (post EPIC-13)
 
-Completed: EPIC-02, EPIC-11(#12), EPIC-01, EPIC-03, EPIC-12(#115), EPIC-05, EPIC-06, EPIC-08, EPIC-04, EPIC-07, EPIC-10, EPIC-11(#444 tags), EPIC-12(#445 refinement), EPIC-14(#495), EPIC-15(#602)
-Planned: EPIC-09(#9 dashboard), EPIC-13(#446 construction diary)
+Completed: EPIC-02, EPIC-11(#12), EPIC-01, EPIC-03, EPIC-12(#115), EPIC-05, EPIC-06, EPIC-08, EPIC-04, EPIC-07, EPIC-10, EPIC-11(#444 tags), EPIC-12(#445 refinement), EPIC-14(#495), EPIC-15(#602), EPIC-09(#9), EPIC-13(#446)
+Planned: (none)
 
 Note: EPIC-11 and EPIC-12 each have two issues -- original (#12/#115) and new (#444/#445). Both pairs are completed.
 

--- a/.claude/skills/batch-develop/SKILL.md
+++ b/.claude/skills/batch-develop/SKILL.md
@@ -26,6 +26,27 @@ You are the orchestrator running a sequential development pipeline. This skill a
 - **Empty lines**: Skipped
 - **Comment lines** (starting with `#`): Skipped — but note that `#42` (digits after `#`) is treated as an issue number, not a comment
 
+## Task Tracking
+
+Use tasks to track progress across the batch. Tasks survive context compression — after any compression event, run `TaskList` to recover your place.
+
+**Create these tasks upfront** (using `TaskCreate`):
+
+1. **Read and parse queue** — Parse input arguments or /tmp/notes.md into items queue
+2. **Session setup** — Fetch latest beta, sync wiki
+
+**After parsing** — create one task per item in the queue:
+
+3–N. **Item #\<issue-number\>: \<title or description\>** — Full /develop cycle for this item
+
+**After all items complete:**
+
+- **Print summary** — Final batch results summary
+
+**Progress rule:** Before starting each item, mark its task `in_progress`. After completing (merged + closed), mark it `completed`. If an item fails, mark it `completed` with a note describing the failure.
+
+**Recovery rule:** If you lose track of progress (e.g., after context compression), run `TaskList` to see which tasks are completed and resume from the first pending task.
+
 ## Steps
 
 ### 1. Read and Parse

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -35,6 +35,29 @@ In multi-item mode, maintain an ordered **items list** throughout the workflow. 
 
 If the input was a `@`-prefixed file path, also store the **source file path** (without the `@` prefix) for use during cleanup in step 11.
 
+## Task Tracking
+
+At the start of each `/develop` invocation, create tasks to track progress. These tasks survive context compression and let you recover your place if context is lost.
+
+**Create these tasks upfront** (using `TaskCreate`):
+
+1. **Rebase onto beta** — Fetch and rebase worktree branch onto origin/beta
+2. **Resolve issues** — Read/create GitHub Issues for all items
+3. **Visual spec** — Launch ux-designer for UI-touching stories (skip if all bugs or backend-only)
+4. **Create branch** — Rename worktree branch to conventional name
+5. **Move to In Progress** — Update Projects board status
+6. **Implement + Test** — Full multi-phase cycle: spec → backend → frontend → QA/E2E → review → fix loop → commit → trailer verification
+7. **Verify PR** — Confirm PR exists targeting beta
+8. **Agent reviews** — Launch product-architect, security-engineer, product-owner, ux-designer reviews
+9. **Merge** — Wait for CI, persist metrics, squash merge to beta
+10. **Close issues & clean up** — Close issues, move to Done, clean up branch
+
+**Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped (conditional), mark it `completed` with a note in the description.
+
+**Recovery rule:** If you lose track of progress (e.g., after context compression), run `TaskList` to see which tasks are completed and resume from the first pending task.
+
+**Dynamic task rule:** When a fix loop starts (step 6f or step 9), create a new task for each round (e.g., "Fix Loop Round 1", "Fix Loop Round 2") so iterations are tracked.
+
 ## Steps
 
 ### 1. Rebase

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -14,6 +14,32 @@ You are the orchestrator running the closing phase for a completed epic. Follow 
 
 `$ARGUMENTS` contains the epic issue number. If empty, ask the user to provide the epic issue number before proceeding.
 
+## Task Tracking
+
+At the start of each `/epic-close` invocation, create tasks to track progress. These tasks survive context compression and let you recover your place if context is lost.
+
+**Create these tasks upfront** (using `TaskCreate`):
+
+1. **Rebase** — Fetch and rebase worktree branch onto origin/beta
+2. **Verify all stories merged** — Confirm all sub-issues are closed
+3. **Epic metrics + lint check** — Generate metrics report (step 2a) and lint health check (step 2b)
+4. **Collect refinement items** — Review story PRs for non-blocking observations
+5. **Refinement PR** — Address refinement items via implementation agents (skip if none)
+6. **E2E validation** — Launch e2e-test-engineer to verify coverage and pass rate
+7. **UAT validation** — Launch product-owner for UAT scenarios
+8. **Branch sync** — Sync main→beta if diverged (skip if no divergence)
+9. **Epic promotion PR + UAT criteria** — Create promotion PR, post detailed UAT criteria
+10. **CI gate** — Wait for all CI checks including full E2E suite
+11. **Promotion approval loop** — Present to user, handle feedback rounds if needed
+12. **Documentation** — Launch docs-writer to update docs site, README, RELEASE_SUMMARY, and .env.example
+13. **Lessons learned + merge** — Update implementation checklist, merge, close epic
+
+**Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped (conditional), mark it `completed` with a note in the description.
+
+**Recovery rule:** If you lose track of progress (e.g., after context compression), run `TaskList` to see which tasks are completed and resume from the first pending task.
+
+**Dynamic task rule:** When a UAT fix round or E2E fix cycle starts, create a new task for each round (e.g., "UAT Fix Round 1", "E2E Fix Round 1") so iterations are tracked.
+
 ## Steps
 
 ### 1. Rebase

--- a/.claude/skills/epic-run/SKILL.md
+++ b/.claude/skills/epic-run/SKILL.md
@@ -42,6 +42,39 @@ Merged PRs and closed issues are durable state. If the session crashes:
 - Phase 2 detects already-closed stories and skips them
 - An in-progress story may have an open PR; the user can finish it with `/develop` then re-run `/epic-run`
 
+## Task Tracking
+
+Use tasks to track progress across the entire epic lifecycle. Tasks survive context compression — after any compression event, run `TaskList` to recover your place.
+
+**Phase 0 — create these tasks immediately:**
+
+1. **Session setup** — Rebase onto beta + wiki sync + initialize tracking state
+2. **Planning phase** — Execute /epic-start steps 3–5 (PO + architect + present to user)
+3. **Build story queue** — Topologically sort stories and post execution order
+
+**After story queue is built** — create one task per story:
+
+4–N. **Story #\<number\>: \<title\>** — Full /develop cycle for this story
+
+**After all stories complete** — create closing tasks:
+
+- **Pre-check** — Handle failed stories (if any)
+- **Verify all stories merged** — Confirm all sub-issues closed
+- **Epic metrics + lint check** — Generate metrics report and lint health check
+- **Refinement PR** — Address refinement items (skip if none)
+- **E2E validation** — Confirm E2E coverage and pass rate
+- **UAT validation** — Product-owner UAT scenarios
+- **Branch sync + promotion** — Sync main→beta if needed, create promotion PR + UAT criteria
+- **CI gate + promotion approval** — Wait for CI, present to user, handle feedback rounds
+- **Documentation + lessons learned** — Update docs/README/RELEASE_SUMMARY, sync implementation checklist
+- **Merge & post-merge** — Merge to main, close epic
+
+**Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped, mark it `completed` with a note.
+
+**Recovery rule:** If you lose track of progress (e.g., after context compression), run `TaskList` to see which tasks are completed and resume from the first pending task.
+
+**Dynamic task rule:** When fix loops, UAT rounds, or E2E fix cycles start, create a new task for each round so iterations are tracked.
+
 ---
 
 ## Phase 0: Session Setup

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A self-hosted home building project management tool for homeowners. Track work i
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, and work item linking
 - **Project Dashboard** -- At-a-glance project health with budget, timeline, invoice, and subsidy cards, mini Gantt preview, and customizable layout
+- **Construction Diary** -- Construction diary with daily logs, site visits, delivery records, automatic system events, photo attachments, and digital signature capture
 - **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices
 - **Authentication** -- Local accounts with setup wizard, OIDC single sign-on
 - **User Management** -- Admin and Member roles, admin panel
@@ -78,7 +79,7 @@ Open `http://localhost:3000` -- the setup wizard will guide you through creating
 - [x] **EPIC-14**: Cross-Entity Code Deduplication
 - [x] **EPIC-15**: Budget-Line Invoice Linking Rework
 - [x] **EPIC-09**: Dashboard and Overview
-- [ ] **EPIC-13**: Construction Diary
+- [x] **EPIC-13**: Construction Diary
 
 Track live progress on the [GitHub Projects board](https://github.com/users/steilerDev/projects/4).
 

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,10 +1,12 @@
 ## What's New
 
-Cornerstone now includes a project dashboard that gives you an at-a-glance view of your entire home building project. The dashboard pulls together budget health, timeline progress, invoices, and subsidies into a single page of customizable cards.
+Cornerstone now includes a Construction Diary (Bautagebuch) that helps you maintain a detailed record of your home building project. Track daily activities, site visits, deliveries, and issues while the system automatically logs significant events like status changes, invoice processing, and milestone delays.
 
 ### Highlights
 
-- **Project Dashboard** -- A new overview page at Project > Overview with eight information cards covering budget summary, budget alerts, source utilization, timeline status, a mini Gantt preview, invoice pipeline, subsidy pipeline, and quick actions
-- **Card Customization** -- Dismiss cards you do not need and re-enable them later via the Customize menu; preferences are saved per user
-- **Responsive Layout** -- On mobile, cards are grouped into collapsible sections (Primary, Timeline, Budget Details) with summary lines
-- **Mini Gantt Preview** -- A compact 30-day Gantt chart rendered inline on the dashboard; click it to jump to the full Gantt chart view
+- **Manual Diary Entries** -- Create five types of entries: daily logs, site visits, delivery records, issues, and general notes with weather tracking and photo attachments
+- **Automatic System Events** -- Key project changes (work item status, invoices, milestones, budget breaches, schedule changes, subsidies) are automatically recorded in the diary
+- **Photo Attachments** -- Attach photos directly when creating or editing diary entries for visual documentation
+- **Digital Signatures** -- Capture signatures from users or vendors with a drawing canvas; signed entries become immutable for accountability
+- **Dashboard Integration** -- A new "Recent Diary" card on the project dashboard shows the latest entries at a glance
+- **Filtering** -- Filter entries by All, Manual, or Automatic with type-specific chips for quick navigation

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -87,6 +87,7 @@ const config = {
               { label: 'Timeline', to: '/guides/timeline' },
               { label: 'Household Items', to: '/guides/household-items' },
               { label: 'Documents', to: '/guides/documents' },
+              { label: 'Diary', to: '/guides/diary' },
               { label: 'Roadmap', to: '/roadmap' },
             ],
           },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -76,6 +76,16 @@ const sidebars = {
         'guides/household-items/delivery-and-dependencies',
       ],
     },
+    {
+      type: 'category',
+      label: 'Diary',
+      link: { type: 'doc', id: 'guides/diary/index' },
+      items: [
+        'guides/diary/manual-entries',
+        'guides/diary/automatic-events',
+        'guides/diary/signatures',
+      ],
+    },
     'guides/dashboard/index',
     'guides/appearance/dark-mode',
     'roadmap',

--- a/docs/src/guides/dashboard/index.md
+++ b/docs/src/guides/dashboard/index.md
@@ -20,6 +20,7 @@ The dashboard is organized into cards, each focused on a specific aspect of your
 | **Mini Gantt** | A compact 30-day Gantt chart preview -- click it to open the full [Gantt chart](/guides/timeline/gantt-chart) |
 | **Invoice Pipeline** | Breakdown of invoices by status (pending, paid, claimed) |
 | **Subsidy Pipeline** | Status overview of your [subsidy programs](/guides/budget/subsidies) |
+| **Recent Diary** | Latest diary entries with scrollable list -- click to open the full [diary](/guides/diary/) |
 | **Quick Actions** | Navigation links to frequently used actions like creating work items or viewing the budget |
 
 ## Customizing Your Dashboard
@@ -37,7 +38,7 @@ Each user's dashboard layout is independent -- dismissing a card only affects yo
 
 On smaller screens, the dashboard switches from a flat grid to a sectioned layout:
 
-- **Primary cards** (Budget Summary, Budget Alerts, Invoice Pipeline, Quick Actions) are always visible
+- **Primary cards** (Budget Summary, Budget Alerts, Invoice Pipeline, Recent Diary, Quick Actions) are always visible
 - **Timeline cards** (Timeline Status, Mini Gantt) are grouped under a collapsible "Timeline" section with a summary line
 - **Budget Details cards** (Source Utilization, Subsidy Pipeline) are grouped under a collapsible "Budget Details" section
 

--- a/docs/src/guides/diary/automatic-events.md
+++ b/docs/src/guides/diary/automatic-events.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+title: Automatic Events
+---
+
+# Automatic System Events
+
+Cornerstone automatically creates diary entries when significant changes happen elsewhere in the application. These events give you a chronological audit trail of your project without any manual effort.
+
+## How It Works
+
+When you perform certain actions in Cornerstone -- such as changing a work item's status, creating an invoice, or triggering a schedule recalculation -- the system automatically generates a diary entry recording what happened. These entries appear in the diary timeline alongside your manual entries, sorted by date.
+
+## Event Types
+
+| Event Type | What Triggers It |
+|------------|-----------------|
+| **Work Item Status** | A work item moves to a different status (e.g., "Not Started" to "In Progress" or "Completed") |
+| **Invoice Created** | A new invoice is added to a vendor |
+| **Invoice Status** | An invoice status changes (e.g., "Pending" to "Paid" or "Claimed") |
+| **Milestone Delay** | A milestone's projected completion date moves past its target date |
+| **Budget Breach** | Actual or projected costs for a budget category exceed the allocated amount |
+| **Schedule** | The project schedule is recalculated (e.g., after auto-scheduling or dependency changes) |
+| **Subsidy** | A subsidy program's status or amount changes |
+
+## Reading Automatic Events
+
+Each automatic event includes:
+
+- **Title** -- A summary of what changed (e.g., "Work item 'Install kitchen cabinets' moved to In Progress")
+- **Body** -- Additional context about the change (no "[Source]" prefix -- the body contains plain descriptive text)
+- **Related item link** -- A "Go to related item" link that navigates directly to the entity that triggered the event (work item, invoice, milestone, etc.)
+
+Automatic events do not have metadata, weather, or photo attachments.
+
+## Filtering
+
+On the diary page, use the filter chips to isolate automatic events:
+
+1. Select the **Automatic** chip to show only system-generated entries
+2. Additional type-specific chips appear for finer filtering:
+   - **Work Item** -- Work item status changes
+   - **Invoice** -- Both invoice creation and invoice status changes
+   - **Milestone** -- Milestone delay events
+   - **Budget** -- Budget breach events
+   - **Schedule** -- Schedule change events
+   - **Subsidy** -- Subsidy change events
+
+## Limitations
+
+- Automatic events **cannot be edited or deleted** -- they are system-generated records
+- Events are created at the time the triggering action occurs; they are not retroactively generated for past changes

--- a/docs/src/guides/diary/index.md
+++ b/docs/src/guides/diary/index.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 8
+title: Diary
+---
+
+# Construction Diary
+
+The construction diary (Bautagebuch) gives you a chronological record of everything that happens on your building project. It combines manual entries you write with automatic system events that Cornerstone generates when significant changes occur elsewhere in the application.
+
+## Overview
+
+The diary provides:
+
+- **Manual Entries** -- Write daily logs, record site visits, track deliveries, flag issues, and add general notes
+- **Automatic Events** -- System-generated entries for work item status changes, invoice creation and status changes, milestone delays, budget breaches, schedule changes, and subsidy changes
+- **Photo Attachments** -- Attach photos to manual entries for visual documentation
+- **Signature Capture** -- Collect digital signatures from users or vendors with a drawing canvas; signed entries become immutable
+- **Filtering** -- Filter the diary by All, Manual, or Automatic entries with type-specific filter chips
+
+## Entry Types
+
+### Manual Entries
+
+You create these entries to document activities and observations:
+
+| Type | Purpose |
+|------|---------|
+| **Daily Log** | General daily progress notes and observations |
+| **Site Visit** | Record a visit to the construction site |
+| **Delivery** | Track materials or items delivered to the site |
+| **Issue** | Flag a problem that needs attention -- supports acknowledgment signatures |
+| **General Note** | Anything that does not fit the other categories |
+
+### Automatic Events
+
+Cornerstone automatically creates diary entries when significant changes happen in the system:
+
+| Event | Trigger |
+|-------|---------|
+| **Work Item Status** | A work item's status changes (e.g., from "Not Started" to "In Progress") |
+| **Invoice Created** | A new invoice is added to a vendor |
+| **Invoice Status** | An invoice status changes (e.g., from "Pending" to "Paid") |
+| **Milestone Delay** | A milestone's projected completion date slips past its target date |
+| **Budget Breach** | A budget category's costs exceed its allocated amount |
+| **Schedule** | The project schedule is recalculated or changed |
+| **Subsidy** | A subsidy program status or amount changes |
+
+Automatic events are interleaved chronologically with manual entries -- there is no separate section for them. Each automatic event includes a link to the related entity so you can navigate directly to the source.
+
+## Filtering
+
+At the top of the diary page, filter chips let you narrow the view:
+
+- **All** -- Show every entry (manual and automatic)
+- **Manual** -- Show only your hand-written entries
+- **Automatic** -- Show only system-generated events
+
+When the Automatic filter is active, additional type-specific chips appear for finer control (e.g., "Invoice" groups both invoice creation and status change events).
+
+## Next Steps
+
+- [Manual Entries](manual-entries) -- Creating and editing diary entries
+- [Automatic Events](automatic-events) -- How system events are generated
+- [Signatures](signatures) -- Digital signature capture and immutability
+
+:::info Screenshot needed
+Diary screenshots will be captured on the next stable release.
+:::

--- a/docs/src/guides/diary/manual-entries.md
+++ b/docs/src/guides/diary/manual-entries.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+title: Manual Entries
+---
+
+# Manual Diary Entries
+
+Manual diary entries let you document daily activities, site visits, deliveries, issues, and general notes throughout your construction project.
+
+## Entry Types
+
+Choose the type that best fits what you are recording:
+
+- **Daily Log** -- A summary of the day's work progress, conditions, and observations
+- **Site Visit** -- Notes from a visit to the construction site, useful for recording who was present and what was discussed
+- **Delivery** -- Track a materials or items delivery; uses an "Items" field instead of a free-text description
+- **Issue** -- Flag a problem that needs attention; issue entries support acknowledgment [signatures](/guides/diary/signatures)
+- **General Note** -- Anything that does not fit the categories above
+
+## Creating an Entry
+
+1. Navigate to the diary page at `/diary`
+2. Click **New Entry**
+3. Fill in the entry form:
+
+| Field | Description |
+|-------|-------------|
+| **Type** | Select the entry type (daily log, site visit, delivery, issue, or general note) |
+| **Date** | The date of the entry (defaults to today) |
+| **Weather** | Temperature and conditions (sunny, cloudy, rainy, snowy, windy, foggy) -- optional |
+| **Title** | A short summary of the entry |
+| **Body** | Detailed description (or "Items" for delivery entries) |
+
+4. Optionally attach photos (see below)
+5. Click **Save**
+
+## Weather Tracking
+
+Each entry can record the weather conditions at the time. This is useful for tracking how weather affects construction progress and for documenting conditions during deliveries or site visits.
+
+- **Temperature** -- Numeric value in degrees
+- **Conditions** -- One of: sunny, cloudy, rainy, snowy, windy, foggy
+
+## Photo Attachments
+
+You can attach photos directly when creating or editing a diary entry. Photos are added inline during the creation flow -- there is no separate upload step.
+
+Photos provide visual documentation of progress, deliveries, issues, or site conditions.
+
+:::caution
+Once an entry is signed, the photo section is hidden when no photos are attached, and no new photos can be added. Attach photos before collecting signatures.
+:::
+
+## Editing Entries
+
+To edit an existing entry, navigate to its detail page and click the **Edit** button. You can update any field including the title, body, weather, and photos.
+
+:::caution
+Signed entries cannot be edited. The edit button is hidden on entries that have signatures. See [Signatures](/guides/diary/signatures) for details on immutability.
+:::
+
+## Delivery Entries
+
+Delivery entries work slightly differently from other types:
+
+- The description field is replaced with an **Items** field to list what was delivered
+- There is no "Delivery Confirmed" checkbox -- confirmation is tracked through the delivery status of [household items](/guides/household-items/delivery-and-dependencies) instead

--- a/docs/src/guides/diary/signatures.md
+++ b/docs/src/guides/diary/signatures.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 3
+title: Signatures
+---
+
+# Digital Signatures
+
+The diary supports digital signature capture for accountability and record-keeping. Signatures are particularly useful for issue entries where you need acknowledgment from a contractor or vendor.
+
+## Adding Signatures
+
+Diary entries support multiple signers. To add a signature:
+
+1. Open the diary entry detail page
+2. Click the signature section
+3. Select the signer type:
+   - **User** -- Select an existing Cornerstone user
+   - **Vendor** -- Enter a signatory name (for people who do not have a Cornerstone account)
+4. Draw the signature on the canvas
+5. Save the signature
+
+You can add multiple signatures to a single entry -- for example, both a homeowner and a contractor acknowledging an issue.
+
+## Immutability
+
+Once an entry has at least one signature, it becomes **immutable**:
+
+- The **Edit** button is hidden -- the entry can no longer be modified
+- The **photo section** is hidden when there are no existing photos -- no new photos can be added
+- Existing photos remain visible but cannot be removed
+
+This ensures that signed entries serve as reliable records that cannot be altered after the fact.
+
+:::caution
+Attach all photos and finalize the entry content before collecting signatures. Once signed, the entry is locked.
+:::
+
+## Signed Badge
+
+Entries with signatures display a **"Signed"** badge, making it easy to identify which entries have been formally acknowledged.
+
+## Issue Acknowledgment
+
+Issue entries are the most common use case for signatures. When you flag a problem with an issue entry, you can have the responsible party sign the entry to acknowledge:
+
+- They are aware of the issue
+- They have reviewed the documented details
+- The record is accurate as written
+
+This creates an auditable trail of issue communication on your project.

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -39,6 +39,7 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, delivery scheduling, budget integration, work item linking, and timeline dependencies
 - **Authentication** -- Local accounts with first-run setup wizard, plus OIDC single sign-on for existing identity providers
 - **User Management** -- Admin and Member roles with a dedicated admin panel
+- **Construction Diary** -- Maintain a construction diary (Bautagebuch) with daily logs, site visits, delivery records, issue tracking, automatic system events, photo attachments, and digital signature capture
 - **Project Dashboard** -- At-a-glance project health with budget summary, timeline status, invoice and subsidy pipelines, mini Gantt preview, and customizable card layout
 - **Document Integration** -- Browse, search, and link documents from a connected [Paperless-ngx](https://docs.paperless-ngx.com/) instance to work items and invoices
 - **Dark Mode** -- Light, Dark, or System theme with instant switching
@@ -53,6 +54,7 @@ See the [Roadmap](roadmap) for upcoming features.
 - [Budget Guide](guides/budget) -- Track costs, invoices, and financing sources
 - [Timeline Guide](guides/timeline) -- Gantt chart, calendar view, and milestones
 - [Household Items Guide](guides/household-items) -- Manage furniture, appliances, and fixture purchases
+- [Diary Guide](guides/diary) -- Construction diary with manual entries and automatic events
 - [Dashboard Guide](guides/dashboard) -- Project health overview and card customization
 - [Documents Guide](guides/documents) -- Paperless-ngx integration for document linking
 - [OIDC Setup](guides/users/oidc-setup) -- Connect your identity provider

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -24,13 +24,9 @@ Cornerstone is under active development. Here is the current state of planned fe
 - [x] **EPIC-12: Codebase Refinement and Consistency** ([#445](https://github.com/steilerDev/cornerstone/issues/445)) -- Shared route factories, standardized API clients, consolidated error handling, reusable modal component
 - [x] **EPIC-14: Cross-Entity Code Deduplication** ([#495](https://github.com/steilerDev/cornerstone/issues/495)) -- Shared service factories, unified React components for budget and subsidy logic, accessibility improvements, harmonized design tokens
 - [x] **EPIC-15: Budget-Line Invoice Linking Rework** ([#602](https://github.com/steilerDev/cornerstone/issues/602)) -- Many-to-many invoice-budget-line linking with itemized amounts, bidirectional linking UI, invoice groups on item detail pages, subsidy recalculation using itemized amounts
-
 - [x] **EPIC-09: Dashboard and Overview** ([#9](https://github.com/steilerDev/cornerstone/issues/9)) -- Project dashboard with budget summary, timeline status, invoice and subsidy pipelines, mini Gantt preview, and customizable card layout
+- [x] **EPIC-13: Construction Diary** ([#446](https://github.com/steilerDev/cornerstone/issues/446)) -- Construction diary with manual entries, automatic system events, photo attachments, and signature capture
 
 ## Planned
 
-- [ ] **EPIC-13: Construction Diary** ([#446](https://github.com/steilerDev/cornerstone/issues/446)) -- Project-level construction diary with automatic system events and manual entries
-
-## Live Tracking
-
-Track progress in real-time on the [GitHub Projects board](https://github.com/users/steilerDev/projects/4).
+No epics are currently planned. Track progress in real-time on the [GitHub Projects board](https://github.com/users/steilerDev/projects/4).

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -397,6 +397,36 @@ async function seedHouseholdItems(request: Parameters<typeof test>[2], baseUrl: 
   return householdItemIds;
 }
 
+async function seedDiaryEntries(request: Parameters<typeof test>[2], baseUrl: string) {
+  const entries = [
+    {
+      type: 'daily_log',
+      date: '2026-03-10',
+      title: 'Foundation inspection passed',
+      body: 'Building inspector confirmed the foundation meets all code requirements. Ready to proceed with framing.',
+      weather: { temperature: 18, conditions: 'sunny' },
+    },
+    {
+      type: 'site_visit',
+      date: '2026-03-08',
+      title: 'Pre-pour walkthrough with contractor',
+      body: 'Met with general contractor to review rebar placement and form alignment before the concrete pour.',
+      weather: { temperature: 14, conditions: 'cloudy' },
+    },
+    {
+      type: 'delivery',
+      date: '2026-03-06',
+      title: 'Lumber delivery for framing',
+      items: '2x4 studs (200), 2x6 joists (80), 4x4 posts (12), plywood sheathing (40 sheets)',
+      weather: { temperature: 10, conditions: 'cloudy' },
+    },
+  ];
+
+  for (const entry of entries) {
+    await request.post(`${baseUrl}${API.diaryEntries}`, { data: entry });
+  }
+}
+
 test.describe('Documentation screenshots', () => {
   const baseUrl = process.env.APP_BASE_URL || 'http://localhost:3000';
 
@@ -410,6 +440,7 @@ test.describe('Documentation screenshots', () => {
     vendorIds = budgetResult.vendorIds;
     await seedTimelineData(request, baseUrl, workItemIds);
     householdItemIds = await seedHouseholdItems(request, baseUrl);
+    await seedDiaryEntries(request, baseUrl);
   });
 
   test.describe('Unauthenticated screenshots', () => {
@@ -717,6 +748,43 @@ test.describe('Documentation screenshots', () => {
       await setTheme(page, theme);
       await page.waitForTimeout(300);
       await saveScreenshot(page, 'household-items-list', theme);
+    }
+  });
+
+  // Diary screenshots
+
+  test('Diary list', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.diary}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: /diary/i })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'diary-list', theme);
+    }
+  });
+
+  test('Diary entry detail', async ({ page }) => {
+    // Navigate to first diary entry
+    await page.goto(`${baseUrl}${ROUTES.diary}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: /diary/i })).toBeVisible();
+
+    // Click first entry to navigate to detail
+    const firstEntry = page.locator('[data-testid="diary-entry-card"]').first();
+    if ((await firstEntry.count()) > 0) {
+      await firstEntry.click();
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+      await page.waitForTimeout(500);
+
+      for (const theme of ['light', 'dark'] as const) {
+        await setTheme(page, theme);
+        await page.waitForTimeout(300);
+        await saveScreenshot(page, 'diary-entry-detail', theme);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- **EPIC-13 Documentation**: Added missing Construction Diary docs (guide pages, roadmap, README, RELEASE_SUMMARY, dashboard, screenshot tests) that were skipped during EPIC-13's close cycle due to context compression
- **Task Tracking**: Added `## Task Tracking` sections to `/develop`, `/epic-close`, `/epic-run`, and `/batch-develop` skills so the orchestrator creates persistent tasks and can recover after context compression

## Test plan
- [ ] `npm run docs:build` succeeds (CI validates)
- [ ] New diary guide pages render correctly in sidebar
- [ ] Roadmap shows EPIC-13 as completed
- [ ] Screenshot test file has valid TypeScript (CI validates)
- [ ] Skill files parse correctly (no broken markdown)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>