### PR TITLE
chore: enforce PR mergeability check before CI polling

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -133,7 +133,7 @@ For each piece of work, follow this order:
 Before considering any task complete, verify:
 
 - [ ] Pre-commit hook passes (triggers on commit: selective tests, typecheck, build, audit)
-- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`)
+- [ ] PR is mergeable (no conflicts) and CI checks pass after push (verify mergeability first, then use the **CI Gate Polling** pattern from `CLAUDE.md`)
 - [ ] New code is structured for testability (clear interfaces, injectable dependencies)
 - [ ] API responses match the contract shapes exactly
 - [ ] Error responses use correct HTTP status codes and error shapes from the contract
@@ -175,7 +175,7 @@ Before considering any task complete, verify:
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
+6. **Wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-architect` and `security-engineer` to review the PR. Both must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/dev-team-lead.md
+++ b/.claude/agents/dev-team-lead.md
@@ -373,7 +373,7 @@ For multi-item batches, include per-item summary bullets and one `Fixes #N` line
 
 ### CI Monitoring
 
-Watch CI checks after pushing using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
+After pushing, **wait 5 seconds** for GitHub to compute merge status, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if the result is `MERGEABLE`.** If `CONFLICTING`, rebase onto the target branch, force-push, and re-check. If `UNKNOWN`, wait a few more seconds and retry. Once mergeability is confirmed, watch CI checks using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
 
 If CI fails:
 
@@ -437,7 +437,7 @@ In `[MODE: commit]`:
 2. Stage specific files and commit with conventional message + all contributing agent trailers
 3. Push: `git push -u origin <branch-name>`
 4. Create PR targeting `beta` (if not already created)
-5. Watch CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
+5. **Wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, watch CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 6. If CI fails, return a fix spec (do NOT fix directly)
 7. Return PR URL with CI status to orchestrator
 

--- a/.claude/agents/e2e-test-engineer.md
+++ b/.claude/agents/e2e-test-engineer.md
@@ -280,7 +280,7 @@ If you discover something that requires a fix, write a bug report. If you need c
 
 ## E2E Smoke Tests
 
-E2E smoke tests run automatically in CI (see `e2e-smoke` job in `.github/workflows/ci.yml`) — **do not run them locally**. After pushing your branch and creating a PR, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant). If CI E2E smoke tests fail, investigate and fix before proceeding.
+E2E smoke tests run automatically in CI (see `e2e-smoke` job in `.github/workflows/ci.yml`) — **do not run them locally**. After pushing your branch and creating a PR, **wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant). If CI E2E smoke tests fail, investigate and fix before proceeding.
 
 ## Quality Assurance Self-Checks
 
@@ -298,7 +298,7 @@ Before considering your work complete, verify:
 - [ ] Dependent systems are tested via real containers (not only mocked)
 - [ ] Smoke tests expanded if new major capabilities were added
 - [ ] Bug reports have complete reproduction steps
-- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`) — includes E2E smoke tests
+- [ ] PR is mergeable (no conflicts) and CI checks pass after push (verify mergeability first, then use the **CI Gate Polling** pattern from `CLAUDE.md`) — includes E2E smoke tests
 
 ---
 

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -153,7 +153,7 @@ Before building any UI element, check if a shared component exists. Using shared
 Before considering any task complete:
 
 1. **Commit** your changes — the pre-commit hook runs all quality gates (lint, format, tests, typecheck, build, audit)
-2. **Wait for CI** after pushing (use the **CI Gate Polling** pattern from `CLAUDE.md`) — do not proceed until green
+2. **Wait for CI** after pushing — first **wait 5 seconds**, then verify mergeability (`gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`), **only continue if `MERGEABLE`**. If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, use the **CI Gate Polling** pattern from `CLAUDE.md` — do not proceed until green
 3. **Verify** that all new components handle loading, error, and empty states
 4. **Check** that TypeScript types are properly defined (no `any` types without justification)
 5. **Ensure** new API client functions match the contract on the GitHub Wiki API Contract page
@@ -194,7 +194,7 @@ Before considering any task complete:
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
+6. **Wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-architect` and `security-engineer` to review the PR. Both must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/product-architect.md
+++ b/.claude/agents/product-architect.md
@@ -236,7 +236,7 @@ Your verdict must match the severity of your findings. Use `approve` or `request
 3. Commit with conventional commit message and your Co-Authored-By trailer (the pre-commit hook runs all quality gates automatically — selective lint/format/tests on staged files + full typecheck/build/audit)
 4. Push: `git push -u origin <branch-name>`
 5. Create a PR targeting `beta`: `gh pr create --base beta --title "..." --body "..."`
-6. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
+6. **Wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. Once confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant)
 7. **Request review**: After CI passes, the orchestrator launches `product-owner`, `product-architect`, and `security-engineer` to review the PR. All must approve before merge.
 8. **Address feedback**: If a reviewer requests changes, fix the issues on the same branch and push. The orchestrator will re-request review from the reviewer(s) that requested changes.
 9. After merge, clean up: `git checkout beta && git pull && git branch -d <branch-name>`

--- a/.claude/agents/qa-integration-tester.md
+++ b/.claude/agents/qa-integration-tester.md
@@ -231,7 +231,7 @@ Before considering your work complete, verify:
 - [ ] Performance metrics validated against baselines (bundle size, load time, API response time)
 - [ ] Docker deployment tested if applicable
 - [ ] i18n coverage: new translation keys exist in both `en` and `de`, no hardcoded user-facing strings
-- [ ] CI checks pass after push (use the **CI Gate Polling** pattern from `CLAUDE.md`)
+- [ ] PR is mergeable (no conflicts) and CI checks pass after push (verify mergeability first, then use the **CI Gate Polling** pattern from `CLAUDE.md`)
 
 ---
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -391,7 +391,7 @@ If any reviewer identifies blocking issues:
 
 Once all reviews are clean, wait for CI to go green:
 
-Use the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` only).
+After pushing, **wait 5 seconds** for GitHub to compute merge status, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if the result is `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. If `UNKNOWN`, wait a few more seconds and retry. Once mergeability is confirmed, use the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` + `CLA`).
 
 After CI is green, present the user with:
 

