### PR TITLE
feat(datatable): enhance filters with SVG icon, enum shortcuts, range sliders, column-level entity filters

### DIFF
--- a/client/src/components/DataTable/DataTable.module.css
+++ b/client/src/components/DataTable/DataTable.module.css
@@ -276,6 +276,12 @@
   box-shadow: var(--shadow-focus);
 }
 
+.tableHeaderFilterButton svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}
+
 .tableHeaderFilterButtonActive {
   background-color: var(--color-primary-bg);
   color: var(--color-primary);

--- a/client/src/components/DataTable/DataTableHeader.tsx
+++ b/client/src/components/DataTable/DataTableHeader.tsx
@@ -79,7 +79,16 @@ export function DataTableHeader<T>({
                   aria-label={t('dataTable.filter.filterByColumn', { column: col.label })}
                   title={t('dataTable.filter.filterByColumn', { column: col.label })}
                 >
-                  🔽
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path d="M0.75 1.5h10.5L7.5 6v4.5L4.5 9V6L0.75 1.5z" />
+                  </svg>
                 </button>
               )}
             </div>

--- a/client/src/components/DataTable/filters/EnumFilter.tsx
+++ b/client/src/components/DataTable/filters/EnumFilter.tsx
@@ -41,8 +41,24 @@ export function EnumFilter({ value, onChange, options }: EnumFilterProps) {
     onChange('');
   }, [onChange]);
 
