### PR TITLE
chore: migrate project board management to native gh project CLI

### DIFF
--- a/.claude/agent-memory/product-owner/MEMORY.md
+++ b/.claude/agent-memory/product-owner/MEMORY.md
@@ -97,9 +97,13 @@ All 12 stories merged. Paperless-ngx links for invoices are EPIC-08; budget repo
 - Board name: "Cornerstone Backlog", project number 4, owner steilerDev
 - Project ID: `PVT_kwHOAGtLQM4BOlve`
 - Status Field ID: `PVTSSF_lAHOAGtLQM4BOlvezg9P0yo`
-- Status Option IDs: Backlog=`7404f88c`, Todo=`dc74a3b0`, In Progress=`296eeabe`, Done=`c558f50d`
+- Status Option IDs: Backlog=`7404f88c`, Todo=`dc74a3b0`, In Progress=`296eeabe`, Done=`c558f50d`, Wont-Do=`90c1bc33`
+- Use native `gh project` commands for board management (not raw GraphQL):
+  - Query items: `gh project item-list 4 --owner steilerDev --format json --query "is:issue #<N>"`
+  - Set status: `gh project item-edit --id <ITEM_ID> --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id <STATUS_ID>`
+  - Add to board: `gh project item-add 4 --owner steilerDev --url <issue-url>`
+- GraphQL still needed for: `addSubIssue`, `addBlockedBy` (no native CLI equivalent yet)
 - GraphQL: `addBlockedBy` uses `blockingIssueId` (NOT `blockedByIssueId`)
-- Epic node IDs: EPIC-05=`I_kwDORK8WYc7pGysn`, EPIC-06=`I_kwDORK8WYc7pGy3a`
 
 ## User Feedback Batch (2026-02-27)
 

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -97,9 +97,34 @@ mutation {
 }'
 ```
 
-#### Board Status Categories
+#### Board Status Management
 
-When creating or moving items on the Projects board, use these status categories:
+Use native `gh project` commands to manage board status. The project is **#4** owned by **steilerDev**.
+
+**Querying items:**
+
+```bash
+# List items with filtering (supports GitHub Projects filter syntax)
+gh project item-list 4 --owner steilerDev --format json --query "is:issue #<N>"
+
+# Get a specific issue's project item ID
+ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<N>" --jq '.items[0].id')
+```
+
+**Setting status:**
+
+```bash
+# Move an item to a status
+gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id <STATUS_OPTION_ID>
+```
+
+**Adding issues to the project:**
+
+```bash
+gh project item-add 4 --owner steilerDev --url https://github.com/steilerDev/cornerstone/issues/<N>
+```
+
+#### Board Status Categories
 
 | Status          | Option ID  | Purpose                                      |
 | --------------- | ---------- | -------------------------------------------- |
@@ -107,6 +132,7 @@ When creating or moving items on the Projects board, use these status categories
 | **Todo**        | `dc74a3b0` | Current sprint stories ready for development |
 | **In Progress** | `296eeabe` | Stories actively being developed             |
 | **Done**        | `c558f50d` | Completed and accepted                       |
+| **Wont-Do**     | `90c1bc33` | Cancelled or deferred indefinitely           |
 
 Project ID: `PVT_kwHOAGtLQM4BOlve`
 Status Field ID: `PVTSSF_lAHOAGtLQM4BOlvezg9P0yo`
@@ -117,7 +143,8 @@ After creating a new user story issue:
 
 1. **Link as sub-issue** of the parent epic via `addSubIssue`
 2. **Create blocked-by links** for each dependency listed in the story's Notes section
-3. **Set board status** — new stories go to `Backlog` (future sprints) or `Todo` (current sprint)
+3. **Add to project board**: `gh project item-add 4 --owner steilerDev --url <issue-url>`
+4. **Set board status** — new stories go to `Backlog` (future sprints) or `Todo` (current sprint)
 
 ## Strict Boundaries — What You Must NOT Do
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -134,13 +134,13 @@ Move the issue(s) to **In Progress** on the Projects board.
 #### Single-item mode
 
 ```bash
-ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "296eeabe" } }) { clientMutationId } }'
+ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<issue-number>" --jq '.items[0].id')
+gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id 296eeabe
 ```
 
 #### Multi-item mode
 
-Run the same GraphQL mutation for **each issue** in the items list.
+Run the same `gh project item-edit` command for **each issue** in the items list.
 
 ### 6. Implement + Test (Multi-Phase)
 
@@ -422,8 +422,8 @@ After merge:
    ```
 2. Move the issue to **Done** on the Projects board:
    ```bash
-   ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-   gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "c558f50d" } }) { clientMutationId } }'
+   ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<issue-number>" --jq '.items[0].id')
+   gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id c558f50d
    ```
 3. **Remove resolved line from source file** (only when input was a `@`-prefixed file path):
    - Remove the line from the source file that produced the resolved item (matched by original text).
@@ -443,7 +443,7 @@ After merge:
    ```
    gh issue close <issue-number>
    ```
-2. Move **each issue** to **Done** on the Projects board (run the GraphQL mutation for each).
+2. Move **each issue** to **Done** on the Projects board (run the `gh project item-edit` command for each).
 3. **Remove resolved lines from source file** (only when input was a `@`-prefixed file path):
    - For each closed issue, remove the line from the source file that produced it (matched by original text — the issue number or description as it appeared in the file).
    - Preserve comments (`#`-prefixed lines) and empty lines that were not part of the resolved items.

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -321,8 +321,8 @@ After user approval:
    ```
 4. Move the epic to **Done** on the Projects board:
    ```bash
-   ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <epic-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
-   gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "c558f50d" } }) { clientMutationId } }'
+   ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<epic-number>" --jq '.items[0].id')
+   gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id c558f50d
    ```
 5. Exit the session and remove the worktree:
    ```

--- a/.claude/skills/epic-start/SKILL.md
+++ b/.claude/skills/epic-start/SKILL.md
@@ -61,10 +61,10 @@ Launch the **product-owner** agent to:
 - Set board statuses: **Backlog** for future-sprint stories, **Todo** for first-sprint stories:
 
   ```bash
-  ITEM_ID=$(gh api graphql -f query='{ repository(owner: "steilerDev", name: "cornerstone") { issue(number: <issue-number>) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
+  ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<issue-number>" --jq '.items[0].id')
 
   # Move to Todo (dc74a3b0) or Backlog (7404f88c)
-  gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwHOAGtLQM4BOlve", itemId: "'"$ITEM_ID"'", fieldId: "PVTSSF_lAHOAGtLQM4BOlvezg9P0yo", value: { singleSelectOptionId: "dc74a3b0" } }) { clientMutationId } }'
+  gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id dc74a3b0
   ```
 
 - Post acceptance criteria (Given/When/Then format) on each story issue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Wiki pages are markdown files in `wiki/`. Sync before reading: `git submodule up
 
 ### Board & Issue Relationships
 
-The GitHub Projects board uses 4 statuses: Backlog, Todo, In Progress, Done. All stories must be linked as sub-issues of their parent epic, and dependency relationships must be maintained. Board IDs, GraphQL mutations, and exact commands are in the skill files.
+The GitHub Projects board uses 5 statuses: Backlog, Todo, In Progress, Done, Wont-Do. All stories must be linked as sub-issues of their parent epic, and dependency relationships must be maintained. Use native `gh project` CLI commands for board status management (`gh project item-list`, `gh project item-edit`, `gh project item-add`). GraphQL mutations are still needed for `addSubIssue` and `addBlockedBy`. Board IDs and exact commands are in the skill files and agent definitions.
 
 ## Agile Workflow
 


### PR DESCRIPTION
## Summary

- Replace raw GraphQL mutations with native `gh project` commands (`item-list`, `item-edit`, `item-add`) across all skill files, agent definitions, and agent memory
- GraphQL retained only for `addSubIssue` and `addBlockedBy` (no native CLI equivalent)
- Add newly discovered `Wont-Do` board status option

## Test plan
- [x] Verified `gh project item-list 4 --owner steilerDev --query "is:issue #9"` returns correct item
- [x] Verified `gh project item-edit` command structure works with project/field/option IDs
- [x] Verified no `updateProjectV2ItemFieldValue` or `projectItems(first:` references remain

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>