### PR TITLE
chore: add i18n conventions to agent definitions and CLAUDE.md

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -149,6 +149,12 @@ Before considering any task complete, verify:
 - Never expose internal error details (stack traces, SQL errors) to the client
 - Log errors with sufficient context for debugging
 - Use consistent error response shapes as defined in the API contract
+- **Always use `ErrorCode` enum values** in error responses (e.g., `WORK_ITEM_NOT_FOUND`, `VALIDATION_ERROR`). The frontend translates these codes into locale-specific user-facing messages via `translateApiError()`. Never send pre-formatted human-readable error messages — send machine-readable error codes with optional `details` for field-level context
+
+## i18n Backend Support
+
+- The `CURRENCY` environment variable controls the currency code used for formatting (default: `EUR`). It is exposed to the frontend via `GET /api/config`. When adding new currency-related features, respect this configuration.
+- All user-facing text lives on the frontend. The backend sends data values and machine-readable error codes — never translated strings.
 
 ## Attribution
 

--- a/.claude/agents/dev-team-lead.md
+++ b/.claude/agents/dev-team-lead.md
@@ -169,6 +169,7 @@ The spec document you return must follow this structure exactly:
 - Reference existing files for patterns rather than describing patterns abstractly
 - Frontend specs must reference the shared component library (Badge, SearchPicker, Modal, Skeleton, EmptyState, FormError) where applicable — include which shared components to use in the step-by-step instructions
 - If the spec introduces a new UI pattern that resembles an existing shared component, use the shared component instead
+- **Frontend specs must include i18n requirements**: list the translation namespace(s), specify the translation keys to add for both `en` and `de` locales, and note which strings need `t()` wrapping. Include `client/src/i18n/locales/en/<namespace>.json` and `client/src/i18n/locales/de/<namespace>.json` in the files-to-modify table
 
 ## Work Decomposition Rules
 
@@ -207,6 +208,7 @@ After the orchestrator routes work to implementation agents, you review all modi
 - Look for security issues (unsanitized input, missing auth checks, SQL injection)
 - Verify shared component usage — if the PR introduces new badge, picker, modal, skeleton, or empty state components instead of using the shared library, flag as CHANGES_REQUIRED
 - Verify CSS token compliance — no hardcoded color, spacing, radius, or font-size values (must use `var(--token-name)` from `tokens.css`)
+- **Verify i18n compliance** — all user-facing strings in frontend code must use `t()` from react-i18next (no hardcoded text in JSX). Translation keys must exist in both `en` and `de` locale files. API error responses must use `ErrorCode` enum values, not hardcoded messages. Date/currency/percent formatting must use the locale-aware formatters from `client/src/lib/formatters.ts`
 
 **Return format:**
 

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -78,21 +78,26 @@ npm run docs:build  # Build to docs/build/
 
 **Deployment:** Automated via the `docs-deploy` job in `.github/workflows/release.yml` — stable releases trigger screenshot capture from the released Docker image, followed by a docs build and GitHub Pages deployment.
 
-### README.md (Lean Pointer)
+### README.md (End-User Focused)
 
-The README.md is intentionally minimal — it exists to give GitHub visitors a quick overview and link them to the docs site. Keep it short:
+The README.md is the project's front door for GitHub visitors. It should communicate the **unique value proposition** for end users — why someone building a home would want Cornerstone — not list technical capabilities.
+
+**Tone**: Speak to a homeowner, not a developer. Focus on what problems Cornerstone solves and what makes it different, not on CRUD operations, user management, or technical feature checklists.
+
+Structure:
 
 1. Protected `> [!NOTE]` block (never touch)
-2. Project title and tagline
-3. Link to full docs site
-4. Brief feature list (bullets only, no sub-details)
-5. Quick start (Docker run command + link to detailed docs)
-6. Compact roadmap checklist (no issue links needed in the list)
-7. Documentation table (docs site, wiki, CLAUDE.md)
-8. Contributing
-9. License
+2. Project title and compelling tagline that speaks to the end user
+3. Value proposition — 2-3 sentences on what makes Cornerstone uniquely useful for homeowners managing a construction project (e.g., unified budget tracking across financing sources, timeline visibility, document integration)
+4. Link to full docs site
+5. Key benefits (user-facing language, not technical features — e.g., "Track every euro across loans, subsidies, and personal funds" not "Multi-source budget management with CRUD API")
+6. Quick start (Docker run command + link to detailed docs)
+7. Compact roadmap checklist (no issue links needed in the list)
+8. Documentation table (docs site, wiki, CLAUDE.md)
+9. Contributing
+10. License
 
-Do NOT add detailed configuration tables, multi-step setup instructions, or long feature descriptions to the README — those live in the docs site.
+Do NOT list technical capabilities (authentication, REST API, database) or generic features (user management, CRUD) in the README. Those belong in the docs site. The README should make a homeowner think "this is exactly what I need" — not impress a developer with the tech stack.
 
 ## Your Responsibilities
 
@@ -100,6 +105,7 @@ Do NOT add detailed configuration tables, multi-step setup instructions, or long
 
 Before writing anything, read and synthesize from multiple sources:
 
+- **Changelog since last docs update** (primary): Review git log since the last docs commit to understand what changed. This is the most important source — it tells you exactly what's new.
 - **GitHub Wiki** (at `wiki/` in the repo): Architecture, API Contract, Schema, Style Guide
 - **GitHub Issues & Projects board**: Completed and planned epics
 - **Source code**: `package.json`, `Dockerfile`, server plugin config, environment variables
