### PR TITLE
fix(e2e): increase vendor URL search param timeout for mobile viewport

### DIFF
--- a/e2e/tests/budget/vendors.spec.ts
+++ b/e2e/tests/budget/vendors.spec.ts
@@ -924,7 +924,7 @@ test.describe('Search vendors (Scenario 12)', { tag: '@responsive' }, () => {
       // on tablet the URL update from react-router can lag slightly after the API
       // response returns, causing a synchronous expect(page.url()).toContain('q=')
       // to fail intermittently.
-      await page.waitForURL((url) => url.searchParams.has('q'), { timeout: 5000 });
+      await page.waitForURL((url) => url.searchParams.has('q'), { timeout: 15000 });
     } finally {
       if (createdId) await deleteVendorViaApi(page, createdId);
     }


### PR DESCRIPTION
## Summary
- Increase `waitForURL` timeout from 5s to 15s in vendor search URL param test
- On mobile viewports, react-router URL updates lag more, causing intermittent failures in E2E Shard 14/16

## Test plan
- [ ] E2E Shard 14/16 passes on mobile viewport (vendors.spec.ts:910)