### PR TITLE
fix(ci): add GITHUB_TOKEN to CLA check workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
-          # Only use app token (PAT) — omit GITHUB_TOKEN so the action uses PAT for all operations
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           remote-organization-name: steilerDev


### PR DESCRIPTION
## Summary
- The `contributor-assistant/github-action` requires `GITHUB_TOKEN` for Octokit client initialization
- Without it, the action crashes: `Error: Parameter token or opts.auth is required`
- `PERSONAL_ACCESS_TOKEN` (app token) is still used for CLA signature commits to the remote repo

## Test plan
- [ ] CLA check passes on this PR itself (self-validating fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)