@@ -107,6 +113,10 @@ Before writing anything, read and synthesize from multiple sources:
 - **Existing README.md**: Current content to preserve or update
 
 ```bash
+# Find the last docs commit and review changes since then
+LAST_DOCS_COMMIT=$(git log --all --oneline --grep='docs:' -1 --format='%H')
+git log --oneline "$LAST_DOCS_COMMIT"..origin/beta
+
 # Read wiki
 ls wiki/
 # cat wiki/Architecture.md, wiki/API-Contract.md, etc.

--- a/.claude/agents/e2e-test-engineer.md
+++ b/.claude/agents/e2e-test-engineer.md
@@ -155,6 +155,13 @@ Verify:
 - Test API error responses are surfaced correctly in the UI
 - Verify form submissions produce correct results visible in subsequent page loads
 
+### 7. i18n Browser Testing
+
+- Test browser language detection: verify that a German browser locale results in German UI on first visit
+- Test locale switching: verify that changing language in the UI updates all visible text, date formatting (e.g., "Mar 16, 2026" → "16. Mär. 2026"), and currency formatting without page reload
+- Test that API error messages are displayed in the current locale
+- Verify that no untranslated strings (raw translation keys like `common.save`) appear in the UI for both `en` and `de` locales
+
 ---
 
 ## Test Writing Standards

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -108,7 +108,7 @@ Follow this workflow for every task:
 - Follow the coding standards and component patterns defined by the Architect on the GitHub Wiki Architecture page
 - Components are organized by **feature/domain**, not by type (e.g., `features/work-items/` not `components/buttons/`)
 - Form validation happens on the client before submission, with server-side validation as backup
-- All user-facing text is in English
+- **All user-facing strings must use i18n**: Use `t()` from `react-i18next` for every user-visible string — labels, buttons, headings, placeholders, error messages, tooltips, empty states. Never hardcode user-facing text directly in JSX. Organize translations in namespace JSON files under `client/src/i18n/locales/{lang}/`. When creating new UI, add translation keys for both `en` and `de` locales. Use `formatDate`, `formatCurrency`, and `formatPercent` from `client/src/lib/formatters.ts` for locale-aware formatting — these read the locale from i18next automatically. For API error messages, use `translateApiError()` from `client/src/lib/errorTranslation.ts` instead of displaying raw error text.
 - **Every data-fetching view must handle**: loading state, error state, and empty state
 - Use semantic HTML elements for accessibility
 - Keyboard shortcuts for common actions; document them for discoverability

--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -209,6 +209,14 @@ If you discover something that requires a fix, write a bug report. If you need c
 
 ---
 
+### 8. i18n Testing
+
+- Verify that all user-facing strings in new/modified components use `t()` — no hardcoded text in JSX
+- Test that translation keys exist in both `en` and `de` locale files for any new keys added
+- Test that `formatDate`, `formatCurrency`, and `formatPercent` produce correct output for both `en` and `de` locales
+- Test that `translateApiError()` maps all `ErrorCode` enum values to translated messages
+- Test locale switching: verify that changing locale updates all visible text without page reload
+
 ## Quality Assurance Self-Checks
 
 Before considering your work complete, verify:
@@ -222,6 +230,7 @@ Before considering your work complete, verify:
 - [ ] Bug reports have complete reproduction steps
 - [ ] Performance metrics validated against baselines (bundle size, load time, API response time)
 - [ ] Docker deployment tested if applicable
+- [ ] i18n coverage: new translation keys exist in both `en` and `de`, no hardcoded user-facing strings
 - [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`)
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,16 @@ When tests fail during development, a structured diagnostic protocol determines 
 - **Protocol owner**: The `dev-team-lead` runs the diagnostic decision tree during `[MODE: review]` when test failures are present in the review input. See the dev-team-lead agent definition for the full classification table and escalation rules.
 - **Test agents report, not diagnose**: `qa-integration-tester` and `e2e-test-engineer` submit structured failure reports but do not determine whether the fault lies in code or tests — that judgment belongs to the dev-team-lead.
 
+### Internationalization (i18n)
+
+The application supports multiple locales (English and German) via `i18next` and `react-i18next`. All agents must follow these conventions:
+
+- **Frontend**: All user-facing strings must use `t()` from react-i18next — never hardcode text in JSX. Translation files live in `client/src/i18n/locales/{lang}/{namespace}.json`. Every new string needs keys in both `en` and `de`.
+- **Backend**: API error responses must use `ErrorCode` enum values (machine-readable codes), not human-readable messages. The frontend translates error codes into locale-specific messages via `translateApiError()`. The `CURRENCY` env var (default: `EUR`) is exposed via `GET /api/config`.
+- **Formatting**: Use `formatDate`, `formatCurrency`, `formatPercent` from `client/src/lib/formatters.ts` — these read the locale from i18next automatically. Never use raw `toLocaleDateString()` or `Intl.NumberFormat` directly.
+- **Testing**: QA must verify translation keys exist in both locales. E2E tests must verify locale detection and switching behavior.
+- **Specs**: Dev-team-lead specs must include i18n requirements — translation namespace, keys to add, and locale files to modify.
+
 ### Review Metrics
 
 All reviewing agents (product-architect, security-engineer, product-owner, ux-designer) must append a structured metrics block as an HTML comment at the end of every PR review body. This is invisible to GitHub readers but parsed by the orchestrator for performance tracking.


### PR DESCRIPTION
## Summary

- Add i18n conventions across 6 agent definitions: frontend-developer (`t()` usage), backend-developer (`ErrorCode` enum, `CURRENCY` env var), dev-team-lead (i18n review checklist + spec requirements), qa-integration-tester (i18n test coverage), e2e-test-engineer (browser locale testing)
- Update docs-writer: changelog as primary data source, end-user focused README guidance
- Add cross-team Internationalization (i18n) convention to CLAUDE.md

Relates to #916

## Test plan
- [ ] Agent definitions are markdown-only — no code changes, no tests needed
- [ ] Verify CI passes (no production code modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>