### PR TITLE
fix(ci): pin CLA action to SHA (v2 tag removed)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           app-id: ${{ vars.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
-      - uses: contributor-assistant/github-action@v2
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The `contributor-assistant/github-action@v2` major tag was removed upstream, breaking CLA checks. Pin to `v2.6.1` SHA per project dependency policy.