### PR TITLE
fix(sidebar): use dvh units to prevent footer cutoff on iPadOS Safari

### DIFF
--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
 }
 
 .logoArea {
@@ -138,6 +139,7 @@
     top: 0;
     left: 0;
     bottom: 0;
+    height: auto;
     width: 240px;
     z-index: var(--z-sidebar);
     transform: translateX(-100%);


### PR DESCRIPTION
## Summary
- Use `100dvh` (with `100vh` fallback) on the sidebar to track iPadOS Safari's dynamic viewport as the URL bar compacts/expands
- Reset `height: auto` in the mobile/tablet media query so `top: 0; bottom: 0` fixed-position insets define the sidebar height

## Test plan
- [ ] iPadOS Safari: open app, verify sidebar footer (project info box) is fully visible with URL bar both expanded and compacted
- [ ] Desktop browser: sidebar still full-height with footer pinned at bottom
- [ ] Mobile (≤1024px): sidebar overlay fills screen without footer clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)