### PR TITLE
feat(ui): add AreaBreadcrumb shared component and SearchPicker secondary-line slot

### DIFF
--- a/.claude/agent-memory/translator/MEMORY.md
+++ b/.claude/agent-memory/translator/MEMORY.md
@@ -10,7 +10,7 @@
 
 - Formal register: use "Sie" form in German
 - Translation files: `client/src/i18n/{locale}/{namespace}.json`
-- Namespaces: auth, budget, common, dashboard, diary, documents, errors, householdItems, schedule, settings, workItems
+- Namespaces: areas, auth, budget, common, dashboard, diary, documents, errors, householdItems, schedule, settings, workItems
 - Preserve `{{variable}}` interpolation placeholders exactly
 - Preserve `_one` / `_other` pluralization suffixes
 
@@ -43,6 +43,7 @@ Action labels in German follow the pattern: `{Noun} {Verb}` with capitalised fir
 - `de/common.json` was missing `subnav.settings.backups` — added 2026-03-22 (Issue #1146)
 - `de/settings.json` was missing `backups` section entirely — added 2026-03-22 (Issue #1146)
 - `de/errors.json` had four backup/restore keys with empty placeholder values (left by frontend-developer) — filled in 2026-03-22 (Issue #1146)
+- `de/areas.json` created 2026-04-16 (Story #1237): `noArea` → "Kein Bereich", `pathLabel` → "Bereichspfad"
 - Always check key parity when picking up a new translator spec
 
 ## Backup/Restore Terminology (2026-03-22)

--- a/.claude/agent-memory/ux-designer/MEMORY.md
+++ b/.claude/agent-memory/ux-designer/MEMORY.md
@@ -250,6 +250,17 @@ Key decisions:
 
 See `story-9-2-dashboard.md`. Key: 3/2/1 col grid, card = `<article>`, skeleton replaces body only (header+footer always visible), Customize button only when ≥1 hidden card, no new tokens needed.
 
+## AreaBreadcrumb + SearchPicker renderSecondary (Issue #1237)
+
+- Breadcrumb tokens: `--font-size-xs`, `--color-text-muted` (no new tokens)
+- Compact truncation: CSS `direction: rtl` + `unicode-bidi: plaintext` + `text-overflow: ellipsis` (no JS needed)
+- Tooltip on compact: wrap in existing `Tooltip` component; add `tabIndex={0}` for touch/tap
+- Null area: same muted style, NOT italic; plain `<span>` (no nav/ol)
+- ARIA: `<nav aria-label="Area path"><ol>` with separator `<li aria-hidden="true">` for populated; plain `<span>` for null
+- `color` field on AreaAncestor: ignore in breadcrumb (used by Badge elsewhere)
+- SearchPicker `.resultSecondary`: `--font-size-xs`, `--color-text-muted`, `margin-top: --spacing-0-5`; omit from selectedDisplay
+- Tooltip component already handles `onFocus`/`onBlur` — no new Tooltip behavior needed
+
 ## Issue #933 — DAV Access Card + Vendor Contacts
 
 See `story-933-dav-vendor-contacts.md`. Token-once reveal panel: `role="status" aria-atomic="true"`. ContactCard is a new shared component. VendorContacts section placed between Vendor Info card and Invoices card.

--- a/client/src/components/AreaBreadcrumb/AreaBreadcrumb.module.css
+++ b/client/src/components/AreaBreadcrumb/AreaBreadcrumb.module.css
@@ -1,0 +1,56 @@
+.muted {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.nav {
+  display: inline;
+}
+
+.list {
+  display: inline-flex;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.segment {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.separator {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  opacity: 0.6;
+  line-height: 1.4;
+  user-select: none;
+}
+
+.compact {
+  display: inline-block;
+  max-width: 100%;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  direction: rtl;
+  unicode-bidi: plaintext;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.compact:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}

--- a/client/src/components/AreaBreadcrumb/AreaBreadcrumb.test.tsx
+++ b/client/src/components/AreaBreadcrumb/AreaBreadcrumb.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import type { AreaSummary } from '@cornerstone/shared';
+import { AreaBreadcrumb } from './AreaBreadcrumb.js';
+
+// client/src/test/setupTests.ts initialises i18n globally, so t('noArea')
+// returns "No area" and t('pathLabel') returns "Area path" without per-test setup.
+
+// ── Helper fixtures ──────────────────────────────────────────────────────────
+
+const areaNoAncestors: AreaSummary = {
+  id: '1',
+  name: 'Garage',
+  color: null,
+  ancestors: [],
+};
+
+const areaTwoAncestors: AreaSummary = {
+  id: '3',
+  name: 'Bathroom',
+  color: null,
+  ancestors: [
+    { id: '1', name: 'House', color: null },
+    { id: '2', name: 'Basement', color: null },
+  ],
+};
+
+const areaWithColor: AreaSummary = {
+  id: '4',
+  name: 'Kitchen',
+  color: '#ff0000',
+  ancestors: [{ id: '1', name: 'House', color: '#00ff00' }],
+};
+
+const areaCompactMulti: AreaSummary = {
+  id: '5',
+  name: 'Pantry',
+  color: null,
+  ancestors: [
+    { id: '1', name: 'Property', color: null },
+    { id: '2', name: 'House', color: null },
+  ],
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AreaBreadcrumb', () => {
+  // ── 1. Null area — default variant ─────────────────────────────────────────
+
+  describe('null area — default variant', () => {
+    it('renders "No area" text', () => {
+      render(<AreaBreadcrumb area={null} />);
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+
+    it('does not render a nav element', () => {
+      render(<AreaBreadcrumb area={null} />);
+      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    });
+
+    it('does not render an ol element', () => {
+      render(<AreaBreadcrumb area={null} />);
+      const { container } = render(<AreaBreadcrumb area={null} />);
+      expect(container.querySelector('ol')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── 2. Null area — compact variant ─────────────────────────────────────────
+
+  describe('null area — compact variant', () => {
+    it('renders "No area" text', () => {
+      render(<AreaBreadcrumb area={null} variant="compact" />);
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+
+    it('does not render a tooltip (no role="tooltip" in DOM)', () => {
+      const { container } = render(<AreaBreadcrumb area={null} variant="compact" />);
+      expect(container.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── 3. Default variant — single segment (no ancestors) ─────────────────────
+
+  describe('default variant — single segment (no ancestors)', () => {
+    it('renders the area name', () => {
+      render(<AreaBreadcrumb area={areaNoAncestors} />);
+      expect(screen.getByText('Garage')).toBeInTheDocument();
+    });
+
+    it('renders nav with aria-label "Area path"', () => {
+      render(<AreaBreadcrumb area={areaNoAncestors} />);
+      expect(screen.getByRole('navigation', { name: 'Area path' })).toBeInTheDocument();
+    });
+
+    it('renders no aria-hidden separator elements', () => {
+      const { container } = render(<AreaBreadcrumb area={areaNoAncestors} />);
+      const separators = container.querySelectorAll('[aria-hidden="true"]');
+      expect(separators).toHaveLength(0);
+    });
+
+    it('renders exactly 1 li element', () => {
+      const { container } = render(<AreaBreadcrumb area={areaNoAncestors} />);
+      const lis = container.querySelectorAll('li');
+      expect(lis).toHaveLength(1);
+    });
+  });
+
+  // ── 4. Default variant — multi-segment (2 ancestors + self) ────────────────
+
+  describe('default variant — multi-segment (2 ancestors + self)', () => {
+    it('renders all three names', () => {
+      render(<AreaBreadcrumb area={areaTwoAncestors} />);
+      expect(screen.getByText('House')).toBeInTheDocument();
+      expect(screen.getByText('Basement')).toBeInTheDocument();
+      expect(screen.getByText('Bathroom')).toBeInTheDocument();
+    });
+
+    it('renders nav with aria-label "Area path"', () => {
+      render(<AreaBreadcrumb area={areaTwoAncestors} />);
+      expect(screen.getByRole('navigation', { name: 'Area path' })).toBeInTheDocument();
+    });
+
+    it('renders exactly 2 aria-hidden separator elements', () => {
+      const { container } = render(<AreaBreadcrumb area={areaTwoAncestors} />);
+      const separators = container.querySelectorAll('[aria-hidden="true"]');
+      expect(separators).toHaveLength(2);
+    });
+
+    it('renders 5 li items total (3 segments + 2 separators)', () => {
+      const { container } = render(<AreaBreadcrumb area={areaTwoAncestors} />);
+      const lis = container.querySelectorAll('li');
+      expect(lis).toHaveLength(5);
+    });
+  });
+
+  // ── 5. Default variant — color ignored ─────────────────────────────────────
+
+  describe('default variant — color prop is ignored (no inline style)', () => {
+    it('segment li elements have no inline color style when color is non-null', () => {
+      const { container } = render(<AreaBreadcrumb area={areaWithColor} />);
+      const lis = container.querySelectorAll('li');
+      lis.forEach((li) => {
+        expect((li as HTMLElement).style.color).toBe('');
+      });
+    });
+  });
+
+  // ── 6. Default variant — default prop ──────────────────────────────────────
+
+  describe('default variant — default prop', () => {
+    it('renders nav (variant defaults to "default") when no variant prop supplied', () => {
+      render(<AreaBreadcrumb area={areaNoAncestors} />);
+      expect(screen.getByRole('navigation')).toBeInTheDocument();
+    });
+  });
+
+  // ── 7. Compact variant — tooltip wraps full path ────────────────────────────
+
+  describe('compact variant — tooltip wraps full path', () => {
+    it('renders a tabindex="0" element with full path as textContent', () => {
+      const { container } = render(<AreaBreadcrumb area={areaCompactMulti} variant="compact" />);
+      const focusable = container.querySelector('[tabindex="0"]');
+      expect(focusable).toBeInTheDocument();
+      expect((focusable as HTMLElement).textContent).toBe('Property \u203a House \u203a Pantry');
+    });
+
+    it('renders a role="tooltip" element containing the full path', () => {
+      const { container } = render(<AreaBreadcrumb area={areaCompactMulti} variant="compact" />);
+      const tooltip = container.querySelector('[role="tooltip"]');
+      expect(tooltip).toBeInTheDocument();
+      expect((tooltip as HTMLElement).textContent).toBe('Property \u203a House \u203a Pantry');
+    });
+
+    it('does not render a nav element', () => {
+      render(<AreaBreadcrumb area={areaCompactMulti} variant="compact" />);
+      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── 8. Compact variant — single segment tooltip ─────────────────────────────
+
+  describe('compact variant — single segment tooltip', () => {
+    it('tooltip textContent equals the single area name', () => {
+      const { container } = render(<AreaBreadcrumb area={areaNoAncestors} variant="compact" />);
+      const tooltip = container.querySelector('[role="tooltip"]');
+      expect(tooltip).toBeInTheDocument();
+      expect((tooltip as HTMLElement).textContent).toBe('Garage');
+    });
+
+    it('tabindex="0" element textContent equals the single area name', () => {
+      const { container } = render(<AreaBreadcrumb area={areaNoAncestors} variant="compact" />);
+      const focusable = container.querySelector('[tabindex="0"]');
+      expect(focusable).toBeInTheDocument();
+      expect((focusable as HTMLElement).textContent).toBe('Garage');
+    });
+  });
+});

--- a/client/src/components/AreaBreadcrumb/AreaBreadcrumb.tsx
+++ b/client/src/components/AreaBreadcrumb/AreaBreadcrumb.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AreaSummary } from '@cornerstone/shared';
+import { Tooltip } from '../Tooltip/Tooltip.js';
+import styles from './AreaBreadcrumb.module.css';
+
+export interface AreaBreadcrumbProps {
+  area: AreaSummary | null;
+  variant?: 'default' | 'compact';
+}
+
+const SEPARATOR = ' \u203a ';
+
+export function AreaBreadcrumb({ area, variant = 'default' }: AreaBreadcrumbProps): ReactNode {
+  const { t } = useTranslation('areas');
+
+  if (area === null) {
+    return <span className={styles.muted}>{t('noArea')}</span>;
+  }
+
+  const segments = [...area.ancestors.map((a) => a.name), area.name];
+  const fullPath = segments.join(SEPARATOR);
+
+  if (variant === 'compact') {
+    return (
+      <Tooltip content={fullPath}>
+        <span className={styles.compact} tabIndex={0}>
+          {fullPath}
+        </span>
+      </Tooltip>
+    );
+  }
+
+  const listItems: ReactNode[] = [];
+  segments.forEach((name, index) => {
+    if (index > 0) {
+      listItems.push(
+        <li key={`sep-${index}`} className={styles.separator} aria-hidden="true">
+          {SEPARATOR}
+        </li>,
+      );
+    }
+    listItems.push(
+      <li key={`seg-${index}`} className={styles.segment}>
+        {name}
+      </li>,
+    );
+  });
+
+  return (
+    <nav aria-label={t('pathLabel')} className={styles.nav}>
+      <ol className={styles.list}>{listItems}</ol>
+    </nav>
+  );
+}

--- a/client/src/components/AreaBreadcrumb/index.ts
+++ b/client/src/components/AreaBreadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { AreaBreadcrumb, type AreaBreadcrumbProps } from './AreaBreadcrumb.js';

--- a/client/src/components/SearchPicker/SearchPicker.module.css
+++ b/client/src/components/SearchPicker/SearchPicker.module.css
@@ -120,6 +120,22 @@
   white-space: nowrap;
 }
 
+.resultContent {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.resultSecondary {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--spacing-0-5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .stateMessage {
   padding: var(--spacing-4);
   text-align: center;

--- a/client/src/components/SearchPicker/SearchPicker.test.tsx
+++ b/client/src/components/SearchPicker/SearchPicker.test.tsx
@@ -884,3 +884,110 @@ describe('SearchPicker', () => {
     });
   });
 });
+
+// ── renderSecondary slot ──────────────────────────────────────────────────────
+// Tests for the renderSecondary prop added to SearchPicker.
+// These use the same TestItem / mockSearchFn / renderPicker helpers defined above.
+
+describe('renderSecondary slot', () => {
+  beforeEach(() => {
+    mockSearchFn.mockReset();
+    mockSearchFn.mockResolvedValue(sampleItems);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ── 9. Secondary renders per item ─────────────────────────────────────────
+
+  it('renders one secondary element per result item', async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      showItemsOnFocus: true,
+      renderSecondary: (item: TestItem) => (
+        <span data-testid="secondary-line">{item.status}</span>
+      ),
+      placeholder: 'Search...',
+    });
+
+    const input = screen.getByPlaceholderText('Search...');
+    await user.click(input);
+
+    await waitFor(() => {
+      const secondaries = screen.getAllByTestId('secondary-line');
+      expect(secondaries).toHaveLength(3);
+    });
+  });
+
+  // ── 10. CSS classes applied (identity-obj-proxy) ──────────────────────────
+
+  it('applies resultSecondary and resultContent CSS classes to each result', async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      showItemsOnFocus: true,
+      renderSecondary: (item: TestItem) => (
+        <span data-testid="secondary-line">{item.status}</span>
+      ),
+      placeholder: 'Search...',
+    });
+
+    const input = screen.getByPlaceholderText('Search...');
+    await user.click(input);
+
+    await waitFor(() => {
+      // identity-obj-proxy returns the class name as a string, so class="resultSecondary"
+      const secondarySpans = document.querySelectorAll('[class*="resultSecondary"]');
+      expect(secondarySpans).toHaveLength(3);
+
+      const contentSpans = document.querySelectorAll('[class*="resultContent"]');
+      expect(contentSpans).toHaveLength(3);
+    });
+  });
+
+  // ── 11. No secondary DOM when prop absent (regression guard) ──────────────
+
+  it('renders no resultSecondary or resultContent elements when renderSecondary is absent', async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      showItemsOnFocus: true,
+      placeholder: 'Search...',
+      // renderSecondary intentionally omitted
+    });
+
+    const input = screen.getByPlaceholderText('Search...');
+    await user.click(input);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Alpha Widget' })).toBeInTheDocument();
+    });
+
+    expect(document.querySelectorAll('[class*="resultSecondary"]')).toHaveLength(0);
+    expect(document.querySelectorAll('[class*="resultContent"]')).toHaveLength(0);
+  });
+
+  // ── 12. Secondary NOT in selectedDisplay ─────────────────────────────────
+
+  it('secondary element is absent after an item is selected', async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      showItemsOnFocus: true,
+      renderSecondary: (item: TestItem) => (
+        <span data-testid="secondary-line">{item.status}</span>
+      ),
+      placeholder: 'Search...',
+    });
+
+    const input = screen.getByPlaceholderText('Search...');
+    await user.click(input);
+
+    await waitFor(() => expect(screen.getByText('Alpha Widget')).toBeInTheDocument());
+
+    await user.click(screen.getByText('Alpha Widget'));
+
+    await waitFor(() => {
+      // After selection the input is replaced by selectedDisplay — no secondary
+      expect(screen.queryByTestId('secondary-line')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/SearchPicker/SearchPicker.tsx
+++ b/client/src/components/SearchPicker/SearchPicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import styles from './SearchPicker.module.css';
@@ -18,6 +19,7 @@ export interface SearchPickerProps<T> {
   placeholder?: string;
   searchFn: (query: string, excludeIds: string[]) => Promise<T[]>;
   renderItem: (item: T) => { id: string; label: string };
+  renderSecondary?: (item: T) => ReactNode;
   getStatusBorderColor?: (item: T) => string | undefined;
   specialOptions?: SpecialOption[];
   showItemsOnFocus?: boolean;
@@ -38,6 +40,7 @@ export function SearchPicker<T>({
   placeholder,
   searchFn,
   renderItem,
+  renderSecondary,
   getStatusBorderColor,
   specialOptions,
   showItemsOnFocus,
@@ -329,7 +332,14 @@ export function SearchPicker<T>({
                   className={styles.resultOption}
                   onClick={() => handleSelect(item)}
                 >
-                  <span className={styles.resultTitle}>{rendered.label}</span>
+                  {renderSecondary !== undefined ? (
+                    <span className={styles.resultContent}>
+                      <span className={styles.resultTitle}>{rendered.label}</span>
+                      <span className={styles.resultSecondary}>{renderSecondary(item)}</span>
+                    </span>
+                  ) : (
+                    <span className={styles.resultTitle}>{rendered.label}</span>
+                  )}
                 </button>
               );
             })}

--- a/client/src/i18n/de/areas.json
+++ b/client/src/i18n/de/areas.json
@@ -1,0 +1,4 @@
+{
+  "noArea": "Kein Bereich",
+  "pathLabel": "Bereichspfad"
+}

--- a/client/src/i18n/en/areas.json
+++ b/client/src/i18n/en/areas.json
@@ -1,0 +1,4 @@
+{
+  "noArea": "No area",
+  "pathLabel": "Area path"
+}

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -13,6 +13,7 @@ import enSchedule from './en/schedule.json';
 import enDiary from './en/diary.json';
 import enDocuments from './en/documents.json';
 import enSettings from './en/settings.json';
+import enAreas from './en/areas.json';
 
 import deCommon from './de/common.json';
 import deErrors from './de/errors.json';
@@ -25,6 +26,7 @@ import deSchedule from './de/schedule.json';
 import deDiary from './de/diary.json';
 import deDocuments from './de/documents.json';
 import deSettings from './de/settings.json';
+import deAreas from './de/areas.json';
 
 const resources = {
   en: {
@@ -39,6 +41,7 @@ const resources = {
     diary: enDiary,
     documents: enDocuments,
     settings: enSettings,
+    areas: enAreas,
   },
   de: {
     common: deCommon,
@@ -52,6 +55,7 @@ const resources = {
     diary: deDiary,
     documents: deDocuments,
     settings: deSettings,
+    areas: deAreas,
   },
 };
 
@@ -91,6 +95,7 @@ void i18n.use(initReactI18next).init({
     'diary',
     'documents',
     'settings',
+    'areas',
   ],
   interpolation: {
     escapeValue: false,


### PR DESCRIPTION
## Summary

- New `AreaBreadcrumb` shared component with default and compact variants: RTL text-overflow truncation reuses the existing `Tooltip` for full-path display on hover
- `SearchPicker` gains an optional `renderSecondary` render-prop slot for a secondary info line beneath each option label; fully additive with zero regression on existing usages
- New `areas` i18n namespace with EN + DE translations ("No Area" / "Kein Bereich", "Area path" / "Bereichspfad"); 20 new AreaBreadcrumb unit tests + 4 SearchPicker slot tests

Fixes #1237

## Test plan

- [ ] 20 AreaBreadcrumb unit tests pass (default variant, compact variant, tooltip trigger, empty/null area state)
- [ ] 4 SearchPicker `renderSecondary` slot tests pass (renders secondary line, slot absent leaves layout unchanged)
- [ ] `areas` i18n namespace keys verified present in both `en` and `de` locale files
- [ ] Quality Gates CI passes

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>