### PR TITLE
fix(ci): set INPUT_GITHUB_TOKEN for CLA action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_GITHUB_TOKEN: ${{ github.token }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           remote-organization-name: steilerDev


### PR DESCRIPTION
Sets INPUT_GITHUB_TOKEN explicitly since the runner stopped auto-populating it. The contributor-assistant action reads GITHUB_TOKEN via core.getInput() which resolves to INPUT_GITHUB_TOKEN.