### PR TITLE
feat(budget-sources): GET /api/budget-sources/:sourceId/budget-lines (#1245)

### DIFF
--- a/server/src/routes/budgetSources.budgetLines.test.ts
+++ b/server/src/routes/budgetSources.budgetLines.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Route integration tests for GET /api/budget-sources/:sourceId/budget-lines
+ *
+ * Uses Fastify's app.inject() — no HTTP server required.
+ * Setup/teardown follows the exact pattern of budgetSources.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { buildApp } from '../app.js';
+import * as userService from '../services/userService.js';
+import * as sessionService from '../services/sessionService.js';
+import type { FastifyInstance } from 'fastify';
+import type {
+  BudgetSourceBudgetLinesResponse,
+  ApiErrorResponse,
+} from '@cornerstone/shared';
+import {
+  budgetSources,
+  workItems,
+  workItemBudgets,
+  householdItems,
+  householdItemBudgets,
+  invoices,
+  invoiceBudgetLines,
+  vendors,
+  areas,
+} from '../db/schema.js';
+
+describe('GET /api/budget-sources/:sourceId/budget-lines', () => {
+  let app: FastifyInstance;
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  let counter = 0;
+  const uid = (prefix: string) => `${prefix}-${++counter}`;
+  const ts = () => new Date().toISOString();
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-bsbl-route-test-'));
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    process.env.SECURE_COOKIES = 'false';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+    process.env = originalEnv;
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+  async function createUserWithSession(
+    email: string,
+    displayName: string,
+    password: string,
+    role: 'admin' | 'member' = 'member',
+  ): Promise<{ userId: string; cookie: string }> {
+    const user = await userService.createLocalUser(app.db, email, displayName, password, role);
+    const sessionToken = sessionService.createSession(app.db, user.id, 3600);
+    return {
+      userId: user.id,
+      cookie: `cornerstone_session=${sessionToken}`,
+    };
+  }
+
+  function createTestSource(name = 'Test Source', totalAmount = 100_000): string {
+    const id = uid('src');
+    const now = ts();
+    app.db
+      .insert(budgetSources)
+      .values({
+        id,
+        name,
+        sourceType: 'bank_loan',
+        totalAmount,
+        interestRate: null,
+        terms: null,
+        notes: null,
+        status: 'active',
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function createArea(name: string): string {
+    const id = uid('area');
+    const now = ts();
+    app.db
+      .insert(areas)
+      .values({ id, name, parentId: null, color: '#ff0000', description: null, sortOrder: 0, createdAt: now, updatedAt: now })
+      .run();
+    return id;
+  }
+
+  function createVendor(name = 'Test Vendor'): string {
+    const id = uid('vnd');
+    const now = ts();
+    app.db.insert(vendors).values({ id, name, createdAt: now, updatedAt: now }).run();
+    return id;
+  }
+
+  function createWorkItem(areaId?: string | null, title = 'Test WI'): string {
+    const id = uid('wi');
+    const now = ts();
+    app.db
+      .insert(workItems)
+      .values({ id, title, status: 'not_started', areaId: areaId ?? null, createdAt: now, updatedAt: now })
+      .run();
+    return id;
+  }
+
+  function createWorkItemBudgetLine(wiId: string, sourceId: string | null, plannedAmount = 1000): string {
+    const id = uid('wib');
+    const now = ts();
+    app.db
+      .insert(workItemBudgets)
+      .values({
+        id,
+        workItemId: wiId,
+        budgetSourceId: sourceId,
+        plannedAmount,
+        confidence: 'own_estimate',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function createHouseholdItem(areaId?: string | null, name = 'Test HI'): string {
+    const id = uid('hi');
+    const now = ts();
+    app.db
+      .insert(householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        status: 'planned',
+        areaId: areaId ?? null,
+        quantity: 1,
+        isLate: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function createHouseholdItemBudgetLine(hiId: string, sourceId: string | null, plannedAmount = 1000): string {
+    const id = uid('hib');
+    const now = ts();
+    app.db
+      .insert(householdItemBudgets)
+      .values({
+        id,
+        householdItemId: hiId,
+        budgetSourceId: sourceId,
+        plannedAmount,
+        confidence: 'own_estimate',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function createInvoice(vendorId: string, status: 'pending' | 'paid' | 'claimed' | 'quotation', amount = 500): string {
+    const id = uid('inv');
+    const now = ts();
+    app.db
+      .insert(invoices)
+      .values({ id, vendorId, amount, date: '2026-01-15', status, createdAt: now, updatedAt: now })
+      .run();
+    return id;
+  }
+
+  function linkInvoiceToWorkItemBudget(invoiceId: string, wibId: string, itemizedAmount: number): void {
+    const now = ts();
+    app.db
+      .insert(invoiceBudgetLines)
+      .values({
+        id: randomUUID(),
+        invoiceId,
+        workItemBudgetId: wibId,
+        householdItemBudgetId: null,
+        itemizedAmount,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  function linkInvoiceToHouseholdItemBudget(invoiceId: string, hibId: string, itemizedAmount: number): void {
+    const now = ts();
+    app.db
+      .insert(invoiceBudgetLines)
+      .values({
+        id: randomUUID(),
+        invoiceId,
+        workItemBudgetId: null,
+        householdItemBudgetId: hibId,
+        itemizedAmount,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  // ─── Tests ───────────────────────────────────────────────────────────────────
+
+  // 1. 401 without auth
+  it('returns 401 without authentication', async () => {
+    const sourceId = createTestSource();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+    });
+
+    expect(response.statusCode).toBe(401);
+    const body = response.json<ApiErrorResponse>();
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  // 2. 404 for nonexistent sourceId
+  it('returns 404 for nonexistent sourceId', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/budget-sources/nonexistent-source-id/budget-lines',
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(404);
+    const body = response.json<ApiErrorResponse>();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  // 3. 200 with empty arrays when source has no lines
+  it('returns 200 with empty arrays when source has no budget lines', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource('Empty Source');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    expect(body.workItemLines).toEqual([]);
+    expect(body.householdItemLines).toEqual([]);
+  });
+
+  // 4. 200 with a work-item line present — verify shape
+  it('returns 200 with work-item line present and correct shape', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource('WI Source');
+    const wiId = createWorkItem(null, 'Plumbing');
+    createWorkItemBudgetLine(wiId, sourceId, 5000);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    expect(body.workItemLines).toHaveLength(1);
+    expect(body.householdItemLines).toHaveLength(0);
+
+    const line = body.workItemLines[0];
+    expect(line.parentName).toBe('Plumbing');
+    expect(line.plannedAmount).toBe(5000);
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCost).toBe(0);
+    expect(line.invoiceCount).toBe(0);
+    expect(line.invoiceLink).toBeNull();
+    expect(line.area).toBeNull();
+  });
+
+  // 5. 200 with a household-item line present
+  it('returns 200 with household-item line present and correct shape', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource('HI Source');
+    const hiId = createHouseholdItem(null, 'Bookshelf');
+    createHouseholdItemBudgetLine(hiId, sourceId, 800);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    expect(body.workItemLines).toHaveLength(0);
+    expect(body.householdItemLines).toHaveLength(1);
+
+    const line = body.householdItemLines[0];
+    expect(line.parentName).toBe('Bookshelf');
+    expect(line.plannedAmount).toBe(800);
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.invoiceLink).toBeNull();
+  });
+
+  // 6. hasClaimedInvoice: true when claimed invoice linked to work item line
+  it('hasClaimedInvoice is true when a claimed invoice is linked to the work-item line', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, 2000);
+    const invoiceId = createInvoice(vendorId, 'claimed', 1800);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 1800);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    const line = body.workItemLines[0];
+    expect(line.hasClaimedInvoice).toBe(true);
+    expect(line.actualCost).toBe(1800);
+    expect(line.actualCostPaid).toBe(1800);
+    expect(line.invoiceCount).toBe(1);
+    expect(line.invoiceLink).not.toBeNull();
+    expect(line.invoiceLink?.invoiceStatus).toBe('claimed');
+  });
+
+  // 7. hasClaimedInvoice: false when paid invoice linked
+  it('hasClaimedInvoice is false when only a paid invoice is linked', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, 2000);
+    const invoiceId = createInvoice(vendorId, 'paid', 700);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 700);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    const line = body.workItemLines[0];
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCostPaid).toBe(700);
+    expect(line.invoiceLink?.invoiceStatus).toBe('paid');
+  });
+
+  // 8. Member user can access
+  it('member user can access the budget-lines endpoint', async () => {
+    const { cookie } = await createUserWithSession('member@test.com', 'Member', 'password', 'member');
+    const sourceId = createTestSource();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  // 9. Admin user can access
+  it('admin user can access the budget-lines endpoint', async () => {
+    const { cookie } = await createUserWithSession('admin@test.com', 'Admin', 'password', 'admin');
+    const sourceId = createTestSource();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  // 10. Response includes all BaseBudgetLine fields
+  it('response includes all BaseBudgetLine fields on work item line', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource('Field Check Source');
+    const areaId = createArea('Zone A');
+    const wiId = createWorkItem(areaId, 'Full Field WI');
+    createWorkItemBudgetLine(wiId, sourceId, 3000);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    const line = body.workItemLines[0];
+
+    // BaseBudgetLine required fields
+    expect(line).toHaveProperty('id');
+    expect(line).toHaveProperty('description');
+    expect(line).toHaveProperty('plannedAmount');
+    expect(line).toHaveProperty('confidence');
+    expect(line).toHaveProperty('confidenceMargin');
+    expect(line).toHaveProperty('budgetCategory');
+    expect(line).toHaveProperty('budgetSource');
+    expect(line).toHaveProperty('vendor');
+    expect(line).toHaveProperty('actualCost');
+    expect(line).toHaveProperty('actualCostPaid');
+    expect(line).toHaveProperty('invoiceCount');
+    expect(line).toHaveProperty('invoiceLink');
+    expect(line).toHaveProperty('quantity');
+    expect(line).toHaveProperty('unit');
+    expect(line).toHaveProperty('unitPrice');
+    expect(line).toHaveProperty('includesVat');
+    expect(line).toHaveProperty('createdBy');
+    expect(line).toHaveProperty('createdAt');
+    expect(line).toHaveProperty('updatedAt');
+
+    // BudgetSourceBudgetLine additional fields
+    expect(line).toHaveProperty('parentId');
+    expect(line).toHaveProperty('parentName');
+    expect(line).toHaveProperty('area');
+    expect(line).toHaveProperty('hasClaimedInvoice');
+
+    // Verify types
+    expect(typeof line.plannedAmount).toBe('number');
+    expect(typeof line.actualCost).toBe('number');
+    expect(typeof line.invoiceCount).toBe('number');
+    expect(typeof line.hasClaimedInvoice).toBe('boolean');
+    expect(typeof line.confidenceMargin).toBe('number');
+
+    // Area is populated (we set areaId)
+    expect(line.area).not.toBeNull();
+    expect(line.area?.name).toBe('Zone A');
+    expect(line.parentName).toBe('Full Field WI');
+    expect(line.budgetSource?.id).toBe(sourceId);
+  });
+
+  // Extra: HI line with claimed invoice via route
+  it('household item line hasClaimedInvoice is true when claimed invoice is linked', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource();
+    const vendorId = createVendor();
+    const hiId = createHouseholdItem(null, 'Smart TV');
+    const hibId = createHouseholdItemBudgetLine(hiId, sourceId, 1200);
+    const invoiceId = createInvoice(vendorId, 'claimed', 1100);
+    linkInvoiceToHouseholdItemBudget(invoiceId, hibId, 1100);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    const line = body.householdItemLines[0];
+    expect(line.hasClaimedInvoice).toBe(true);
+    expect(line.actualCost).toBe(1100);
+  });
+
+  // Extra: route properly groups mixed work item + HI lines
+  it('returns both work item and household item lines in their respective arrays', async () => {
+    const { cookie } = await createUserWithSession('user@test.com', 'Test', 'password');
+    const sourceId = createTestSource('Mixed Source');
+    const wiId = createWorkItem(null, 'Work Task');
+    createWorkItemBudgetLine(wiId, sourceId, 2500);
+    const hiId = createHouseholdItem(null, 'Chair');
+    createHouseholdItemBudgetLine(hiId, sourceId, 400);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/budget-sources/${sourceId}/budget-lines`,
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<BudgetSourceBudgetLinesResponse>();
+    expect(body.workItemLines).toHaveLength(1);
+    expect(body.householdItemLines).toHaveLength(1);
+    expect(body.workItemLines[0].parentName).toBe('Work Task');
+    expect(body.householdItemLines[0].parentName).toBe('Chair');
+  });
+});

--- a/server/src/routes/budgetSources.ts
+++ b/server/src/routes/budgetSources.ts
@@ -73,6 +73,17 @@ const sourceIdSchema = {
   },
 };
 
+// JSON schema for GET /:sourceId/budget-lines
+const budgetLinesParamsSchema = {
+  params: {
+    type: 'object',
+    required: ['sourceId'],
+    properties: {
+      sourceId: { type: 'string' },
+    },
+  },
+};
+
 export default async function budgetSourceRoutes(fastify: FastifyInstance) {
   /**
    * GET /api/budget-sources
@@ -166,6 +177,25 @@ export default async function budgetSourceRoutes(fastify: FastifyInstance) {
 
       budgetSourceService.deleteBudgetSource(fastify.db, request.params.id);
       return reply.status(204).send();
+    },
+  );
+
+  /**
+   * GET /api/budget-sources/:sourceId/budget-lines
+   * Get all budget lines for a budget source, grouped by parent entity type (work item vs household item).
+   * Sorted by area name (nulls last), parent item name, and createdAt (all ascending).
+   * Auth required: Yes (both admin and member)
+   */
+  fastify.get<{ Params: { sourceId: string } }>(
+    '/:sourceId/budget-lines',
+    { schema: budgetLinesParamsSchema },
+    async (request, reply) => {
+      if (!request.user) {
+        throw new UnauthorizedError();
+      }
+
+      const result = budgetSourceService.getBudgetSourceBudgetLines(fastify.db, request.params.sourceId);
+      return reply.status(200).send(result);
     },
   );
 }

--- a/server/src/services/budgetSourceService.budgetLines.test.ts
+++ b/server/src/services/budgetSourceService.budgetLines.test.ts
@@ -1,0 +1,673 @@
+/**
+ * Unit tests for budgetSourceService.getBudgetSourceBudgetLines()
+ * and its private helpers: buildWorkItemBudgetLine, buildHouseholdItemBudgetLine,
+ * getWorkItemLineInvoiceData, getHouseholdItemLineInvoiceData,
+ * getWorkItemLineInvoiceLink, getHouseholdItemLineInvoiceLink, compareBudgetSourceLines.
+ *
+ * Uses an in-memory SQLite database via buildApp() + full migration stack.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { buildApp } from '../app.js';
+import { getBudgetSourceBudgetLines } from './budgetSourceService.js';
+import * as userService from './userService.js';
+import type { FastifyInstance } from 'fastify';
+import type { BudgetSourceBudgetLinesResponse } from '@cornerstone/shared';
+import {
+  budgetSources,
+  workItems,
+  workItemBudgets,
+  householdItems,
+  householdItemBudgets,
+  invoices,
+  invoiceBudgetLines,
+  vendors,
+  budgetCategories,
+  areas,
+} from '../db/schema.js';
+
+describe('budgetSourceService.getBudgetSourceBudgetLines()', () => {
+  let app: FastifyInstance;
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  // Counter to ensure unique IDs across tests
+  let counter = 0;
+  const uid = (prefix: string) => `${prefix}-${++counter}`;
+
+  const now = () => new Date().toISOString();
+  const nowTs = () => now();
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-bsbl-svc-test-'));
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    process.env.SECURE_COOKIES = 'false';
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+    process.env = originalEnv;
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+  function createSource(name = 'Test Source', totalAmount = 100_000): string {
+    const id = uid('src');
+    const ts = nowTs();
+    app.db
+      .insert(budgetSources)
+      .values({
+        id,
+        name,
+        sourceType: 'bank_loan',
+        totalAmount,
+        interestRate: null,
+        terms: null,
+        notes: null,
+        status: 'active',
+        createdBy: null,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createArea(name: string, color = '#ff0000'): string {
+    const id = uid('area');
+    const ts = nowTs();
+    app.db
+      .insert(areas)
+      .values({
+        id,
+        name,
+        color,
+        parentId: null,
+        description: null,
+        sortOrder: 0,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createVendor(name = 'Test Vendor'): string {
+    const id = uid('vnd');
+    const ts = nowTs();
+    app.db.insert(vendors).values({ id, name, createdAt: ts, updatedAt: ts }).run();
+    return id;
+  }
+
+  function createBudgetCategory(name = 'Test Category'): string {
+    const id = uid('bcat');
+    const ts = nowTs();
+    app.db
+      .insert(budgetCategories)
+      .values({ id, name, sortOrder: 0, createdAt: ts, updatedAt: ts })
+      .run();
+    return id;
+  }
+
+  function createWorkItem(areaId?: string | null, title = 'Test Work Item'): string {
+    const id = uid('wi');
+    const ts = nowTs();
+    app.db
+      .insert(workItems)
+      .values({
+        id,
+        title,
+        status: 'not_started',
+        areaId: areaId ?? null,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createWorkItemBudgetLine(
+    workItemId: string,
+    sourceId: string | null,
+    opts: {
+      plannedAmount?: number;
+      confidence?: 'own_estimate' | 'professional_estimate' | 'quote' | 'invoice';
+      budgetCategoryId?: string | null;
+      vendorId?: string | null;
+      createdBy?: string | null;
+      createdAt?: string;
+    } = {},
+  ): string {
+    const id = uid('wib');
+    const ts = opts.createdAt ?? nowTs();
+    app.db
+      .insert(workItemBudgets)
+      .values({
+        id,
+        workItemId,
+        budgetSourceId: sourceId,
+        plannedAmount: opts.plannedAmount ?? 1000,
+        confidence: opts.confidence ?? 'own_estimate',
+        budgetCategoryId: opts.budgetCategoryId ?? null,
+        vendorId: opts.vendorId ?? null,
+        createdBy: opts.createdBy ?? null,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createHouseholdItem(areaId?: string | null, name = 'Test HI'): string {
+    const id = uid('hi');
+    const ts = nowTs();
+    app.db
+      .insert(householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture', // seeded by migration 0016
+        status: 'planned',
+        areaId: areaId ?? null,
+        quantity: 1,
+        isLate: false,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createHouseholdItemBudgetLine(
+    householdItemId: string,
+    sourceId: string | null,
+    opts: {
+      plannedAmount?: number;
+      confidence?: 'own_estimate' | 'professional_estimate' | 'quote' | 'invoice';
+      budgetCategoryId?: string | null;
+      vendorId?: string | null;
+      createdBy?: string | null;
+      createdAt?: string;
+    } = {},
+  ): string {
+    const id = uid('hib');
+    const ts = opts.createdAt ?? nowTs();
+    app.db
+      .insert(householdItemBudgets)
+      .values({
+        id,
+        householdItemId,
+        budgetSourceId: sourceId,
+        plannedAmount: opts.plannedAmount ?? 1000,
+        confidence: opts.confidence ?? 'own_estimate',
+        budgetCategoryId: opts.budgetCategoryId ?? null,
+        vendorId: opts.vendorId ?? null,
+        createdBy: opts.createdBy ?? null,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function createInvoice(
+    vendorId: string,
+    status: 'pending' | 'paid' | 'claimed' | 'quotation',
+    amount = 500,
+  ): string {
+    const id = uid('inv');
+    const ts = nowTs();
+    app.db
+      .insert(invoices)
+      .values({
+        id,
+        vendorId,
+        amount,
+        date: '2026-01-15',
+        status,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function linkInvoiceToWorkItemBudget(
+    invoiceId: string,
+    workItemBudgetId: string,
+    itemizedAmount: number,
+  ): string {
+    const id = randomUUID();
+    const ts = nowTs();
+    app.db
+      .insert(invoiceBudgetLines)
+      .values({
+        id,
+        invoiceId,
+        workItemBudgetId,
+        householdItemBudgetId: null,
+        itemizedAmount,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  function linkInvoiceToHouseholdItemBudget(
+    invoiceId: string,
+    householdItemBudgetId: string,
+    itemizedAmount: number,
+  ): string {
+    const id = randomUUID();
+    const ts = nowTs();
+    app.db
+      .insert(invoiceBudgetLines)
+      .values({
+        id,
+        invoiceId,
+        workItemBudgetId: null,
+        householdItemBudgetId,
+        itemizedAmount,
+        createdAt: ts,
+        updatedAt: ts,
+      })
+      .run();
+    return id;
+  }
+
+  // ─── Tests ───────────────────────────────────────────────────────────────────
+
+  // 1. Source not found → throws NotFoundError
+  it('throws NotFoundError when source does not exist', () => {
+    expect(() => getBudgetSourceBudgetLines(app.db, 'nonexistent-src-id')).toThrow(
+      'Budget source not found',
+    );
+  });
+
+  // 2. Empty source → empty arrays
+  it('returns empty arrays when source has no budget lines', () => {
+    const sourceId = createSource('Empty Source');
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+
+    expect(result.workItemLines).toEqual([]);
+    expect(result.householdItemLines).toEqual([]);
+  });
+
+  // 3. Work item line, no invoice → zero aggregates, no invoiceLink
+  it('work item line with no invoice: hasClaimedInvoice=false, all amounts zero, invoiceLink=null', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 5000 });
+
+    const result: BudgetSourceBudgetLinesResponse = getBudgetSourceBudgetLines(app.db, sourceId);
+
+    expect(result.workItemLines).toHaveLength(1);
+    const line = result.workItemLines[0];
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCost).toBe(0);
+    expect(line.actualCostPaid).toBe(0);
+    expect(line.invoiceCount).toBe(0);
+    expect(line.invoiceLink).toBeNull();
+    expect(line.plannedAmount).toBe(5000);
+  });
+
+  // 4. Work item line, claimed invoice linked → hasClaimedInvoice=true, actualCost, invoiceLink with status 'claimed'
+  it('work item line with claimed invoice: hasClaimedInvoice=true, actualCost === itemizedAmount, invoiceCount=1, invoiceLink populated', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 2000 });
+    const invoiceId = createInvoice(vendorId, 'claimed', 1500);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 1500);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+
+    expect(result.workItemLines).toHaveLength(1);
+    const line = result.workItemLines[0];
+    expect(line.hasClaimedInvoice).toBe(true);
+    expect(line.actualCost).toBe(1500);
+    expect(line.actualCostPaid).toBe(1500); // claimed counts as paid
+    expect(line.invoiceCount).toBe(1);
+    expect(line.invoiceLink).not.toBeNull();
+    expect(line.invoiceLink?.invoiceStatus).toBe('claimed');
+    expect(line.invoiceLink?.itemizedAmount).toBe(1500);
+    expect(line.invoiceLink?.invoiceId).toBe(invoiceId);
+  });
+
+  // 5. Work item line, paid invoice → hasClaimedInvoice=false, actualCostPaid > 0
+  it('work item line with paid invoice: hasClaimedInvoice=false, actualCostPaid > 0', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 2000 });
+    const invoiceId = createInvoice(vendorId, 'paid', 800);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 800);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCostPaid).toBe(800);
+    expect(line.actualCost).toBe(800);
+    expect(line.invoiceLink?.invoiceStatus).toBe('paid');
+  });
+
+  // 6. Work item line, pending invoice → hasClaimedInvoice=false, actualCostPaid=0
+  it('work item line with pending invoice: hasClaimedInvoice=false, actualCostPaid=0, actualCost>0', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 2000 });
+    const invoiceId = createInvoice(vendorId, 'pending', 600);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 600);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    // pending does not count as paid
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCostPaid).toBe(0);
+    // pending invoice still contributes to actualCost (all statuses sum)
+    expect(line.actualCost).toBe(600);
+  });
+
+  // 7. Work item line, quotation invoice → hasClaimedInvoice=false
+  it('work item line with quotation invoice: hasClaimedInvoice=false, actualCostPaid=0', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor();
+    const wiId = createWorkItem();
+    const lineId = createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 3000 });
+    const invoiceId = createInvoice(vendorId, 'quotation', 900);
+    linkInvoiceToWorkItemBudget(invoiceId, lineId, 900);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.hasClaimedInvoice).toBe(false);
+    expect(line.actualCostPaid).toBe(0);
+  });
+
+  // 8. Work item with area → area populated
+  it('work item line with area: area field is populated with id, name, color', () => {
+    const sourceId = createSource();
+    const areaId = createArea('Kitchen', '#aabbcc');
+    const wiId = createWorkItem(areaId);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(areaId);
+    expect(line.area?.name).toBe('Kitchen');
+    expect(line.area?.color).toBe('#aabbcc');
+  });
+
+  // 9. Work item with no area (areaId null) → area: null
+  it('work item line with no area: area is null', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem(null);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area).toBeNull();
+  });
+
+  // 10. Household item line → appears in householdItemLines, correct parentId and parentName
+  it('household item line appears in householdItemLines with correct parentId and parentName', () => {
+    const sourceId = createSource();
+    const hiId = createHouseholdItem(null, 'My Couch');
+    createHouseholdItemBudgetLine(hiId, sourceId, { plannedAmount: 1200 });
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+
+    expect(result.workItemLines).toHaveLength(0);
+    expect(result.householdItemLines).toHaveLength(1);
+    const line = result.householdItemLines[0];
+    expect(line.parentId).toBe(hiId);
+    expect(line.parentName).toBe('My Couch');
+    expect(line.plannedAmount).toBe(1200);
+  });
+
+  // 11. Household item with area populated
+  it('household item line with area: area field is populated', () => {
+    const sourceId = createSource();
+    const areaId = createArea('Living Room', '#00ff00');
+    const hiId = createHouseholdItem(areaId, 'Sofa');
+    createHouseholdItemBudgetLine(hiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.householdItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(areaId);
+    expect(line.area?.name).toBe('Living Room');
+    expect(line.area?.color).toBe('#00ff00');
+  });
+
+  // 12. Mixed source: one WI line + one HI line → both present in respective arrays
+  it('mixed source: work item and household item lines both present in their respective arrays', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 500 });
+    const hiId = createHouseholdItem();
+    createHouseholdItemBudgetLine(hiId, sourceId, { plannedAmount: 300 });
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+
+    expect(result.workItemLines).toHaveLength(1);
+    expect(result.householdItemLines).toHaveLength(1);
+  });
+
+  // 13. Sorting by area name: nulls last
+  it('sorting: work item lines sorted by area name (nulls last)', () => {
+    const sourceId = createSource();
+    const areaZebra = createArea('Zebra');
+    const areaAlpha = createArea('Alpha');
+
+    // Insert in reverse alphabetical order to test sorting
+    const wiZebra = createWorkItem(areaZebra, 'Zebra WI');
+    createWorkItemBudgetLine(wiZebra, sourceId);
+
+    const wiNull = createWorkItem(null, 'Null Area WI');
+    createWorkItemBudgetLine(wiNull, sourceId);
+
+    const wiAlpha = createWorkItem(areaAlpha, 'Alpha WI');
+    createWorkItemBudgetLine(wiAlpha, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const lines = result.workItemLines;
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0].area?.name).toBe('Alpha');
+    expect(lines[1].area?.name).toBe('Zebra');
+    expect(lines[2].area).toBeNull(); // null last
+  });
+
+  // 14. Sorting: two lines in same area → sorted by parentName
+  it('sorting: two lines in same area sorted by parentName ascending', () => {
+    const sourceId = createSource();
+    const areaId = createArea('Bathroom');
+
+    const wiBath = createWorkItem(areaId, 'Bathroom fixtures');
+    createWorkItemBudgetLine(wiBath, sourceId);
+
+    const wiAttic = createWorkItem(areaId, 'Attic insulation');
+    createWorkItemBudgetLine(wiAttic, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const lines = result.workItemLines;
+
+    expect(lines[0].parentName).toBe('Attic insulation');
+    expect(lines[1].parentName).toBe('Bathroom fixtures');
+  });
+
+  // 15. Sorting: two lines on same work item (same parentName) → earlier createdAt first
+  it('sorting: two lines on same work item sorted by createdAt ascending', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem(null, 'Shared Work Item');
+
+    // Insert older line first
+    const olderTs = '2026-01-01T00:00:00.000Z';
+    const newerTs = '2026-06-01T00:00:00.000Z';
+
+    createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 100, createdAt: olderTs });
+    createWorkItemBudgetLine(wiId, sourceId, { plannedAmount: 200, createdAt: newerTs });
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const lines = result.workItemLines;
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0].createdAt).toBe(olderTs);
+    expect(lines[1].createdAt).toBe(newerTs);
+  });
+
+  // 16. Lines from a different source are excluded
+  it('lines from a different source are not included in results', () => {
+    const sourceA = createSource('Source A');
+    const sourceB = createSource('Source B');
+
+    const wiA = createWorkItem(null, 'WI for Source A');
+    createWorkItemBudgetLine(wiA, sourceA, { plannedAmount: 1000 });
+
+    const wiB = createWorkItem(null, 'WI for Source B');
+    createWorkItemBudgetLine(wiB, sourceB, { plannedAmount: 2000 });
+
+    const resultA = getBudgetSourceBudgetLines(app.db, sourceA);
+    expect(resultA.workItemLines).toHaveLength(1);
+    expect(resultA.workItemLines[0].parentName).toBe('WI for Source A');
+
+    const resultB = getBudgetSourceBudgetLines(app.db, sourceB);
+    expect(resultB.workItemLines).toHaveLength(1);
+    expect(resultB.workItemLines[0].parentName).toBe('WI for Source B');
+  });
+
+  // 17. parentName matches work item title
+  it('parentName matches work item title', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem(null, 'Flooring Installation');
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    expect(result.workItemLines[0].parentName).toBe('Flooring Installation');
+  });
+
+  // 18. parentName matches household item name
+  it('parentName matches household item name', () => {
+    const sourceId = createSource();
+    const hiId = createHouseholdItem(null, 'Dining Table');
+    createHouseholdItemBudgetLine(hiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    expect(result.householdItemLines[0].parentName).toBe('Dining Table');
+  });
+
+  // 19. budgetCategory and vendor populated when IDs set
+  it('budgetCategory and vendor are populated when IDs are set on the budget line', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor('Acme Corp');
+    const catId = createBudgetCategory('Electrical');
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId, {
+      budgetCategoryId: catId,
+      vendorId,
+    });
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.vendor).not.toBeNull();
+    expect(line.vendor?.name).toBe('Acme Corp');
+    expect(line.budgetCategory).not.toBeNull();
+    expect(line.budgetCategory?.name).toBe('Electrical');
+  });
+
+  // 20. createdBy populated when user exists
+  it('createdBy is populated when the user exists', async () => {
+    const sourceId = createSource();
+    const user = await userService.createLocalUser(
+      app.db,
+      'creator@example.com',
+      'Creator User',
+      'password',
+      'member',
+    );
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId, { createdBy: user.id });
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.createdBy).not.toBeNull();
+    expect(line.createdBy?.id).toBe(user.id);
+    expect(line.createdBy?.displayName).toBe('Creator User');
+  });
+
+  // Extra: budgetSource field is populated on returned line (self-referential)
+  it('budgetSource summary is populated on the returned line', () => {
+    const sourceId = createSource('My Source');
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.budgetSource).not.toBeNull();
+    expect(line.budgetSource?.id).toBe(sourceId);
+    expect(line.budgetSource?.name).toBe('My Source');
+  });
+
+  // Extra: household item line invoice data (claimed)
+  it('household item line with claimed invoice: hasClaimedInvoice=true', () => {
+    const sourceId = createSource();
+    const vendorId = createVendor();
+    const hiId = createHouseholdItem();
+    const lineId = createHouseholdItemBudgetLine(hiId, sourceId, { plannedAmount: 400 });
+    const invoiceId = createInvoice(vendorId, 'claimed', 350);
+    linkInvoiceToHouseholdItemBudget(invoiceId, lineId, 350);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.householdItemLines[0];
+
+    expect(line.hasClaimedInvoice).toBe(true);
+    expect(line.actualCost).toBe(350);
+    expect(line.actualCostPaid).toBe(350);
+    expect(line.invoiceLink).not.toBeNull();
+    expect(line.invoiceLink?.invoiceStatus).toBe('claimed');
+  });
+
+  // Extra: parentId matches work item id
+  it('parentId on work item line matches the work item id', () => {
+    const sourceId = createSource();
+    const wiId = createWorkItem();
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    expect(result.workItemLines[0].parentId).toBe(wiId);
+  });
+
+  // Extra: parentId on household item line matches household item id
+  it('parentId on household item line matches the household item id', () => {
+    const sourceId = createSource();
+    const hiId = createHouseholdItem();
+    createHouseholdItemBudgetLine(hiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    expect(result.householdItemLines[0].parentId).toBe(hiId);
+  });
+});

--- a/server/src/services/budgetSourceService.ts
+++ b/server/src/services/budgetSourceService.ts
@@ -9,16 +9,32 @@ import {
   invoiceBudgetLines,
   invoices,
   users,
+  workItems,
+  householdItems,
+  areas,
+  budgetCategories,
+  vendors,
 } from '../db/schema.js';
 import type {
   BudgetSource,
   BudgetSourceType,
   BudgetSourceStatus,
+  BudgetSourceBudgetLine,
+  BudgetSourceBudgetLinesResponse,
   CreateBudgetSourceRequest,
   UpdateBudgetSourceRequest,
   UserSummary,
+  BudgetLineInvoiceLink,
+  ConfidenceLevel,
 } from '@cornerstone/shared';
 import { CONFIDENCE_MARGINS } from '@cornerstone/shared';
+import {
+  toAreaSummary,
+  toBudgetCategory,
+  toBudgetSourceSummary,
+  toVendorSummary,
+  toUserSummary,
+} from './shared/converters.js';
 import {
   NotFoundError,
   ValidationError,
@@ -30,18 +46,6 @@ type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
 const VALID_SOURCE_TYPES: BudgetSourceType[] = ['bank_loan', 'credit_line', 'savings', 'other'];
 const VALID_STATUSES: BudgetSourceStatus[] = ['active', 'exhausted', 'closed'];
-
-/**
- * Convert database user row to UserSummary shape.
- */
-function toUserSummary(user: typeof users.$inferSelect | null | undefined): UserSummary | null {
-  if (!user) return null;
-  return {
-    id: user.id,
-    displayName: user.displayName,
-    email: user.email,
-  };
-}
 
 /**
  * Convert database budget source row to BudgetSource API shape.
@@ -521,4 +525,307 @@ export function deleteBudgetSource(db: DbType, id: string): void {
 
   // Delete source
   db.delete(budgetSources).where(eq(budgetSources.id, id)).run();
+}
+
+/**
+ * Get invoice aggregates for a work item budget line.
+ * Returns actualCost (sum of all itemized amounts), actualCostPaid (sum of paid/claimed amounts),
+ * and invoiceCount (number of linked invoices).
+ */
+function getWorkItemLineInvoiceData(
+  db: DbType,
+  lineId: string,
+): { actualCost: number; actualCostPaid: number; invoiceCount: number; hasClaimedInvoice: boolean } {
+  const result = db.get<{
+    actualCost: number;
+    actualCostPaid: number;
+    invoiceCount: number;
+    hasClaimedInvoice: number;
+  }>(
+    sql`SELECT
+      COALESCE(SUM(ibl.itemized_amount), 0) AS actualCost,
+      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0) AS actualCostPaid,
+      COUNT(*) AS invoiceCount,
+      CASE WHEN COUNT(CASE WHEN i.status = 'claimed' THEN 1 END) > 0 THEN 1 ELSE 0 END AS hasClaimedInvoice
+    FROM invoice_budget_lines ibl
+    INNER JOIN invoices i ON i.id = ibl.invoice_id
+    WHERE ibl.work_item_budget_id = ${lineId}`,
+  );
+
+  return {
+    actualCost: result?.actualCost ?? 0,
+    actualCostPaid: result?.actualCostPaid ?? 0,
+    invoiceCount: result?.invoiceCount ?? 0,
+    hasClaimedInvoice: (result?.hasClaimedInvoice ?? 0) === 1,
+  };
+}
+
+/**
+ * Get invoice aggregates for a household item budget line.
+ * Returns actualCost (sum of all itemized amounts), actualCostPaid (sum of paid/claimed amounts),
+ * and invoiceCount (number of linked invoices).
+ */
+function getHouseholdItemLineInvoiceData(
+  db: DbType,
+  lineId: string,
+): { actualCost: number; actualCostPaid: number; invoiceCount: number; hasClaimedInvoice: boolean } {
+  const result = db.get<{
+    actualCost: number;
+    actualCostPaid: number;
+    invoiceCount: number;
+    hasClaimedInvoice: number;
+  }>(
+    sql`SELECT
+      COALESCE(SUM(ibl.itemized_amount), 0) AS actualCost,
+      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0) AS actualCostPaid,
+      COUNT(*) AS invoiceCount,
+      CASE WHEN COUNT(CASE WHEN i.status = 'claimed' THEN 1 END) > 0 THEN 1 ELSE 0 END AS hasClaimedInvoice
+    FROM invoice_budget_lines ibl
+    INNER JOIN invoices i ON i.id = ibl.invoice_id
+    WHERE ibl.household_item_budget_id = ${lineId}`,
+  );
+
+  return {
+    actualCost: result?.actualCost ?? 0,
+    actualCostPaid: result?.actualCostPaid ?? 0,
+    invoiceCount: result?.invoiceCount ?? 0,
+    hasClaimedInvoice: (result?.hasClaimedInvoice ?? 0) === 1,
+  };
+}
+
+/**
+ * Get the first linked invoice for a budget line (or null if none).
+ * Used for work item budget lines.
+ */
+function getWorkItemLineInvoiceLink(
+  db: DbType,
+  lineId: string,
+): BudgetLineInvoiceLink | null {
+  const row = db.get<{
+    ibl_id: string;
+    invoice_id: string;
+    invoice_number: string | null;
+    date: string;
+    status: string;
+    itemized_amount: number;
+  }>(
+    sql`SELECT ibl.id AS ibl_id, i.id AS invoice_id, i.invoice_number, i.date, i.status, ibl.itemized_amount
+    FROM invoice_budget_lines ibl
+    INNER JOIN invoices i ON i.id = ibl.invoice_id
+    WHERE ibl.work_item_budget_id = ${lineId}
+    LIMIT 1`,
+  );
+
+  if (!row) return null;
+  return {
+    invoiceBudgetLineId: row.ibl_id,
+    invoiceId: row.invoice_id,
+    invoiceNumber: row.invoice_number,
+    invoiceDate: row.date,
+    invoiceStatus: row.status,
+    itemizedAmount: row.itemized_amount,
+  };
+}
+
+/**
+ * Get the first linked invoice for a budget line (or null if none).
+ * Used for household item budget lines.
+ */
+function getHouseholdItemLineInvoiceLink(
+  db: DbType,
+  lineId: string,
+): BudgetLineInvoiceLink | null {
+  const row = db.get<{
+    ibl_id: string;
+    invoice_id: string;
+    invoice_number: string | null;
+    date: string;
+    status: string;
+    itemized_amount: number;
+  }>(
+    sql`SELECT ibl.id AS ibl_id, i.id AS invoice_id, i.invoice_number, i.date, i.status, ibl.itemized_amount
+    FROM invoice_budget_lines ibl
+    INNER JOIN invoices i ON i.id = ibl.invoice_id
+    WHERE ibl.household_item_budget_id = ${lineId}
+    LIMIT 1`,
+  );
+
+  if (!row) return null;
+  return {
+    invoiceBudgetLineId: row.ibl_id,
+    invoiceId: row.invoice_id,
+    invoiceNumber: row.invoice_number,
+    invoiceDate: row.date,
+    invoiceStatus: row.status,
+    itemizedAmount: row.itemized_amount,
+  };
+}
+
+/**
+ * Build a BudgetSourceBudgetLine from a work item budget row.
+ * Resolves related entities (work item, area, category, source, vendor, user) and invoice data.
+ */
+function buildWorkItemBudgetLine(db: DbType, line: typeof workItemBudgets.$inferSelect): BudgetSourceBudgetLine {
+  const workItem = db.select().from(workItems).where(eq(workItems.id, line.workItemId)).get();
+  const area = workItem && workItem.areaId
+    ? db.select().from(areas).where(eq(areas.id, workItem.areaId)).get()
+    : null;
+  const category = line.budgetCategoryId
+    ? db.select().from(budgetCategories).where(eq(budgetCategories.id, line.budgetCategoryId)).get()
+    : null;
+  const source = line.budgetSourceId
+    ? db.select().from(budgetSources).where(eq(budgetSources.id, line.budgetSourceId)).get()
+    : null;
+  const vendor = line.vendorId
+    ? db.select().from(vendors).where(eq(vendors.id, line.vendorId)).get()
+    : null;
+  const createdByUser = line.createdBy
+    ? db.select().from(users).where(eq(users.id, line.createdBy)).get()
+    : null;
+
+  const invoiceData = getWorkItemLineInvoiceData(db, line.id);
+  const invoiceLink = getWorkItemLineInvoiceLink(db, line.id);
+
+  return {
+    id: line.id,
+    description: line.description,
+    plannedAmount: line.plannedAmount,
+    confidence: line.confidence as ConfidenceLevel,
+    confidenceMargin: CONFIDENCE_MARGINS[line.confidence as keyof typeof CONFIDENCE_MARGINS] ?? 0,
+    budgetCategory: toBudgetCategory(category),
+    budgetSource: toBudgetSourceSummary(source),
+    vendor: toVendorSummary(vendor),
+    actualCost: invoiceData.actualCost,
+    actualCostPaid: invoiceData.actualCostPaid,
+    invoiceCount: invoiceData.invoiceCount,
+    invoiceLink,
+    quantity: line.quantity ?? null,
+    unit: line.unit ?? null,
+    unitPrice: line.unitPrice ?? null,
+    includesVat: line.includesVat ?? null,
+    createdBy: toUserSummary(createdByUser),
+    createdAt: line.createdAt,
+    updatedAt: line.updatedAt,
+    parentId: line.workItemId,
+    parentName: workItem?.title ?? '(Unknown Work Item)',
+    area: toAreaSummary(area),
+    hasClaimedInvoice: invoiceData.hasClaimedInvoice,
+  };
+}
+
+/**
+ * Build a BudgetSourceBudgetLine from a household item budget row.
+ * Resolves related entities (household item, area, category, source, vendor, user) and invoice data.
+ */
+function buildHouseholdItemBudgetLine(db: DbType, line: typeof householdItemBudgets.$inferSelect): BudgetSourceBudgetLine {
+  const householdItem = db.select().from(householdItems).where(eq(householdItems.id, line.householdItemId)).get();
+  const area = householdItem && householdItem.areaId
+    ? db.select().from(areas).where(eq(areas.id, householdItem.areaId)).get()
+    : null;
+  const category = line.budgetCategoryId
+    ? db.select().from(budgetCategories).where(eq(budgetCategories.id, line.budgetCategoryId)).get()
+    : null;
+  const source = line.budgetSourceId
+    ? db.select().from(budgetSources).where(eq(budgetSources.id, line.budgetSourceId)).get()
+    : null;
+  const vendor = line.vendorId
+    ? db.select().from(vendors).where(eq(vendors.id, line.vendorId)).get()
+    : null;
+  const createdByUser = line.createdBy
+    ? db.select().from(users).where(eq(users.id, line.createdBy)).get()
+    : null;
+
+  const invoiceData = getHouseholdItemLineInvoiceData(db, line.id);
+  const invoiceLink = getHouseholdItemLineInvoiceLink(db, line.id);
+
+  return {
+    id: line.id,
+    description: line.description,
+    plannedAmount: line.plannedAmount,
+    confidence: line.confidence as ConfidenceLevel,
+    confidenceMargin: CONFIDENCE_MARGINS[line.confidence as keyof typeof CONFIDENCE_MARGINS] ?? 0,
+    budgetCategory: toBudgetCategory(category),
+    budgetSource: toBudgetSourceSummary(source),
+    vendor: toVendorSummary(vendor),
+    actualCost: invoiceData.actualCost,
+    actualCostPaid: invoiceData.actualCostPaid,
+    invoiceCount: invoiceData.invoiceCount,
+    invoiceLink,
+    quantity: line.quantity ?? null,
+    unit: line.unit ?? null,
+    unitPrice: line.unitPrice ?? null,
+    includesVat: line.includesVat ?? null,
+    createdBy: toUserSummary(createdByUser),
+    createdAt: line.createdAt,
+    updatedAt: line.updatedAt,
+    parentId: line.householdItemId,
+    parentName: householdItem?.name ?? '(Unknown Household Item)',
+    area: toAreaSummary(area),
+    hasClaimedInvoice: invoiceData.hasClaimedInvoice,
+  };
+}
+
+/**
+ * Comparator for sorting budget source budget lines.
+ * Sort by: area name (nulls last) → parent item name → createdAt (all ascending).
+ */
+function compareBudgetSourceLines(
+  a: BudgetSourceBudgetLine,
+  b: BudgetSourceBudgetLine,
+): number {
+  // Area name: nulls last
+  if (a.area === null && b.area !== null) return 1;
+  if (a.area !== null && b.area === null) return -1;
+  if (a.area !== null && b.area !== null) {
+    const areaCompare = a.area.name.localeCompare(b.area.name);
+    if (areaCompare !== 0) return areaCompare;
+  }
+
+  // Parent name
+  const parentCompare = a.parentName.localeCompare(b.parentName);
+  if (parentCompare !== 0) return parentCompare;
+
+  // CreatedAt
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+}
+
+/**
+ * Get all budget lines for a budget source, grouped by parent entity type.
+ * Returns work item budget lines and household item budget lines, sorted by area name, parent name, and createdAt.
+ * @throws NotFoundError if budget source does not exist
+ */
+export function getBudgetSourceBudgetLines(
+  db: DbType,
+  sourceId: string,
+): BudgetSourceBudgetLinesResponse {
+  // Verify budget source exists
+  const source = db.select().from(budgetSources).where(eq(budgetSources.id, sourceId)).get();
+  if (!source) {
+    throw new NotFoundError('Budget source not found');
+  }
+
+  // Fetch work item budget lines
+  const wibRows = db
+    .select()
+    .from(workItemBudgets)
+    .where(eq(workItemBudgets.budgetSourceId, sourceId))
+    .all();
+  const workItemLines = wibRows
+    .map((line) => buildWorkItemBudgetLine(db, line))
+    .sort(compareBudgetSourceLines);
+
+  // Fetch household item budget lines
+  const hibRows = db
+    .select()
+    .from(householdItemBudgets)
+    .where(eq(householdItemBudgets.budgetSourceId, sourceId))
+    .all();
+  const householdItemLines = hibRows
+    .map((line) => buildHouseholdItemBudgetLine(db, line))
+    .sort(compareBudgetSourceLines);
+
+  return {
+    workItemLines,
+    householdItemLines,
+  };
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -153,6 +153,8 @@ export type {
   UpdateBudgetSourceRequest,
   BudgetSourceListResponse,
   BudgetSourceResponse,
+  BudgetSourceBudgetLine,
+  BudgetSourceBudgetLinesResponse,
 } from './types/budgetSource.js';
 
 // Shared Budget Base Types

--- a/shared/src/types/budgetSource.ts
+++ b/shared/src/types/budgetSource.ts
@@ -5,6 +5,8 @@
  */
 
 import type { UserSummary } from './workItem.js';
+import type { BaseBudgetLine } from './budget.js';
+import type { AreaSummary } from './area.js';
 
 /**
  * The type/category of a financing source.
@@ -81,4 +83,24 @@ export interface BudgetSourceListResponse {
  */
 export interface BudgetSourceResponse {
   budgetSource: BudgetSource;
+}
+
+/**
+ * A budget line with parent context, used in budget source detail responses.
+ * Extends BaseBudgetLine with parent entity identification and area information.
+ */
+export interface BudgetSourceBudgetLine extends BaseBudgetLine {
+  parentId: string;
+  parentName: string;
+  area: AreaSummary | null;
+  hasClaimedInvoice: boolean;
+}
+
+/**
+ * Response for GET /api/budget-sources/:sourceId/budget-lines
+ * Groups budget lines by their parent entity type (work item vs household item).
+ */
+export interface BudgetSourceBudgetLinesResponse {
+  workItemLines: BudgetSourceBudgetLine[];
+  householdItemLines: BudgetSourceBudgetLine[];
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/budget-sources/:sourceId/budget-lines` endpoint that returns all budget lines (work item lines + household item lines) linked to a given budget source
- New shared types `BudgetSourceBudgetLine` and `BudgetSourceBudgetLinesResponse` expose `parentId`, `parentName`, `area`, and `hasClaimedInvoice` alongside the existing `BaseBudgetLine` fields
- Results are sorted by area (nulls last), then parent name, then `createdAt`
- API-Contract wiki page updated with the new endpoint documentation

Fixes #1245

## Test plan

- [x] Unit tests for `budgetSourceService` new functions (budgetSourceService.test.ts)
- [x] Integration tests for `GET /api/budget-sources/:sourceId/budget-lines` route (budgetSources.test.ts)
- [x] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>