### PR TITLE
fix(ci): use app token for all CLA operations

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,8 @@ jobs:
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use app token for all operations (bypass branch protection for signature storage)
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: '.github/cla/signatures.json'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,4 +504,3 @@ All reviewing agents (product-architect, security-engineer, product-owner, ux-de
 - `verdict` must match the `gh pr review` action (`--approve` → `"approve"`, `--request-changes` → `"request-changes"`, `--comment` → `"comment"`)
 - Count each distinct issue raised, classified by severity
 - If no issues found, all counts are 0
-<!-- CLA test -->


### PR DESCRIPTION
## Summary
- Use the GitHub App token for both `GITHUB_TOKEN` and `PERSONAL_ACCESS_TOKEN` in the CLA workflow
- This allows the bot to bypass branch protection when storing signatures

## Test plan
- [ ] Quality Gates pass
- [ ] After merge, open a new test PR to verify CLA check works

🤖 Generated with [Claude Code](https://claude.com/claude-code)