### PR TITLE
chore: add branch and beta tag cleanup policies

### DIFF
--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -484,8 +484,9 @@ After merge:
 3. **Remove resolved line from source file** (only when input was a `@`-prefixed file path):
    - Remove the line from the source file that produced the resolved item (matched by original text).
    - Preserve comments (`#`-prefixed lines) and empty lines.
-4. Clean up the branch:
+4. Clean up the branch (remote and local):
    ```
+   git push origin --delete <branch-name> 2>/dev/null || true
    git checkout beta && git pull && git branch -d <branch-name>
    ```
 5. Exit the session and remove the worktree:
@@ -504,8 +505,9 @@ After merge:
    - For each closed issue, remove the line from the source file that produced it (matched by original text — the issue number or description as it appeared in the file).
    - Preserve comments (`#`-prefixed lines) and empty lines that were not part of the resolved items.
    - If all non-comment, non-empty lines have been removed, leave the file with only its comments (or empty).
-4. Clean up the branch:
+4. Clean up the branch (remote and local):
    ```
+   git push origin --delete <branch-name> 2>/dev/null || true
    git checkout beta && git pull && git branch -d <branch-name>
    ```
 5. Exit the session and remove the worktree:

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -288,13 +288,23 @@ After user approval:
    ```bash
    git checkout beta && git pull && git merge origin/main && git push
    ```
-3. **If epic context is provided**, close the epic issue and move to Done on the Projects board:
+3. **Clean up old beta tags**: After the stable release is published by semantic-release, delete all beta pre-release tags and releases from previous release cycles. Only beta tags belonging to the **current** (post-merge) release cycle should remain:
+   ```bash
+   # Get the latest stable version from main
+   LATEST_STABLE=$(gh release list --repo steilerDev/cornerstone --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName')
+   echo "Latest stable: $LATEST_STABLE"
+   # Delete all beta releases and tags (the new cycle hasn't started yet, so all betas are old)
+   gh release list --repo steilerDev/cornerstone --json tagName,isPrerelease -q '.[] | select(.isPrerelease) | .tagName' | while read tag; do
+     gh release delete "$tag" --repo steilerDev/cornerstone --yes --cleanup-tag 2>/dev/null || true
+   done
+   ```
+4. **If epic context is provided**, close the epic issue and move to Done on the Projects board:
    ```bash
    gh issue close <epic-number>
    ITEM_ID=$(gh project item-list 4 --owner steilerDev --format json --limit 1 --query "is:issue #<epic-number>" --jq '.items[0].id')
    gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAGtLQM4BOlve --field-id PVTSSF_lAHOAGtLQM4BOlvezg9P0yo --single-select-option-id c558f50d
    ```
-4. Exit the session and remove the worktree:
+5. Exit the session and remove the worktree:
    ```
    /exit
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,7 @@ Production files: any file under `server/`, `client/`, or `shared/`.
 
 - **Branch naming**: `<type>/<issue-number>-<short-description>` (e.g., `feat/42-work-item-crud`, `fix/55-budget-calc`)
 - **Never push a `worktree-<anything>` branch.** Worktree branches carry auto-generated names. Before pushing, always rename the branch to match the naming convention above: `git branch -m <type>/<issue-number>-<short-description>`. If the scope of work is not yet clear, determine it before pushing — do not publish placeholder branch names.
+- **Branch cleanup after merge**: GitHub auto-deletes head branches when PRs are merged. As a safety net, agents must also delete the remote branch explicitly after merging (`git push origin --delete <branch-name>`) and clean up the local branch (`git branch -d <branch-name>`). Never leave stale branches behind.
 
 ### Session Isolation (Worktrees)
 
@@ -228,6 +229,7 @@ Cornerstone uses a two-tier release model:
 - **`beta` -> `main`** (epic promotion): Merge commit (preserves individual commits so semantic-release can analyze them)
 
 - **Hotfixes:** Cherry-pick any `main` hotfix back to `beta` immediately. See `/release` for merge-back, release summary, and DockerHub sync details.
+- **Beta tag cleanup:** When a stable release is published (beta promoted to main), all previous beta pre-release tags and releases must be deleted. Only beta tags from the current (active) release cycle should exist at any time. This cleanup is automated in the `/release` skill (step 7.3).
 
 ### Branch Protection
 


### PR DESCRIPTION
## Summary

- Add branch cleanup after merge (remote + local deletion) to `/develop` skill step 11
- Add beta tag cleanup to `/release` skill step 7.3 — all previous beta pre-release tags are deleted when a stable release is published
- Document both policies in `CLAUDE.md` (branching strategy + release model sections)

## Context

The repo had accumulated 280+ stale branches and 521 old beta tags. Branches and old beta tags from previous release cycles (v1.7 through v2.1) have been cleaned up manually. These policy changes ensure cleanup happens automatically going forward.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>