### PR TITLE
fix(e2e): use exact locator for Open menu button in design review screenshots

### DIFF
--- a/e2e/tests/design-review/capture-all-views.spec.ts
+++ b/e2e/tests/design-review/capture-all-views.spec.ts
@@ -75,7 +75,7 @@ async function waitForPage(page: Page) {
 async function openSidebarIfNeeded(page: Page) {
   const viewport = getViewportName();
   if (viewport === 'tablet' || viewport === 'mobile') {
-    const menuButton = page.getByRole('button', { name: /menu/i });
+    const menuButton = page.getByRole('button', { name: 'Open menu' });
     if (await menuButton.isVisible()) {
       await menuButton.click();
       await page.waitForTimeout(300);


### PR DESCRIPTION
## Summary
- Fixed strict mode violation in the design review screenshot workflow where `getByRole('button', { name: /menu/i })` matched both "Open menu" and "Close menu" buttons on tablet/mobile viewports
- Changed to exact `'Open menu'` name match

## Test plan
- [ ] Re-run the Design Review Screenshots workflow and verify the sidebar navigation test passes on tablet and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)