### PR TITLE
chore: extract /release skill for standalone beta-to-main promotion

### DIFF
--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -27,12 +27,7 @@ At the start of each `/epic-close` invocation, create tasks to track progress. T
 5. **Refinement PR** — Address refinement items via implementation agents (skip if none)
 6. **E2E validation** — Launch e2e-test-engineer to verify coverage and pass rate
 7. **UAT validation** — Launch product-owner for UAT scenarios
-8. **Branch sync** — Sync main→beta if diverged (skip if no divergence)
-9. **Epic promotion PR + UAT criteria** — Create promotion PR, post detailed UAT criteria
-10. **CI gate** — Wait for all CI checks including full E2E suite
-11. **Promotion approval loop** — Present to user, handle feedback rounds if needed
-12. **Documentation** — Launch docs-writer to update docs site, README, RELEASE_SUMMARY, and .env.example
-13. **Lessons learned + merge** — Update implementation checklist, merge, close epic
+8. **Release** — Delegate to /release for promotion, approval, docs, and merge
 
 **Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped (conditional), mark it `completed` with a note in the description.
 
@@ -152,241 +147,26 @@ Launch the **product-owner** agent to produce UAT scenarios. The e2e-test-engine
 
 The UAT scenarios are included in the promotion PR (step 8) as a manual validation checklist so the user can spot-check during the promotion gate.
 
