### PR TITLE
chore: address refinement items for epic #915

### DIFF
--- a/client/src/i18n/de/common.json
+++ b/client/src/i18n/de/common.json
@@ -6,6 +6,7 @@
     "diary": "Tagebuch",
     "settings": "Einstellungen"
   },
+  "name": "Name",
   "button": {
     "logout": "Abmelden",
     "close": "Schließen",

--- a/client/src/i18n/de/householdItems.json
+++ b/client/src/i18n/de/householdItems.json
@@ -74,7 +74,7 @@
     "clearAllFilters": "Alle Filter löschen"
   },
   "menu": {
-    "actions": "Aktionen für",
+    "actions": "Aktionen für {{name}}",
     "edit": "Bearbeiten",
     "delete": "Löschen"
   },

--- a/client/src/i18n/en/common.json
+++ b/client/src/i18n/en/common.json
@@ -6,6 +6,7 @@
     "diary": "Diary",
     "settings": "Settings"
   },
+  "name": "Name",
   "button": {
     "logout": "Logout",
     "close": "Close",

--- a/client/src/i18n/en/householdItems.json
+++ b/client/src/i18n/en/householdItems.json
@@ -74,7 +74,7 @@
     "clearAllFilters": "Clear All Filters"
   },
   "menu": {
-    "actions": "Actions for",
+    "actions": "Actions for {{name}}",
     "edit": "Edit",
     "delete": "Delete"
   },


### PR DESCRIPTION
## Summary
- Fix missing `common.name` translation key (#943)
- Fix missing `{{name}}` interpolation in household items actions (#944)

Fixes #943
Fixes #944

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>