### PR TITLE
refactor(datatable): fix recurring review findings across all migrated pages

### DIFF
--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
@@ -128,8 +128,8 @@
 }
 
 .itemLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -171,7 +171,7 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   min-width: 120px;
-  z-index: 10;
+  z-index: var(--z-dropdown);
 }
 
 .menuItem {

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { HouseholdItemSummary, HouseholdItemListQuery } from '@cornerstone/shared';
 import type { ColumnDef, TableState } from '../../components/DataTable/DataTable.js';
@@ -186,9 +186,9 @@ export function HouseholdItemsPage() {
         sortKey: 'name',
         defaultVisible: true,
         render: (item) => (
-          <a href={`/project/household-items/${item.id}`} className={styles.itemLink}>
+          <Link to={`/project/household-items/${item.id}`} className={styles.itemLink}>
             {item.name}
-          </a>
+          </Link>
         ),
       },
       {
@@ -270,6 +270,26 @@ export function HouseholdItemsPage() {
     ],
     [t, categories, formatCurrency, formatDate, hiStatusVariants],
   );
+
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
 
   // Render actions menu
   const renderActions = (item: HouseholdItemSummary) => (

--- a/client/src/pages/InvoicesPage/InvoicesPage.module.css
+++ b/client/src/pages/InvoicesPage/InvoicesPage.module.css
@@ -106,8 +106,8 @@
 }
 
 .invoiceLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -126,8 +126,8 @@
 }
 
 .vendorLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -258,7 +258,7 @@
  * RESPONSIVE — Tablet (768px – 1024px)
  * ============================================================ */
 
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (min-width: 768px) and (max-width: 1023px) {
   .container {
     padding: var(--spacing-6);
   }

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, type FormEvent } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Invoice, CreateInvoiceRequest, InvoiceStatus } from '@cornerstone/shared';
 import type { ColumnDef, TableState } from '../../components/DataTable/DataTable.js';
@@ -244,16 +244,16 @@ export function InvoicesPage() {
         defaultVisible: true,
         render: (inv) =>
           inv.invoiceNumber ? (
-            <a href={`/budget/invoices/${inv.id}`} className={styles.invoiceLink}>
+            <Link to={`/budget/invoices/${inv.id}`} className={styles.invoiceLink}>
               {inv.invoiceNumber}
-            </a>
+            </Link>
           ) : (
-            <a
-              href={`/budget/invoices/${inv.id}`}
+            <Link
+              to={`/budget/invoices/${inv.id}`}
               className={`${styles.invoiceLink} ${styles.invoiceLinkNoNumber}`}
             >
               —
-            </a>
+            </Link>
           ),
       },
       {
@@ -263,9 +263,9 @@ export function InvoicesPage() {
         sortKey: 'vendor_name',
         defaultVisible: true,
         render: (inv) => (
-          <a href={`/budget/vendors/${inv.vendorId}`} className={styles.vendorLink}>
+          <Link to={`/budget/vendors/${inv.vendorId}`} className={styles.vendorLink}>
             {inv.vendorName}
-          </a>
+          </Link>
         ),
       },
       {

--- a/client/src/pages/MilestonesPage/MilestonesPage.module.css
+++ b/client/src/pages/MilestonesPage/MilestonesPage.module.css
@@ -28,7 +28,7 @@
   border: none;
   color: var(--color-text-muted);
   font-size: var(--font-size-xl);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-sm);
@@ -55,7 +55,7 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   min-width: 120px;
-  z-index: 10;
+  z-index: var(--z-dropdown);
 }
 
 .menuItem {
@@ -113,7 +113,7 @@
   }
 }
 
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (min-width: 768px) and (max-width: 1023px) {
   .container {
     padding: var(--spacing-6);
   }

--- a/client/src/pages/MilestonesPage/MilestonesPage.tsx
+++ b/client/src/pages/MilestonesPage/MilestonesPage.tsx
@@ -260,6 +260,26 @@ export function MilestonesPage() {
     [t, formatDate, milestoneStatusVariants],
   );
 
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
+
   // Render actions menu
   const renderActions = (milestone: MilestoneSummary) => (
     <div className={styles.actionsMenu}>

--- a/client/src/pages/UserManagementPage/UserManagementPage.module.css
+++ b/client/src/pages/UserManagementPage/UserManagementPage.module.css
@@ -141,7 +141,7 @@
   }
 }
 
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (min-width: 768px) and (max-width: 1023px) {
   .container {
     padding: var(--spacing-6);
   }

--- a/client/src/pages/UserManagementPage/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage/UserManagementPage.tsx
@@ -383,6 +383,26 @@ export function UserManagementPage() {
     [t, formatDate, roleVariants, statusVariants],
   );
 
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
+
   // Render actions menu
   const renderActions = (user: UserResponse) => {
     const isActive = !user.deactivatedAt;

--- a/client/src/pages/VendorsPage/VendorsPage.module.css
+++ b/client/src/pages/VendorsPage/VendorsPage.module.css
@@ -48,7 +48,7 @@
   border: none;
   color: var(--color-text-muted);
   font-size: var(--font-size-xl);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-sm);
@@ -75,7 +75,7 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   min-width: 120px;
-  z-index: 10;
+  z-index: var(--z-dropdown);
 }
 
 .menuItem {
@@ -131,8 +131,8 @@
 }
 
 .vendorLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -147,8 +147,8 @@
 }
 
 .contactLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -272,7 +272,7 @@
  * RESPONSIVE — Tablet (768px – 1024px)
  * ============================================================ */
 
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (min-width: 768px) and (max-width: 1023px) {
   .container {
     padding: var(--spacing-6);
   }

--- a/client/src/pages/VendorsPage/VendorsPage.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, type FormEvent } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Vendor, CreateVendorRequest, VendorListQuery } from '@cornerstone/shared';
 import type { ColumnDef, TableState } from '../../components/DataTable/DataTable.js';