-### 7. Branch Sync
-
-Check if `main` has commits that `beta` doesn't (e.g., hotfixes cherry-picked to main):
-
-```bash
-git log origin/beta..origin/main --oneline
-```
-
-If so, create a sync PR (`main` → `beta`), wait for CI, merge before proceeding. This ensures the promotion PR merges cleanly.
-
-If no divergence, skip to step 8.
-
-### 8. Epic Promotion
-
-Create a PR from `beta` to `main` using a **merge commit** (not squash). The promotion PR is the single human checkpoint — include a comprehensive summary:
-
-```bash
-gh pr create --base main --head beta --title "release: promote epic #<epic-number> to main" --body "$(cat <<'EOF'
-## Epic Summary
-<Epic title and description>
-
-### Stories Completed
-- #<story-1> — <title>
-- #<story-2> — <title>
-...
-
-### Findings & Fix Loops
-- Total PRs: N | Fix loops: N | Total findings: N (C/H/M/L/I breakdown)
-
-## Change Inventory
-
-### Backend (`server/`, `shared/`)
-<List of changed files grouped by area>
-
-### Frontend (`client/`)
-<List of changed files grouped by area>
-
-### E2E Tests (`e2e/`)
-<List of changed files>
-
-### Docs / Config
-<List of changed files>
-
-## Validation Report
-- E2E test results: <pass/fail summary>
-- Agent review metrics: <summary from epic metrics report>
-- Security findings: <summary of resolved/outstanding>
-
-## Manual Validation Checklist
-<UAT scenarios from step 6, presented as a checklist the user can walk through to spot-check>
-
-- [ ] <Scenario 1: page to visit, action to take, expected result>
-- [ ] <Scenario 2: ...>
-- ...
-
-## Testing
-- **DockerHub beta image**: `docker pull steilerdev/cornerstone:beta`
-- **PR-specific image**: `docker pull steilerdev/cornerstone:pr-<pr-number>`
-EOF
-)"
-```
-
-### 9. Post Detailed UAT Criteria
-
-Post detailed UAT validation criteria as a comment on the promotion PR — step-by-step instructions the user can follow to validate each story:
-
-```bash
-gh pr comment <pr-number> --body "$(cat <<'EOF'
-## Detailed UAT Validation
-
-### Story #<N>: <title>
-<Step-by-step manual validation instructions>
-
-### Story #<N>: <title>
-<Step-by-step manual validation instructions>
-
-...
-EOF
-)"
-```
-
-### 10. CI Gate
-
-Wait for all required CI gates to pass on the promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
-
-If any gate fails, investigate and resolve before proceeding.
-
-### 11. Promotion Approval Loop
-
-Initialize `uatFeedbackRound = 0`. This step loops until the user explicitly approves.
-
-#### 11a. Present for Approval
-
-Present the user with:
-
-1. **Promotion PR link** — with the comprehensive summary, change inventory, and validation checklist
-2. **DockerHub beta image** — `docker pull steilerdev/cornerstone:beta` for manual testing
-3. **E2E + review summary** — confirmation that all automated validation passed
-
-If `uatFeedbackRound > 0`, also include a summary of changes made in the previous feedback round (issues created, PRs merged, what was fixed).
-
-Tell the user:
-
-- **To approve**: say "approved" (or similar confirmation) → proceed to step 12
-- **To provide feedback**: write feedback to `/tmp/notes.md` and say "feedback in notes" → fixes will be applied autonomously
-
-Do NOT merge without explicit user confirmation.
-
-#### 11b. Await Response
-
-Wait for the user's response. Branch:
-
-- If the user **approves** → proceed to step 12 (Documentation & Env Drift Check)
-- If the user says **"feedback in notes"** (or similar) → continue to 11c
-
-#### 11c. Read Feedback
-
-Read `/tmp/notes.md` and parse non-empty, non-comment lines. Print a numbered summary of the feedback items for the user to confirm.
-
-#### 11d. PO Grouping
-
-Launch the **product-owner** agent to:
-
-- Analyze the feedback items
-- Group related items that should be fixed together
-- Create a GitHub Issue for each group, labeled `bug`, linked as a sub-issue of the epic, and added to the Projects board in **Todo** status
-- Return the list of created issue numbers and their groupings
-
-#### 11e. Execute Fixes
-
-For each group of issues from 11d:
-
-1. Create a fresh branch from `origin/beta`: `git checkout -B fix/<issue-number>-<short-description> origin/beta`
-2. Execute `/develop` steps 2–11 (skipping step 1 Rebase and step 4 Branch — branch is already created)
-3. **UAT fix batches MUST go through the standard review pipeline.** Launch at minimum:
-   - `product-architect` review
-   - `product-owner` review (if any items are user-story-adjacent or touch acceptance criteria)
-   - `ux-designer` review (if the fix touches `client/src/`)
-   - `security-engineer` review may be skipped for frontend-only UAT fixes (per Security Review Trigger Rules in `/develop` step 8)
-4. Track success/failure for each group
-
-If any group fails after retry budget exhaustion, report the failure to the user and ask whether to continue with remaining groups or pause.
-
-**Important**: Never bypass reviews for UAT fix batches regardless of urgency. Large unreviewed PRs are the highest-risk code path.
-
-#### 11f. Update Promotion PR
-
-After all fix groups are merged to `beta`:
-
-1. Close the current promotion PR: `gh pr close <pr-number>`
-2. Re-run Branch Sync (step 7) to ensure `main` and `beta` are aligned
-3. Create a new promotion PR with:
-   - Updated change inventory reflecting all fixes
-   - A **Feedback Rounds** section listing each round's issues and PRs
-   - Reference to the superseded PR: `Supersedes #<old-pr-number>`
-4. Post updated detailed UAT criteria (step 9) on the new PR
-
-#### 11g. CI Gate
-
-Wait for all required CI gates to pass on the new promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
-
-If any gate fails, investigate and resolve before proceeding.
-
-#### 11h. Loop
-
-Increment `uatFeedbackRound`. Go to **11a** with the new promotion PR.
-
-### 12. Documentation & Env Drift Check
-
-Launch the **docs-writer** agent to:
-
-- Update the documentation site (`docs/`) with new feature guides
-- Update `README.md` with newly shipped capabilities
-- Write `RELEASE_SUMMARY.md` for the GitHub Release changelog enrichment
-- **Verify `.env.example` freshness**: Scan server source code for all `process.env.*` references (primarily `server/src/plugins/config.ts`), compare against `.env.example` entries, and fix any drift. Rules:
-  - Optional features (OIDC, Paperless, etc.) must remain **commented out** with example placeholder values
-  - Preserve inline `# Optional: ...` documentation comments
-  - Update the Environment Variables table in `CLAUDE.md` if new vars were added
-
-Commit documentation updates to `beta` via a PR:
-
-```bash
-gh pr create --base beta --title "docs: update documentation for epic #<epic-number>" --body "..."
-```
-
-Wait for CI, then squash merge.
-
-**Note:** Documentation runs after user approval (step 11) to ensure docs reflect the final state, including any changes from UAT feedback rounds.
-
-### 13. Lessons Learned Sync
-
-After user approval and before merging, update the implementation checklist with patterns learned during this epic:
-
-1. Read agent memory files for reviewing agents:
-   - `product-owner/MEMORY.md` — recurring acceptance criteria gaps
-   - `ux-designer/MEMORY.md` — recurring token/pattern violations
-   - `product-architect/MEMORY.md` — recurring architecture deviations
-2. Read `.claude/metrics/review-metrics.jsonl` filtered for this epic's PRs
-3. Identify any new recurring patterns from this epic's fix loops that are NOT yet in `.claude/checklists/implementation-checklist.md`
-4. If new patterns found, add them to the checklist and commit:
-
-   ```bash
-   git add .claude/checklists/implementation-checklist.md
-   git commit -m "chore: update implementation checklist with lessons from epic #<epic-number>
-
-   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
-   git push
-   ```
-
-5. If no new patterns, skip the commit
-
-This creates a flywheel: each epic's review findings reduce fix loops in subsequent epics.
-
-### 14. Merge & Post-Merge
-
-After user approval:
-
-1. Merge with a merge commit (preserves individual commits for semantic-release):
-   ```
-   gh pr merge --merge <pr-url>
-   ```
-2. Verify the merge-back job succeeded (automated by `release.yml` — creates a PR from `main` into `beta`). If it fails, manually resolve:
-   ```bash
-   git checkout beta && git pull && git merge origin/main && git push
-   ```
-3. Close the epic issue:
-   ```
-   gh issue close <epic-number>
-   ```
-4. Move the epic to **Done** on the Projects board:
-   ```bash
-   ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<epic-number>" --jq '.items[0].id')
-   gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id c558f50d
-   ```
-5. Exit the session and remove the worktree:
-   ```
-   /exit
-   ```
+### 7. Delegate to `/release`
+
+Invoke `/release <epic-number>` to handle the remaining steps: branch sync, promotion PR, CI gate, user approval loop, documentation, lessons learned, and merge.
+
+Before invoking, prepare the **epic context** that `/release` will use to enrich the promotion PR body:
+
+1. **Stories completed** — list of all sub-issues with titles
+2. **Metrics report** — from step 2a
+3. **UAT scenarios** — from step 6, formatted as a manual validation checklist
+4. **Refinement summary** — from step 4 (if applicable)
+5. **E2E validation summary** — from step 5
+6. **Security findings summary** — resolved/outstanding from story PR reviews
+
+The `/release` skill uses this context to build the promotion PR body (see `/release` step 2b, epic-enriched variant). It also handles:
+
+- Branch sync (main->beta if diverged)
+- Creating the promotion PR with the epic-enriched body
+- Posting detailed UAT validation criteria per story
+- CI gate polling (Quality Gates + E2E Gates)
+- User approval loop with autonomous feedback fix rounds
+- Documentation & env drift check (after user approval)
+- Lessons learned sync
+- Merge to main, epic closure, and post-merge verification

