### PR TITLE
feat(budget-overview): replace category breakdown with expandable area tree (#1243)

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -257,7 +257,6 @@ describe('App', () => {
       remainingVsActualClaimed: 0,
       remainingVsMinPlannedWithPayback: 0,
       remainingVsMaxPlannedWithPayback: 0,
-      categorySummaries: [],
       areaSummaries: [],
       unassignedSummary: null,
       subsidySummary: {

--- a/client/src/components/AreaTreeTable/AreaTreeTable.module.css
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.module.css
@@ -1,0 +1,271 @@
+.treeCard {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.treeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.treeTitle {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.expandAllBtn {
+  font-size: var(--font-size-xs);
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: none;
+  font-weight: var(--font-weight-normal);
+}
+
+.expandAllBtn:hover {
+  color: var(--color-primary-hover);
+  text-decoration: underline;
+}
+
+.expandAllBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  role: treegrid;
+}
+
+.table thead th {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border-strong);
+  padding: var(--spacing-3) var(--spacing-3);
+  text-align: left;
+}
+
+/* Column widths */
+.colName {
+  text-align: left;
+  min-width: 200px;
+}
+
+.colPlanned,
+.colActual,
+.colVariance {
+  text-align: right;
+  min-width: 120px;
+  font-variant-numeric: tabular-nums;
+}
+
+.table td {
+  padding: var(--spacing-2-5) var(--spacing-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Root rows (depth 0) */
+.rowRoot td {
+  background: var(--color-bg-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  padding: var(--spacing-2-5) var(--spacing-3);
+}
+
+.rowRoot:hover td {
+  background: var(--color-bg-hover);
+}
+
+/* Child rows (depth 1+) */
+.rowChild td {
+  background: var(--color-bg-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-body);
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.rowChild:hover td {
+  background: var(--color-bg-hover);
+}
+
+/* Unassigned row */
+.rowUnassigned td {
+  background: var(--color-bg-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-body);
+  padding: var(--spacing-2-5) var(--spacing-3);
+  border-top: 2px solid var(--color-border-strong);
+}
+
+.rowUnassigned:hover td {
+  background: var(--color-bg-hover);
+}
+
+/* Name cell structure */
+.nameContent {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.indent {
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.expandBtn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.expandBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-secondary);
+}
+
+.expandBtn:active {
+  background: var(--color-bg-tertiary);
+}
+
+.expandBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.expandBtnPlaceholder {
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.chevron {
+  width: 16px;
+  height: 16px;
+  transition: transform var(--transition-normal);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+.areaName {
+  flex: 1;
+}
+
+.unassignedName {
+  flex: 1;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+/* Variance colors */
+.variancePositive {
+  color: var(--color-success-text-on-light);
+}
+
+.varianceNegative {
+  color: var(--color-danger-text-on-light);
+}
+
+/* Visually hidden for screen readers */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Responsive: Tablet and Mobile */
+@media (max-width: 767px) {
+  .treeCard {
+    padding: var(--spacing-4);
+  }
+
+  .table {
+    min-width: 480px;
+  }
+
+  .colName {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+  }
+
+  .rowRoot .colName {
+    background: var(--color-bg-secondary);
+  }
+
+  .rowChild .colName {
+    background: var(--color-bg-primary);
+  }
+
+  .rowUnassigned .colName {
+    background: var(--color-bg-secondary);
+  }
+
+  .expandBtn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .colPlanned,
+  .colActual,
+  .colVariance {
+    font-size: var(--font-size-xs);
+    min-width: auto;
+  }
+
+  .table thead th {
+    font-size: var(--font-size-2xs);
+    padding: var(--spacing-2) var(--spacing-2);
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .chevron {
+    transition: none;
+  }
+}

--- a/client/src/components/AreaTreeTable/AreaTreeTable.module.css
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.module.css
@@ -54,7 +54,6 @@
 .table {
   width: 100%;
   border-collapse: collapse;
-  role: treegrid;
 }
 
 .table thead th {

--- a/client/src/components/AreaTreeTable/AreaTreeTable.test.tsx
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.test.tsx
@@ -547,21 +547,15 @@ describe('AreaTreeTable — leaf node placeholder', () => {
   });
 
   it('leaf rows have expandBtnPlaceholder class in their name cell', () => {
-    render(
+    const { container } = render(
       <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
 
-    const { container } = render(
-      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
-    );
-
-    // After expanding, the leaf row should contain expandBtnPlaceholder
+    // After expanding, the leaf child row should contain expandBtnPlaceholder
     // (identity-obj-proxy makes class attributes carry the original key name)
     const placeholders = container.querySelectorAll('[class*="expandBtnPlaceholder"]');
-    // Root A's expand btn is replaced by a placeholder on the unassigned/other leaf rows
-    // For leaf children, placeholder should appear
     expect(placeholders.length).toBeGreaterThan(0);
   });
 });

--- a/client/src/components/AreaTreeTable/AreaTreeTable.test.tsx
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.test.tsx
@@ -1,0 +1,685 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { AreaBudgetSummary } from '@cornerstone/shared';
+import { AreaTreeTable } from './AreaTreeTable.js';
+
+// CSS modules mocked via identity-obj-proxy (returns class name as the key)
+
+// i18next is initialized with English translations by setupTests.ts
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Pass-through formatter — makes values easy to assert in tests. */
+const fmt = (v: number) => v.toString();
+
+function makeArea(overrides: Partial<AreaBudgetSummary> & { areaId: string; name: string }): AreaBudgetSummary {
+  return {
+    parentId: null,
+    planned: 10000,
+    actual: 8000,
+    variance: 2000,
+    ...overrides,
+  };
+}
+
+const ROOT_A = makeArea({ areaId: 'a', name: 'Root A', planned: 10000, actual: 8000, variance: 2000 });
+const ROOT_B = makeArea({ areaId: 'b', name: 'Root B', planned: 5000, actual: 6000, variance: -1000 });
+const CHILD_A1 = makeArea({ areaId: 'a1', name: 'Child A1', parentId: 'a', planned: 3000, actual: 2500, variance: 500 });
+const GRANDCHILD_A1a = makeArea({ areaId: 'a1a', name: 'Grandchild A1a', parentId: 'a1', planned: 1000, actual: 900, variance: 100 });
+
+// ─── 1. Empty state ─────────────────────────────────────────────────────────
+
+describe('AreaTreeTable — empty state', () => {
+  it('renders EmptyState when areas=[] and unassigned=null', () => {
+    render(<AreaTreeTable areas={[]} unassigned={null} formatCurrency={fmt} />);
+
+    // The component renders EmptyState which shows the emptyMessage text
+    expect(
+      screen.getByText(/no areas have been set up yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render a table when areas=[] and unassigned=null', () => {
+    render(<AreaTreeTable areas={[]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.queryByRole('treegrid')).not.toBeInTheDocument();
+  });
+
+  it('does not show EmptyState when areas=[] but unassigned is present', () => {
+    render(
+      <AreaTreeTable
+        areas={[]}
+        unassigned={{ planned: 5000, actual: 4000, variance: 1000 }}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.queryByText(/no areas have been set up yet/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('treegrid')).toBeInTheDocument();
+  });
+});
+
+// ─── 2. Flat list ────────────────────────────────────────────────────────────
+
+describe('AreaTreeTable — flat list', () => {
+  it('renders both root areas', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByText('Root A')).toBeInTheDocument();
+    expect(screen.getByText('Root B')).toBeInTheDocument();
+  });
+
+  it('renders planned values for root areas', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    // ROOT_A planned=10000, ROOT_B planned=5000
+    expect(screen.getByText('10000')).toBeInTheDocument();
+    expect(screen.getByText('5000')).toBeInTheDocument();
+  });
+
+  it('renders actual values for root areas', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    // ROOT_A actual=8000, ROOT_B actual=6000
+    expect(screen.getByText('8000')).toBeInTheDocument();
+    expect(screen.getByText('6000')).toBeInTheDocument();
+  });
+
+  it('renders variance values for root areas', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    // ROOT_A variance=2000, ROOT_B variance=-1000
+    expect(screen.getByText('2000')).toBeInTheDocument();
+    expect(screen.getByText('-1000')).toBeInTheDocument();
+  });
+
+  it('root rows have aria-level="1"', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    const rows = screen.getAllByRole('row').filter(
+      (r) => r.getAttribute('aria-level') === '1',
+    );
+    // 2 root rows + header row (no aria-level) = header row doesn't match
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('leaf root rows have placeholder (no expand button)', () => {
+    render(<AreaTreeTable areas={[ROOT_A, ROOT_B]} unassigned={null} formatCurrency={fmt} />);
+
+    // No expand buttons visible when all areas are leaf nodes
+    expect(screen.queryByRole('button', { name: /expand/i })).not.toBeInTheDocument();
+  });
+});
+
+// ─── 3. Expand/collapse toggle ───────────────────────────────────────────────
+
+describe('AreaTreeTable — expand/collapse toggle', () => {
+  it('child is hidden before expand', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    expect(screen.queryByText('Child A1')).not.toBeInTheDocument();
+  });
+
+  it('clicking expand reveals the child row', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const expandBtn = screen.getByRole('button', { name: /expand root a/i });
+    fireEvent.click(expandBtn);
+
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+  });
+
+  it('clicking collapse hides the child row', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const expandBtn = screen.getByRole('button', { name: /expand root a/i });
+    fireEvent.click(expandBtn);
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+
+    const collapseBtn = screen.getByRole('button', { name: /collapse root a/i });
+    fireEvent.click(collapseBtn);
+
+    expect(screen.queryByText('Child A1')).not.toBeInTheDocument();
+  });
+
+  it('expand button has aria-expanded="false" before expanding', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const btn = screen.getByRole('button', { name: /expand root a/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expand button has aria-expanded="true" after expanding', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const btn = screen.getByRole('button', { name: /expand root a/i });
+    fireEvent.click(btn);
+
+    expect(screen.getByRole('button', { name: /collapse root a/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('expand button has aria-controls pointing to the children container', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const btn = screen.getByRole('button', { name: /expand root a/i });
+    expect(btn).toHaveAttribute('aria-controls', 'area-children-a');
+  });
+});
+
+// ─── 4. Nested tree ──────────────────────────────────────────────────────────
+
+describe('AreaTreeTable — nested tree', () => {
+  it('initially renders only the root row', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, GRANDCHILD_A1a]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.getByText('Root A')).toBeInTheDocument();
+    expect(screen.queryByText('Child A1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grandchild A1a')).not.toBeInTheDocument();
+  });
+
+  it('expanding root shows root + child but not grandchild', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, GRANDCHILD_A1a]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    expect(screen.getByText('Root A')).toBeInTheDocument();
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+    expect(screen.queryByText('Grandchild A1a')).not.toBeInTheDocument();
+  });
+
+  it('expanding root and child shows all three levels', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, GRANDCHILD_A1a]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+    fireEvent.click(screen.getByRole('button', { name: /expand child a1/i }));
+
+    expect(screen.getByText('Root A')).toBeInTheDocument();
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+    expect(screen.getByText('Grandchild A1a')).toBeInTheDocument();
+  });
+
+  it('child has aria-level="2" after expanding root', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, GRANDCHILD_A1a]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    const rows = screen.getAllByRole('row').filter(
+      (r) => r.getAttribute('aria-level') === '2',
+    );
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── 5. Expand All / Collapse All ────────────────────────────────────────────
+
+describe('AreaTreeTable — Expand All / Collapse All', () => {
+  // Two roots each with a child → 2 non-leaf nodes → showExpandAll = true
+  const ROOT_C = makeArea({ areaId: 'c', name: 'Root C' });
+  const CHILD_C1 = makeArea({ areaId: 'c1', name: 'Child C1', parentId: 'c' });
+
+  it('Expand all button is visible when more than 1 non-leaf node exists', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, ROOT_C, CHILD_C1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /expand all/i })).toBeInTheDocument();
+  });
+
+  it('clicking Expand all reveals all children', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, ROOT_C, CHILD_C1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand all/i }));
+
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+    expect(screen.getByText('Child C1')).toBeInTheDocument();
+  });
+
+  it('clicking Collapse all (when all expanded) hides all children', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, ROOT_C, CHILD_C1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    // First expand all
+    fireEvent.click(screen.getByRole('button', { name: /expand all/i }));
+    expect(screen.getByText('Child A1')).toBeInTheDocument();
+
+    // Then collapse all (button label changes)
+    fireEvent.click(screen.getByRole('button', { name: /collapse all/i }));
+
+    expect(screen.queryByText('Child A1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Child C1')).not.toBeInTheDocument();
+  });
+
+  it('Expand all button toggles label to Collapse all when fully expanded', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A, CHILD_A1, ROOT_C, CHILD_C1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /expand all/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /expand all/i }));
+
+    expect(screen.getByRole('button', { name: /collapse all/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^expand all$/i })).not.toBeInTheDocument();
+  });
+});
+
+// ─── 6. Expand All button absence ────────────────────────────────────────────
+
+describe('AreaTreeTable — Expand All button absent when not needed', () => {
+  it('no Expand all button for a single root with no children', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.queryByRole('button', { name: /expand all/i })).not.toBeInTheDocument();
+  });
+
+  it('no Expand all button for a single non-leaf (exactly 1 non-leaf node)', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    // ROOT_A has one child → 1 non-leaf → showExpandAll requires > 1, so no button
+    expect(screen.queryByRole('button', { name: /expand all/i })).not.toBeInTheDocument();
+  });
+});
+
+// ─── 7. Unassigned row present ───────────────────────────────────────────────
+
+describe('AreaTreeTable — unassigned row', () => {
+  it('renders unassigned row when unassigned is non-null', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A]}
+        unassigned={{ planned: 5000, actual: 4800, variance: 200 }}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.getByText('Unassigned')).toBeInTheDocument();
+  });
+
+  it('renders unassigned planned/actual/variance values', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_A]}
+        unassigned={{ planned: 5000, actual: 4800, variance: 200 }}
+        formatCurrency={fmt}
+      />,
+    );
+
+    expect(screen.getByText('5000')).toBeInTheDocument();
+    expect(screen.getByText('4800')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+});
+
+// ─── 8. Unassigned row absent ────────────────────────────────────────────────
+
+describe('AreaTreeTable — unassigned row absent', () => {
+  it('does not render unassigned row when unassigned=null', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.queryByText('Unassigned')).not.toBeInTheDocument();
+  });
+});
+
+// ─── 9. Variance color ───────────────────────────────────────────────────────
+
+describe('AreaTreeTable — variance color classes', () => {
+  it('positive variance cell has variancePositive class', () => {
+    // ROOT_A variance=2000 (positive)
+    const { container } = render(
+      <AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    // identity-obj-proxy makes className='variancePositive'
+    const positiveCells = container.querySelectorAll('[class*="variancePositive"]');
+    expect(positiveCells.length).toBeGreaterThan(0);
+  });
+
+  it('negative variance cell has varianceNegative class', () => {
+    // ROOT_B variance=-1000 (negative)
+    const { container } = render(
+      <AreaTreeTable areas={[ROOT_B]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const negativeCells = container.querySelectorAll('[class*="varianceNegative"]');
+    expect(negativeCells.length).toBeGreaterThan(0);
+  });
+
+  it('unassigned positive variance has variancePositive class', () => {
+    const { container } = render(
+      <AreaTreeTable
+        areas={[]}
+        unassigned={{ planned: 5000, actual: 4000, variance: 1000 }}
+        formatCurrency={fmt}
+      />,
+    );
+
+    const positiveCells = container.querySelectorAll('[class*="variancePositive"]');
+    expect(positiveCells.length).toBeGreaterThan(0);
+  });
+
+  it('unassigned negative variance has varianceNegative class', () => {
+    const { container } = render(
+      <AreaTreeTable
+        areas={[]}
+        unassigned={{ planned: 5000, actual: 6000, variance: -1000 }}
+        formatCurrency={fmt}
+      />,
+    );
+
+    const negativeCells = container.querySelectorAll('[class*="varianceNegative"]');
+    expect(negativeCells.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 10. ARIA attributes ──────────────────────────────────────────────────────
+
+describe('AreaTreeTable — ARIA attributes', () => {
+  it('root rows have aria-level="1"', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const rootRow = screen.getAllByRole('row').find(
+      (r) => r.getAttribute('aria-level') === '1' && r.textContent?.includes('Root A'),
+    );
+    expect(rootRow).toBeTruthy();
+    expect(rootRow).toHaveAttribute('aria-level', '1');
+  });
+
+  it('child rows have aria-level="2" after expanding', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    const childRow = screen.getAllByRole('row').find(
+      (r) => r.getAttribute('aria-level') === '2',
+    );
+    expect(childRow).toBeTruthy();
+  });
+
+  it('expand button has aria-expanded="false" initially', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const btn = screen.getByRole('button', { name: /expand root a/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expand button has aria-controls="area-children-{id}"', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const btn = screen.getByRole('button', { name: /expand root a/i });
+    expect(btn).toHaveAttribute('aria-controls', 'area-children-a');
+  });
+
+  it('table has role="treegrid"', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('treegrid')).toBeInTheDocument();
+  });
+});
+
+// ─── 11. Screen-reader live region ───────────────────────────────────────────
+
+describe('AreaTreeTable — screen reader live region', () => {
+  it('role="status" element is present in the DOM', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('live region shows expanded announcement after clicking expand', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const statusEl = screen.getByRole('status');
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    // The component sets announcement synchronously before clearing with setTimeout
+    expect(statusEl).toHaveTextContent(/root a/i);
+  });
+
+  it('live region shows collapsed announcement after clicking collapse', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    const statusEl = screen.getByRole('status');
+    // Expand first
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+    // Then collapse
+    fireEvent.click(screen.getByRole('button', { name: /collapse root a/i }));
+
+    expect(statusEl).toHaveTextContent(/root a/i);
+  });
+});
+
+// ─── 12. Leaf node placeholder ───────────────────────────────────────────────
+
+describe('AreaTreeTable — leaf node placeholder', () => {
+  it('leaf rows render the expandBtnPlaceholder span, not an expand button', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    // Expand so CHILD_A1 is visible (it's a leaf)
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    // CHILD_A1 is a leaf: its row should NOT have an expand button
+    const childRow = screen.getAllByRole('row').find(
+      (r) => r.textContent?.includes('Child A1'),
+    );
+    expect(childRow).toBeTruthy();
+    // No button inside the child row
+    const btnsInChild = childRow!.querySelectorAll('button');
+    expect(btnsInChild.length).toBe(0);
+  });
+
+  it('leaf rows have expandBtnPlaceholder class in their name cell', () => {
+    render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expand root a/i }));
+
+    const { container } = render(
+      <AreaTreeTable areas={[ROOT_A, CHILD_A1]} unassigned={null} formatCurrency={fmt} />,
+    );
+
+    // After expanding, the leaf row should contain expandBtnPlaceholder
+    // (identity-obj-proxy makes class attributes carry the original key name)
+    const placeholders = container.querySelectorAll('[class*="expandBtnPlaceholder"]');
+    // Root A's expand btn is replaced by a placeholder on the unassigned/other leaf rows
+    // For leaf children, placeholder should appear
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 13. Keyboard ArrowDown ───────────────────────────────────────────────────
+
+describe('AreaTreeTable — keyboard ArrowDown', () => {
+  it('ArrowDown moves focus to the next expand button', () => {
+    // Two parent nodes with children → 2 expand buttons visible
+    const ROOT_D = makeArea({ areaId: 'd', name: 'Root D' });
+    const CHILD_D1 = makeArea({ areaId: 'd1', name: 'Child D1', parentId: 'd' });
+    const ROOT_E = makeArea({ areaId: 'e', name: 'Root E' });
+    const CHILD_E1 = makeArea({ areaId: 'e1', name: 'Child E1', parentId: 'e' });
+
+    render(
+      <AreaTreeTable
+        areas={[ROOT_D, CHILD_D1, ROOT_E, CHILD_E1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    const [firstBtn] = screen.getAllByRole('button', { name: /expand root/i });
+    firstBtn.focus();
+    expect(document.activeElement).toBe(firstBtn);
+
+    fireEvent.keyDown(firstBtn, { key: 'ArrowDown' });
+
+    // Focus should have moved — the second expand button is now active
+    const allExpandBtns = screen.getAllByRole('button', { name: /expand root/i });
+    expect(document.activeElement).toBe(allExpandBtns[1]);
+  });
+});
+
+// ─── 14. Keyboard Home/End ───────────────────────────────────────────────────
+
+describe('AreaTreeTable — keyboard Home/End', () => {
+  const ROOT_F = makeArea({ areaId: 'f', name: 'Root F' });
+  const CHILD_F1 = makeArea({ areaId: 'f1', name: 'Child F1', parentId: 'f' });
+  const ROOT_G = makeArea({ areaId: 'g', name: 'Root G' });
+  const CHILD_G1 = makeArea({ areaId: 'g1', name: 'Child G1', parentId: 'g' });
+
+  it('Home key focuses the first expand button', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_F, CHILD_F1, ROOT_G, CHILD_G1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    const allBtns = screen.getAllByRole('button', { name: /expand root/i });
+    const lastBtn = allBtns[allBtns.length - 1];
+    lastBtn.focus();
+
+    fireEvent.keyDown(lastBtn, { key: 'Home' });
+
+    expect(document.activeElement).toBe(allBtns[0]);
+  });
+
+  it('End key focuses the last visible expand button', () => {
+    render(
+      <AreaTreeTable
+        areas={[ROOT_F, CHILD_F1, ROOT_G, CHILD_G1]}
+        unassigned={null}
+        formatCurrency={fmt}
+      />,
+    );
+
+    const allBtns = screen.getAllByRole('button', { name: /expand root/i });
+    allBtns[0].focus();
+
+    fireEvent.keyDown(allBtns[0], { key: 'End' });
+
+    expect(document.activeElement).toBe(allBtns[allBtns.length - 1]);
+  });
+});
+
+// ─── Column headers ──────────────────────────────────────────────────────────
+
+describe('AreaTreeTable — column headers', () => {
+  it('renders Area column header', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('columnheader', { name: /area/i })).toBeInTheDocument();
+  });
+
+  it('renders Planned column header', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('columnheader', { name: /planned/i })).toBeInTheDocument();
+  });
+
+  it('renders Actual column header', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('columnheader', { name: /actual/i })).toBeInTheDocument();
+  });
+
+  it('renders Variance column header', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('columnheader', { name: /variance/i })).toBeInTheDocument();
+  });
+});
+
+// ─── Section heading ─────────────────────────────────────────────────────────
+
+describe('AreaTreeTable — section heading', () => {
+  it('renders the "Area Breakdown" section heading', () => {
+    render(<AreaTreeTable areas={[ROOT_A]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('heading', { name: /area breakdown/i })).toBeInTheDocument();
+  });
+
+  it('renders the heading in empty state too', () => {
+    render(<AreaTreeTable areas={[]} unassigned={null} formatCurrency={fmt} />);
+
+    expect(screen.getByRole('heading', { name: /area breakdown/i })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/AreaTreeTable/AreaTreeTable.tsx
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.tsx
@@ -329,7 +329,6 @@ export function AreaTreeTable({ areas, unassigned, formatCurrency }: AreaTreeTab
   // Keyboard navigation
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLButtonElement>, nodeId: string) => {
-      const visibleButtonIds: string[] = [];
       const allButtons = Array.from(buttonRefs.current.entries())
         .filter(([, btn]) => btn && btn.offsetParent !== null) // visible
         .map(([id]) => id);
@@ -447,7 +446,7 @@ export function AreaTreeTable({ areas, unassigned, formatCurrency }: AreaTreeTab
       <div className={styles.tableWrapper}>
         <table className={styles.table} role="treegrid">
           <caption className={styles.srOnly}>
-            Area budget breakdown with expandable tree
+            {t('overview.areaBreakdown.tableCaption')}
           </caption>
           <thead>
             <tr>

--- a/client/src/components/AreaTreeTable/AreaTreeTable.tsx
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.tsx
@@ -1,0 +1,517 @@
+import { useState, useRef, useEffect, useCallback, Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AreaBudgetSummary } from '@cornerstone/shared';
+import { EmptyState } from '../EmptyState/EmptyState.js';
+import styles from './AreaTreeTable.module.css';
+
+export interface AreaTreeTableProps {
+  areas: AreaBudgetSummary[];
+  unassigned: { planned: number; actual: number; variance: number } | null;
+  formatCurrency: (value: number) => string;
+}
+
+interface TreeNode {
+  area: AreaBudgetSummary;
+  depth: number;
+  children: TreeNode[];
+  parentId: string | null;
+}
+
+/**
+ * Build a tree of areas from a flat array, maintaining original order.
+ */
+function buildTree(areas: AreaBudgetSummary[]): TreeNode[] {
+  const roots: TreeNode[] = [];
+  const nodeMap = new Map<string, TreeNode>();
+
+  // First pass: create all nodes
+  areas.forEach((area) => {
+    const node: TreeNode = {
+      area,
+      depth: 0,
+      children: [],
+      parentId: area.parentId,
+    };
+    nodeMap.set(area.areaId, node);
+  });
+
+  // Second pass: build hierarchy and calculate depths
+  const queue: { node: TreeNode; depth: number }[] = [];
+
+  areas.forEach((area) => {
+    const node = nodeMap.get(area.areaId)!;
+    if (area.parentId === null) {
+      roots.push(node);
+      queue.push({ node, depth: 0 });
+    }
+  });
+
+  // BFS to set depths and attach children
+  while (queue.length > 0) {
+    const { node, depth } = queue.shift()!;
+    node.depth = depth;
+
+    // Find all direct children
+    areas.forEach((area) => {
+      if (area.parentId === node.area.areaId) {
+        const childNode = nodeMap.get(area.areaId)!;
+        node.children.push(childNode);
+        queue.push({ node: childNode, depth: depth + 1 });
+      }
+    });
+  }
+
+  return roots;
+}
+
+/**
+ * Count total non-leaf nodes (nodes with children).
+ */
+function countNonLeafNodes(roots: TreeNode[]): number {
+  let count = 0;
+  const walk = (node: TreeNode) => {
+    if (node.children.length > 0) {
+      count++;
+      node.children.forEach(walk);
+    }
+  };
+  roots.forEach(walk);
+  return count;
+}
+
+/**
+ * Get all non-leaf node IDs (for expand all / collapse all).
+ */
+function getNonLeafIds(roots: TreeNode[]): string[] {
+  const ids: string[] = [];
+  const walk = (node: TreeNode) => {
+    if (node.children.length > 0) {
+      ids.push(node.area.areaId);
+      node.children.forEach(walk);
+    }
+  };
+  roots.forEach(walk);
+  return ids;
+}
+
+/**
+ * Inline SVG chevron (16×16).
+ */
+function ChevronSvg({ className }: { className: string }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" className={className}>
+      <path
+        d="M6 4l4 4-4 4"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Render a single row (area or unassigned).
+ */
+interface AreaRowProps {
+  nodeId: string | null;
+  isExpanded: boolean;
+  onToggle: (id: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>, id: string) => void;
+  formatCurrency: (value: number) => string;
+  depth: number;
+  hasChildren: boolean;
+  isUnassigned?: boolean;
+  planned: number;
+  actual: number;
+  variance: number;
+  name: string;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  rowClassName: string;
+  siblings: number;
+  index: number;
+  expandLabel: string;
+  collapseLabel: string;
+}
+
+function AreaRow({
+  nodeId,
+  isExpanded,
+  onToggle,
+  onKeyDown,
+  formatCurrency,
+  depth,
+  hasChildren,
+  isUnassigned,
+  planned,
+  actual,
+  variance,
+  name,
+  buttonRef,
+  rowClassName,
+  siblings,
+  index,
+  expandLabel,
+  collapseLabel,
+}: AreaRowProps) {
+  return (
+    <tr role="row" className={rowClassName} aria-level={depth + 1} aria-setsize={siblings} aria-posinset={index + 1}>
+      <td role="gridcell" className={styles.colName}>
+        <div className={styles.nameContent}>
+          <span
+            className={styles.indent}
+            style={{ width: `calc(var(--spacing-6) * ${depth})` }}
+            aria-hidden="true"
+          />
+          {hasChildren && nodeId ? (
+            <button
+              ref={buttonRef}
+              type="button"
+              className={styles.expandBtn}
+              aria-expanded={isExpanded}
+              aria-label={isExpanded ? collapseLabel : expandLabel}
+              aria-controls={`area-children-${nodeId}`}
+              onClick={() => onToggle(nodeId)}
+              onKeyDown={(e) => onKeyDown(e, nodeId)}
+            >
+              <ChevronSvg className={`${styles.chevron} ${isExpanded ? styles.chevronOpen : ''}`} />
+            </button>
+          ) : (
+            <span className={styles.expandBtnPlaceholder} aria-hidden="true" />
+          )}
+          <span className={isUnassigned ? styles.unassignedName : styles.areaName}>{name}</span>
+        </div>
+      </td>
+      <td role="gridcell" className={styles.colPlanned}>
+        {formatCurrency(planned)}
+      </td>
+      <td role="gridcell" className={styles.colActual}>
+        {formatCurrency(actual)}
+      </td>
+      <td
+        role="gridcell"
+        className={`${styles.colVariance} ${variance >= 0 ? styles.variancePositive : styles.varianceNegative}`}
+      >
+        {formatCurrency(variance)}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * Recursively render all visible rows.
+ */
+function renderVisibleRows(
+  nodes: TreeNode[],
+  expandedIds: Set<string>,
+  onToggle: (id: string) => void,
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>, id: string) => void,
+  formatCurrency: (value: number) => string,
+  buttonRefs: Map<string, HTMLButtonElement | null>,
+  rowClassMap: Map<string, string>,
+  t: (key: string, vars?: Record<string, string>) => string,
+): React.ReactNode[] {
+  const rows: React.ReactNode[] = [];
+
+  const walk = (node: TreeNode, siblings: number, index: number) => {
+    const rowClass = rowClassMap.get(node.area.areaId) || styles.rowRoot;
+    const isExpanded = expandedIds.has(node.area.areaId);
+    const expandLabel = t('overview.areaBreakdown.expandArea', { name: node.area.name });
+    const collapseLabel = t('overview.areaBreakdown.collapseArea', { name: node.area.name });
+
+    rows.push(
+      <AreaRow
+        key={node.area.areaId}
+        nodeId={node.area.areaId}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        onKeyDown={onKeyDown}
+        formatCurrency={formatCurrency}
+        depth={node.depth}
+        hasChildren={node.children.length > 0}
+        planned={node.area.planned}
+        actual={node.area.actual}
+        variance={node.area.variance}
+        name={node.area.name}
+        buttonRef={(el) => {
+          if (el) buttonRefs.set(node.area.areaId, el);
+        }}
+        rowClassName={rowClass}
+        siblings={siblings}
+        index={index}
+        expandLabel={expandLabel}
+        collapseLabel={collapseLabel}
+      />,
+    );
+
+    // Render children if expanded
+    if (isExpanded) {
+      node.children.forEach((child, childIdx) => {
+        walk(child, node.children.length, childIdx);
+      });
+    }
+  };
+
+  nodes.forEach((node, idx) => {
+    walk(node, nodes.length, idx);
+  });
+
+  return rows;
+}
+
+/**
+ * Main AreaTreeTable Component
+ */
+export function AreaTreeTable({ areas, unassigned, formatCurrency }: AreaTreeTableProps) {
+  const { t } = useTranslation('budget');
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [announcement, setAnnouncement] = useState('');
+  const buttonRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map());
+
+  // Build tree
+  const roots = buildTree(areas);
+  const nonLeafCount = countNonLeafNodes(roots);
+  const allNonLeafIds = getNonLeafIds(roots);
+  const showExpandAll = nonLeafCount > 1;
+
+  // Determine row classes
+  const rowClassMap = new Map<string, string>();
+  const walk = (node: TreeNode) => {
+    rowClassMap.set(node.area.areaId, node.depth === 0 ? styles.rowRoot : styles.rowChild);
+    node.children.forEach(walk);
+  };
+  roots.forEach(walk);
+
+  // Create area ID to node map for parent lookups
+  const nodeIdMap = new Map<string, TreeNode>();
+  const mapWalk = (node: TreeNode) => {
+    nodeIdMap.set(node.area.areaId, node);
+    node.children.forEach(mapWalk);
+  };
+  roots.forEach(mapWalk);
+
+  // Toggle expand/collapse
+  const toggle = (id: string) => {
+    const next = new Set(expandedIds);
+    const wasExpanded = next.has(id);
+    if (wasExpanded) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setExpandedIds(next);
+
+    // Set announcement for screen reader
+    const area = areas.find((a) => a.areaId === id);
+    if (area) {
+      if (wasExpanded) {
+        setAnnouncement(t('overview.areaBreakdown.collapsed', { name: area.name }));
+      } else {
+        setAnnouncement(t('overview.areaBreakdown.expanded', { name: area.name }));
+      }
+      // Reset announcement after a delay
+      setTimeout(() => setAnnouncement(''), 300);
+    }
+  };
+
+  // Expand all / collapse all
+  const handleExpandAll = () => {
+    if (expandedIds.size === allNonLeafIds.length) {
+      // All expanded, collapse all
+      setExpandedIds(new Set());
+    } else {
+      // Expand all
+      setExpandedIds(new Set(allNonLeafIds));
+    }
+  };
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, nodeId: string) => {
+      const visibleButtonIds: string[] = [];
+      const allButtons = Array.from(buttonRefs.current.entries())
+        .filter(([, btn]) => btn && btn.offsetParent !== null) // visible
+        .map(([id]) => id);
+
+      if (allButtons.length === 0) return;
+
+      const currentIdx = allButtons.indexOf(nodeId);
+      if (currentIdx === -1) return;
+
+      const node = nodeIdMap.get(nodeId);
+      if (!node) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          if (currentIdx < allButtons.length - 1) {
+            buttonRefs.current.get(allButtons[currentIdx + 1])?.focus();
+          }
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (currentIdx > 0) {
+            buttonRefs.current.get(allButtons[currentIdx - 1])?.focus();
+          }
+          break;
+        case 'Home':
+          e.preventDefault();
+          buttonRefs.current.get(allButtons[0])?.focus();
+          break;
+        case 'End':
+          e.preventDefault();
+          buttonRefs.current.get(allButtons[allButtons.length - 1])?.focus();
+          break;
+        case 'ArrowRight': {
+          e.preventDefault();
+          const isExpanded = expandedIds.has(nodeId);
+          if (!isExpanded && node.children.length > 0) {
+            // Collapsed with children — expand
+            toggle(nodeId);
+          } else if (isExpanded && node.children.length > 0) {
+            // Expanded — focus first child if it has a button
+            const firstChildId = node.children[0]?.area.areaId;
+            if (firstChildId) {
+              const childButton = buttonRefs.current.get(firstChildId);
+              if (childButton) {
+                childButton.focus();
+              }
+            }
+          }
+          break;
+        }
+        case 'ArrowLeft': {
+          e.preventDefault();
+          const isExpanded = expandedIds.has(nodeId);
+          if (isExpanded) {
+            // Expanded — collapse
+            toggle(nodeId);
+          } else if (node.parentId) {
+            // Collapsed and has parent — focus parent
+            const parentBtn = buttonRefs.current.get(node.parentId);
+            if (parentBtn) {
+              parentBtn.focus();
+            }
+          }
+          break;
+        }
+      }
+    },
+    [expandedIds, areas, nodeIdMap],
+  );
+
+  // Empty state
+  if (areas.length === 0 && !unassigned) {
+    return (
+      <section className={styles.treeCard} aria-labelledby="area-breakdown-heading">
+        <h2 id="area-breakdown-heading" className={styles.treeTitle}>
+          {t('overview.areaBreakdown.title')}
+        </h2>
+        <EmptyState icon="📁" message={t('overview.areaBreakdown.emptyMessage')} />
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.treeCard} aria-labelledby="area-breakdown-heading">
+      {/* Header with title and expand/collapse all */}
+      <div className={styles.treeHeader}>
+        <h2 id="area-breakdown-heading" className={styles.treeTitle}>
+          {t('overview.areaBreakdown.title')}
+        </h2>
+        {showExpandAll && (
+          <button
+            type="button"
+            className={styles.expandAllBtn}
+            onClick={handleExpandAll}
+            aria-label={
+              expandedIds.size === allNonLeafIds.length
+                ? t('overview.areaBreakdown.collapseAll')
+                : t('overview.areaBreakdown.expandAll')
+            }
+          >
+            {expandedIds.size === allNonLeafIds.length
+              ? t('overview.areaBreakdown.collapseAll')
+              : t('overview.areaBreakdown.expandAll')}
+          </button>
+        )}
+      </div>
+
+      {/* Screen reader live region */}
+      <span role="status" aria-atomic="true" className={styles.srOnly}>
+        {announcement}
+      </span>
+
+      {/* Table */}
+      <div className={styles.tableWrapper}>
+        <table className={styles.table} role="treegrid">
+          <caption className={styles.srOnly}>
+            Area budget breakdown with expandable tree
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col" className={styles.colName} role="columnheader">
+                {t('overview.areaBreakdown.colName')}
+              </th>
+              <th scope="col" className={styles.colPlanned} role="columnheader">
+                {t('overview.areaBreakdown.colPlanned')}
+              </th>
+              <th scope="col" className={styles.colActual} role="columnheader">
+                {t('overview.areaBreakdown.colActual')}
+              </th>
+              <th scope="col" className={styles.colVariance} role="columnheader">
+                {t('overview.areaBreakdown.colVariance')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {/* Render all visible area rows */}
+            {renderVisibleRows(roots, expandedIds, toggle, handleKeyDown, formatCurrency, buttonRefs.current, rowClassMap, t).map(
+              (row, idx) => (
+                <Fragment key={idx}>{row}</Fragment>
+              ),
+            )}
+
+            {/* Unassigned row */}
+            {unassigned && (
+              <tr
+                role="row"
+                className={styles.rowUnassigned}
+                aria-level={1}
+                aria-setsize={1}
+                aria-posinset={1}
+              >
+                <td role="gridcell" className={styles.colName}>
+                  <div className={styles.nameContent}>
+                    <span className={styles.indent} style={{ width: 'calc(var(--spacing-6) * 0)' }} aria-hidden="true" />
+                    <span className={styles.expandBtnPlaceholder} aria-hidden="true" />
+                    <span className={styles.unassignedName}>
+                      {t('overview.areaBreakdown.unassignedBucket')}
+                    </span>
+                  </div>
+                </td>
+                <td role="gridcell" className={styles.colPlanned}>
+                  {formatCurrency(unassigned.planned)}
+                </td>
+                <td role="gridcell" className={styles.colActual}>
+                  {formatCurrency(unassigned.actual)}
+                </td>
+                <td
+                  role="gridcell"
+                  className={`${styles.colVariance} ${
+                    unassigned.variance >= 0 ? styles.variancePositive : styles.varianceNegative
+                  }`}
+                >
+                  {formatCurrency(unassigned.variance)}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default AreaTreeTable;

--- a/client/src/components/AreaTreeTable/AreaTreeTable.tsx
+++ b/client/src/components/AreaTreeTable/AreaTreeTable.tsx
@@ -330,7 +330,7 @@ export function AreaTreeTable({ areas, unassigned, formatCurrency }: AreaTreeTab
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLButtonElement>, nodeId: string) => {
       const allButtons = Array.from(buttonRefs.current.entries())
-        .filter(([, btn]) => btn && btn.offsetParent !== null) // visible
+        .filter(([, btn]) => btn !== null)
         .map(([id]) => id);
 
       if (allButtons.length === 0) return;

--- a/client/src/components/AreaTreeTable/index.ts
+++ b/client/src/components/AreaTreeTable/index.ts
@@ -1,0 +1,2 @@
+export { AreaTreeTable } from './AreaTreeTable.js';
+export type { AreaTreeTableProps } from './AreaTreeTable.js';

--- a/client/src/components/BudgetSummaryCard/BudgetSummaryCard.test.tsx
+++ b/client/src/components/BudgetSummaryCard/BudgetSummaryCard.test.tsx
@@ -88,7 +88,6 @@ const baseOverview: BudgetOverview = {
   remainingVsActualClaimed: 90000,
   remainingVsMinPlannedWithPayback: 20000,
   remainingVsMaxPlannedWithPayback: 10000,
-  categorySummaries: [],
   areaSummaries: [],
   unassignedSummary: null,
   subsidySummary: {

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -252,7 +252,6 @@ function buildOverview(
     remainingVsActualClaimed: 0,
     remainingVsMinPlannedWithPayback: 0,
     remainingVsMaxPlannedWithPayback: 0,
-    categorySummaries: [],
     areaSummaries: [],
     unassignedSummary: null,
     subsidySummary: {

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -42,6 +42,22 @@
       "vsMaxPlannedWithPayback": "Verbleibend vs. Max. Geplant (inkl. Rückzahlung)"
     },
     "ofAvailableFunds": "der verfügbaren Mittel",
+    "areaBreakdown": {
+      "title": "Bereichsaufschlüsselung",
+      "colName": "Bereich",
+      "colPlanned": "Geplant",
+      "colActual": "Tatsächlich",
+      "colVariance": "Abweichung",
+      "expandArea": "{{name}} ausklappen",
+      "collapseArea": "{{name}} einklappen",
+      "expandAll": "Alle ausklappen",
+      "collapseAll": "Alle einklappen",
+      "unassignedBucket": "Nicht zugewiesen",
+      "emptyMessage": "Es wurden noch keine Bereiche eingerichtet. Weisen Sie Arbeitspaketen Bereiche zu, um die Ausgaben nach Standort zu sehen.",
+      "expanded": "{{name}} ausgeklappt",
+      "collapsed": "{{name}} eingeklappt",
+      "tableCaption": "Bereichsbudget-Aufschlüsselung mit ausklappbarem Baum"
+    },
     "costBreakdown": {
       "loading": "Kostenaufschlüsselung wird geladen…",
       "title": "Kostenaufschlüsselung",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -55,7 +55,8 @@
       "unassignedBucket": "Unassigned",
       "emptyMessage": "No areas have been set up yet. Assign areas to work items to see spending by location.",
       "expanded": "{{name}} expanded",
-      "collapsed": "{{name}} collapsed"
+      "collapsed": "{{name}} collapsed",
+      "tableCaption": "Area budget breakdown with expandable tree"
     },
     "costBreakdown": {
       "loading": "Loading cost breakdown…",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -42,6 +42,21 @@
       "vsMaxPlannedWithPayback": "Remaining vs Max Planned (incl. payback)"
     },
     "ofAvailableFunds": "of available funds",
+    "areaBreakdown": {
+      "title": "Area Breakdown",
+      "colName": "Area",
+      "colPlanned": "Planned",
+      "colActual": "Actual",
+      "colVariance": "Variance",
+      "expandArea": "Expand {{name}}",
+      "collapseArea": "Collapse {{name}}",
+      "expandAll": "Expand all",
+      "collapseAll": "Collapse all",
+      "unassignedBucket": "Unassigned",
+      "emptyMessage": "No areas have been set up yet. Assign areas to work items to see spending by location.",
+      "expanded": "{{name}} expanded",
+      "collapsed": "{{name}} collapsed"
+    },
     "costBreakdown": {
       "loading": "Loading cost breakdown…",
       "title": "Cost Breakdown",

--- a/client/src/i18n/glossary.json
+++ b/client/src/i18n/glossary.json
@@ -2,7 +2,7 @@
   "_meta": {
     "description": "Single source of truth for domain terminology translations. The translator agent enforces these.",
     "locales": ["de"],
-    "lastUpdated": "2026-03-19"
+    "lastUpdated": "2026-04-16"
   },
   "terms": {
     "Work Item": { "de": { "singular": "Arbeitspaket", "plural": "Arbeitspakete" } },
@@ -22,6 +22,7 @@
     "Dashboard": { "de": { "singular": "Projektübersicht" } },
     "Quotation": { "de": { "singular": "Angebot", "plural": "Angebote" } },
     "Area": { "de": { "singular": "Bereich", "plural": "Bereiche" } },
-    "Trade": { "de": { "singular": "Gewerk", "plural": "Gewerke" } }
+    "Trade": { "de": { "singular": "Gewerk", "plural": "Gewerke" } },
+    "Unassigned": { "de": { "singular": "Nicht zugewiesen" } }
   }
 }

--- a/client/src/lib/budgetOverviewApi.test.ts
+++ b/client/src/lib/budgetOverviewApi.test.ts
@@ -20,32 +20,6 @@ describe('budgetOverviewApi', () => {
     remainingVsActualClaimed: 150000,
     remainingVsMinPlannedWithPayback: 110000,
     remainingVsMaxPlannedWithPayback: 90000,
-    categorySummaries: [
-      {
-        categoryId: 'cat-1',
-        categoryName: 'Materials',
-        categoryColor: '#FF5733',
-        categoryTranslationKey: null,
-        minPlanned: 45000,
-        maxPlanned: 55000,
-        actualCost: 45000,
-        actualCostPaid: 45000,
-        actualCostClaimed: 45000,
-        budgetLineCount: 3,
-      },
-      {
-        categoryId: 'cat-2',
-        categoryName: 'Labor',
-        categoryColor: null,
-        categoryTranslationKey: null,
-        minPlanned: 45000,
-        maxPlanned: 55000,
-        actualCost: 35000,
-        actualCostPaid: 30000,
-        actualCostClaimed: 20000,
-        budgetLineCount: 2,
-      },
-    ],
     areaSummaries: [],
     unassignedSummary: null,
     subsidySummary: {
@@ -129,7 +103,7 @@ describe('budgetOverviewApi', () => {
       expect(result.remainingVsActualPaid).toBe(125000);
     });
 
-    it('returns overview with categorySummaries array', async () => {
+    it('returns overview with areaSummaries array', async () => {
       const mockResponse: BudgetOverviewResponse = { overview: sampleOverview };
 
       mockFetch.mockResolvedValueOnce({
@@ -139,9 +113,7 @@ describe('budgetOverviewApi', () => {
 
       const result = await fetchBudgetOverview();
 
-      expect(result.categorySummaries).toHaveLength(2);
-      expect(result.categorySummaries[0].categoryName).toBe('Materials');
-      expect(result.categorySummaries[1].categoryName).toBe('Labor');
+      expect(Array.isArray(result.areaSummaries)).toBe(true);
     });
 
     it('returns overview with subsidySummary fields', async () => {
@@ -158,10 +130,10 @@ describe('budgetOverviewApi', () => {
       expect(result.subsidySummary.activeSubsidyCount).toBe(2);
     });
 
-    it('handles an overview with empty categorySummaries array', async () => {
+    it('handles an overview with empty areaSummaries array', async () => {
       const emptyOverview: BudgetOverview = {
         ...sampleOverview,
-        categorySummaries: [],
+        areaSummaries: [],
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -171,7 +143,7 @@ describe('budgetOverviewApi', () => {
 
       const result = await fetchBudgetOverview();
 
-      expect(result.categorySummaries).toEqual([]);
+      expect(result.areaSummaries).toEqual([]);
     });
 
     it('handles an all-zero overview (empty project)', async () => {
@@ -190,7 +162,6 @@ describe('budgetOverviewApi', () => {
         remainingVsActualClaimed: 0,
         remainingVsMinPlannedWithPayback: 0,
         remainingVsMaxPlannedWithPayback: 0,
-        categorySummaries: [],
         areaSummaries: [],
         unassignedSummary: null,
         subsidySummary: {

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
@@ -439,14 +439,6 @@
   color: var(--color-success-text-on-light);
 }
 
-/* ---- Category filter row ---- */
-
-.categoryFilterRow {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-}
-
 /* ---- Breakdown loading state ---- */
 
 .breakdownLoading {
@@ -460,132 +452,6 @@
   font-size: var(--font-size-sm);
 }
 
-/* ---- Category filter dropdown ---- */
-
-.categoryFilter {
-  position: relative;
-}
-
-.categoryFilterButton {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-3);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-md);
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: var(--transition-button-border);
-  min-height: 36px;
-}
-
-.categoryFilterButton:hover {
-  background: var(--color-bg-tertiary);
-  border-color: var(--color-border-strong);
-}
-
-.categoryFilterButton:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-}
-
-.categoryFilterChevron {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-}
-
-.categoryDropdown {
-  position: absolute;
-  top: calc(100% + var(--spacing-1));
-  left: 0;
-  z-index: var(--z-dropdown);
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
-  min-width: 220px;
-  max-width: 320px;
-  max-height: 320px;
-  overflow-y: auto;
-  padding: var(--spacing-2) 0;
-}
-
-.categoryDropdownActions {
-  display: flex;
-  gap: var(--spacing-2);
-  padding: var(--spacing-1) var(--spacing-3) var(--spacing-2);
-}
-
-.dropdownAction {
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-primary);
-  cursor: pointer;
-  transition: opacity var(--transition-fast);
-}
-
-.dropdownAction:hover {
-  opacity: 0.75;
-}
-
-.dropdownAction:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-  border-radius: var(--radius-sm);
-}
-
-.categoryDropdownDivider {
-  height: 1px;
-  background: var(--color-border);
-  margin: 0 0 var(--spacing-1);
-}
-
-.categoryOption {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-3);
-  cursor: pointer;
-  transition: background-color var(--transition-fast);
-  min-height: 36px;
-}
-
-.categoryOption:hover {
-  background: var(--color-bg-secondary);
-}
-
-.categoryOptionCheckbox {
-  accent-color: var(--color-primary);
-  width: 15px;
-  height: 15px;
-  flex-shrink: 0;
-  cursor: pointer;
-}
-
-.categoryDot {
-  width: 10px;
-  height: 10px;
-  border-radius: var(--radius-circle);
-  background: var(--color-text-placeholder);
-  flex-shrink: 0;
-  display: inline-block;
-}
-
-.categoryOptionName {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 /* ============================================================
  * RESPONSIVE — Tablet (768px – 1024px)
  * ============================================================ */
@@ -596,14 +462,6 @@
   }
 
   .retryButton {
-    min-height: 44px;
-  }
-
-  .categoryFilterButton {
-    min-height: 44px;
-  }
-
-  .categoryOption {
     min-height: 44px;
   }
 
@@ -669,18 +527,6 @@
     flex-direction: column;
     align-items: flex-start;
     gap: var(--spacing-2);
-  }
-
-  /* Category filter: full width on mobile */
-  .categoryFilterButton {
-    width: 100%;
-    min-height: 44px;
-    justify-content: space-between;
-  }
-
-  /* Category option touch target */
-  .categoryOption {
-    min-height: 44px;
   }
 
   /* Desktop tooltip hidden on mobile — use inline panel instead */

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
@@ -110,7 +110,6 @@ describe('BudgetOverviewPage', () => {
     remainingVsActualClaimed: 0,
     remainingVsMinPlannedWithPayback: 0,
     remainingVsMaxPlannedWithPayback: 0,
-    categorySummaries: [],
     areaSummaries: [],
     unassignedSummary: null,
     subsidySummary: {
@@ -140,32 +139,6 @@ describe('BudgetOverviewPage', () => {
     remainingVsActualClaimed: 140000,
     remainingVsMinPlannedWithPayback: 80000,
     remainingVsMaxPlannedWithPayback: 20000,
-    categorySummaries: [
-      {
-        categoryId: 'cat-1',
-        categoryName: 'Materials',
-        categoryColor: '#FF5733',
-        categoryTranslationKey: null,
-        minPlanned: 64000,
-        maxPlanned: 96000,
-        actualCost: 70000,
-        actualCostPaid: 65000,
-        actualCostClaimed: 40000,
-        budgetLineCount: 5,
-      },
-      {
-        categoryId: 'cat-2',
-        categoryName: 'Labor',
-        categoryColor: null,
-        categoryTranslationKey: null,
-        minPlanned: 56000,
-        maxPlanned: 84000,
-        actualCost: 50000,
-        actualCostPaid: 35000,
-        actualCostClaimed: 20000,
-        budgetLineCount: 3,
-      },
-    ],
     areaSummaries: [],
     unassignedSummary: null,
     subsidySummary: {
@@ -567,184 +540,55 @@ describe('BudgetOverviewPage', () => {
     });
   });
 
-  // ─── Category filter ──────────────────────────────────────────────────────────
+  // ─── AreaTreeTable integration ──────────────────────────────────────────────
 
-  describe('category filter', () => {
-    it('renders category filter button when categories exist', async () => {
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /categories:/i })).toBeInTheDocument();
-      });
-    });
-
-    it('does not render category filter when no categories exist', async () => {
-      mockFetchBudgetOverview.mockResolvedValueOnce(zeroOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.queryByRole('button', { name: /categories:/i })).not.toBeInTheDocument();
-      });
-    });
-
-    it('shows "All categories" label when all categories are selected initially', async () => {
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-    });
-
-    it('opens dropdown on button click showing all categories', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-
-      // Dropdown should show category names
-      expect(screen.getByText('Materials')).toBeInTheDocument();
-      expect(screen.getByText('Labor')).toBeInTheDocument();
-    });
-
-    it('shows "Select All" and "Clear All" buttons in dropdown', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-
-      expect(screen.getByRole('button', { name: 'Select All' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Clear All' })).toBeInTheDocument();
-    });
-
-    it('deselecting a category updates the filter label', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      // Open dropdown
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-
-      // Deselect "Materials" checkbox
-      const materialsCheckbox = screen.getByRole('checkbox', { name: 'Materials' });
-      await user.click(materialsCheckbox);
-
-      // Label should now show "Labor" (only 1 selected — <= 2 shows names)
-      expect(screen.getByRole('button', { name: /categories: labor/i })).toBeInTheDocument();
-    });
-
-    it('"Clear All" button deselects all categories', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('button', { name: 'Clear All' }));
-
-      // All categories cleared
-      expect(screen.getByRole('button', { name: /no categories/i })).toBeInTheDocument();
-    });
-
-    it('"Select All" button re-selects all categories after clearing', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      // Open and clear all
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('button', { name: 'Clear All' }));
-
-      // Reopen dropdown (it's still open) and click Select All
-      await user.click(screen.getByRole('button', { name: 'Select All' }));
-
-      expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-    });
-
-    it('selecting a subset of 3+ categories shows count label', async () => {
-      const user = userEvent.setup();
-      // Use an overview with 4 categories to trigger the count label
-      const fourCatOverview: BudgetOverview = {
+  describe('AreaTreeTable integration', () => {
+    it('renders AreaTreeTable section when areaSummaries has entries', async () => {
+      const overviewWithAreas: BudgetOverview = {
         ...richOverview,
-        categorySummaries: [
-          ...richOverview.categorySummaries,
-          {
-            categoryId: 'cat-3',
-            categoryName: 'Permits',
-            categoryColor: null,
-            categoryTranslationKey: null,
-            minPlanned: 0,
-            maxPlanned: 0,
-            actualCost: 0,
-            actualCostPaid: 0,
-            actualCostClaimed: 0,
-            budgetLineCount: 0,
-          },
-          {
-            categoryId: 'cat-4',
-            categoryName: 'Design',
-            categoryColor: null,
-            categoryTranslationKey: null,
-            minPlanned: 0,
-            maxPlanned: 0,
-            actualCost: 0,
-            actualCostPaid: 0,
-            actualCostClaimed: 0,
-            budgetLineCount: 0,
-          },
+        areaSummaries: [
+          { areaId: 'area-1', name: 'Kitchen', parentId: null, planned: 50000, actual: 40000, variance: 10000 },
         ],
       };
-      mockFetchBudgetOverview.mockResolvedValueOnce(fourCatOverview);
+      mockFetchBudgetOverview.mockResolvedValueOnce(overviewWithAreas);
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /area breakdown/i })).toBeInTheDocument();
       });
 
-      // Open dropdown and deselect one category
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('checkbox', { name: 'Permits' }));
-
-      // 3 of 4 selected — shows "3 of 4 categories"
-      expect(screen.getByRole('button', { name: /3 of 4 categories/i })).toBeInTheDocument();
+      expect(screen.getByText('Kitchen')).toBeInTheDocument();
     });
 
-    it('closes dropdown on Escape key', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
+    it('renders unassigned row when unassignedSummary is non-null', async () => {
+      const overviewWithUnassigned: BudgetOverview = {
+        ...richOverview,
+        areaSummaries: [],
+        unassignedSummary: { planned: 8000, actual: 7000, variance: 1000 },
+      };
+      mockFetchBudgetOverview.mockResolvedValueOnce(overviewWithUnassigned);
       renderPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
+        expect(screen.getByText('Unassigned')).toBeInTheDocument();
+      });
+    });
+
+    it('does not crash when areaSummaries=[] and unassignedSummary=null', async () => {
+      const emptyAreasOverview: BudgetOverview = {
+        ...richOverview,
+        areaSummaries: [],
+        unassignedSummary: null,
+      };
+      mockFetchBudgetOverview.mockResolvedValueOnce(emptyAreasOverview);
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/loading budget overview/i)).not.toBeInTheDocument();
       });
 
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      expect(screen.getByRole('listbox')).toBeInTheDocument();
-
-      await user.keyboard('{Escape}');
-      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      // Page renders without error — heading is present
+      expect(screen.getByRole('heading', { name: /^budget$/i, level: 1 })).toBeInTheDocument();
     });
   });
 
@@ -836,187 +680,7 @@ describe('BudgetOverviewPage', () => {
     });
   });
 
-  // ─── Category filter updates metrics ────────────────────────────────────────
-
-  describe('category filter effects on metrics', () => {
-    it('clearing all categories shows €0 in projected range', async () => {
-      const user = userEvent.setup();
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /all categories/i })).toBeInTheDocument();
-      });
-
-      // Open filter and clear all
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('button', { name: 'Clear All' }));
-
-      // With 0 categories selected, filtered totals are all 0
-      // minPlanned=0, maxPlanned=0 → displayed as €0.00 (both sides of range)
-      await waitFor(() => {
-        const zeroElements = screen.getAllByText(/0\.00/);
-        expect(zeroElements.length).toBeGreaterThan(0);
-      });
-    });
-
-    it('all categories selected uses global totals (not per-category sum)', async () => {
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      renderPage();
-
-      // richOverview: minPlanned=120000 → €120K
-      await waitFor(() => {
-        expect(screen.getByText(/120K/)).toBeInTheDocument();
-      });
-    });
-  });
-
-  // ─── Category filter scope: Budget Health vs Cost Breakdown ─────────────────
-
-  describe('category filter scope', () => {
-    /**
-     * Breakdown fixture matching richOverview's two categories (Materials / Labor).
-     * Both are included so the CostBreakdownTable renders an "Expand" button for each.
-     */
-    const breakdownWithTwoCategories = {
-      workItems: {
-        categories: [
-          {
-            categoryId: 'cat-1',
-            categoryName: 'Materials',
-            categoryColor: '#FF5733',
-            categoryTranslationKey: null,
-            projectedMin: 72000,
-            projectedMax: 88000,
-            actualCost: 70000,
-            subsidyPayback: 0,
-            rawProjectedMin: 72000,
-            rawProjectedMax: 88000,
-            minSubsidyPayback: 0,
-            items: [],
-          },
-          {
-            categoryId: 'cat-2',
-            categoryName: 'Labor',
-            categoryColor: null,
-            categoryTranslationKey: null,
-            projectedMin: 68000,
-            projectedMax: 72000,
-            actualCost: 50000,
-            subsidyPayback: 0,
-            rawProjectedMin: 68000,
-            rawProjectedMax: 72000,
-            minSubsidyPayback: 0,
-            items: [],
-          },
-        ],
-        totals: {
-          projectedMin: 140000,
-          projectedMax: 160000,
-          actualCost: 120000,
-          subsidyPayback: 0,
-          rawProjectedMin: 140000,
-          rawProjectedMax: 160000,
-          minSubsidyPayback: 0,
-        },
-      },
-      householdItems: {
-        categories: [],
-        totals: {
-          projectedMin: 0,
-          projectedMax: 0,
-          actualCost: 0,
-          subsidyPayback: 0,
-          rawProjectedMin: 0,
-          rawProjectedMax: 0,
-          minSubsidyPayback: 0,
-        },
-      },
-      subsidyAdjustments: [],
-    };
-
-    it('selecting only one category updates Budget Health projected range but not Cost Breakdown', async () => {
-      const user = userEvent.setup();
-
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      mockFetchBudgetBreakdown.mockResolvedValueOnce(breakdownWithTwoCategories);
-      renderPage();
-
-      // Wait for the page and the breakdown to finish loading
-      await waitFor(() => {
-        expect(screen.queryByText(/loading budget overview/i)).not.toBeInTheDocument();
-        // The WI section expand button signals that the CostBreakdownTable rendered
-        expect(
-          screen.getByRole('button', { name: /expand work item budget categories/i }),
-        ).toBeInTheDocument();
-      });
-
-      // Expand the WI section so category rows become visible
-      await user.click(screen.getByRole('button', { name: /expand work item budget categories/i }));
-
-      // Both category expand buttons must be present before filtering
-      expect(screen.getByRole('button', { name: /expand materials/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /expand labor/i })).toBeInTheDocument();
-
-      // Budget Health shows full planned range: €120K–€180K
-      expect(screen.getByText(/€120K/)).toBeInTheDocument();
-      expect(screen.getByText(/€180K/)).toBeInTheDocument();
-
-      // Open the category filter and deselect "Labor" — leaving only "Materials" selected
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('checkbox', { name: 'Labor' }));
-
-      // Budget Health planned range should now show only Materials totals:
-      // minPlanned=64000 → €64K, maxPlanned=96000 → €96K
-      await waitFor(() => {
-        expect(screen.getByText(/€64K/)).toBeInTheDocument();
-        expect(screen.getByText(/€96K/)).toBeInTheDocument();
-      });
-
-      // Cost Breakdown must still show BOTH category rows regardless of the filter.
-      // The page always passes emptyCategories (size=0) to CostBreakdownTable,
-      // which treats size===0 as "show all" — so neither category is hidden.
-      expect(screen.getByRole('button', { name: /expand materials/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /expand labor/i })).toBeInTheDocument();
-    });
-
-    it('clearing all categories shows €0 projected range in Budget Health but Cost Breakdown keeps all categories', async () => {
-      const user = userEvent.setup();
-
-      mockFetchBudgetOverview.mockResolvedValueOnce(richOverview);
-      mockFetchBudgetBreakdown.mockResolvedValueOnce(breakdownWithTwoCategories);
-      renderPage();
-
-      // Wait for the breakdown to render (WI section expand button is present)
-      await waitFor(() => {
-        expect(screen.queryByText(/loading budget overview/i)).not.toBeInTheDocument();
-        expect(
-          screen.getByRole('button', { name: /expand work item budget categories/i }),
-        ).toBeInTheDocument();
-      });
-
-      // Expand the WI section to reveal individual category rows
-      await user.click(screen.getByRole('button', { name: /expand work item budget categories/i }));
-      expect(screen.getByRole('button', { name: /expand materials/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /expand labor/i })).toBeInTheDocument();
-
-      // Open filter and clear all categories
-      await user.click(screen.getByRole('button', { name: /all categories/i }));
-      await user.click(screen.getByRole('button', { name: 'Clear All' }));
-
-      // Budget Health: all filtered totals become 0 (no category selected),
-      // projected range collapses — at least one €0.00 value appears
-      await waitFor(() => {
-        const zeroEls = screen.getAllByText(/0\.00/);
-        expect(zeroEls.length).toBeGreaterThan(0);
-      });
-
-      // Cost Breakdown: both category expand buttons still present (unaffected by filter).
-      // The page passes emptyCategories (size=0) → CostBreakdownTable shows everything.
-      expect(screen.getByRole('button', { name: /expand materials/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /expand labor/i })).toBeInTheDocument();
-    });
-  });
+  // Category filter and category filter scope tests removed in #1243 — categorySummaries dropped
 
   // ─── Currency formatting ────────────────────────────────────────────────────
 

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
@@ -4,19 +4,18 @@ import { useTranslation } from 'react-i18next';
 import type {
   BudgetOverview,
   BudgetBreakdown,
-  CategoryBudgetSummary,
   BudgetSource,
 } from '@cornerstone/shared';
 import { fetchBudgetOverview, fetchBudgetBreakdown } from '../../lib/budgetOverviewApi.js';
 import { fetchBudgetSources } from '../../lib/budgetSourcesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import { useFormatters } from '../../lib/formatters.js';
-import { getCategoryDisplayName } from '../../lib/categoryUtils.js';
 import { PageLayout } from '../../components/PageLayout/PageLayout.js';
 import { SubNav, type SubNavTab } from '../../components/SubNav/SubNav.js';
 import { BudgetBar } from '../../components/BudgetBar/BudgetBar.js';
 import type { BudgetBarSegment } from '../../components/BudgetBar/BudgetBar.js';
 import { Tooltip } from '../../components/Tooltip/Tooltip.js';
+import { AreaTreeTable } from '../../components/AreaTreeTable/index.js';
 import { CostBreakdownTable } from '../../components/CostBreakdownTable/CostBreakdownTable.js';
 import styles from './BudgetOverviewPage.module.css';
 
@@ -28,9 +27,6 @@ const BUDGET_TABS: SubNavTab[] = [
   { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies' },
 ];
 
-/** Stable empty set passed to CostBreakdownTable so it always shows all categories. */
-const emptyCategories = new Set<string | null>();
-
 // ---- Helpers ----
 
 // formatShort is defined inside the component to access formatCurrency from useFormatters()
@@ -38,140 +34,6 @@ const emptyCategories = new Set<string | null>();
 function formatPct(value: number, total: number): string {
   if (total <= 0) return '0.0%';
   return `${((value / total) * 100).toFixed(1)}%`;
-}
-
-// ---- Category Filter Dropdown ----
-
-interface CategoryFilterProps {
-  categories: CategoryBudgetSummary[];
-  selectedIds: Set<string | null>;
-  onChange: (ids: Set<string | null>) => void;
-}
-
-function CategoryFilter({ categories, selectedIds, onChange }: CategoryFilterProps) {
-  const { t: tBudget } = useTranslation('budget');
-  const { t: tSettings } = useTranslation('settings');
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const allSelected = selectedIds.size === categories.length;
-
-  // Close on outside click
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [open]);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!open) return;
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [open]);
-
-  function toggleCategory(id: string | null) {
-    const next = new Set(selectedIds);
-    if (next.has(id)) {
-      next.delete(id);
-    } else {
-      next.add(id);
-    }
-    onChange(next);
-  }
-
-  function selectAll() {
-    onChange(new Set(categories.map((c) => c.categoryId)));
-  }
-
-  function clearAll() {
-    onChange(new Set());
-  }
-
-  // Button label
-  let label: string;
-  if (allSelected) {
-    label = tBudget('overview.allCategories');
-  } else if (selectedIds.size === 0) {
-    label = tBudget('overview.noCategories');
-  } else if (selectedIds.size <= 2) {
-    label = categories
-      .filter((c) => selectedIds.has(c.categoryId))
-      .map((c) => getCategoryDisplayName(tSettings, c.categoryName, c.categoryTranslationKey))
-      .join(', ');
-  } else {
-    label = `${selectedIds.size} of ${categories.length} categories`;
-  }
-
-  return (
-    <div className={styles.categoryFilter} ref={containerRef}>
-      <button
-        type="button"
-        className={styles.categoryFilterButton}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        <span>
-          {tBudget('overview.categories')}: {label}
-        </span>
-        <span className={styles.categoryFilterChevron} aria-hidden="true">
-          {open ? '▲' : '▼'}
-        </span>
-      </button>
-
-      {open && (
-        <div className={styles.categoryDropdown} role="listbox" aria-multiselectable="true">
-          {/* Select All / Clear All */}
-          <div className={styles.categoryDropdownActions}>
-            <button type="button" className={styles.dropdownAction} onClick={selectAll}>
-              {tBudget('overview.selectAll')}
-            </button>
-            <button type="button" className={styles.dropdownAction} onClick={clearAll}>
-              {tBudget('overview.clearAll')}
-            </button>
-          </div>
-
-          <div className={styles.categoryDropdownDivider} />
-
-          {categories.map((cat) => {
-            const checked = selectedIds.has(cat.categoryId);
-            const id = `cat-filter-${cat.categoryId ?? '__uncategorized__'}`;
-            return (
-              <label key={cat.categoryId ?? '__uncategorized__'} className={styles.categoryOption}>
-                <input
-                  id={id}
-                  type="checkbox"
-                  checked={checked}
-                  onChange={() => toggleCategory(cat.categoryId)}
-                  className={styles.categoryOptionCheckbox}
-                />
-                {cat.categoryColor ? (
-                  <span
-                    className={styles.categoryDot}
-                    style={{ backgroundColor: cat.categoryColor }}
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <span className={styles.categoryDot} aria-hidden="true" />
-                )}
-                <span className={styles.categoryOptionName}>
-                  {getCategoryDisplayName(tSettings, cat.categoryName, cat.categoryTranslationKey)}
-                </span>
-              </label>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
 }
 
 // ---- Remaining Detail Panel ----
@@ -280,40 +142,6 @@ function SegmentTooltipContent({ segment, availableFunds, formatCurrency }: Segm
   );
 }
 
-// ---- Computed filtered totals ----
-
-interface FilteredTotals {
-  actualCostClaimed: number;
-  actualCostPaid: number;
-  actualCost: number;
-  minPlanned: number;
-  maxPlanned: number;
-}
-
-function computeFilteredTotals(
-  overview: BudgetOverview,
-  selectedIds: Set<string | null>,
-): FilteredTotals {
-  // If all selected — use the global totals (avoids floating point from summing categories)
-  if (selectedIds.size === overview.categorySummaries.length) {
-    return {
-      actualCostClaimed: overview.actualCostClaimed,
-      actualCostPaid: overview.actualCostPaid,
-      actualCost: overview.actualCost,
-      minPlanned: overview.minPlanned,
-      maxPlanned: overview.maxPlanned,
-    };
-  }
-
-  const selected = overview.categorySummaries.filter((c) => selectedIds.has(c.categoryId));
-  return {
-    actualCostClaimed: selected.reduce((s, c) => s + c.actualCostClaimed, 0),
-    actualCostPaid: selected.reduce((s, c) => s + c.actualCostPaid, 0),
-    actualCost: selected.reduce((s, c) => s + c.actualCost, 0),
-    minPlanned: selected.reduce((s, c) => s + c.minPlanned, 0),
-    maxPlanned: selected.reduce((s, c) => s + c.maxPlanned, 0),
-  };
-}
 
 // ---- Main component ----
 
@@ -346,9 +174,6 @@ export function BudgetOverviewPage() {
 
   // Budget sources state
   const [budgetSources, setBudgetSources] = useState<BudgetSource[]>([]);
-
-  // Category filter state — set once overview loads
-  const [selectedCategories, setSelectedCategories] = useState<Set<string | null>>(new Set());
 
   // Hovered bar segment (desktop tooltip)
   const [hoveredSegment, setHoveredSegment] = useState<BudgetBarSegment | null>(null);
@@ -396,8 +221,6 @@ export function BudgetOverviewPage() {
     try {
       const data = await fetchBudgetOverview();
       setOverview(data);
-      // Initialise filter — all selected
-      setSelectedCategories(new Set(data.categorySummaries.map((c) => c.categoryId)));
 
       // Fetch breakdown data (non-critical, so silent failure)
       setIsBreakdownLoading(true);
@@ -522,11 +345,18 @@ export function BudgetOverviewPage() {
   const hasData =
     overview.minPlanned > 0 ||
     overview.actualCost > 0 ||
-    overview.categorySummaries.length > 0 ||
+    overview.areaSummaries.length > 0 ||
+    overview.unassignedSummary !== null ||
     overview.sourceCount > 0;
 
-  // Compute filtered totals based on selected categories
-  const filtered = computeFilteredTotals(overview, selectedCategories);
+  // Use direct totals from overview (no filtering)
+  const filtered = {
+    actualCostClaimed: overview.actualCostClaimed,
+    actualCostPaid: overview.actualCostPaid,
+    actualCost: overview.actualCost,
+    minPlanned: overview.minPlanned,
+    maxPlanned: overview.maxPlanned,
+  };
 
   // Segment values
   const claimedVal = filtered.actualCostClaimed;
@@ -782,17 +612,14 @@ export function BudgetOverviewPage() {
           />
         </div>
 
-        {/* Category filter */}
-        {overview.categorySummaries.length > 0 && (
-          <div className={styles.categoryFilterRow}>
-            <CategoryFilter
-              categories={overview.categorySummaries}
-              selectedIds={selectedCategories}
-              onChange={setSelectedCategories}
-            />
-          </div>
-        )}
       </section>
+
+      {/* Area Tree Table */}
+      <AreaTreeTable
+        areas={overview.areaSummaries}
+        unassigned={overview.unassignedSummary}
+        formatCurrency={formatCurrency}
+      />
 
       {/* Cost Breakdown Table */}
       {overview &&
@@ -808,7 +635,7 @@ export function BudgetOverviewPage() {
           <CostBreakdownTable
             breakdown={breakdown}
             overview={overview}
-            selectedCategories={emptyCategories}
+            selectedCategories={new Set<string | null>()}
             budgetSources={budgetSources}
           />
         ) : null)}

--- a/client/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/client/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -134,7 +134,6 @@ const minimalBudgetOverview: BudgetOverview = {
   remainingVsActualClaimed: 90000,
   remainingVsMinPlannedWithPayback: 20000,
   remainingVsMaxPlannedWithPayback: 10000,
-  categorySummaries: [],
   areaSummaries: [],
   unassignedSummary: null,
   subsidySummary: {

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
@@ -214,7 +214,6 @@ describe('SubsidyProgramsPage', () => {
       remainingVsActualClaimed: 0,
       remainingVsMinPlannedWithPayback: 0,
       remainingVsMaxPlannedWithPayback: 0,
-      categorySummaries: [],
       areaSummaries: [],
       unassignedSummary: null,
       subsidySummary: {

--- a/e2e/pages/BudgetOverviewPage.ts
+++ b/e2e/pages/BudgetOverviewPage.ts
@@ -11,7 +11,7 @@
  *   - A key metrics row: Available Funds, Projected Cost Range, Remaining
  *   - A BudgetBar stacked bar chart (role="img")
  *   - A footer showing subsidies and sources info
- *   - A category filter dropdown button
+ * - Area Breakdown tree (role="treegrid") with expand/collapse controls
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -40,7 +40,11 @@ export class BudgetOverviewPage {
   // Budget overview hero card
   readonly heroCard: Locator;
   readonly budgetBar: Locator;
-  readonly categoryFilterButton: Locator;
+
+  // Area Breakdown tree
+  readonly areaTreeCard: Locator;
+  readonly expandAllButton: Locator;
+  readonly collapseAllButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -68,8 +72,27 @@ export class BudgetOverviewPage {
     // Budget bar: BudgetBar stacked bar chart with role="img"
     this.budgetBar = page.getByRole('img').filter({ has: page.locator('[class*="bar"]') });
 
-    // Category filter dropdown button
-    this.categoryFilterButton = page.getByRole('button', { name: /categories/i });
+    // Area Breakdown tree: the treegrid element's immediate ancestor card container
+    this.areaTreeCard = page.locator('[role="treegrid"]').locator('xpath=ancestor::*[1]');
+
+    // Expand All / Collapse All buttons within the area breakdown section
+    this.expandAllButton = page.getByRole('button', { name: /expand all/i });
+    this.collapseAllButton = page.getByRole('button', { name: /collapse all/i });
+  }
+
+  /**
+   * Return the treegrid row that contains the given area name text.
+   */
+  areaRow(name: string): Locator {
+    return this.page.getByRole('row').filter({ hasText: name });
+  }
+
+  /**
+   * Return the expand button for the given area name.
+   * Expand buttons have an aria-label matching "expand <name>" (case-insensitive).
+   */
+  areaExpandButton(name: string): Locator {
+    return this.page.getByRole('button', { name: new RegExp(`expand ${name}`, 'i') });
   }
 
   async goto(): Promise<void> {

--- a/e2e/pages/BudgetOverviewPage.ts
+++ b/e2e/pages/BudgetOverviewPage.ts
@@ -88,11 +88,12 @@ export class BudgetOverviewPage {
   }
 
   /**
-   * Return the expand button for the given area name.
-   * Expand buttons have an aria-label matching "expand <name>" (case-insensitive).
+   * Return the expand/collapse toggle button for the given area name.
+   * The aria-label alternates between "Expand <name>" and "Collapse <name>" as the
+   * row is toggled, so the regex matches both states.
    */
-  areaExpandButton(name: string): Locator {
-    return this.page.getByRole('button', { name: new RegExp(`expand ${name}`, 'i') });
+  areaToggleButton(name: string): Locator {
+    return this.page.getByRole('button', { name: new RegExp(`(?:expand|collapse) ${name}`, 'i') });
   }
 
   async goto(): Promise<void> {

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -411,7 +411,7 @@ test.describe('Area Breakdown tree', { tag: '@responsive' }, () => {
       await overviewPage.waitForLoaded();
 
       // Click the expand button for Rohbau
-      await overviewPage.areaExpandButton('Rohbau').click();
+      await overviewPage.areaToggleButton('Rohbau').click();
 
       // Children should now be visible
       await expect(overviewPage.areaRow('Keller')).toBeVisible();
@@ -430,10 +430,10 @@ test.describe('Area Breakdown tree', { tag: '@responsive' }, () => {
       await overviewPage.waitForLoaded();
 
       // Expand then collapse
-      await overviewPage.areaExpandButton('Rohbau').click();
+      await overviewPage.areaToggleButton('Rohbau').click();
       await expect(overviewPage.areaRow('Keller')).toBeVisible();
 
-      await overviewPage.areaExpandButton('Rohbau').click();
+      await overviewPage.areaToggleButton('Rohbau').click();
 
       // Children should be hidden again
       await expect(overviewPage.areaRow('Keller')).not.toBeVisible();

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -85,6 +85,7 @@ function populatedOverviewResponse() {
       { areaId: 'area-002', name: 'Keller',      parentId: 'area-001', planned: 40000,  actual: 38000,  variance: 2000  },
       { areaId: 'area-003', name: 'Erdgeschoss', parentId: 'area-001', planned: 80000,  actual: 57000,  variance: 23000 },
       { areaId: 'area-004', name: 'Innenausbau', parentId: null,       planned: 80000,  actual: 82000,  variance: -2000 },
+      { areaId: 'area-005', name: 'Dachgeschoss', parentId: 'area-004', planned: 50000, actual: 52000, variance: -2000 },
     ],
     unassignedSummary: null,
     subsidySummary: {
@@ -451,12 +452,13 @@ test.describe('Area Breakdown tree', { tag: '@responsive' }, () => {
       await overviewPage.goto();
       await overviewPage.waitForLoaded();
 
-      // Expand All → all 4 rows visible
+      // Expand All → all rows visible (both root parents and their children)
       await overviewPage.expandAllButton.click();
       await expect(overviewPage.areaRow('Rohbau')).toBeVisible();
       await expect(overviewPage.areaRow('Keller')).toBeVisible();
       await expect(overviewPage.areaRow('Erdgeschoss')).toBeVisible();
       await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Dachgeschoss')).toBeVisible();
 
       // Collapse All → only root rows visible
       await overviewPage.collapseAllButton.click();
@@ -464,6 +466,7 @@ test.describe('Area Breakdown tree', { tag: '@responsive' }, () => {
       await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
       await expect(overviewPage.areaRow('Keller')).not.toBeVisible();
       await expect(overviewPage.areaRow('Erdgeschoss')).not.toBeVisible();
+      await expect(overviewPage.areaRow('Dachgeschoss')).not.toBeVisible();
     } finally {
       await teardown();
     }

--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E tests for the Budget Overview page (Story #148 + feat/budget-hero-bar)
+ * E2E tests for the Budget Overview page (Story #148 + feat/budget-hero-bar + feat/1243)
  *
  * UAT Scenarios covered:
  * - Page loads with the correct h1 "Budget" heading
@@ -7,10 +7,18 @@
  * - Empty state shown when no budget data exists
  * - Budget overview hero card visible when data is present
  * - Budget bar (stacked chart) is visible
- * - Category filter button is accessible
  * - Error state with Retry button when API returns 500
  * - Responsive layout: no horizontal scroll
  * - Dark mode rendering
+ * - Area Breakdown tree: root areas visible on load
+ * - Area Breakdown tree: expand root reveals children
+ * - Area Breakdown tree: collapse root hides children
+ * - Area Breakdown tree: Expand All / Collapse All controls
+ * - Area Breakdown tree: negative variance row visible and formatted
+ * - Area Breakdown tree: Unassigned row appears when unassignedSummary present
+ * - Area Breakdown tree: Unassigned row absent when unassignedSummary is null
+ * - Area Breakdown tree: empty tree state (no treegrid or EmptyState visible)
+ * - Area Breakdown tree: visible in dark mode
  */
 
 import { test, expect } from '../../fixtures/auth.js';
@@ -40,7 +48,10 @@ function emptyOverviewResponse() {
     remainingVsProjectedMin: 0,
     remainingVsProjectedMax: 0,
     remainingVsActualClaimed: 0,
-    categorySummaries: [],
+    remainingVsMinPlannedWithPayback: 0,
+    remainingVsMaxPlannedWithPayback: 0,
+    areaSummaries: [],
+    unassignedSummary: null,
     subsidySummary: {
       totalReductions: 0,
       activeSubsidyCount: 0,
@@ -48,7 +59,7 @@ function emptyOverviewResponse() {
   };
 }
 
-/** BudgetOverview response with data populated across all hero card metrics and two category rows. */
+/** BudgetOverview response with data populated across all hero card metrics and an area tree. */
 function populatedOverviewResponse() {
   return {
     availableFunds: 300000,
@@ -67,34 +78,15 @@ function populatedOverviewResponse() {
     remainingVsProjectedMin: 40000,
     remainingVsProjectedMax: 30000,
     remainingVsActualClaimed: 220000,
-    categorySummaries: [
-      {
-        categoryId: 'cat-001',
-        categoryName: 'Materials',
-        categoryColor: '#3b82f6',
-        minPlanned: 120000,
-        maxPlanned: 132000,
-        actualCost: 95000,
-        actualCostPaid: 80000,
-        projectedMin: 125000,
-        projectedMax: 130000,
-        actualCostClaimed: 50000,
-        budgetLineCount: 4,
-      },
-      {
-        categoryId: 'cat-002',
-        categoryName: 'Labor',
-        categoryColor: '#10b981',
-        minPlanned: 130000,
-        maxPlanned: 143000,
-        actualCost: 90000,
-        actualCostPaid: 70000,
-        projectedMin: 135000,
-        projectedMax: 140000,
-        actualCostClaimed: 30000,
-        budgetLineCount: 3,
-      },
+    remainingVsMinPlannedWithPayback: 50000,
+    remainingVsMaxPlannedWithPayback: 25000,
+    areaSummaries: [
+      { areaId: 'area-001', name: 'Rohbau',     parentId: null,       planned: 120000, actual: 95000,  variance: 25000 },
+      { areaId: 'area-002', name: 'Keller',      parentId: 'area-001', planned: 40000,  actual: 38000,  variance: 2000  },
+      { areaId: 'area-003', name: 'Erdgeschoss', parentId: 'area-001', planned: 80000,  actual: 57000,  variance: 23000 },
+      { areaId: 'area-004', name: 'Innenausbau', parentId: null,       planned: 80000,  actual: 82000,  variance: -2000 },
     ],
+    unassignedSummary: null,
     subsidySummary: {
       totalReductions: 12500,
       activeSubsidyCount: 2,
@@ -243,31 +235,6 @@ test.describe('Hero card', { tag: '@responsive' }, () => {
     }
   });
 
-  test('Category filter button is visible', async ({ page }) => {
-    const overviewPage = new BudgetOverviewPage(page);
-
-    await page.route(`${API.budgetOverview}`, async (route) => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ overview: populatedOverviewResponse() }),
-        });
-      } else {
-        await route.continue();
-      }
-    });
-
-    try {
-      await overviewPage.goto();
-      await overviewPage.waitForLoaded();
-
-      // Then: The category filter dropdown button is visible
-      await expect(overviewPage.categoryFilterButton).toBeVisible({ timeout: 8000 });
-    } finally {
-      await page.unroute(`${API.budgetOverview}`);
-    }
-  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -388,6 +355,230 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       await expect(overviewPage.heroCard).toBeVisible({ timeout: 8000 });
     } finally {
       await page.unroute(`${API.budgetOverview}`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Area Breakdown tree
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Area Breakdown tree', { tag: '@responsive' }, () => {
+  /**
+   * Helper: mount a route returning the given overview payload.
+   * Returns a teardown function that must be called in a finally block.
+   */
+  async function mountRoute(page: Parameters<typeof test>[1]['page'], body: object) {
+    await page.route(`${API.budgetOverview}`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ overview: body }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+    return () => page.unroute(`${API.budgetOverview}`);
+  }
+
+  test('Root areas are visible on load, children are not', async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Root rows should be visible immediately
+      await expect(overviewPage.areaRow('Rohbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
+
+      // Child rows should not be visible (collapsed by default)
+      await expect(overviewPage.areaRow('Keller')).not.toBeVisible();
+      await expect(overviewPage.areaRow('Erdgeschoss')).not.toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Expanding a root area reveals its children', async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Click the expand button for Rohbau
+      await overviewPage.areaExpandButton('Rohbau').click();
+
+      // Children should now be visible
+      await expect(overviewPage.areaRow('Keller')).toBeVisible();
+      await expect(overviewPage.areaRow('Erdgeschoss')).toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Collapsing a root area hides its children', async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Expand then collapse
+      await overviewPage.areaExpandButton('Rohbau').click();
+      await expect(overviewPage.areaRow('Keller')).toBeVisible();
+
+      await overviewPage.areaExpandButton('Rohbau').click();
+
+      // Children should be hidden again
+      await expect(overviewPage.areaRow('Keller')).not.toBeVisible();
+      await expect(overviewPage.areaRow('Erdgeschoss')).not.toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Expand All shows all rows; Collapse All shows only root rows', async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Expand All → all 4 rows visible
+      await overviewPage.expandAllButton.click();
+      await expect(overviewPage.areaRow('Rohbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Keller')).toBeVisible();
+      await expect(overviewPage.areaRow('Erdgeschoss')).toBeVisible();
+      await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
+
+      // Collapse All → only root rows visible
+      await overviewPage.collapseAllButton.click();
+      await expect(overviewPage.areaRow('Rohbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Keller')).not.toBeVisible();
+      await expect(overviewPage.areaRow('Erdgeschoss')).not.toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Row with negative variance is visible and contains the formatted value', async ({
+    page,
+  }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Innenausbau has variance -2000 — the row must be visible
+      const innenausbauRow = overviewPage.areaRow('Innenausbau');
+      await expect(innenausbauRow).toBeVisible();
+
+      // The formatted negative amount must appear somewhere in the row
+      const rowText = await innenausbauRow.textContent();
+      // Negative variance appears as a negative-formatted number (e.g. "-2,000", "-€2,000", etc.)
+      expect(rowText).toMatch(/-[\d,./€\s]*2[,.]?000/);
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Unassigned row appears at the bottom when unassignedSummary is present', async ({
+    page,
+  }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+
+    const responseWithUnassigned = {
+      ...populatedOverviewResponse(),
+      unassignedSummary: { planned: 5000, actual: 4800, variance: 200 },
+    };
+
+    const teardown = await mountRoute(page, responseWithUnassigned);
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // The Unassigned row should be visible
+      await expect(overviewPage.areaRow('Unassigned')).toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Unassigned row is absent when unassignedSummary is null', async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    // populatedOverviewResponse() has unassignedSummary: null
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // No Unassigned row should appear
+      await expect(overviewPage.areaRow('Unassigned')).not.toBeVisible();
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Empty tree state: treegrid not rendered or EmptyState visible inside tree card', async ({
+    page,
+  }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+    // emptyOverviewResponse() has areaSummaries: [] and unassignedSummary: null
+    const teardown = await mountRoute(page, emptyOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Either the treegrid is absent from the DOM / not visible, OR an EmptyState is rendered
+      const treegrid = page.locator('[role="treegrid"]');
+      const treegridVisible = await treegrid.isVisible().catch(() => false);
+
+      if (treegridVisible) {
+        // If the treegrid renders even for empty data, an EmptyState must be visible inside it
+        await expect(page.locator('[role="treegrid"]').locator('div[class*="emptyState"]')).toBeVisible();
+      } else {
+        // Treegrid absent — that is acceptable empty-tree behavior
+        expect(treegridVisible).toBe(false);
+      }
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Area Breakdown tree is visible in dark mode', { tag: '@responsive' }, async ({ page }) => {
+    const overviewPage = new BudgetOverviewPage(page);
+
+    await page.addInitScript(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    const teardown = await mountRoute(page, populatedOverviewResponse());
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Tree card must be visible in dark mode
+      await expect(overviewPage.areaTreeCard).toBeVisible();
+
+      // Root area rows must be visible
+      await expect(overviewPage.areaRow('Rohbau')).toBeVisible();
+      await expect(overviewPage.areaRow('Innenausbau')).toBeVisible();
+    } finally {
+      await teardown();
     }
   });
 });

--- a/e2e/tests/navigation/dashboard.spec.ts
+++ b/e2e/tests/navigation/dashboard.spec.ts
@@ -63,24 +63,16 @@ function mockBudgetOverview() {
     remainingVsProjectedMin: 40000,
     remainingVsProjectedMax: 30000,
     remainingVsActualClaimed: 220000,
-    categorySummaries: [
-      {
-        categoryId: 'cat-001',
-        categoryName: 'Materials',
-        categoryColor: '#3b82f6',
-        minPlanned: 120000,
-        maxPlanned: 132000,
-        actualCost: 95000,
-        actualCostPaid: 80000,
-        projectedMin: 125000,
-        projectedMax: 130000,
-        actualCostClaimed: 50000,
-        budgetLineCount: 4,
-      },
-    ],
+    remainingVsMinPlannedWithPayback: 0,
+    remainingVsMaxPlannedWithPayback: 0,
+    areaSummaries: [],
+    unassignedSummary: null,
     subsidySummary: {
       totalReductions: 12500,
       activeSubsidyCount: 1,
+      minTotalPayback: 0,
+      maxTotalPayback: 0,
+      oversubscribedSubsidies: [],
     },
   };
 }

--- a/server/src/routes/budgetOverview.test.ts
+++ b/server/src/routes/budgetOverview.test.ts
@@ -246,8 +246,8 @@ describe('Budget Overview Routes', () => {
       expect(typeof overview.remainingVsActualCost).toBe('number');
       expect(typeof overview.remainingVsActualPaid).toBe('number');
 
-      // categorySummaries array
-      expect(Array.isArray(overview.categorySummaries)).toBe(true);
+      // areaSummaries array (categorySummaries removed in #1243)
+      expect(Array.isArray(overview.areaSummaries)).toBe(true);
 
       // subsidySummary object
       expect(typeof overview.subsidySummary.totalReductions).toBe('number');
@@ -276,8 +276,8 @@ describe('Budget Overview Routes', () => {
       expect(overview.remainingVsMaxPlanned).toBe(0);
       expect(overview.remainingVsActualCost).toBe(0);
       expect(overview.remainingVsActualPaid).toBe(0);
-      // 7 seeded categories after migration 0028 removes 5 unused defaults on fresh DB
-      expect(overview.categorySummaries).toHaveLength(7);
+      // categorySummaries removed in #1243
+      expect(Array.isArray(overview.areaSummaries)).toBe(true);
       expect(overview.sourceCount).toBe(1); // seeded discretionary source
       expect(overview.subsidySummary.activeSubsidyCount).toBe(0);
     });
@@ -342,28 +342,6 @@ describe('Budget Overview Routes', () => {
       expect(overview.actualCostPaid).toBe(60000); // both are paid
     });
 
-    it('returns each category summary with required fields', async () => {
-      const { cookie } = await createUserWithSession('user@example.com', 'Test User', 'password');
-
-      const response = await app.inject({
-        method: 'GET',
-        url: '/api/budget/overview',
-        headers: { cookie },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const { overview } = response.json<BudgetOverviewResponse>();
-
-      // Each category summary has required fields
-      for (const cat of overview.categorySummaries) {
-        expect(typeof cat.categoryId).toBe('string');
-        expect(typeof cat.categoryName).toBe('string');
-        expect(typeof cat.minPlanned).toBe('number');
-        expect(typeof cat.maxPlanned).toBe('number');
-        expect(typeof cat.actualCost).toBe('number');
-        expect(typeof cat.actualCostPaid).toBe('number');
-        expect(typeof cat.budgetLineCount).toBe('number');
-      }
-    });
+    // 'returns each category summary with required fields' test removed — categorySummaries dropped in #1243
   });
 });

--- a/server/src/services/budgetOverviewService.household.test.ts
+++ b/server/src/services/budgetOverviewService.household.test.ts
@@ -344,10 +344,9 @@ describe('Budget Overview Service - Household Item Invoice Aggregation', () => {
 
       const overview = budgetOverviewService.getBudgetOverview(db);
 
-      // Find the category summary for the assigned category
-      const categorySummary = overview.categorySummaries.find((cs) => cs.categoryId === categoryId);
-      expect(categorySummary).toBeDefined();
-      expect(categorySummary?.actualCost).toBe(2500);
+      // Verify global actualCost includes the household item invoice amount
+      expect(overview.actualCost).toBe(2500);
+      // Per-category assertion removed — categorySummaries dropped in #1243
     });
 
     it('combines household and work item invoices in category summary', () => {
@@ -442,23 +441,12 @@ describe('Budget Overview Service - Household Item Invoice Aggregation', () => {
 
       const overview = budgetOverviewService.getBudgetOverview(db);
 
-      const categorySummary = overview.categorySummaries.find((cs) => cs.categoryId === categoryId);
-      expect(categorySummary).toBeDefined();
       // 1000 (household) + 800 (work item) = 1800
-      expect(categorySummary?.actualCost).toBe(1800);
+      expect(overview.actualCost).toBe(1800);
+      // Per-category assertion removed — categorySummaries dropped in #1243
     });
 
-    it('returns per-category actualCost as 0 for categories with no invoices', () => {
-      const overview = budgetOverviewService.getBudgetOverview(db);
-
-      // All categories should be present (from seeded data)
-      expect(overview.categorySummaries.length).toBeGreaterThan(0);
-
-      // All should have actualCost: 0 initially
-      for (const summary of overview.categorySummaries) {
-        expect(summary.actualCost).toBe(0);
-      }
-    });
+    // 'returns per-category actualCost as 0' test removed — categorySummaries dropped in #1243
   });
 
   // ─── getBudgetOverview() household items without category ────────────────────
@@ -532,21 +520,15 @@ describe('Budget Overview Service - Household Item Invoice Aggregation', () => {
 
       // Verify top-level structure
       expect(overview).toHaveProperty('availableFunds');
-      expect(overview).toHaveProperty('categorySummaries');
+      expect(overview).toHaveProperty('areaSummaries');
 
       // Verify top-level fields
       expect(overview).toHaveProperty('availableFunds');
       expect(overview).toHaveProperty('sourceCount');
       expect(overview).toHaveProperty('actualCost');
 
-      // Verify categorySummaries structure
-      expect(Array.isArray(overview.categorySummaries)).toBe(true);
-      if (overview.categorySummaries.length > 0) {
-        const summary = overview.categorySummaries[0];
-        expect(summary).toHaveProperty('categoryId');
-        expect(summary).toHaveProperty('categoryName');
-        expect(summary).toHaveProperty('actualCost');
-      }
+      // Verify areaSummaries structure (categorySummaries removed in #1243)
+      expect(Array.isArray(overview.areaSummaries)).toBe(true);
     });
   });
 });

--- a/server/src/services/budgetOverviewService.test.ts
+++ b/server/src/services/budgetOverviewService.test.ts
@@ -317,23 +317,6 @@ describe('getBudgetOverview', () => {
       expect(result.subsidySummary.activeSubsidyCount).toBe(0);
     });
 
-    it('returns 7 category summaries (seeded defaults after migration 0028) with all-zero values', () => {
-      const result = getBudgetOverview(db);
-
-      // After migration 0028 on a fresh DB (no budget lines):
-      // Original 10 (0003) + 1 bc-household-items (0016) + 1 bc-waste (0028)
-      // - 5 deleted by 0028 (bc-equipment, bc-landscaping, bc-utilities, bc-insurance, bc-contingency)
-      // = 7 categories: bc-materials, bc-labor, bc-permits, bc-design, bc-other, bc-household-items, bc-waste
-      expect(result.categorySummaries).toHaveLength(7);
-
-      for (const cat of result.categorySummaries) {
-        expect(cat.minPlanned).toBe(0);
-        expect(cat.maxPlanned).toBe(0);
-        expect(cat.actualCost).toBe(0);
-        expect(cat.actualCostPaid).toBe(0);
-        expect(cat.budgetLineCount).toBe(0);
-      }
-    });
   });
 
   // ─── Available funds from budget sources ──────────────────────────────────
@@ -530,139 +513,7 @@ describe('getBudgetOverview', () => {
     });
   });
 
-  // ─── Category summaries ───────────────────────────────────────────────────
-
-  describe('category summaries', () => {
-    it('includes all seeded categories even with no assigned budget lines', () => {
-      const result = getBudgetOverview(db);
-
-      const seededNames = ['Materials', 'Labor', 'Permits', 'Design', 'Waste', 'Other'];
-      const resultNames = result.categorySummaries.map((c) => c.categoryName);
-      for (const name of seededNames) {
-        expect(resultNames).toContain(name);
-      }
-    });
-
-    it('includes custom category with no budget lines, showing zeroes', () => {
-      const catId = insertBudgetCategory('Custom Test Category');
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat).toBeDefined();
-      expect(cat!.minPlanned).toBe(0);
-      expect(cat!.maxPlanned).toBe(0);
-      expect(cat!.actualCost).toBe(0);
-      expect(cat!.actualCostPaid).toBe(0);
-      expect(cat!.budgetLineCount).toBe(0);
-    });
-
-    it('aggregates minPlanned/maxPlanned per category with confidence margins', () => {
-      const catId = insertBudgetCategory('Cat Margin Test');
-      // own_estimate (±20%): min=8000, max=12000; no invoices → projected = planned
-      insertWorkItem({ plannedAmount: 10000, confidence: 'own_estimate', budgetCategoryId: catId });
-      // quote (±5%): min=4750, max=5250; no invoices → projected = planned
-      insertWorkItem({ plannedAmount: 5000, confidence: 'quote', budgetCategoryId: catId });
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat).toBeDefined();
-      expect(cat!.minPlanned).toBeCloseTo(12750, 5); // 8000 + 4750
-      expect(cat!.maxPlanned).toBeCloseTo(17250, 5); // 12000 + 5250
-      expect(cat!.budgetLineCount).toBe(2);
-    });
-
-    it('aggregates actualCost and actualCostPaid per category from invoices', () => {
-      const catId = insertBudgetCategory('Cat Invoice Test');
-      insertWorkItem({
-        plannedAmount: 10000,
-        budgetCategoryId: catId,
-        actualCost: 8000,
-        actualCostPending: 1500,
-      });
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat!.actualCost).toBe(9500); // 8000 paid + 1500 pending
-      expect(cat!.actualCostPaid).toBe(8000); // only paid
-    });
-
-    it('counts budget lines per category correctly', () => {
-      const catId = insertBudgetCategory('Count Test Cat');
-      insertWorkItem({ plannedAmount: 1000, budgetCategoryId: catId });
-      insertWorkItem({ plannedAmount: 2000, budgetCategoryId: catId });
-      insertWorkItem({ plannedAmount: 3000, budgetCategoryId: catId });
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat!.budgetLineCount).toBe(3);
-    });
-
-    it('budget lines without a category do not appear in any category summary', () => {
-      const catId = insertBudgetCategory('Exclusive Cat');
-      insertWorkItem({ plannedAmount: 5000, budgetCategoryId: catId });
-      insertWorkItem({ plannedAmount: 9999 }); // no category
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      // Only the first line's contribution should appear
-      expect(cat!.minPlanned).toBeCloseTo(4000, 5); // own_estimate: 5000 * 0.8
-      expect(cat!.budgetLineCount).toBe(1);
-    });
-
-    it('includes categoryColor in summary', () => {
-      const catId = insertBudgetCategory('Colored Cat', '#FF5733');
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat!.categoryColor).toBe('#FF5733');
-    });
-
-    it('returns null categoryColor when category has no color', () => {
-      const catId = insertBudgetCategory('No Color Cat', null);
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat!.categoryColor).toBeNull();
-    });
-
-    it('keeps categories from different budget lines independent', () => {
-      const catA = insertBudgetCategory('Cat Alpha');
-      const catB = insertBudgetCategory('Cat Beta');
-      // invoice confidence (±0%): line has invoice → all values = actualCost
-      insertWorkItem({
-        plannedAmount: 1000,
-        confidence: 'invoice',
-        budgetCategoryId: catA,
-        actualCost: 800,
-      });
-      insertWorkItem({
-        plannedAmount: 2000,
-        confidence: 'invoice',
-        budgetCategoryId: catB,
-        actualCost: 2500,
-      });
-
-      const result = getBudgetOverview(db);
-      const a = result.categorySummaries.find((c) => c.categoryId === catA);
-      const b = result.categorySummaries.find((c) => c.categoryId === catB);
-
-      // catA line has invoice (800) → min/max planned overridden by actualCost
-      expect(a!.minPlanned).toBe(800);
-      expect(a!.maxPlanned).toBe(800);
-      expect(a!.actualCost).toBe(800);
-      // catB line has invoice (2500) → min/max planned overridden by actualCost
-      expect(b!.minPlanned).toBe(2500);
-      expect(b!.maxPlanned).toBe(2500);
-      expect(b!.actualCost).toBe(2500);
-    });
-  });
+  // categorySummaries describe removed — field dropped in story #1243
 
   // ─── Subsidy summary ──────────────────────────────────────────────────────
 
@@ -958,28 +809,7 @@ describe('getBudgetOverview', () => {
       expect(result.subsidySummary.totalReductions).toBeCloseTo(1000, 5);
     });
 
-    it('applies category-matched reductions in per-category summaries', () => {
-      const catId = insertBudgetCategory('Cat Reduction In Summary');
-      const { workItemId } = insertWorkItem({
-        plannedAmount: 10000,
-        confidence: 'invoice',
-        budgetCategoryId: catId,
-      });
-      const progId = insertSubsidyProgram({
-        reductionType: 'percentage',
-        reductionValue: 20,
-        applicationStatus: 'approved',
-        categoryIds: [catId],
-      });
-      linkWorkItemSubsidy(workItemId, progId);
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      // minPlanned/maxPlanned = raw projected (no subsidy subtraction): 10000
-      expect(cat!.minPlanned).toBeCloseTo(10000, 5);
-      expect(cat!.maxPlanned).toBeCloseTo(10000, 5);
-    });
+    // 'applies category-matched reductions in per-category summaries' test removed — categorySummaries dropped in #1243
 
     it('sums reductions from multiple work item-subsidy category matches', () => {
       const catA = insertBudgetCategory('Cat Reduce A');
@@ -1137,21 +967,7 @@ describe('getBudgetOverview', () => {
       expect(result.subsidySummary.totalReductions).toBeCloseTo(4500, 5);
       expect(result.subsidySummary.activeSubsidyCount).toBe(1);
 
-      // Category A: wi1 (has invoice 45000 → min/max=45000) + wi3 (no invoice → 19000/21000)
-      const a = result.categorySummaries.find((c) => c.categoryId === catA);
-      expect(a!.minPlanned).toBeCloseTo(64000, 5); // 45000 + 19000
-      expect(a!.maxPlanned).toBeCloseTo(66000, 5); // 45000 + 21000
-      expect(a!.actualCost).toBe(45000);
-      expect(a!.actualCostPaid).toBe(45000);
-      expect(a!.budgetLineCount).toBe(2);
-
-      // Category B: wi2 (has invoice 32000 pending → min/max=32000)
-      const b = result.categorySummaries.find((c) => c.categoryId === catB);
-      expect(b!.minPlanned).toBeCloseTo(32000, 5); // overridden by actualCost
-      expect(b!.maxPlanned).toBeCloseTo(32000, 5); // overridden by actualCost
-      expect(b!.actualCost).toBe(32000);
-      expect(b!.actualCostPaid).toBe(0);
-      expect(b!.budgetLineCount).toBe(1);
+      // Per-category assertions removed — categorySummaries dropped in story #1243
     });
   });
 
@@ -1297,79 +1113,7 @@ describe('getBudgetOverview', () => {
       expect(result.actualCostClaimed).toBe(0);
     });
 
-    it('aggregates per-category actualCostClaimed correctly', () => {
-      const catId = insertBudgetCategory('Cat Claimed Test');
-      const { budgetLineId: bl1 } = insertWorkItem({
-        plannedAmount: 10000,
-        budgetCategoryId: catId,
-      });
-      const { budgetLineId: bl2 } = insertWorkItem({
-        plannedAmount: 8000,
-        budgetCategoryId: catId,
-      });
-      insertClaimedInvoice(bl1!, 4000);
-      insertClaimedInvoice(bl2!, 2000);
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat).toBeDefined();
-      expect(cat!.actualCostClaimed).toBe(6000); // 4000 + 2000
-    });
-
-    it('per-category actualCostClaimed is zero for categories with only paid invoices', () => {
-      const catId = insertBudgetCategory('Cat Paid Only');
-      insertWorkItem({ plannedAmount: 10000, budgetCategoryId: catId, actualCost: 5000 }); // paid
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat).toBeDefined();
-      expect(cat!.actualCostClaimed).toBe(0);
-    });
-
-    it('per-category claimed sums are independent across different categories', () => {
-      const catA = insertBudgetCategory('Cat Claimed A');
-      const catB = insertBudgetCategory('Cat Claimed B');
-
-      const { budgetLineId: blA } = insertWorkItem({
-        plannedAmount: 10000,
-        budgetCategoryId: catA,
-      });
-      const { budgetLineId: blB } = insertWorkItem({ plannedAmount: 8000, budgetCategoryId: catB });
-      insertClaimedInvoice(blA!, 3500);
-      insertClaimedInvoice(blB!, 1800);
-
-      const result = getBudgetOverview(db);
-      const a = result.categorySummaries.find((c) => c.categoryId === catA);
-      const b = result.categorySummaries.find((c) => c.categoryId === catB);
-
-      expect(a!.actualCostClaimed).toBe(3500);
-      expect(b!.actualCostClaimed).toBe(1800);
-      // Global total
-      expect(result.actualCostClaimed).toBe(5300);
-    });
-
-    it('mixed paid and claimed invoices in same category sum correctly', () => {
-      const catId = insertBudgetCategory('Cat Mixed Invoice Types');
-      insertWorkItem({
-        plannedAmount: 10000,
-        budgetCategoryId: catId,
-        actualCost: 5000, // paid
-      });
-      const { budgetLineId: bl2 } = insertWorkItem({
-        plannedAmount: 8000,
-        budgetCategoryId: catId,
-      });
-      insertClaimedInvoice(bl2!, 3000); // claimed
-
-      const result = getBudgetOverview(db);
-      const cat = result.categorySummaries.find((c) => c.categoryId === catId);
-
-      expect(cat!.actualCost).toBe(8000); // 5000 paid + 3000 claimed
-      expect(cat!.actualCostPaid).toBe(8000); // both paid and claimed count as paid
-      expect(cat!.actualCostClaimed).toBe(3000); // only claimed
-    });
+    // Per-category actualCostClaimed tests removed — categorySummaries dropped in story #1243
   });
 
   // ─── Subsidy payback aggregation (#346) ────────────────────────────────────

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -4,7 +4,6 @@ import type * as schemaTypes from '../db/schema.js';
 import { CONFIDENCE_MARGINS } from '@cornerstone/shared';
 import type {
   BudgetOverview,
-  CategoryBudgetSummary,
   AreaBudgetSummary,
   OversubscribedSubsidy,
 } from '@cornerstone/shared';
@@ -194,22 +193,9 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
   //
   // We'll compute this lazily per-line below.
 
-  // ── 7. Compute per-line planned amounts and per-category aggregates ─────────
+  // ── 7. Compute per-line planned amounts ──────────────────────────────────────
   let totalMinPlanned = 0;
   let totalMaxPlanned = 0;
-
-  // Category summaries: categoryId -> running totals
-  const categoryAgg = new Map<
-    string | null,
-    {
-      minPlanned: number;
-      maxPlanned: number;
-      actualCost: number;
-      actualCostPaid: number;
-      actualCostClaimed: number;
-      budgetLineCount: number;
-    }
-  >();
 
   // Per-work-item fixed subsidy line counts (memoized):
   // key = `${workItemId}:${subsidyId}` -> count of matching lines
@@ -295,23 +281,6 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
 
     totalMinPlanned += minPlanned;
     totalMaxPlanned += maxPlanned;
-
-    // Aggregate per category (null key = uncategorized)
-    let agg = categoryAgg.get(line.budgetCategoryId);
-    if (!agg) {
-      agg = {
-        minPlanned: 0,
-        maxPlanned: 0,
-        actualCost: 0,
-        actualCostPaid: 0,
-        actualCostClaimed: 0,
-        budgetLineCount: 0,
-      };
-      categoryAgg.set(line.budgetCategoryId, agg);
-    }
-    agg.minPlanned += minPlanned;
-    agg.maxPlanned += maxPlanned;
-    agg.budgetLineCount += 1;
   }
 
   // ── 8. Actual costs from invoices linked to budget lines ──────────────────
@@ -335,103 +304,7 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
   const actualCostPaid = invoiceTotalsRow?.actualCostPaid ?? 0;
   const actualCostClaimed = invoiceTotalsRow?.actualCostClaimed ?? 0;
 
-  // ── 9. Per-category actual costs from invoices ────────────────────────────
-  // Include both work item and household item budget invoices using UNION ALL
-  // Exclude quotation invoices from actual cost aggregates
-  const categoryInvoiceRows = db.all<{
-    budgetCategoryId: string | null;
-    actualCost: number;
-    actualCostPaid: number;
-    actualCostClaimed: number;
-  }>(
-    sql`SELECT
-      wib.budget_category_id                                                                      AS budgetCategoryId,
-      COALESCE(SUM(ibl.itemized_amount), 0)                                                                AS actualCost,
-      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0)   AS actualCostPaid,
-      COALESCE(SUM(CASE WHEN i.status = 'claimed' THEN ibl.itemized_amount ELSE 0 END), 0)              AS actualCostClaimed
-    FROM invoice_budget_lines ibl
-    INNER JOIN invoices i ON i.id = ibl.invoice_id
-    INNER JOIN work_item_budgets wib ON wib.id = ibl.work_item_budget_id
-    WHERE i.status != 'quotation'
-    GROUP BY wib.budget_category_id
-    UNION ALL
-    SELECT
-      hib.budget_category_id                                                                      AS budgetCategoryId,
-      COALESCE(SUM(ibl.itemized_amount), 0)                                                                AS actualCost,
-      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0)   AS actualCostPaid,
-      COALESCE(SUM(CASE WHEN i.status = 'claimed' THEN ibl.itemized_amount ELSE 0 END), 0)              AS actualCostClaimed
-    FROM invoice_budget_lines ibl
-    INNER JOIN invoices i ON i.id = ibl.invoice_id
-    INNER JOIN household_item_budgets hib ON hib.id = ibl.household_item_budget_id
-    WHERE i.status != 'quotation'
-    GROUP BY hib.budget_category_id`,
-  );
-
-  for (const row of categoryInvoiceRows) {
-    let agg = categoryAgg.get(row.budgetCategoryId);
-    if (!agg) {
-      agg = {
-        minPlanned: 0,
-        maxPlanned: 0,
-        actualCost: 0,
-        actualCostPaid: 0,
-        actualCostClaimed: 0,
-        budgetLineCount: 0,
-      };
-      categoryAgg.set(row.budgetCategoryId, agg);
-    }
-    // Use += to accumulate for duplicate categories (one from work items, one from household items)
-    agg.actualCost += row.actualCost;
-    agg.actualCostPaid += row.actualCostPaid;
-    agg.actualCostClaimed += row.actualCostClaimed;
-  }
-
-  // ── 10. Budget category metadata (name, color, translation_key) ────────────────────────────
-  const categoryMetaRows = db.all<{
-    id: string;
-    name: string;
-    color: string | null;
-    translationKey: string | null;
-  }>(
-    sql`SELECT id, name, color, translation_key AS translationKey
-    FROM budget_categories
-    ORDER BY sort_order ASC, name ASC`,
-  );
-
-  const categorySummaries: CategoryBudgetSummary[] = categoryMetaRows.map((cat) => {
-    const agg = categoryAgg.get(cat.id);
-    return {
-      categoryId: cat.id,
-      categoryName: cat.name,
-      categoryColor: cat.color,
-      categoryTranslationKey: cat.translationKey,
-      minPlanned: agg?.minPlanned ?? 0,
-      maxPlanned: agg?.maxPlanned ?? 0,
-      actualCost: agg?.actualCost ?? 0,
-      actualCostPaid: agg?.actualCostPaid ?? 0,
-      actualCostClaimed: agg?.actualCostClaimed ?? 0,
-      budgetLineCount: agg?.budgetLineCount ?? 0,
-    };
-  });
-
-  // Append virtual "Uncategorized" entry if any budget lines have no category
-  const uncategorizedAgg = categoryAgg.get(null);
-  if (uncategorizedAgg) {
-    categorySummaries.push({
-      categoryId: null,
-      categoryName: 'Uncategorized',
-      categoryColor: null,
-      categoryTranslationKey: null,
-      minPlanned: uncategorizedAgg.minPlanned,
-      maxPlanned: uncategorizedAgg.maxPlanned,
-      actualCost: uncategorizedAgg.actualCost,
-      actualCostPaid: uncategorizedAgg.actualCostPaid,
-      actualCostClaimed: uncategorizedAgg.actualCostClaimed,
-      budgetLineCount: uncategorizedAgg.budgetLineCount,
-    });
-  }
-
-  // ── 10b. Area-grouped budget aggregation ──────────────────────────────────
+  // ── 9. Area-grouped budget aggregation ────────────────────────────────────
   const areaRows = db.all<{
     id: string;
     name: string;
@@ -513,14 +386,14 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
     unassignedSummary = { planned: uPlanned, actual: uActual, variance: uPlanned - uActual };
   }
 
-  // ── 11. Subsidy summary ───────────────────────────────────────────────────
+  // ── 10. Subsidy summary ───────────────────────────────────────────────────
   const subsidyCountRow = db.get<{ activeSubsidyCount: number }>(
     sql`SELECT COUNT(*) AS activeSubsidyCount
     FROM subsidy_programs
     WHERE application_status != 'rejected'`,
   );
 
-  // ── 11b. Aggregate subsidy payback across all work items ──────────────────
+  // ── 10b. Aggregate subsidy payback across all work items ─────────────────
   //
   // Replicates subsidyPaybackService logic globally across all budget lines.
   // For percentage subsidies: iterate over matching budget lines per work item.
@@ -642,7 +515,7 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
     oversubscribedSubsidies,
   };
 
-  // ── 12. Remaining-funds perspectives ───────────────────────────────────────
+  // ── 11. Remaining-funds perspectives ───────────────────────────────────────
   const remainingVsMinPlanned = availableFunds - totalMinPlanned;
   const remainingVsMaxPlanned = availableFunds - totalMaxPlanned;
   const remainingVsActualCost = availableFunds - actualCost;
@@ -670,7 +543,6 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
     remainingVsActualClaimed,
     remainingVsMinPlannedWithPayback,
     remainingVsMaxPlannedWithPayback,
-    categorySummaries,
     areaSummaries,
     unassignedSummary,
     subsidySummary,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -187,7 +187,6 @@ export type {
 // Budget Overview
 export type {
   AreaBudgetSummary,
-  CategoryBudgetSummary,
   BudgetOverview,
   BudgetOverviewResponse,
   OversubscribedSubsidy,

--- a/shared/src/types/budgetOverview.ts
+++ b/shared/src/types/budgetOverview.ts
@@ -4,19 +4,6 @@
  * subsidy reductions, and four remaining-funds perspectives.
  */
 
-export interface CategoryBudgetSummary {
-  categoryId: string | null;
-  categoryName: string;
-  categoryColor: string | null;
-  categoryTranslationKey: string | null;
-  minPlanned: number; // invoiced lines use actualCost; non-invoiced use confidence margins
-  maxPlanned: number; // invoiced lines use actualCost; non-invoiced use confidence margins
-  actualCost: number;
-  actualCostPaid: number;
-  actualCostClaimed: number;
-  budgetLineCount: number;
-}
-
 /**
  * Budget summary for a single area node.
  * planned = raw sum of work_item_budgets.planned_amount for all work items
@@ -54,8 +41,6 @@ export interface BudgetOverview {
   remainingVsMinPlannedWithPayback: number;
   /** Payback-adjusted remaining vs max planned: availableFunds + maxTotalPayback - maxPlanned */
   remainingVsMaxPlannedWithPayback: number;
-
-  categorySummaries: CategoryBudgetSummary[];
 
   areaSummaries: AreaBudgetSummary[];
 


### PR DESCRIPTION
## Summary
- New shared `AreaTreeTable` component: expandable tree with chevrons, indent per depth, ARIA treegrid, keyboard nav, dark mode, responsive
- `BudgetOverviewPage`: swap category breakdown for area tree; remove `CategoryFilter`
- Remove `categorySummaries` / `CategoryBudgetSummary` from API and shared types
- German translations + glossary entry for "Unassigned"
- 53 unit tests for AreaTreeTable; 9 new E2E scenarios; fixtures updated across client + server

Fixes #1243

## Test plan
- [ ] Quality Gates green

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>