### PR TITLE
fix(ci): use github.token for CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           remote-organization-name: steilerDev


### PR DESCRIPTION
## Summary
- `secrets.GITHUB_TOKEN` appears to resolve to empty in `pull_request_target` context (GitHub-side behavioral change)
- Switch to `github.token` which is the canonical reference for the workflow token
- This fixes the CLA check crash: `Error: Parameter token or opts.auth is required`

## Test plan
- [ ] Merge this PR (with branch protection disabled), then verify CLA check passes on test PR #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)