--- a/.claude/skills/epic-run/SKILL.md
+++ b/.claude/skills/epic-run/SKILL.md
@@ -64,10 +64,7 @@ Use tasks to track progress across the entire epic lifecycle. Tasks survive cont
 - **Refinement PR** — Address refinement items (skip if none)
 - **E2E validation** — Confirm E2E coverage and pass rate
 - **UAT validation** — Product-owner UAT scenarios
-- **Branch sync + promotion** — Sync main→beta if needed, create promotion PR + UAT criteria
-- **CI gate + promotion approval** — Wait for CI, present to user, handle feedback rounds
-- **Documentation + lessons learned** — Update docs/README/RELEASE_SUMMARY, sync implementation checklist
-- **Merge & post-merge** — Merge to main, close epic
+- **Release** — Delegate to /release for promotion, approval, docs, and merge
 
 **Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped, mark it `completed` with a note.
 
@@ -196,9 +193,9 @@ gh issue comment <epic-number> --body "**[orchestrator]** Progress: <N>/<total> 
 
 If `failedStories` is non-empty, ask the user: proceed with completed stories only, retry failures, or abort. Note excluded stories for inclusion in the promotion PR body.
 
-### 3.1 Execute `/epic-close` steps 2–13
+### 3.1 Execute `/epic-close` steps 2–7
 
