### PR TITLE
chore(ci): replace CLA Assistant app with GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,44 @@
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+    branches: [beta]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA Check
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+      || (github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'beta')
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+      - uses: contributor-assistant/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          path-to-signatures: '.github/cla/signatures.json'
+          path-to-document: 'https://github.com/steilerDev/cornerstone/blob/main/CLA.md'
+          branch: 'beta'
+          allowlist: dependabot[bot],github-actions[bot],steilerdev-cornerstone-bot[bot],claude
+          custom-notsigned-prcomment: >-
+            Thank you for your submission! We require all contributors to sign our
+            [Contributor License Agreement](https://github.com/steilerDev/cornerstone/blob/main/CLA.md)
+            before we can accept your contribution.<br/><br/>
+            To sign, please comment on this PR with:<br/>
+            **I have read the CLA Document and I hereby sign the CLA**
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'


### PR DESCRIPTION
## Summary

- Replaces external cla-assistant.io GitHub App with `contributor-assistant/github-action` for faster, self-contained CLA enforcement
- Triggers on `pull_request_target` (beta) and `issue_comment` (for signing)
- Uses bot app token for signature commits; allowlists known bots

## Manual steps after merge

1. Uninstall the CLA Assistant GitHub App from repo settings
2. Optionally remove old `license/cla` required status check from rulesets
3. Optionally add `CLA Check` as a required check on beta

## Test plan

- [ ] Open a test PR from a non-allowlisted account to verify CLA request appears
- [ ] Verify allowlisted accounts bypass CLA check

🤖 Generated with [Claude Code](https://claude.com/claude-code)