### PR TITLE
fix(datatable): fix filter auto-apply regression — onChange now propagates to onApply

### DIFF
--- a/client/src/components/DataTable/DataTableFilterPopover.test.tsx
+++ b/client/src/components/DataTable/DataTableFilterPopover.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { ColumnDef } from './DataTable.js';
 import { DataTableFilterPopover } from './DataTableFilterPopover.js';
 
@@ -165,6 +165,42 @@ describe('DataTableFilterPopover', () => {
         />,
       );
       expect(screen.getByRole('textbox')).toHaveValue('hello');
+    });
+  });
+
+  describe('auto-apply', () => {
+    it('calls onApply immediately when string filter input changes', () => {
+      const mockOnApply = jest.fn();
+      render(
+        <DataTableFilterPopover
+          column={makeColumn({ filterType: 'string' })}
+          value=""
+          onApply={mockOnApply}
+          triggerRect={makeTriggerRect()}
+        />,
+      );
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test' } });
+      expect(mockOnApply).toHaveBeenCalledWith('test');
+    });
+
+    it('calls onApply immediately when enum filter checkbox is toggled', () => {
+      const mockOnApply = jest.fn();
+      render(
+        <DataTableFilterPopover
+          column={makeColumn({
+            filterType: 'enum',
+            enumOptions: [
+              { value: 'a', label: 'Option A' },
+              { value: 'b', label: 'Option B' },
+            ],
+          })}
+          value=""
+          onApply={mockOnApply}
+          triggerRect={makeTriggerRect()}
+        />,
+      );
+      fireEvent.click(screen.getByText('Option A'));
+      expect(mockOnApply).toHaveBeenCalledWith('a');
     });
   });
 

--- a/client/src/components/DataTable/DataTableFilterPopover.tsx
+++ b/client/src/components/DataTable/DataTableFilterPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ColumnDef, FilterType } from './DataTable.js';
 import { StringFilter } from './filters/StringFilter.js';
@@ -28,7 +28,10 @@ export function DataTableFilterPopover<T>({
 }: DataTableFilterPopoverProps<T>) {
   const { t } = useTranslation('common');
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [localValue, setLocalValue] = useState(value);
+
+  // Auto-apply: pass onApply directly to filter components as onChange
+  // No local state needed — filters propagate immediately
+  const handleChange = onApply;
 
   // Position the popover using getBoundingClientRect
   const popoverStyle = {
@@ -39,29 +42,6 @@ export function DataTableFilterPopover<T>({
     zIndex: 1000,
   };
 
-  // Close on outside click or Escape
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
-        // Popover closes without needing to apply — filters auto-apply
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        // Popover closes without needing to apply — filters auto-apply
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, []);
-
   const renderFilterComponent = () => {
     const filterType = column.filterType as FilterType;
 
@@ -69,35 +49,35 @@ export function DataTableFilterPopover<T>({
       case 'string':
         return (
           <StringFilter
-            value={localValue}
-            onChange={setLocalValue}
+            value={value}
+            onChange={handleChange}
             placeholder={t('dataTable.filter.textPlaceholder')}
           />
         );
       case 'number':
-        return <NumberFilter value={localValue} onChange={setLocalValue} />;
+        return <NumberFilter value={value} onChange={handleChange} />;
       case 'date':
-        return <DateFilter value={localValue} onChange={setLocalValue} />;
+        return <DateFilter value={value} onChange={handleChange} />;
       case 'enum':
         return (
           column.enumOptions && (
             <EnumFilter
-              value={localValue}
-              onChange={setLocalValue}
+              value={value}
+              onChange={handleChange}
               options={column.enumOptions}
               hierarchy={column.enumHierarchy}
             />
           )
         );
       case 'boolean':
-        return <BooleanFilter value={localValue} onChange={setLocalValue} />;
+        return <BooleanFilter value={value} onChange={handleChange} />;
       case 'entity':
         return (
           column.entitySearchFn &&
           column.entityRenderItem && (
             <EntityFilter
-              value={localValue}
-              onChange={setLocalValue}
+              value={value}
+              onChange={handleChange}
               searchFn={column.entitySearchFn}
               renderItem={column.entityRenderItem}
               placeholder={column.entityPlaceholder}

--- a/client/src/components/DataTable/DataTableHeader.tsx
+++ b/client/src/components/DataTable/DataTableHeader.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ColumnDef, TableState } from './DataTable.js';
 import { DataTableFilterPopover } from './DataTableFilterPopover.js';
@@ -27,6 +27,26 @@ export function DataTableHeader<T>({
   const { t } = useTranslation('common');
   const [activeFilterColumn, setActiveFilterColumn] = useState<string | null>(null);
   const filterTriggerRefs = useRef<Record<string, HTMLButtonElement>>({});
+
+  // Close filter popover on outside click or Escape
+  useEffect(() => {
+    if (!activeFilterColumn) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(`.${styles.filterPopover}`) && !target.closest(`.${styles.tableHeaderFilterButton}`)) {
+        setActiveFilterColumn(null);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActiveFilterColumn(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeFilterColumn]);
 
   const visibleCols = columns.filter((col) => visibleColumns.has(col.key));
 
@@ -105,7 +125,6 @@ export function DataTableHeader<T>({
                   value={tableState.filters.get(col.filterParamKey)?.value || ''}
                   onApply={(value) => {
                     onFilter(col.filterParamKey || '', value || null);
-                    setActiveFilterColumn(null);
                   }}
                   triggerRect={filterTriggerRefs.current[col.key].getBoundingClientRect()}
                 />


### PR DESCRIPTION
## Summary

Fixes a regression from PR #1129 where filters stopped working entirely.

**Root cause**: `DataTableFilterPopover` passed `setLocalValue` (local state setter) as `onChange` to filter components. Filter values got stuck in local state and never reached `onApply` → `onFilter` → `onStateChange`.

**Fix**:
- Remove `localValue` intermediary — pass `onApply` directly as `onChange` to filter components
- Add outside-click + Escape close handler to `DataTableHeader` (popover stays open during multi-select, closes on click away)
- Add auto-apply test coverage verifying `onApply` is called when filters change

## Test plan
- [ ] Quality Gates pass
- [ ] Auto-apply tests verify onApply called on string input change and enum checkbox toggle

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>