-Execute `/epic-close` steps 2 through 13 in order. Step 1 (Rebase) is skipped — the worktree is already on the latest beta from the story loop.
+Execute `/epic-close` steps 2 through 7 in order. Step 1 (Rebase) is skipped — the worktree is already on the latest beta from the story loop.
 
 - **Step 2** (Verify All Stories Merged)
 - **Step 2a** (Generate Epic Metrics Report)
@@ -207,12 +204,6 @@ Execute `/epic-close` steps 2 through 13 in order. Step 1 (Rebase) is skipped �
 - **Step 4** (Refinement PR)
 - **Step 5** (E2E Validation)
 - **Step 6** (UAT Validation)
-- **Step 7** (Branch Sync)
-- **Step 8** (Epic Promotion)
-- **Step 9** (Post Detailed UAT Criteria)
-- **Step 10** (CI Gate)
-- **Step 11** (Promotion Approval Loop) — **mandatory human gate** with autonomous feedback fix loop
-- **Step 12** (Documentation & Env Drift Check) — runs after user approval
-- **Step 13** (Merge & Post-Merge)
+- **Step 7** (Delegate to `/release`) — handles branch sync, promotion PR, CI gate, **mandatory human gate** with autonomous feedback fix loop, documentation, lessons learned, merge & post-merge
 
 If any step in `/epic-close` references "failed stories" or "excluded stories", use the `failedStories` list from Phase 2.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: release
