### PR TITLE
refactor(sidebar): remove redundant close button

### DIFF
--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -127,9 +127,6 @@
   background-color: var(--color-sidebar-active);
 }
 
-.sidebarHeader {
-  display: none;
-}
 
 /* Mobile and tablet: fixed position, hidden by default */
 @media (max-width: 1024px) {
@@ -147,41 +144,6 @@
 
   .sidebar.open {
     transform: translateX(0);
-  }
-
-  .sidebarHeader {
-    display: flex;
-    justify-content: flex-start;
-    padding: var(--spacing-2);
-  }
-
-  .closeButton {
-    min-width: 44px;
-    min-height: 44px;
-    border: none;
-    background: transparent;
-    color: var(--color-sidebar-text);
-    font-size: var(--font-size-2xl);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    opacity: 0;
-    transition: opacity var(--transition-fast) 0.2s;
-  }
-
-  .closeButton:hover {
-    background-color: var(--color-sidebar-hover);
-  }
-
-  .closeButton:focus-visible {
-    outline: 2px solid var(--color-sidebar-focus-ring);
-    outline-offset: 2px;
-  }
-
-  .sidebar.open .closeButton {
-    opacity: 1;
   }
 
   .navLink {

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -23,16 +23,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         <Logo size={32} className={styles.logo} />
         <span className={styles.logoText}>{t('appName')}</span>
       </Link>
-      <div className={styles.sidebarHeader}>
-        <button
-          type="button"
-          className={styles.closeButton}
-          onClick={onClose}
-          aria-label={t('aria.closeMenu')}
-        >
-          ✕
-        </button>
-      </div>
       <nav className={styles.nav} aria-label="Main navigation">
         <NavLink
           to="/project"


### PR DESCRIPTION
## Summary

Remove the redundant close button from the Sidebar component. The FAB in AppShell already handles sidebar toggling on mobile/tablet, so this button added unnecessary complexity and visual clutter.

### Changes

- Removed `sidebarHeader` div containing the close button from `Sidebar.tsx`
- Removed all related CSS styles (`.sidebarHeader` and `.closeButton`) from `Sidebar.module.css`
- Kept `onClose` prop intact as it's used by nav link and settings/logout button handlers

### Files Modified

- `client/src/components/Sidebar/Sidebar.tsx`
- `client/src/components/Sidebar/Sidebar.module.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)