+  const handleSelectAll = useCallback(() => {
+    setSelected(new Set(options.map((opt) => opt.value)));
+  }, [options]);
+
+  const handleSelectNone = useCallback(() => {
+    setSelected(new Set());
+  }, []);
+
   return (
     <div className={styles.filterContent}>
+      <div className={styles.filterQuickActions}>
+        <button type="button" className={styles.filterQuickActionButton} onClick={handleSelectAll}>
+          {t('dataTable.filter.selectAll')}
+        </button>
+        <button type="button" className={styles.filterQuickActionButton} onClick={handleSelectNone}>
+          {t('dataTable.filter.selectNone')}
+        </button>
+      </div>
       <div className={styles.filterCheckboxGroup}>
         {options.map((option) => (
           <div

--- a/client/src/components/DataTable/filters/Filter.module.css
+++ b/client/src/components/DataTable/filters/Filter.module.css
@@ -170,6 +170,36 @@
   cursor: pointer;
 }
 
+.filterQuickActions {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1);
+}
+
+.filterQuickActionButton {
+  flex: 1;
+  padding: var(--spacing-1) var(--spacing-2);
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-normal),
+    color var(--transition-normal);
+}
+
+.filterQuickActionButton:hover {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.filterQuickActionButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
 .filterSegmentedControl {
   display: flex;
   gap: 0;
@@ -211,6 +241,19 @@
   box-shadow: inset var(--shadow-focus-subtle);
 }
 
+.filterRangeSlider {
+  width: 100%;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+  height: 4px;
+  margin: var(--spacing-1) 0;
+}
+
+.filterRangeSlider:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .filterInput,
   .filterDateInput,
@@ -218,7 +261,8 @@
   .filterButton,
   .filterButtonSecondary,
   .filterCheckboxItem,
-  .filterSegmentedButton {
+  .filterSegmentedButton,
+  .filterQuickActionButton {
     transition: none;
   }
 }

--- a/client/src/components/DataTable/filters/NumberFilter.tsx
+++ b/client/src/components/DataTable/filters/NumberFilter.tsx
@@ -50,6 +50,15 @@ export function NumberFilter({ value, onChange }: NumberFilterProps) {
           autoFocus
         />
       </div>
+      <input
+        type="range"
+        value={localMin || '0'}
+        onChange={(e) => setLocalMin(e.target.value)}
+        className={styles.filterRangeSlider}
+        min="0"
+        max="999999"
+        aria-label={t('dataTable.filter.min')}
+      />
       <div className={styles.filterRangeRow}>
         <label className={styles.filterRangeLabel}>{t('dataTable.filter.max')}</label>
         <input
@@ -60,6 +69,15 @@ export function NumberFilter({ value, onChange }: NumberFilterProps) {
           className={styles.filterRangeInput}
         />
       </div>
+      <input
+        type="range"
+        value={localMax || '999999'}
+        onChange={(e) => setLocalMax(e.target.value)}
+        className={styles.filterRangeSlider}
+        min="0"
+        max="999999"
+        aria-label={t('dataTable.filter.max')}
+      />
       <div className={styles.filterActions}>
         <button type="button" className={styles.filterButton} onClick={handleApply}>
           {t('dataTable.filter.applyFilter')}

--- a/client/src/i18n/de/common.json
+++ b/client/src/i18n/de/common.json
@@ -128,7 +128,9 @@
       "filterByColumn": "Nach {{column}} filtern",
       "textPlaceholder": "Suchen...",
       "searchPlaceholder": "Suchen...",
-      "booleanAriaLabel": "Boolesche Filteroption"
+      "booleanAriaLabel": "Boolesche Filteroption",
+      "selectAll": "Alle auswählen",
+      "selectNone": "Keine auswählen"
     },
     "sort": {
       "ascending": "Aufsteigend sortieren",

--- a/client/src/i18n/de/workItems.json
+++ b/client/src/i18n/de/workItems.json
@@ -48,6 +48,8 @@
       "title": "Titel",
       "status": "Status",
       "assignedTo": "Zugewiesen an",
+      "vendor": "Auftragnehmer",
+      "area": "Bereich",
       "startDate": "Startdatum",
       "endDate": "Enddatum",
       "tags": "Tags",

--- a/client/src/i18n/en/common.json
+++ b/client/src/i18n/en/common.json
@@ -128,7 +128,9 @@
       "filterByColumn": "Filter by {{column}}",
       "textPlaceholder": "Search...",
       "searchPlaceholder": "Search...",
-      "booleanAriaLabel": "Boolean filter"
+      "booleanAriaLabel": "Boolean filter",
+      "selectAll": "Select All",
+      "selectNone": "Select None"
     },
     "sort": {
       "ascending": "Sort ascending",

--- a/client/src/i18n/en/workItems.json
+++ b/client/src/i18n/en/workItems.json
@@ -48,6 +48,8 @@
       "title": "Title",
       "status": "Status",
       "assignedTo": "Assigned To",
+      "vendor": "Vendor",
+      "area": "Area",
       "startDate": "Start Date",
       "endDate": "End Date",
       "tags": "Tags",

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -232,6 +232,10 @@ export function HouseholdItemsPage() {
         label: t('table.headers.area'),
         sortable: false,
         defaultVisible: true,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'areaId',
+        enumOptions: areas.map((a) => ({ value: a.id, label: a.name })),
         render: (item) => item.area?.name || '—',
       },
       {
@@ -239,6 +243,10 @@ export function HouseholdItemsPage() {
         label: t('table.headers.vendor'),
         sortable: false,
         defaultVisible: true,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'vendorId',
+        enumOptions: vendors.map((v) => ({ value: v.id, label: v.name })),
         render: (item) => item.vendor?.name || '—',
       },
       {
@@ -272,7 +280,7 @@ export function HouseholdItemsPage() {
         render: (item) => item.budgetLineCount,
       },
     ],
-    [t, categories, formatCurrency, formatDate, hiStatusVariants],
+    [t, categories, formatCurrency, formatDate, hiStatusVariants, vendors, areas],
   );
 
   // Close action menu on outside click and Escape key
@@ -336,47 +344,9 @@ export function HouseholdItemsPage() {
     </div>
   );
 
-  // Custom filters: vendor, area, noBudget
+  // Custom filters: noBudget (vendor and area now use column-level enum filters)
   const customFilters = (
     <div className={styles.customFiltersRow}>
-      <div className={styles.customFilter}>
-        <label htmlFor="vendor-filter" className={styles.customFilterLabel}>
-          {t('filters.vendor')}
-        </label>
-        <select
-          id="vendor-filter"
-          value={tableState.filters.get('vendorId')?.value || ''}
-          onChange={(e) => setFilter('vendorId', e.target.value || null)}
-          className={styles.customFilterSelect}
-        >
-          <option value="">{t('filters.allVendors')}</option>
-          {vendors.map((v) => (
-            <option key={v.id} value={v.id}>
-              {v.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className={styles.customFilter}>
-        <label htmlFor="area-filter" className={styles.customFilterLabel}>
-          {t('filters.area')}
-        </label>
-        <select
-          id="area-filter"
-          value={tableState.filters.get('areaId')?.value || ''}
-          onChange={(e) => setFilter('areaId', e.target.value || null)}
-          className={styles.customFilterSelect}
-        >
-          <option value="">{t('filters.allAreas')}</option>
-          {areas.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
       <button
         type="button"
         className={`${styles.noBudgetToggle} ${

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -146,7 +146,7 @@ export function InvoicesPage() {
     params.set('pageSize', String(newState.pageSize));
 
     // Delete all known filter param keys first
-    const knownFilterKeys = ['status'];
+    const knownFilterKeys = ['status', 'vendorId'];
     for (const key of knownFilterKeys) {
       params.delete(key);
     }
@@ -266,6 +266,10 @@ export function InvoicesPage() {
         sortable: true,
         sortKey: 'vendor_name',
         defaultVisible: true,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'vendorId',
+        enumOptions: vendors.map((v) => ({ value: v.id, label: v.name })),
         render: (inv) => (
           <Link to={`/budget/vendors/${inv.vendorId}`} className={styles.vendorLink}>
             {inv.vendorName}
@@ -337,7 +341,7 @@ export function InvoicesPage() {
         render: (inv) => formatCurrency(calculateRemaining(inv)),
       },
     ],
-    [t, formatDate, formatCurrency, invoiceStatusVariants],
+    [t, formatDate, formatCurrency, invoiceStatusVariants, vendors],
   );
 
   // Summary cards as headerContent

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -229,7 +229,33 @@ export function WorkItemsPage() {
         label: t('list.table.assignedTo'),
         sortable: false,
         defaultVisible: true,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'assignedUserId',
+        enumOptions: users.map((u) => ({ value: u.id, label: u.displayName })),
         render: (item) => item.assignedUser?.displayName || '—',
+      },
+      {
+        key: 'vendor',
+        label: t('list.table.vendor'),
+        sortable: false,
+        defaultVisible: false,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'assignedVendorId',
+        enumOptions: vendors.map((v) => ({ value: v.id, label: v.name })),
+        render: (item) => item.assignedVendor?.name || '—',
+      },
+      {
+        key: 'area',
+        label: t('list.table.area'),
+        sortable: false,
+        defaultVisible: false,
+        filterable: true,
+        filterType: 'enum',
+        filterParamKey: 'areaId',
+        enumOptions: areas.map((a) => ({ value: a.id, label: a.name })),
+        render: (item) => item.area?.name || '—',
       },
       {
         key: 'startDate',
@@ -255,7 +281,7 @@ export function WorkItemsPage() {
         render: (item) => item.budgetLineCount,
       },
     ],
-    [t, formatDate, wiStatusVariants],
+    [t, formatDate, wiStatusVariants, users, vendors, areas],
   );
 
   // Close action menu on outside click and Escape key
@@ -319,66 +345,9 @@ export function WorkItemsPage() {
     </div>
   );
 
-  // Custom filters: assignedUserId, assignedVendorId, areaId, noBudget
+  // Custom filters: noBudget (vendor, assignedTo, and area now use column-level enum filters)
   const customFilters = (
     <div className={styles.customFiltersRow}>
-      <div className={styles.customFilter}>
-        <label htmlFor="user-filter" className={styles.customFilterLabel}>
-          {t('list.filters.assignedTo')}
-        </label>
-        <select
-          id="user-filter"
-          value={tableState.filters.get('assignedUserId')?.value || ''}
-          onChange={(e) => setFilter('assignedUserId', e.target.value || null)}
-          className={styles.customFilterSelect}
-        >
-          <option value="">{t('list.filters.allUsers')}</option>
-          {users.map((u) => (
-            <option key={u.id} value={u.id}>
-              {u.displayName}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className={styles.customFilter}>
-        <label htmlFor="vendor-filter" className={styles.customFilterLabel}>
-          {t('list.filters.assignedVendor')}
-        </label>
-        <select
-          id="vendor-filter"
-          value={tableState.filters.get('assignedVendorId')?.value || ''}
-          onChange={(e) => setFilter('assignedVendorId', e.target.value || null)}
-          className={styles.customFilterSelect}
-        >
-          <option value="">{t('list.filters.allVendors')}</option>
-          {vendors.map((v) => (
-            <option key={v.id} value={v.id}>
-              {v.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className={styles.customFilter}>
-        <label htmlFor="area-filter" className={styles.customFilterLabel}>
-          {t('list.filters.area')}
-        </label>
-        <select
-          id="area-filter"
-          value={tableState.filters.get('areaId')?.value || ''}
-          onChange={(e) => setFilter('areaId', e.target.value || null)}
-          className={styles.customFilterSelect}
-        >
-          <option value="">{t('list.filters.allAreas')}</option>
-          {areas.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
       <button
         type="button"
         className={`${styles.noBudgetToggle} ${


### PR DESCRIPTION
## Summary

- SVG funnel icon replaces emoji filter icon in column headers
- EnumFilter: "Select All" / "Select None" shortcut buttons above checkboxes
- NumberFilter: range sliders synced with min/max input fields
- Convert vendor/area/assignee from customFilters selects to column-level enum filters (WorkItems, HouseholdItems, Invoices)
- German translations for all new i18n keys

Fixes #1124

## Test plan
- [ ] Quality Gates pass

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude translator (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>