### PR TITLE
fix(household-items): add missing actions menu dropdown and delete flow

### DIFF
--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
@@ -161,10 +161,62 @@
   box-shadow: var(--shadow-focus-subtle);
 }
 
+.menuDropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: var(--spacing-1);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  min-width: 120px;
+  z-index: 10;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2-5) var(--spacing-4);
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: var(--transition-normal);
+}
+
+.menuItem:hover {
+  background-color: var(--color-bg-tertiary);
+}
+
+.menuItem:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+
+.menuItem:first-child {
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.menuItem:last-child {
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+.menuItemDanger {
+  color: var(--color-danger);
+}
+
+.menuItemDanger:hover {
+  background-color: var(--color-danger-bg-strong);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .customFilterSelect,
   .noBudgetToggle,
-  .menuButton {
+  .menuButton,
+  .menuItem {
     transition: none;
   }
 }

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -43,6 +43,9 @@ export function HouseholdItemsPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string>('');
 
+  // Actions menu state
+  const [activeMenuId, setActiveMenuId] = useState<string | null>(null);
+
   // Load vendors, categories, and areas on mount
   useEffect(() => {
     const loadData = async () => {
@@ -276,11 +279,32 @@ export function HouseholdItemsPage() {
       <button
         type="button"
         className={styles.menuButton}
+        onClick={() => setActiveMenuId(activeMenuId === item.id ? null : item.id)}
         aria-label={t('menu.actions', { name: item.name })}
         data-testid={`hi-menu-button-${item.id}`}
       >
         ⋮
       </button>
+      {activeMenuId === item.id && (
+        <div className={styles.menuDropdown}>
+          <button
+            type="button"
+            className={styles.menuItem}
+            onClick={() => { navigate(`/project/household-items/${item.id}`); setActiveMenuId(null); }}
+            data-testid={`hi-view-${item.id}`}
+          >
+            {t('menu.edit')}
+          </button>
+          <button
+            type="button"
+            className={`${styles.menuItem} ${styles.menuItemDanger}`}
+            onClick={() => { openDeleteConfirm(item); setActiveMenuId(null); }}
+            data-testid={`hi-delete-${item.id}`}
+          >
+            {t('menu.delete')}
+          </button>
+        </div>
+      )}
     </div>
   );
 


### PR DESCRIPTION
## Summary

- Fixes the broken renderActions function in HouseholdItemsPage
- Adds onClick handler, dropdown menu with Edit and Delete options
- Adds missing CSS classes (menuDropdown, menuItem, menuItemDanger)
- Follows the same actions menu pattern as VendorsPage/MilestonesPage

Fixes #1115

## Test plan
- [ ] Quality Gates pass

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>