@@ -207,9 +207,9 @@ export function VendorsPage() {
         sortKey: 'name',
         defaultVisible: true,
         render: (v) => (
-          <a href={`/budget/vendors/${v.id}`} className={styles.vendorLink}>
+          <Link to={`/budget/vendors/${v.id}`} className={styles.vendorLink}>
             {v.name}
-          </a>
+          </Link>
         ),
       },
       {
@@ -280,6 +280,26 @@ export function VendorsPage() {
     ],
     [t, formatDate],
   );
+
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
 
   // Render actions menu
   const renderActions = (vendor: Vendor) => (

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
@@ -128,8 +128,8 @@
 }
 
 .itemLink:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
 }
 
@@ -171,7 +171,7 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   min-width: 120px;
-  z-index: 10;
+  z-index: var(--z-dropdown);
 }
 
 .menuItem {

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { WorkItemSummary, WorkItemListQuery } from '@cornerstone/shared';
 import type { ColumnDef, TableState } from '../../components/DataTable/DataTable.js';
@@ -193,9 +193,9 @@ export function WorkItemsPage() {
         sortKey: 'title',
         defaultVisible: true,
         render: (item) => (
-          <a href={`/project/work-items/${item.id}`} className={styles.itemLink}>
+          <Link to={`/project/work-items/${item.id}`} className={styles.itemLink}>
             {item.title}
-          </a>
+          </Link>
         ),
       },
       {
@@ -247,6 +247,26 @@ export function WorkItemsPage() {
     ],
     [t, formatDate, wiStatusVariants],
   );
+
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
 
   // Render actions menu
   const renderActions = (item: WorkItemSummary) => (


### PR DESCRIPTION
## Summary

Addresses all recurring review findings from the 6 DataTable migration PRs:

- React Router Links: Replace `<a href>` with `<Link to>` for internal navigation
- z-index tokens: Replace hardcoded z-index: 10 with var(--z-dropdown)
- Focus-visible: Replace outline with box-shadow: var(--shadow-focus)
- Font-weight tokens: Replace font-weight: 700 with var(--font-weight-bold)
- Tablet breakpoint: Fix max-width: 1024px to 1023px
- Click-outside dismiss: Add mousedown + Escape key handlers to action menus

Fixes #1120

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>