### PR TITLE
ci: double unit test shards from 3 to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Doubles the number of Jest unit test shards from 3 to 6 for faster CI feedback

## Test plan
- [ ] Verify all 6 test shards run in parallel
- [ ] Verify Quality Gates still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)