--- a/.claude/skills/epic-close/SKILL.md
+++ b/.claude/skills/epic-close/SKILL.md
@@ -114,7 +114,7 @@ If there are refinement items to address:
    ```
    gh pr create --base beta --title "chore: address refinement items for epic #<epic-number>" --body "..."
    ```
-8. Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` only)
+8. **Wait 5 seconds** after creating the PR, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if the result is `MERGEABLE`.** If `CONFLICTING`, rebase onto `beta`, force-push, and re-check. If `UNKNOWN`, wait a few more seconds and retry. Once mergeability is confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (beta variant — wait for `Quality Gates` + `CLA`)
 9. Squash merge: `gh pr merge --squash <pr-url>`
 
 If no refinement items exist, skip to step 5.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -147,7 +147,7 @@ EOF
 
 ### 3. CI Gate
 
-Wait for all required CI gates to pass on the promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
+After creating/pushing the promotion PR, **wait 5 seconds** for GitHub to compute merge status, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if the result is `MERGEABLE`.** If `CONFLICTING`, rebase onto `main`, force-push, and re-check. If `UNKNOWN`, wait a few more seconds and retry. Once mergeability is confirmed, use the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for `Quality Gates` + `E2E Gates` + `CLA`).
 
 If any gate fails, investigate and resolve before proceeding.
 
@@ -224,7 +224,7 @@ After all fix groups are merged to `beta`:
 
 #### 4g. CI Gate
 
-Wait for all required CI gates to pass on the new promotion PR using the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for both `Quality Gates` + `E2E Gates`).
+After creating/pushing the new promotion PR, **wait 5 seconds** for GitHub to compute merge status, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if the result is `MERGEABLE`.** If `CONFLICTING`, rebase onto `main`, force-push, and re-check. If `UNKNOWN`, wait a few more seconds and retry. Once mergeability is confirmed, use the **CI Gate Polling** pattern from `CLAUDE.md` (main variant — wait for `Quality Gates` + `E2E Gates` + `CLA`).
 
 If any gate fails, investigate and resolve before proceeding.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -129,7 +129,7 @@ Present the blocking findings to the user. **Do NOT wait for CI.**
 
 Post a consolidated `gh pr review --approve` comment on the PR summarizing the review outcome.
 
-Wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
+**Wait 5 seconds**, then check mergeability: `gh pr view <PR> --repo steilerDev/cornerstone --json mergeable -q '.mergeable'`. **Only continue if `MERGEABLE`.** If `CONFLICTING`, report the conflict to the user — do not attempt to resolve. Once mergeability is confirmed, wait for CI using the **CI Gate Polling** pattern from `CLAUDE.md` (use the beta or main variant based on the PR's target branch).
 
 If CI fails, report the specific failures to the user. **Do NOT merge.**
 


### PR DESCRIPTION
## Summary

- Added explicit PR mergeability check (`wait 5s → check mergeable → only continue if MERGEABLE`) before every CI Gate Polling reference across all 10 agent/skill files
- Root cause: multiple `/develop` runs wasted time polling CI that never started due to merge conflicts
- `fix-e2e/SKILL.md` already had the check — no change needed there

## Files changed (10)

**Skills:** `develop`, `release`, `epic-close`, `review-pr`
**Agents:** `dev-team-lead`, `backend-developer`, `frontend-developer`, `product-architect`, `qa-integration-tester`, `e2e-test-engineer`

## Test plan

- [ ] Grep `.claude/` for "CI Gate Polling" — every hit should have a mergeability mention nearby
- [ ] Next `/develop` run should detect merge conflicts before wasting time on CI polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)