### PR TITLE
fix(docs): remove screenshot placeholders and add dashboard capture

### DIFF
--- a/docs/src/guides/dashboard/index.md
+++ b/docs/src/guides/dashboard/index.md
@@ -54,6 +54,4 @@ Cards that have no data to show (for example, the Invoice Pipeline when no invoi
 
 The dashboard uses ARIA landmarks and live regions so screen readers announce updates as data loads. All cards and controls are fully keyboard-navigable.
 
-:::info Screenshot needed
-Dashboard screenshots will be captured on the next stable release.
-:::
+![Dashboard overview](/img/screenshots/dashboard-light.png)

--- a/docs/src/guides/diary/index.md
+++ b/docs/src/guides/diary/index.md
@@ -63,6 +63,4 @@ When the Automatic filter is active, additional type-specific chips appear for f
 - [Automatic Events](automatic-events) -- How system events are generated
 - [Signatures](signatures) -- Digital signature capture and immutability
 
-:::info Screenshot needed
-Diary screenshots will be captured on the next stable release.
-:::
+![Diary page](/img/screenshots/diary-list-light.png)

--- a/docs/src/guides/work-items/tags.md
+++ b/docs/src/guides/work-items/tags.md
@@ -25,4 +25,4 @@ From the tag management page you can:
 - **Edit** a tag's name or color
 - **Delete** a tag (this removes it from all work items that use it)
 
-![Tag management page](/img/screenshots/tags-light.png)
+![Tag management page](/img/screenshots/manage-light.png)

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -423,6 +423,19 @@ test.describe('Documentation screenshots', () => {
     });
   });
 
+  test('Dashboard', async ({ page }) => {
+    await page.goto(`${baseUrl}${ROUTES.home}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: /overview/i })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    for (const theme of ['light', 'dark'] as const) {
+      await setTheme(page, theme);
+      await page.waitForTimeout(300);
+      await saveScreenshot(page, 'dashboard', theme);
+    }
+  });
+
   test('Work items list', async ({ page }) => {
     await page.goto(`${baseUrl}${ROUTES.workItems}`);
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- Remove "Screenshot needed" placeholder admonitions from dashboard and diary docs pages, replacing them with actual screenshot image references
- Fix `tags.md` to reference `manage-light.png` (matching the capture spec's actual output filename after EPIC-18 rename)
- Add dashboard screenshot capture test to `capture-docs-screenshots.spec.ts` producing `dashboard-light.png` / `dashboard-dark.png`

## Test plan
- [ ] `grep -r "Screenshot needed" docs/` returns no results
- [ ] All `![...]` image refs in docs match `saveScreenshot()` filenames in the capture spec
- [ ] Screenshot capture spec includes a dashboard test that produces `dashboard-light.png` / `dashboard-dark.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)