### PR TITLE
fix(datatable): remove redundant headings, add invoice action menu, fix actions header styling

### DIFF
--- a/client/src/components/DataTable/DataTable.tsx
+++ b/client/src/components/DataTable/DataTable.tsx
@@ -297,6 +297,7 @@ export function DataTable<T>({
             tableState={tableState}
             onSort={handleSort}
             onFilter={handleFilter}
+            hasActions={!!renderActions}
           />
           <tbody>
             {items.map((item) => (

--- a/client/src/components/DataTable/DataTableHeader.tsx
+++ b/client/src/components/DataTable/DataTableHeader.tsx
@@ -10,6 +10,7 @@ export interface DataTableHeaderProps<T> {
   tableState: TableState;
   onSort: (columnKey: string, columnSortKey?: string) => void;
   onFilter: (paramKey: string, value: string | null) => void;
+  hasActions?: boolean;
 }
 
 /**
@@ -21,6 +22,7 @@ export function DataTableHeader<T>({
   tableState,
   onSort,
   onFilter,
+  hasActions,
 }: DataTableHeaderProps<T>) {
   const { t } = useTranslation('common');
   const [activeFilterColumn, setActiveFilterColumn] = useState<string | null>(null);
@@ -110,6 +112,7 @@ export function DataTableHeader<T>({
               )}
           </th>
         ))}
+        {hasActions && <th className={styles.tableHeader}>{t('common.actions')}</th>}
       </tr>
     </thead>
   );

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -421,7 +421,11 @@
       "save": "Save Changes",
       "saving": "Saving...",
       "cancel": "Cancel",
-      "view": "View"
+      "view": "View",
+      "delete": "Delete"
+    },
+    "actions": {
+      "menuAriaLabel": "Actions for invoice {{number}}"
     },
     "statusLabels": {
       "pending": "Pending",

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
@@ -18,13 +18,6 @@
   margin: 0;
 }
 
-.sectionTitle {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 var(--spacing-4) 0;
-}
-
 .errorBanner {
   background-color: var(--color-danger-bg);
   border: 1px solid var(--color-danger-border);

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -422,8 +422,6 @@ export function HouseholdItemsPage() {
 
       <ProjectSubNav />
 
-      <h2 className={styles.sectionTitle}>{t('table.sectionTitle')}</h2>
-
       <DataTable<HouseholdItemSummary>
         pageKey="householdItems"
         columns={columns}

--- a/client/src/pages/InvoicesPage/InvoicesPage.module.css
+++ b/client/src/pages/InvoicesPage/InvoicesPage.module.css
@@ -209,6 +209,78 @@
   line-height: 1.5;
 }
 
+/* ---- Actions menu ---- */
+
+.actionsMenu {
+  position: relative;
+  display: inline-block;
+}
+
+.menuButton {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  cursor: pointer;
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-sm);
+  transition: var(--transition-button);
+}
+
+.menuButton:hover {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+.menuButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus-subtle);
+}
+
+.menuDropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: var(--spacing-1);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  min-width: 120px;
+  z-index: var(--z-dropdown);
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2-5) var(--spacing-4);
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: var(--transition-normal);
+}
+
+.menuItem:hover {
+  background-color: var(--color-bg-tertiary);
+}
+
+.menuItem:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+
+.menuItem:first-child {
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.menuItem:last-child {
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
 /* ============================================================
  * RESPONSIVE — Mobile (max 767px)
  * ============================================================ */

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -85,6 +85,29 @@ export function InvoicesPage() {
   // Form ref for submit button in modal
   const formRef = useRef<HTMLFormElement>(null);
 
+  // Actions menu state
+  const [activeMenuId, setActiveMenuId] = useState<string | null>(null);
+
+  // Close action menu on outside click and Escape key
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.actionsMenu}`)) {
+        setActiveMenuId(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveMenuId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeMenuId]);
+
   // Load invoices when table state changes
   useEffect(() => {
     void loadInvoices();
@@ -347,6 +370,40 @@ export function InvoicesPage() {
     [t, formatDate, formatCurrency, invoiceStatusVariants, vendors],
   );
 
+  // Render actions menu
+  const renderActions = (invoice: Invoice) => (
+    <div className={styles.actionsMenu}>
+      <button
+        type="button"
+        className={styles.menuButton}
+        onClick={() =>
+          setActiveMenuId(activeMenuId === invoice.id ? null : invoice.id)
+        }
+        aria-label={t('invoices.actions.menuAriaLabel', {
+          number: invoice.invoiceNumber || 'Invoice',
+        })}
+        data-testid={`invoice-menu-button-${invoice.id}`}
+      >
+        ⋮
+      </button>
+      {activeMenuId === invoice.id && (
+        <div className={styles.menuDropdown}>
+          <button
+            type="button"
+            className={styles.menuItem}
+            onClick={() => {
+              navigate(`/budget/invoices/${invoice.id}`);
+              setActiveMenuId(null);
+            }}
+            data-testid={`invoice-view-${invoice.id}`}
+          >
+            {t('invoices.buttons.view')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
   // Summary cards as headerContent
   const headerContent = (
     <div className={styles.summaryGrid}>
@@ -401,6 +458,7 @@ export function InvoicesPage() {
         error={error}
         getRowKey={(inv) => inv.id}
         onRowClick={(inv) => navigate(`/budget/invoices/${inv.id}`)}
+        renderActions={renderActions}
         tableState={tableState}
         onStateChange={handleStateChange}
         headerContent={headerContent}

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.module.css
@@ -18,13 +18,6 @@
   margin: 0;
 }
 
-.sectionTitle {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 var(--spacing-4) 0;
-}
-
 .errorBanner {
   background-color: var(--color-danger-bg);
   border: 1px solid var(--color-danger-border);

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -427,8 +427,6 @@ export function WorkItemsPage() {
 
       <ProjectSubNav />
 
-      <h2 className={styles.sectionTitle}>{t('list.sectionTitle')}</h2>
-
       <DataTable<WorkItemSummary>
         pageKey="workItems"
         columns={columns}


### PR DESCRIPTION
## Summary

- Remove redundant h2 section headings below tab bar on WorkItemsPage and HouseholdItemsPage
- Add standard ⋮ action menu to InvoicesPage with View action and click-outside dismiss
- Fix actions column header to use same th styling as other column headers

Fixes #1132

## Test plan
- [ ] Quality Gates pass

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>