+description: 'Promote beta to main: branch sync, promotion PR, CI gate, user approval loop, documentation, merge. Works standalone or as part of /epic-close.'
+---
+
+# Release — Promote Beta to Main
+
+You are the orchestrator promoting the `beta` branch to `main`. This skill handles branch sync, the promotion PR, CI gates, user approval (with optional feedback fix loops), documentation, and merge. Follow these steps in order. **Do NOT skip steps.** The orchestrator delegates all work — never write production code, tests, or architectural artifacts directly.
+
+**When to use:** Promoting `beta` to `main` — either standalone (no prior epic) or delegated from `/epic-close`.
+**When NOT to use:** Planning a new epic (use `/epic-start`). Implementing stories (use `/develop`). Running the full epic closing workflow (use `/epic-close`, which delegates to this skill).
+
+## Input
+
+`$ARGUMENTS` may contain:
+
+- **Nothing** — standalone release of whatever is on `beta` beyond `main`
+- **An epic issue number** — passed from `/epic-close` to enrich the promotion PR with epic context
+
+When invoked from `/epic-close`, the calling skill provides **epic context** (stories completed, metrics report, UAT scenarios, refinement summary). Use this context to enrich the promotion PR body. When invoked standalone, generate the PR body from the git log diff between `main` and `beta`.
+
+## Task Tracking
+
+At the start of each `/release` invocation, create tasks to track progress. These tasks survive context compression and let you recover your place if context is lost.
+
+**Create these tasks upfront** (using `TaskCreate`):
+
+1. **Branch sync** — Sync main->beta if diverged (skip if no divergence)
+2. **Promotion PR** — Create promotion PR (beta->main) with change summary
+3. **CI gate** — Wait for Quality Gates + E2E Gates
+4. **Promotion approval** — Present to user, handle feedback rounds if needed
+5. **Documentation** — Launch docs-writer to update docs site, README, RELEASE_SUMMARY, and .env.example
+6. **Lessons learned** — Update implementation checklist with patterns from this release
+7. **Merge & post-merge** — Merge to main, verify merge-back, close epic (if applicable)
+
+**Progress rule:** Before starting each step, mark its task `in_progress`. After completing, mark it `completed`. If a step is skipped (conditional), mark it `completed` with a note in the description.
+
+**Recovery rule:** If you lose track of progress (e.g., after context compression), run `TaskList` to see which tasks are completed and resume from the first pending task.
+
+**Dynamic task rule:** When a UAT fix round starts, create a new task for each round (e.g., "UAT Fix Round 1") so iterations are tracked.
+
+## Steps
+
+### 1. Branch Sync
+
+Check if `main` has commits that `beta` doesn't (e.g., hotfixes cherry-picked to main):
+
+```bash
+git fetch origin main beta
+git log origin/beta..origin/main --oneline
+```
+
+If so, create a sync PR (`main` -> `beta`), wait for CI, merge before proceeding. This ensures the promotion PR merges cleanly.
+
+If no divergence, skip to step 2.
+
+### 2. Promotion PR
+
+Create a PR from `beta` to `main` using a **merge commit** (not squash). The promotion PR is the single human checkpoint.
+
+#### 2a. Build Change Summary
+
+Generate the change summary from the git log:
+
+```bash
+# Commits on beta not yet on main
+git log origin/main..origin/beta --oneline --no-merges
+```
+
+Group changes by type (features, fixes, chores, docs, tests) and by area (backend, frontend, E2E, docs/config).
+
+#### 2b. Create the PR
+
+**If epic context is provided** (invoked from `/epic-close`):
+
+Use the epic-enriched body provided by the calling skill — it includes stories completed, metrics report, validation report, and UAT scenarios as a manual validation checklist.
+
+```bash
+gh pr create --base main --head beta --title "release: promote epic #<epic-number> to main" --body "$(cat <<'EOF'
+<epic-enriched body from /epic-close — see epic-close step 8 for format>
+EOF
+)"
+```
+
+**If standalone** (no epic context):
+
+```bash
+gh pr create --base main --head beta --title "release: promote beta to main" --body "$(cat <<'EOF'
+## Release Summary
+
+<One-line summary of what this release includes>
+
+## Changes
+
+### Features
+- <list from git log, grouped>
+
+### Fixes
+- <list from git log, grouped>
+
+### Chores / Refactoring
+- <list from git log, grouped>
+
+## Change Inventory
+
+### Backend (`server/`, `shared/`)
+<List of changed files grouped by area>
+
+### Frontend (`client/`)
+<List of changed files grouped by area>
+
+### E2E Tests (`e2e/`)
+<List of changed files>
+
+### Docs / Config
+<List of changed files>
+
+## Manual Validation Checklist
+<Key user-facing changes presented as a checklist the user can walk through to spot-check>
+
+- [ ] <Scenario 1: page to visit, action to take, expected result>
+- [ ] <Scenario 2: ...>
+- ...
+
+## Testing
+- **DockerHub beta image**: `docker pull steilerdev/cornerstone:beta`
+- **PR-specific image**: `docker pull steilerdev/cornerstone:pr-<pr-number>`
+EOF
+)"
+```
+
+#### 2c. Post Detailed Validation Criteria
+
+Post detailed validation criteria as a comment on the promotion PR — step-by-step instructions the user can follow to validate key changes:
+
+```bash
+gh pr comment <pr-number> --body "$(cat <<'EOF'
+## Detailed Validation
+
+<Step-by-step manual validation instructions for each major change>
+EOF
+)"
+```
+
+**If epic context is provided**, use the UAT scenarios from `/epic-close` step 6.
+**If standalone**, derive validation steps from the feature/fix commits in the diff.
+
+### 3. CI Gate
+
+Wait for all required CI gates to pass on the promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
+
+If any gate fails, investigate and resolve before proceeding.
+
+### 4. Promotion Approval Loop
+
+Initialize `feedbackRound = 0`. This step loops until the user explicitly approves.
+
+#### 4a. Present for Approval
+
+Present the user with:
+
+1. **Promotion PR link** — with the comprehensive summary, change inventory, and validation checklist
+2. **DockerHub beta image** — `docker pull steilerdev/cornerstone:beta` for manual testing
+3. **E2E + review summary** — confirmation that all automated validation passed
+
+If `feedbackRound > 0`, also include a summary of changes made in the previous feedback round (issues created, PRs merged, what was fixed).
+
+Tell the user:
+
+- **To approve**: say "approved" (or similar confirmation) -> proceed to step 5
+- **To provide feedback**: write feedback to `/tmp/notes.md` and say "feedback in notes" -> fixes will be applied autonomously
+
+Do NOT merge without explicit user confirmation.
+
+#### 4b. Await Response
+
+Wait for the user's response. Branch:
+
+- If the user **approves** -> proceed to step 5 (Documentation & Env Drift Check)
+- If the user says **"feedback in notes"** (or similar) -> continue to 4c
+
+#### 4c. Read Feedback
+
+Read `/tmp/notes.md` and parse non-empty, non-comment lines. Print a numbered summary of the feedback items for the user to confirm.
+
+#### 4d. PO Grouping
+
+Launch the **product-owner** agent to:
+
+- Analyze the feedback items
+- Group related items that should be fixed together
+- Create a GitHub Issue for each group, labeled `bug`, and added to the Projects board in **Todo** status
+- If an epic is in context, link issues as sub-issues of the epic
+- Return the list of created issue numbers and their groupings
+
+#### 4e. Execute Fixes
+
+For each group of issues from 4d:
+
+1. Create a fresh branch from `origin/beta`: `git checkout -B fix/<issue-number>-<short-description> origin/beta`
+2. Execute `/develop` steps 2-11 (skipping step 1 Rebase and step 4 Branch — branch is already created)
+3. **Fix batches MUST go through the standard review pipeline.** Launch at minimum:
+   - `product-architect` review
+   - `product-owner` review (if any items are user-story-adjacent or touch acceptance criteria)
+   - `ux-designer` review (if the fix touches `client/src/`)
+   - `security-engineer` review may be skipped for frontend-only fixes (per Security Review Trigger Rules in `/develop` step 8)
+4. Track success/failure for each group
+
+If any group fails after retry budget exhaustion, report the failure to the user and ask whether to continue with remaining groups or pause.
+
+**Important**: Never bypass reviews for fix batches regardless of urgency. Large unreviewed PRs are the highest-risk code path.
+
+#### 4f. Update Promotion PR
+
+After all fix groups are merged to `beta`:
+
+1. Close the current promotion PR: `gh pr close <pr-number>`
+2. Re-run Branch Sync (step 1) to ensure `main` and `beta` are aligned
+3. Create a new promotion PR with:
+   - Updated change inventory reflecting all fixes
+   - A **Feedback Rounds** section listing each round's issues and PRs
+   - Reference to the superseded PR: `Supersedes #<old-pr-number>`
+4. Post updated detailed validation criteria (step 2c) on the new PR
+
+#### 4g. CI Gate
+
+Wait for all required CI gates to pass on the new promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
+
+If any gate fails, investigate and resolve before proceeding.
+
+#### 4h. Loop
+
+Increment `feedbackRound`. Go to **4a** with the new promotion PR.
+
+### 5. Documentation & Env Drift Check
+
+Launch the **docs-writer** agent to:
+
+- Update the documentation site (`docs/`) with new feature guides
+- Update `README.md` with newly shipped capabilities
+- Write `RELEASE_SUMMARY.md` for the GitHub Release changelog enrichment
+- **Verify `.env.example` freshness**: Scan server source code for all `process.env.*` references (primarily `server/src/plugins/config.ts`), compare against `.env.example` entries, and fix any drift. Rules:
+  - Optional features (OIDC, Paperless, etc.) must remain **commented out** with example placeholder values
+  - Preserve inline `# Optional: ...` documentation comments
+  - Update the Environment Variables table in `CLAUDE.md` if new vars were added
+
+Commit documentation updates to `beta` via a PR:
+
+```bash
+gh pr create --base beta --title "docs: update documentation for release" --body "..."
+```
+
+Wait for CI, then squash merge.
+
+**Note:** Documentation runs after user approval (step 4) to ensure docs reflect the final state, including any changes from feedback rounds.
+
+### 6. Lessons Learned Sync
+
+Update the implementation checklist with patterns learned:
+
+1. Read agent memory files for reviewing agents:
+   - `product-owner/MEMORY.md` — recurring acceptance criteria gaps
+   - `ux-designer/MEMORY.md` — recurring token/pattern violations
+   - `product-architect/MEMORY.md` — recurring architecture deviations
+2. Read `.claude/metrics/review-metrics.jsonl` filtered for recent PRs
+3. Identify any new recurring patterns that are NOT yet in `.claude/checklists/implementation-checklist.md`
+4. If new patterns found, add them to the checklist and commit:
+
+   ```bash
+   git add .claude/checklists/implementation-checklist.md
+   git commit -m "chore: update implementation checklist with lessons learned
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+   git push
+   ```
+
+5. If no new patterns, skip the commit
+
+### 7. Merge & Post-Merge
+
+After user approval:
+
+1. Merge with a merge commit (preserves individual commits for semantic-release):
+   ```
+   gh pr merge --merge <pr-url>
+   ```
+2. Verify the merge-back job succeeded (automated by `release.yml` — creates a PR from `main` into `beta`). If it fails, manually resolve:
+   ```bash
+   git checkout beta && git pull && git merge origin/main && git push
+   ```
+3. **If epic context is provided**, close the epic issue and move to Done on the Projects board:
+   ```bash
+   gh issue close <epic-number>
+   ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<epic-number>" --jq '.items[0].id')
+   gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id c558f50d
+   ```
+4. Exit the session and remove the worktree:
+   ```
+   /exit
+   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,8 @@ The orchestrator uses four skills to drive work. Each skill contains the full op
 | ------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | `/epic-start` | Planning: PO creates stories, architect designs schema/API/ADRs            | Epic description or issue number                                |
 | `/develop`    | Full dev cycle for one or more stories/bug fixes, bundled into a single PR | Issue number, description, semicolon-separated list, or `@file` |
-| `/epic-close` | Refinement, E2E validation, UAT, docs, promotion to `main`                 | Epic issue number                                               |
+| `/epic-close` | Refinement, E2E validation, UAT, then delegates to `/release`              | Epic issue number                                               |
+| `/release`    | Promote `beta` to `main`: sync, PR, CI, approval loop, docs, merge        | Optional epic issue number (standalone if omitted)              |
 | `/epic-run`   | Autonomous end-to-end epic: plan, develop all stories, close               | Epic description or issue number                                |
 
 ## Acceptance & Validation
@@ -208,7 +209,7 @@ Production files: any file under `server/`, `client/`, or `shared/`.
 
 **NEVER `cd` to the base project directory to modify files.** All file edits, git operations, and commands must be performed from within the git worktree assigned at session start. The base project directory may have other sessions' uncommitted changes. This applies to subagents too — all file reads, writes, and exploration must use the worktree path.
 
-See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story, or batched for multiple small items) → `/epic-close` (once per epic after all stories merged). Alternatively, `/epic-run` chains all three phases in a single session (only pauses for promotion approval).
+See the skill files (`.claude/skills/`) for the full operational checklists. The typical lifecycle is: `/epic-start` (once per epic) → `/develop` (once per story, or batched for multiple small items) → `/epic-close` (once per epic after all stories merged). Alternatively, `/epic-run` chains all three phases in a single session (only pauses for promotion approval). Use `/release` standalone to promote `beta` to `main` without a prior epic definition.
 
 Note: Dependabot auto-merge (`.github/workflows/dependabot-auto-merge.yml`) targets `beta` — it handles automated dependency updates, not agent work.
 
@@ -226,7 +227,7 @@ Cornerstone uses a two-tier release model:
 - **Feature PR -> `beta`**: Squash merge (clean history)
 - **`beta` -> `main`** (epic promotion): Merge commit (preserves individual commits so semantic-release can analyze them)
 
-- **Hotfixes:** Cherry-pick any `main` hotfix back to `beta` immediately. See `/epic-close` for merge-back, release summary, and DockerHub sync details.
+- **Hotfixes:** Cherry-pick any `main` hotfix back to `beta` immediately. See `/release` for merge-back, release summary, and DockerHub sync details.
 
 ### Branch Protection
 


### PR DESCRIPTION
## Summary
- Extracts release/promotion steps from `/epic-close` into a new standalone `/release` skill
- `/release` can be invoked directly to promote `beta` to `main` without any prior epic definition
- `/epic-close` now delegates to `/release` after its epic-specific steps (refinement, E2E, UAT)
- `/epic-run` updated to reference the new delegation pattern
- `CLAUDE.md` updated with `/release` in the skills table and lifecycle docs

## Test plan
- [ ] Verify `/release` skill is recognized by Claude Code
- [ ] Invoke `/release` standalone — should create promotion PR from git log diff
- [ ] Invoke `/epic-close` — should delegate to `/release` with epic context after step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)