### PR TITLE
fix(work-items): area filter returns no results when parent area selected (#1241)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,12 @@ COPY docs/package.json docs/
 # target platform — no compilation, no build-base/python3 needed.
 RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
+# Ensure workspace node_modules directories exist even when npm hoists all
+# production dependencies to the root node_modules/. Without this, the
+# production stage's COPY --from=deps /app/server/node_modules/ fails with
+# "not found" whenever no packages remain workspace-local.
+RUN mkdir -p /app/server/node_modules /app/client/node_modules /app/shared/node_modules
+
 # Create backups directory (for copying into production stage)
 RUN mkdir -p /backups
 

--- a/client/src/components/DataTable/filters/DateFilter.test.tsx
+++ b/client/src/components/DataTable/filters/DateFilter.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
 import type { ReactNode } from 'react';
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
 import { DateFilter } from './DateFilter.js';
@@ -25,6 +25,22 @@ function findDayButton(container: HTMLElement, dayNumber: number): HTMLButtonEle
 }
 
 describe('DateFilter', () => {
+  // Freeze time to 2026-03-15 so the underlying DateRangePicker's default "current month" is
+  // always March 2026. Tests that click day numbers and assert March dates are time-bombs
+  // without this: once the real clock advances past March 2026 the picker shows a different
+  // month and the expected date strings no longer match.
+  // doNotFake preserves real async timers so React Testing Library's findBy* and internal
+  // microtasks (act, etc.) continue to work correctly.
+  beforeAll(() => {
+    jest.useFakeTimers({
+      doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'queueMicrotask', 'performance'],
+    });
+    jest.setSystemTime(new Date('2026-03-15T12:00:00Z'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe('rendering', () => {
     it('renders the DateRangePicker component with calendar grid', () => {
       const { container } = render(<DateFilter value="" onChange={jest.fn()} />);

--- a/client/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/client/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
 import type { ReactNode } from 'react';
 import { render as rtlRender, screen, fireEvent, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -51,6 +51,22 @@ function getPhaseLabel(container: HTMLElement): string {
 }
 
 describe('DateRangePicker', () => {
+  // Freeze time to 2026-03-15 so the picker's default "current month" is always March 2026.
+  // Without this, tests that click specific day numbers (e.g. day 15) and assert a March date
+  // become time-bombs: once the real clock advances to April 2026+ the picker shows a different
+  // month and the expected date strings no longer match.
+  // doNotFake preserves real async timers so React Testing Library's findBy* and internal
+  // microtasks (act, etc.) continue to work correctly.
+  beforeAll(() => {
+    jest.useFakeTimers({
+      doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'queueMicrotask', 'performance'],
+    });
+    jest.setSystemTime(new Date('2026-03-15T12:00:00Z'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe('rendering', () => {
     it('renders a calendar grid with 7 day header columns', () => {
       const { container } = render(

--- a/e2e/pages/WorkItemsPage.ts
+++ b/e2e/pages/WorkItemsPage.ts
@@ -37,6 +37,7 @@ export class WorkItemsPage {
   readonly statusFilter: Locator;
   readonly userFilter: Locator;
   readonly tagFilter: Locator;
+  readonly areaFilter: Locator;
   readonly sortFilter: Locator;
   readonly sortOrderButton: Locator;
 
@@ -76,11 +77,16 @@ export class WorkItemsPage {
     this.searchInput = page.getByLabel('Search items');
     // DataTable filters are column-header filter buttons, not standalone <select> elements.
     // Each filterable column header renders a button with aria-label="Filter by {column label}".
-    // Column labels come from workItems i18n: Status, Assigned To, Vendor.
+    // Column labels come from workItems i18n: Status, Assigned To, Vendor, Area.
     this.statusFilter = page.getByRole('button', { name: 'Filter by Status' });
     this.userFilter = page.getByRole('button', { name: 'Filter by Assigned To' });
     // Tags column was removed — tagFilter kept for API compatibility, points to userFilter.
     this.tagFilter = page.getByRole('button', { name: 'Filter by Assigned To' });
+    // Area column filter button — the Area column is filterable via DataTable enum filter.
+    // The Area column label comes from workItems i18n: list.table.area = "Area".
+    // aria-label rendered as "Filter by Area" (dataTable.filter.filterByColumn interpolation).
+    // The table header (and this button) is CSS-hidden on mobile (< 768px).
+    this.areaFilter = page.getByRole('button', { name: /Filter by Area/i });
     // sortFilter and sortOrderButton do not exist in DataTable — no standalone sort controls.
     // Sorting is triggered by clicking sortable column headers.
     this.sortFilter = page.locator('[aria-label="Column settings"]');

--- a/e2e/tests/work-items/area-filter.spec.ts
+++ b/e2e/tests/work-items/area-filter.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * E2E tests for the Work Items area filter (Issue #1241)
+ *
+ * The Work Items list page supports filtering by area via the ?areaId=<csv> URL parameter.
+ * The DataTable EnumFilter serialises selections as CSV; the server now correctly expands
+ * descendant areas from CSV input (previously a single-ID mismatch caused zero results when
+ * a parent area was selected).
+ *
+ * Scenarios covered:
+ * 1.  Selecting a parent area shows descendant work items (hierarchy expansion)
+ * 2.  Multi-area CSV filter shows the union of items from both areas
+ * 3.  Unknown areaId shows the filter empty state with "Clear Filters" button
+ * 4.  No area filter: baseline sanity — unfiltered page shows items with no area
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { WorkItemsPage, WORK_ITEMS_ROUTE } from '../../pages/WorkItemsPage.js';
+import {
+  createAreaViaApi,
+  deleteAreaViaApi,
+  createWorkItemViaApi,
+  deleteWorkItemViaApi,
+} from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Selecting a parent area shows descendant work items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Parent area selection includes descendant work items (Scenario 1)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Navigating with ?areaId=<parent> shows items in parent and child areas', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const parentAreaName = `${testPrefix} WI Parent Area`;
+      const childAreaName = `${testPrefix} WI Child Area`;
+      const wiParentName = `${testPrefix} Wi-Parent`;
+      const wiChildName = `${testPrefix} Wi-Child`;
+      const wiOtherName = `${testPrefix} Wi-Other`;
+
+      try {
+        // Create parent area (root), then child area under it
+        const parentAreaId = await createAreaViaApi(page, { name: parentAreaName });
+        areaIds.push(parentAreaId);
+        const childAreaId = await createAreaViaApi(page, {
+          name: childAreaName,
+          parentId: parentAreaId,
+        });
+        areaIds.push(childAreaId);
+
+        // Create work items: one per area + one with no area
+        workItemIds.push(
+          await createWorkItemViaApi(page, {
+            title: wiParentName,
+            areaId: parentAreaId,
+          }),
+        );
+        workItemIds.push(
+          await createWorkItemViaApi(page, {
+            title: wiChildName,
+            areaId: childAreaId,
+          }),
+        );
+        workItemIds.push(
+          await createWorkItemViaApi(page, {
+            title: wiOtherName,
+          }),
+        );
+
+        // Navigate with the parent area filter in the URL.
+        // The server must expand to include the child area's items.
+        await page.goto(`${WORK_ITEMS_ROUTE}?areaId=${encodeURIComponent(parentAreaId)}`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must preserve areaId= pointing to the parent area
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe(parentAreaId);
+
+        // Both the parent-area item and the child-area item must be visible
+        await expect(async () => {
+          const titles = await listPage.getWorkItemTitles();
+          expect(titles).toContain(wiParentName);
+          expect(titles).toContain(wiChildName);
+          expect(titles).not.toContain(wiOtherName);
+        }).toPass({ timeout: 30_000 });
+
+        // Area filter button is visible on tablet and desktop (CSS-hidden on mobile < 768px)
+        const viewport = page.viewportSize();
+        if (viewport && viewport.width >= 768) {
+          await expect(listPage.areaFilter).toBeVisible();
+        }
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        // Delete children before parents (foreign key constraint)
+        for (const id of [...areaIds].reverse()) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Multi-area CSV filter shows the union of items from both areas
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Multi-area CSV filter shows union of matching work items (Scenario 2)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Navigating with ?areaId=<alpha>,<beta> shows items from both areas', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaAlphaName = `${testPrefix} WI Area Alpha`;
+      const areaBetaName = `${testPrefix} WI Area Beta`;
+      const wiAlphaName = `${testPrefix} Wi-Alpha`;
+      const wiBetaName = `${testPrefix} Wi-Beta`;
+      const wiNoneName = `${testPrefix} Wi-None`;
+
+      try {
+        // Create two sibling root areas
+        const areaAlphaId = await createAreaViaApi(page, { name: areaAlphaName });
+        areaIds.push(areaAlphaId);
+        const areaBetaId = await createAreaViaApi(page, { name: areaBetaName });
+        areaIds.push(areaBetaId);
+
+        // Create one work item per area, plus one with no area
+        workItemIds.push(
+          await createWorkItemViaApi(page, { title: wiAlphaName, areaId: areaAlphaId }),
+        );
+        workItemIds.push(
+          await createWorkItemViaApi(page, { title: wiBetaName, areaId: areaBetaId }),
+        );
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiNoneName }));
+
+        // Navigate with a CSV areaId — the server must union both area result sets
+        const csvAreaId = `${areaAlphaId},${areaBetaId}`;
+        await page.goto(`${WORK_ITEMS_ROUTE}?areaId=${encodeURIComponent(csvAreaId)}`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must contain the CSV areaId
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe(csvAreaId);
+
+        // Items from both areas must appear; item with no area must not
+        await expect(async () => {
+          const titles = await listPage.getWorkItemTitles();
+          expect(titles).toContain(wiAlphaName);
+          expect(titles).toContain(wiBetaName);
+          expect(titles).not.toContain(wiNoneName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Unknown areaId shows filter empty state
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Unknown areaId shows filter empty state with Clear Filters button (Scenario 3)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('?areaId=non-existent-uuid shows filter empty state and Clear Filters button', async ({
+      page,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+
+      // Use a well-formed but non-existent UUID as the area filter value
+      await page.goto(`${WORK_ITEMS_ROUTE}?areaId=non-existent-area-uuid`);
+      await listPage.heading.waitFor({ state: 'visible' });
+
+      // Wait for the filter empty state to appear
+      await expect(async () => {
+        await expect(listPage.emptyState).toBeVisible();
+      }).toPass({ timeout: 30_000 });
+
+      // The filtered empty state message must match DataTable's filteredMessage key
+      const emptyText = await listPage.emptyState.textContent();
+      expect(emptyText?.toLowerCase()).toMatch(/no items match the current filters/);
+
+      // DataTable renders a "Clear Filters" button inside the empty state when filters are active.
+      // Use .first() — it may also appear in the toolbar simultaneously.
+      const clearButton = listPage.emptyState.getByRole('button', {
+        name: /Clear Filters/i,
+      });
+      await expect(clearButton).toBeVisible();
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: No area filter — baseline sanity
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('No area filter — work items with no area are visible (Scenario 4)', { tag: '@responsive' }, () => {
+  test.describe.configure({ timeout: 90_000 });
+
+  test('Work item with no area appears when no area filter is applied', async ({
+    page,
+    testPrefix,
+  }) => {
+    const listPage = new WorkItemsPage(page);
+    const workItemIds: string[] = [];
+
+    const wiName = `${testPrefix} Wi-Unfiltered-No-Area`;
+
+    try {
+      workItemIds.push(await createWorkItemViaApi(page, { title: wiName }));
+
+      // Navigate without any areaId param — all items should be visible
+      await listPage.goto();
+      await listPage.waitForLoaded();
+
+      // areaId must not appear in the URL (no filter applied)
+      const url = new URL(page.url());
+      expect(url.searchParams.has('areaId')).toBe(false);
+
+      // The item with no area must appear in the list
+      await expect(async () => {
+        const titles = await listPage.getWorkItemTitles();
+        expect(titles).toContain(wiName);
+      }).toPass({ timeout: 30_000 });
+    } finally {
+      for (const id of workItemIds) {
+        await deleteWorkItemViaApi(page, id);
+      }
+    }
+  });
+});

--- a/server/src/routes/workItems.test.ts
+++ b/server/src/routes/workItems.test.ts
@@ -71,7 +71,11 @@ describe('Work Item Routes', () => {
   /**
    * Helper: Insert a test area directly into the app DB.
    */
-  function insertTestArea(name: string, color: string | null = null): string {
+  function insertTestArea(
+    name: string,
+    color: string | null = null,
+    parentId: string | null = null,
+  ): string {
     const now = new Date().toISOString();
     const areaId = `area-${Date.now()}-${Math.random().toString(36).substring(7)}`;
     app.db
@@ -79,7 +83,7 @@ describe('Work Item Routes', () => {
       .values({
         id: areaId,
         name,
-        parentId: null,
+        parentId,
         color,
         description: null,
         sortOrder: 0,
@@ -1487,6 +1491,109 @@ describe('Work Item Routes', () => {
 
       // Then: 400 validation error (blocked is not in the enum)
       expect(response.statusCode).toBe(400);
+    });
+
+    // ─── areaId CSV / hierarchy expansion — integration (#1241) ───────────────
+
+    it('GET ?areaId=<parent> returns descendant items (hierarchy expansion)', async () => {
+      // Given: A parent→child area hierarchy and work items in each level
+      const { userId, cookie } = await createUserWithSession(
+        'areahier@example.com',
+        'Area Hier User',
+        'password',
+      );
+      const parentId = insertTestArea('Floor 1');
+      const childId = insertTestArea('Floor 1 Kitchen', null, parentId);
+      workItemService.createWorkItem(app.db, userId, { title: 'Hallway Tiles', areaId: parentId });
+      workItemService.createWorkItem(app.db, userId, { title: 'Kitchen Sink', areaId: childId });
+      workItemService.createWorkItem(app.db, userId, { title: 'Unrelated Item' });
+
+      // When: Filtering by the parent area
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/work-items?areaId=${parentId}`,
+        headers: { cookie },
+      });
+
+      // Then: 200, both parent-level and child-level items are returned
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as WorkItemListResponse;
+      expect(body.items).toHaveLength(2);
+      const titles = body.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Hallway Tiles', 'Kitchen Sink']);
+    });
+
+    it('GET ?areaId=<a>,<b> returns union of both area subtrees', async () => {
+      // Given: Two sibling areas each with a work item
+      const { userId, cookie } = await createUserWithSession(
+        'areacsv@example.com',
+        'Area CSV User',
+        'password',
+      );
+      const areaAId = insertTestArea('Wing A');
+      const areaBId = insertTestArea('Wing B');
+      workItemService.createWorkItem(app.db, userId, { title: 'Wing A Task', areaId: areaAId });
+      workItemService.createWorkItem(app.db, userId, { title: 'Wing B Task', areaId: areaBId });
+      workItemService.createWorkItem(app.db, userId, { title: 'No Area Task' });
+
+      // When: Filtering by CSV of both area IDs
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/work-items?areaId=${areaAId},${areaBId}`,
+        headers: { cookie },
+      });
+
+      // Then: 200, items from both areas are included
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as WorkItemListResponse;
+      expect(body.items).toHaveLength(2);
+      const titles = body.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Wing A Task', 'Wing B Task']);
+    });
+
+    it('GET ?areaId=non-existent-area-uuid returns 200 with empty items array', async () => {
+      // Given: Authenticated user with some work items, but no matching area
+      const { userId, cookie } = await createUserWithSession(
+        'areanone@example.com',
+        'Area None User',
+        'password',
+      );
+      workItemService.createWorkItem(app.db, userId, { title: 'Some Item' });
+
+      // When: Filtering by a non-existent area ID
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/work-items?areaId=non-existent-area-uuid',
+        headers: { cookie },
+      });
+
+      // Then: 200, empty items array (unknown IDs silently ignored)
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as WorkItemListResponse;
+      expect(body.items).toHaveLength(0);
+    });
+
+    it('GET ?areaId=<leaf-area-with-no-items> returns 200 with empty items array', async () => {
+      // Given: A leaf area exists but has no work items assigned to it
+      const { userId, cookie } = await createUserWithSession(
+        'arealeaf@example.com',
+        'Area Leaf User',
+        'password',
+      );
+      const emptyAreaId = insertTestArea('Empty Room');
+      workItemService.createWorkItem(app.db, userId, { title: 'Item in Other Area' });
+
+      // When: Filtering by the empty area
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/work-items?areaId=${emptyAreaId}`,
+        headers: { cookie },
+      });
+
+      // Then: 200, no items in result
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as WorkItemListResponse;
+      expect(body.items).toHaveLength(0);
     });
   });
 });

--- a/server/src/services/workItemService.test.ts
+++ b/server/src/services/workItemService.test.ts
@@ -594,15 +594,16 @@ describe('Work Item Service', () => {
         endDate: '2026-03-05',
       });
 
-      // When: Updating both dates
+      // When: Updating both dates (use far-future dates so the scheduler's "today floor"
+      // for not_started items never clamps them to the current date)
       const updated = workItemService.updateWorkItem(db, workItem.id, {
-        startDate: '2026-04-01',
-        endDate: '2026-04-10',
+        startDate: '2099-04-01',
+        endDate: '2099-04-10',
       });
 
       // Then: Both updated successfully
-      expect(updated.startDate).toBe('2026-04-01');
-      expect(updated.endDate).toBe('2026-04-10');
+      expect(updated.startDate).toBe('2099-04-01');
+      expect(updated.endDate).toBe('2099-04-10');
     });
 
     it('allows setting description to null', () => {

--- a/server/src/services/workItemService.test.ts
+++ b/server/src/services/workItemService.test.ts
@@ -1266,6 +1266,163 @@ describe('Work Item Service', () => {
     });
   });
 
+  // ─── areaId CSV and multi-area filter (Issue #1241) ──────────────────────
+
+  describe('listWorkItems() — areaId CSV and multi-area filter', () => {
+    /**
+     * Fixture tree shared across all cases in this block:
+     *
+     *   root  (parentId: null)
+     *     ├─ child-a  (parentId: root)
+     *     │    └─ grandchild-a1  (parentId: child-a)
+     *     └─ child-b  (parentId: root)
+     *
+     * Work items: one per area + one with no area = 5 items total.
+     */
+    let userId: string;
+    let rootId: string;
+    let childAId: string;
+    let grandchildA1Id: string;
+    let childBId: string;
+
+    beforeEach(() => {
+      userId = createTestUser('csvfilter@example.com', 'CSV Filter User');
+      rootId = insertTestArea('Root');
+      childAId = insertTestArea('Child A', null, rootId);
+      grandchildA1Id = insertTestArea('Grandchild A1', null, childAId);
+      childBId = insertTestArea('Child B', null, rootId);
+      workItemService.createWorkItem(db, userId, { title: 'Root Item', areaId: rootId });
+      workItemService.createWorkItem(db, userId, { title: 'Child A Item', areaId: childAId });
+      workItemService.createWorkItem(db, userId, {
+        title: 'Grandchild A1 Item',
+        areaId: grandchildA1Id,
+      });
+      workItemService.createWorkItem(db, userId, { title: 'Child B Item', areaId: childBId });
+      workItemService.createWorkItem(db, userId, { title: 'No Area Item' });
+    });
+
+    it('case 1: single leaf ID returns only that leaf item', () => {
+      // When: Filtering by the grandchild (leaf) area
+      const result = workItemService.listWorkItems(db, { areaId: grandchildA1Id });
+
+      // Then: Only the grandchild item is returned
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].title).toBe('Grandchild A1 Item');
+    });
+
+    it('case 2: single parent ID expands to include direct child items', () => {
+      // When: Filtering by child-a (has one child: grandchild-a1)
+      const result = workItemService.listWorkItems(db, { areaId: childAId });
+
+      // Then: child-a item + grandchild-a1 item are returned
+      expect(result.items).toHaveLength(2);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Child A Item', 'Grandchild A1 Item']);
+    });
+
+    it('case 3: root ID returns full subtree (all 4 area items, excludes no-area item)', () => {
+      // When: Filtering by root
+      const result = workItemService.listWorkItems(db, { areaId: rootId });
+
+      // Then: All 4 items with an area are returned; no-area item excluded
+      expect(result.items).toHaveLength(4);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual([
+        'Child A Item',
+        'Child B Item',
+        'Grandchild A1 Item',
+        'Root Item',
+      ]);
+    });
+
+    it('case 4: CSV of two non-adjacent IDs returns exactly those subtrees', () => {
+      // When: Filtering by CSV of grandchild-a1 + child-b (neither is ancestor of the other)
+      const result = workItemService.listWorkItems(db, {
+        areaId: `${grandchildA1Id},${childBId}`,
+      });
+
+      // Then: Exactly the grandchild-a1 item and the child-b item are returned
+      expect(result.items).toHaveLength(2);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Child B Item', 'Grandchild A1 Item']);
+    });
+
+    it('case 5: CSV of parent + its descendant deduplicates and returns same items as parent alone', () => {
+      // When: client sends both child-a and grandchild-a1 (redundant, but valid)
+      const result = workItemService.listWorkItems(db, {
+        areaId: `${childAId},${grandchildA1Id}`,
+      });
+
+      // Then: 2 items — child-a + grandchild-a1 (no duplication in results)
+      expect(result.items).toHaveLength(2);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Child A Item', 'Grandchild A1 Item']);
+    });
+
+    it('case 6: array input returns union of subtrees', () => {
+      // When: Passing an array (internal API usage pattern)
+      // WorkItemListQuery.areaId is typed `string` on the wire, but resolveAreaIds
+      // accepts `string | string[]` — cast to satisfy TS.
+      const result = workItemService.listWorkItems(
+        db,
+        { areaId: [childAId, childBId] } as unknown as WorkItemListQuery,
+      );
+
+      // Then: 3 items — child-a, grandchild-a1 (descendant of child-a), child-b
+      expect(result.items).toHaveLength(3);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Child A Item', 'Child B Item', 'Grandchild A1 Item']);
+    });
+
+    it('case 7: empty string skips filter and returns all items', () => {
+      // When: areaId is an empty string (falsy guard skips the filter)
+      const result = workItemService.listWorkItems(db, { areaId: '' });
+
+      // Then: All 5 items are returned (filter not applied)
+      expect(result.items).toHaveLength(5);
+    });
+
+    it('case 8: unknown ID returns empty result set', () => {
+      // When: Filtering by a non-existent area ID
+      const result = workItemService.listWorkItems(db, { areaId: 'non-existent-area-uuid' });
+
+      // Then: No items match (unknown IDs are silently ignored; inArray returns no rows)
+      expect(result.items).toHaveLength(0);
+    });
+
+    it('case 9: CSV with empty segments filters them out without error', () => {
+      // When: CSV string has leading/trailing/double commas
+      const result = workItemService.listWorkItems(db, {
+        areaId: `,${childAId},`,
+      });
+
+      // Then: 2 items (child-a + grandchild-a1); empty segments silently dropped
+      expect(result.items).toHaveLength(2);
+      const titles = result.items.map((i) => i.title).sort();
+      expect(titles).toEqual(['Child A Item', 'Grandchild A1 Item']);
+    });
+
+    it('whitespace-only segments in CSV are trimmed and filtered out', () => {
+      // When: CSV contains a whitespace-only segment between commas
+      const result = workItemService.listWorkItems(db, {
+        areaId: `  ,${childBId},  `,
+      });
+
+      // Then: Only child-b item is returned; whitespace segments dropped
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].title).toBe('Child B Item');
+    });
+
+    it('CSV with all empty/whitespace segments resolves to zero IDs — filter skipped, returns all', () => {
+      // When: areaId resolves to empty after trimming all segments
+      // resolveAreaIds returns [] — the guard skips inArray, so all items returned
+      const result = workItemService.listWorkItems(db, { areaId: ' , , ' });
+
+      // Then: filter is skipped entirely, all 5 items returned
+      expect(result.items).toHaveLength(5);
+    });
+  });
+
   // ─── Budget fields: createWorkItem() / updateWorkItem() ───────────────────
   // NOTE: Story #147 budget fields (plannedBudget, actualCost, confidencePercent,
   // budgetCategoryId, budgetSourceId) were removed from work_items in Story 5.9.

--- a/server/src/services/workItemService.ts
+++ b/server/src/services/workItemService.ts
@@ -42,6 +42,28 @@ import { NotFoundError, ValidationError } from '../errors/AppError.js';
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
 /**
+ * Parse the areaId filter (single ID, CSV string, or array) into an expanded,
+ * deduplicated array of area IDs including each supplied ID's descendants.
+ * Empty segments and unknown IDs are silently ignored (inArray on unknown IDs returns no rows).
+ */
+function resolveAreaIds(db: DbType, areaId: string | string[]): string[] {
+  const raw = Array.isArray(areaId)
+    ? areaId
+    : areaId
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+  const expanded = new Set<string>();
+  for (const id of raw) {
+    for (const descendant of getDescendantIds(db, id)) {
+      expanded.add(descendant);
+    }
+  }
+  return [...expanded];
+}
+
+/**
  * Count budget lines for a work item.
  */
 function getBudgetLineCount(db: DbType, workItemId: string): number {
@@ -613,8 +635,10 @@ export function listWorkItems(
   }
 
   if (query.areaId) {
-    const areaIds = getDescendantIds(db, query.areaId);
-    baseConditions.push(inArray(workItems.areaId, areaIds));
+    const areaIds = resolveAreaIds(db, query.areaId);
+    if (areaIds.length > 0) {
+      baseConditions.push(inArray(workItems.areaId, areaIds));
+    }
   }
 
   if (query.assignedVendorId) {


### PR DESCRIPTION
## Summary

- **Bug**: The work items list endpoint returned zero results when filtering by a parent area ID. The `areaId` query parameter value was treated as a plain scalar in the SQL `WHERE` clause, so no rows matched.
- **Fix**: Added a `resolveAreaIds` helper in `workItemService.ts` that normalises the filter value — whether passed as a comma-separated string (e.g. `areaId=1,2,3`) or repeated query params — into a proper string array before building the `IN (...)` clause. The API contract's CSV and array forms are now both handled correctly.
- **Tests**: Unit + integration tests for the new helper and updated filter path (committed separately by `qa-integration-tester`); E2E tests covering hierarchy selection and CSV input (committed separately by `e2e-test-engineer`).

Fixes #1241

## Test plan

- [ ] Unit tests pass for `resolveAreaIds` helper (CSV, array, single value, empty)
- [ ] Integration tests pass for `GET /api/work-items?areaId=` with CSV and array forms
- [ ] E2E tests pass: selecting a parent area in the filter returns its work items
- [ ] Quality Gates CI check passes

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude backend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude qa-integration-tester (Sonnet 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude e2e-test-engineer (Sonnet 4.5) <noreply@anthropic.com>