### PR TITLE
fix(datatable): fix filter click propagation, clear filters, and column settings positioning

### DIFF
--- a/client/src/components/DataTable/DataTableColumnSettings.tsx
+++ b/client/src/components/DataTable/DataTableColumnSettings.tsx
@@ -27,19 +27,6 @@ export function DataTableColumnSettings<T>({
   const [isOpen, setIsOpen] = useState(false);
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
 
-  // Position popover when opened
-  useEffect(() => {
-    if (isOpen && triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setPopoverStyle({
-        position: 'fixed',
-        top: `${rect.bottom + 4}px`,
-        right: `${window.innerWidth - rect.right}px`,
-        maxWidth: '250px',
-        zIndex: 1000,
-      });
-    }
-  }, [isOpen]);
 
   // Close on outside click
   useEffect(() => {
@@ -77,7 +64,19 @@ export function DataTableColumnSettings<T>({
         ref={triggerRef}
         type="button"
         className={styles.columnSettingsButton}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (!isOpen && triggerRef.current) {
+            const rect = triggerRef.current.getBoundingClientRect();
+            setPopoverStyle({
+              position: 'fixed',
+              top: `${rect.bottom + 4}px`,
+              right: `${window.innerWidth - rect.right}px`,
+              maxWidth: '250px',
+              zIndex: 1000,
+            });
+          }
+          setIsOpen(!isOpen);
+        }}
         aria-label={t('dataTable.columnSettings.ariaLabel')}
         aria-expanded={isOpen}
         aria-haspopup="dialog"

--- a/client/src/components/DataTable/DataTableFilterPopover.tsx
+++ b/client/src/components/DataTable/DataTableFilterPopover.tsx
@@ -111,6 +111,8 @@ export function DataTableFilterPopover<T>({
       style={popoverStyle}
       role="dialog"
       aria-label={t('dataTable.filter.filterByColumn', { column: column.label })}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
     >
       {renderFilterComponent()}
     </div>

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -113,12 +113,16 @@ export function HouseholdItemsPage() {
     params.set('page', String(newState.page));
     params.set('pageSize', String(newState.pageSize));
 
+    // Delete all known filter param keys first
+    const knownFilterKeys = ['category', 'status', 'vendorId', 'areaId', 'noBudget'];
+    for (const key of knownFilterKeys) {
+      params.delete(key);
+    }
+
     // Sync filters
     for (const [paramKey, filter] of newState.filters.entries()) {
       if (filter.value) {
         params.set(paramKey, filter.value);
-      } else {
-        params.delete(paramKey);
       }
     }
 

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -145,12 +145,16 @@ export function InvoicesPage() {
     params.set('page', String(newState.page));
     params.set('pageSize', String(newState.pageSize));
 
+    // Delete all known filter param keys first
+    const knownFilterKeys = ['status'];
+    for (const key of knownFilterKeys) {
+      params.delete(key);
+    }
+
     // Sync filters
     for (const [paramKey, filter] of newState.filters.entries()) {
       if (filter.value) {
         params.set(paramKey, filter.value);
-      } else {
-        params.delete(paramKey);
       }
     }
 

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -125,12 +125,16 @@ export function WorkItemsPage() {
     params.set('page', String(newState.page));
     params.set('pageSize', String(newState.pageSize));
 
+    // Delete all known filter param keys first
+    const knownFilterKeys = ['status', 'assignedUserId', 'assignedVendorId', 'areaId', 'noBudget'];
+    for (const key of knownFilterKeys) {
+      params.delete(key);
+    }
+
     // Sync filters
     for (const [paramKey, filter] of newState.filters.entries()) {
       if (filter.value) {
         params.set(paramKey, filter.value);
-      } else {
-        params.delete(paramKey);
       }
     }
 


### PR DESCRIPTION
## Summary

- **Bug 1**: Add stopPropagation on filter popover to prevent sort triggering
- **Bug 2**: Delete stale filter URL params in handleStateChange on server-side pages
- **Bug 3**: Compute column settings position synchronously on click, not in useEffect

Fixes #1122

## Test plan
- [ ] Quality Gates pass

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>