### PR TITLE
feat(budget-sources): inline expansion with grouped budget lines (#1247)

### DIFF
--- a/.claude/agent-memory/translator/MEMORY.md
+++ b/.claude/agent-memory/translator/MEMORY.md
@@ -65,6 +65,21 @@ Fixed terminology inconsistencies from EPIC-17 i18n rollout:
 
 - "Budgetzeile" is a non-glossary term that had slipped into `de/workItems.json` (modals + inlineErrors). Corrected to "Budgetposition(en)". Always scan for "Budgetzeile" when touching workItems or budget namespaces.
 
-## Pluralization Note for "Budgetpositionen"
+## Pluralization Note for "Budgetpositionen" / "Position"
 
-The German plural "Budgetpositionen" is used even when the count is 1 in aria-label contexts (e.g. `"{{count}} Budgetpositionen"`). If the frontend ever uses i18next pluralization keys (`_one`/`_other`), add both forms. For now the English source also uses a single key without suffix, so German matches.
+- When the English source uses `_one`/`_other` keys, German uses "Position" (singular) / "Positionen" (plural).
+- Example: `areaLineCount_one` = "{{count}} Position", `areaLineCount_other` = "{{count}} Positionen" (Issue #1247).
+- "Budgetposition(en)" is the glossary term for the entity "Budget Line". The word "Position" alone (without "Budget-" prefix) is acceptable as a short count label in compact UI contexts.
+
+## Confidence Level Labels (budget lines) — Issue #1247
+
+- `own_estimate` → "Eigene Schätzung"
+- `professional_estimate` → "Fachschätzung"
+- `quote` → "Angebot" (glossary: Quotation = Angebot)
+- `invoice` → "Rechnung" (glossary: Invoice = Rechnung)
+
+## "Invoiced" Badge vs "Claimed" Invoice Status — Issue #1247
+
+- `invoiceLinked` = "Verrechnet" — badge shown on a budget line that has a linked invoice (i.e. the cost has been invoiced/billed)
+- `invoiceStatusLabels.claimed` = "Eingereicht" — invoice payment status (submitted for reimbursement)
+- These are distinct concepts; do not conflate them.

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -1,11 +1,9 @@
 @keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateY(-var(--spacing-2));
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
@@ -23,8 +21,7 @@
 .linesPanel {
   animation: fadeIn var(--transition-medium) ease-out;
   background-color: var(--color-bg-primary);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
   margin-top: var(--spacing-4);
   padding: var(--spacing-4);
 }
@@ -38,11 +35,13 @@
 }
 
 .sectionHeader {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   margin: 0 0 var(--spacing-3) 0;
   padding: 0;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--spacing-2);
 }
 
 .areaGroup {
@@ -66,7 +65,7 @@
   display: inline-block;
   width: var(--spacing-3);
   height: var(--spacing-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-circle);
   flex-shrink: 0;
 }
 
@@ -100,8 +99,9 @@
 .lineRow {
   display: grid;
   grid-template-columns: 1fr auto auto;
+  grid-template-rows: auto auto;
   gap: var(--spacing-3);
-  align-items: center;
+  align-items: start;
   padding: var(--spacing-2) 0;
   font-size: var(--font-size-sm);
   border-bottom: 1px solid var(--color-border);
@@ -114,12 +114,23 @@
 .lineDescription {
   color: var(--color-text-primary);
   word-break: break-word;
+  grid-column: 1 / 2;
+  grid-row: 1;
+}
+
+.lineSubtext {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  grid-column: 1 / 2;
+  grid-row: 2;
 }
 
 .lineBadges {
   display: flex;
   gap: var(--spacing-1);
   align-items: center;
+  grid-column: 2;
+  grid-row: 1 / 3;
 }
 
 .linePlannedAmount {
@@ -127,6 +138,8 @@
   font-weight: var(--font-weight-medium);
   text-align: right;
   white-space: nowrap;
+  grid-column: 3;
+  grid-row: 1 / 3;
 }
 
 /* Confidence badge styles */
@@ -173,19 +186,19 @@
 
 /* Retry button */
 .retryButton {
-  background-color: var(--color-danger-active);
-  color: var(--color-danger-text);
+  background: none;
+  color: var(--color-primary);
   border: none;
-  border-radius: var(--radius-sm);
-  padding: var(--spacing-2) var(--spacing-3);
+  padding: 0;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background-color var(--transition-normal);
+  text-decoration: underline;
+  transition: color var(--transition-normal);
 }
 
 .retryButton:hover {
-  background-color: var(--color-danger);
+  color: var(--color-primary-hover);
 }
 
 .retryButton:focus-visible {
@@ -202,12 +215,22 @@
 @media (max-width: 767px) {
   .lineRow {
     grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
+    grid-template-rows: auto auto auto;
+  }
+
+  .lineDescription {
+    grid-column: 1 / 2;
+    grid-row: 1;
+  }
+
+  .lineSubtext {
+    grid-column: 1 / 2;
+    grid-row: 2;
   }
 
   .lineBadges {
     grid-column: 1 / 3;
-    grid-row: 2;
+    grid-row: 3;
   }
 
   .linePlannedAmount {

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -1,0 +1,217 @@
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-var(--spacing-2));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+.linesPanel {
+  animation: fadeIn var(--transition-medium) ease-out;
+  background-color: var(--color-bg-primary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-4);
+}
+
+.section {
+  margin-bottom: var(--spacing-4);
+}
+
+.section:last-child {
+  margin-bottom: 0;
+}
+
+.sectionHeader {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-3) 0;
+  padding: 0;
+}
+
+.areaGroup {
+  margin-bottom: var(--spacing-3);
+}
+
+.areaGroup:last-child {
+  margin-bottom: 0;
+}
+
+.areaGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+  padding: var(--spacing-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.areaColorDot {
+  display: inline-block;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.areaName {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.areaLineCount {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-normal);
+}
+
+.parentItemHeader {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  margin: var(--spacing-2) 0 var(--spacing-1) 0;
+  padding: 0 0 var(--spacing-1) 0;
+}
+
+.lineList {
+  list-style: none;
+  margin: 0 0 var(--spacing-2) 0;
+  padding: 0;
+}
+
+.lineRow {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: var(--spacing-3);
+  align-items: center;
+  padding: var(--spacing-2) 0;
+  font-size: var(--font-size-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.lineRow:last-child {
+  border-bottom: none;
+}
+
+.lineDescription {
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.lineBadges {
+  display: flex;
+  gap: var(--spacing-1);
+  align-items: center;
+}
+
+.linePlannedAmount {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-medium);
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* Confidence badge styles */
+.confidenceOwnEstimate {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+
+.confidenceProEstimate {
+  background-color: var(--color-primary-bg);
+  color: var(--color-primary-badge-text);
+}
+
+.confidenceQuote {
+  background-color: var(--color-hi-status-scheduled-bg);
+  color: var(--color-hi-status-scheduled-text);
+}
+
+.confidenceInvoice {
+  background-color: var(--color-success-badge-bg);
+  color: var(--color-success-badge-text);
+}
+
+/* Invoice linked badge style */
+.invoiceLinked {
+  background-color: var(--color-success-badge-bg-alt);
+  color: var(--color-success-badge-text);
+}
+
+/* Error banner */
+.errorBanner {
+  background-color: var(--color-danger-bg);
+  border: 1px solid var(--color-danger-border);
+  border-radius: var(--radius-md);
+  color: var(--color-danger-active);
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.errorBanner p {
+  margin: 0 0 var(--spacing-2) 0;
+  font-size: var(--font-size-sm);
+}
+
+/* Retry button */
+.retryButton {
+  background-color: var(--color-danger-active);
+  color: var(--color-danger-text);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color var(--transition-normal);
+}
+
+.retryButton:hover {
+  background-color: var(--color-danger);
+}
+
+.retryButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.retryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Mobile responsive */
+@media (max-width: 767px) {
+  .lineRow {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+  }
+
+  .lineBadges {
+    grid-column: 1 / 3;
+    grid-row: 2;
+  }
+
+  .linePlannedAmount {
+    grid-column: 2;
+    grid-row: 1;
+  }
+}

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -546,4 +546,44 @@ describe('SourceBudgetLinePanel', () => {
       expect(screen.getByText('2 lines')).toBeInTheDocument();
     });
   });
+
+  // ─── Category and vendor display ──────────────────────────
+
+  describe('category and vendor display', () => {
+    it('renders secondary text with both category and vendor when both present', () => {
+      const line = makeLine({
+        budgetCategory: {
+          id: 'cat-1',
+          name: 'Flooring',
+          description: null,
+          color: null,
+          translationKey: null,
+          sortOrder: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        vendor: {
+          id: 'vend-1',
+          name: 'Smith Construction',
+          trade: null,
+        },
+      });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Flooring · Smith Construction')).toBeInTheDocument();
+    });
+
+    it('does NOT render secondary line when both category and vendor are null', () => {
+      const line = makeLine({
+        budgetCategory: null,
+        vendor: null,
+      });
+      renderPanel({ data: makeResponse([line], []) });
+
+      // The line description should be present, but no secondary text
+      expect(screen.getByText('Floor tiles')).toBeInTheDocument();
+      // Verify the separator is not in the document
+      expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -1,0 +1,549 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type {
+  BudgetSourceBudgetLine,
+  BudgetSourceBudgetLinesResponse,
+} from '@cornerstone/shared';
+
+// ─── Mock: formatters ──────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../lib/formatters.js', () => {
+  const fmtCurrency = (n: number) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(n);
+  return {
+    formatCurrency: fmtCurrency,
+    formatDate: (d: string | null | undefined, fallback = '—') => d ?? fallback,
+    formatTime: () => '—',
+    formatDateTime: () => '—',
+    formatPercent: (n: number) => `${n.toFixed(2)}%`,
+    computeActualDuration: () => null,
+    useFormatters: () => ({
+      formatCurrency: fmtCurrency,
+      formatDate: (d: string | null | undefined, fallback = '—') => d ?? fallback,
+      formatTime: () => '—',
+      formatDateTime: () => '—',
+      formatPercent: (n: number) => `${n.toFixed(2)}%`,
+    }),
+  };
+});
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────────
+
+function makeLine(overrides: Partial<BudgetSourceBudgetLine> = {}): BudgetSourceBudgetLine {
+  return {
+    id: 'line-1',
+    parentId: 'parent-1',
+    parentName: 'Kitchen Renovation',
+    area: null,
+    description: 'Floor tiles',
+    plannedAmount: 1500,
+    confidence: 'own_estimate',
+    confidenceMargin: 0.2,
+    budgetCategory: null,
+    budgetSource: null,
+    vendor: null,
+    actualCost: 0,
+    actualCostPaid: 0,
+    invoiceCount: 0,
+    invoiceLink: null,
+    quantity: null,
+    unit: null,
+    unitPrice: null,
+    includesVat: null,
+    createdBy: null,
+    hasClaimedInvoice: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeArea(overrides: { id?: string; name?: string; color?: string | null } = {}) {
+  return {
+    id: overrides.id ?? 'area-1',
+    name: overrides.name ?? 'Kitchen',
+    color: overrides.color !== undefined ? overrides.color : '#ff0000',
+    ancestors: [],
+  };
+}
+
+function makeResponse(
+  workItemLines: BudgetSourceBudgetLine[] = [],
+  householdItemLines: BudgetSourceBudgetLine[] = [],
+): BudgetSourceBudgetLinesResponse {
+  return { workItemLines, householdItemLines };
+}
+
+// ─── Component import (after mocks) ─────────────────────────────────────────────
+
+describe('SourceBudgetLinePanel', () => {
+  let SourceBudgetLinePanel: React.ComponentType<{
+    sourceId: string;
+    sourceName: string;
+    data: BudgetSourceBudgetLinesResponse | null;
+    isLoading: boolean;
+    error: string | null;
+    onRetry: () => void;
+  }>;
+
+  beforeEach(async () => {
+    if (!SourceBudgetLinePanel) {
+      const module = await import('./SourceBudgetLinePanel.js');
+      SourceBudgetLinePanel = module.SourceBudgetLinePanel;
+    }
+  });
+
+  function renderPanel(
+    props: Partial<React.ComponentProps<typeof SourceBudgetLinePanel>> = {},
+  ) {
+    const defaultProps = {
+      sourceId: 'src-1',
+      sourceName: 'Home Loan',
+      data: null,
+      isLoading: false,
+      error: null,
+      onRetry: jest.fn(),
+    };
+    return render(<SourceBudgetLinePanel {...defaultProps} {...props} />);
+  }
+
+  // ─── Loading state (scenario 1) ─────────────────────────────────────────────
+
+  describe('loading state', () => {
+    it('renders Skeleton when isLoading=true', () => {
+      renderPanel({ isLoading: true });
+
+      // Skeleton renders with role="status" for the loading indicator
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('does not render section headers when isLoading=true', () => {
+      renderPanel({ isLoading: true });
+
+      expect(screen.queryByText('Work Item Lines')).not.toBeInTheDocument();
+      expect(screen.queryByText('Household Item Lines')).not.toBeInTheDocument();
+    });
+
+    it('renders a region with aria-label containing loading label when isLoading=true', () => {
+      renderPanel({ isLoading: true, sourceId: 'src-42' });
+
+      const region = document.getElementById('source-lines-src-42');
+      expect(region).toBeInTheDocument();
+      expect(region?.getAttribute('role')).toBe('region');
+    });
+  });
+
+  // ─── Error state (scenario 2) ────────────────────────────────────────────────
+
+  describe('error state', () => {
+    it('shows alert banner with error message', () => {
+      renderPanel({ error: 'Could not load budget lines.' });
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Could not load budget lines.')).toBeInTheDocument();
+    });
+
+    it('shows Retry button in error state', () => {
+      renderPanel({ error: 'Could not load budget lines.' });
+
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('calls onRetry when Retry button is clicked', () => {
+      const onRetry = jest.fn();
+      renderPanel({ error: 'Could not load budget lines.', onRetry });
+
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders error region with correct id and role', () => {
+      renderPanel({ error: 'Some error', sourceId: 'src-err' });
+
+      const region = document.getElementById('source-lines-src-err');
+      expect(region).toBeInTheDocument();
+      expect(region?.getAttribute('role')).toBe('region');
+    });
+
+    it('error region aria-label contains the source name', () => {
+      renderPanel({ error: 'Some error', sourceName: 'Home Loan' });
+
+      const region = screen.getByRole('region');
+      expect(region.getAttribute('aria-label')).toContain('Home Loan');
+    });
+  });
+
+  // ─── Empty state (scenario 3) ────────────────────────────────────────────────
+
+  describe('empty state', () => {
+    it('renders EmptyState message when both arrays are empty', () => {
+      renderPanel({ data: makeResponse([], []) });
+
+      expect(screen.getByText('No budget lines assigned')).toBeInTheDocument();
+    });
+
+    it('does not render section headers when both arrays are empty', () => {
+      renderPanel({ data: makeResponse([], []) });
+
+      expect(screen.queryByText('Work Item Lines')).not.toBeInTheDocument();
+      expect(screen.queryByText('Household Item Lines')).not.toBeInTheDocument();
+    });
+
+    it('renders region with correct id when empty', () => {
+      renderPanel({ data: makeResponse([], []), sourceId: 'src-empty' });
+
+      const region = document.getElementById('source-lines-src-empty');
+      expect(region).toBeInTheDocument();
+    });
+  });
+
+  // ─── WI lines only (scenario 4) ─────────────────────────────────────────────
+
+  describe('work item lines only', () => {
+    it('renders "Work Item Lines" section header', () => {
+      const line = makeLine({ parentId: 'p1', parentName: 'Kitchen' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Work Item Lines')).toBeInTheDocument();
+    });
+
+    it('does NOT render "Household Item Lines" header when HI array is empty', () => {
+      const line = makeLine({ parentId: 'p1', parentName: 'Kitchen' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.queryByText('Household Item Lines')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── HI lines only (scenario 5) ─────────────────────────────────────────────
+
+  describe('household item lines only', () => {
+    it('renders "Household Item Lines" section header', () => {
+      const line = makeLine({ parentId: 'p1', parentName: 'Sofa' });
+      renderPanel({ data: makeResponse([], [line]) });
+
+      expect(screen.getByText('Household Item Lines')).toBeInTheDocument();
+    });
+
+    it('does NOT render "Work Item Lines" header when WI array is empty', () => {
+      const line = makeLine({ parentId: 'p1', parentName: 'Sofa' });
+      renderPanel({ data: makeResponse([], [line]) });
+
+      expect(screen.queryByText('Work Item Lines')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Both sections (scenario 6) ─────────────────────────────────────────────
+
+  describe('both sections present', () => {
+    it('renders both "Work Item Lines" and "Household Item Lines" headers', () => {
+      const wiLine = makeLine({ id: 'wi-1', parentId: 'p1', parentName: 'Kitchen' });
+      const hiLine = makeLine({ id: 'hi-1', parentId: 'p2', parentName: 'Sofa' });
+      renderPanel({ data: makeResponse([wiLine], [hiLine]) });
+
+      expect(screen.getByText('Work Item Lines')).toBeInTheDocument();
+      expect(screen.getByText('Household Item Lines')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Grouping — Unassigned last (scenario 7) ─────────────────────────────────
+
+  describe('grouping — Unassigned appears after named areas', () => {
+    it('Unassigned group appears after named area groups', () => {
+      const namedLine = makeLine({
+        id: 'l1',
+        parentId: 'p1',
+        parentName: 'Parent A',
+        area: makeArea({ id: 'area-1', name: 'Kitchen' }),
+      });
+      const unassignedLine1 = makeLine({
+        id: 'l2',
+        parentId: 'p2',
+        parentName: 'Parent B',
+        area: null,
+      });
+      const unassignedLine2 = makeLine({
+        id: 'l3',
+        parentId: 'p2',
+        parentName: 'Parent B',
+        area: null,
+      });
+
+      renderPanel({ data: makeResponse([namedLine, unassignedLine1, unassignedLine2], []) });
+
+      // Both area headers should appear — named area and "Unassigned"
+      expect(screen.getByText('Kitchen')).toBeInTheDocument();
+      expect(screen.getByText('Unassigned')).toBeInTheDocument();
+
+      // Verify order: "Kitchen" should appear before "Unassigned" in the DOM
+      const allText = document.body.textContent ?? '';
+      const kitchenPos = allText.indexOf('Kitchen');
+      const unassignedPos = allText.indexOf('Unassigned');
+      expect(kitchenPos).toBeLessThan(unassignedPos);
+    });
+  });
+
+  // ─── Grouping — area alphabetical (scenario 8) ─────────────────────────────
+
+  describe('grouping — areas sorted alphabetically', () => {
+    it('renders "Bathroom" before "Kitchen" when alphabetically earlier', () => {
+      const bathroomLine = makeLine({
+        id: 'l1',
+        parentId: 'p1',
+        parentName: 'Tile Work',
+        area: makeArea({ id: 'area-b', name: 'Bathroom' }),
+      });
+      const kitchenLine = makeLine({
+        id: 'l2',
+        parentId: 'p2',
+        parentName: 'Cabinet Work',
+        area: makeArea({ id: 'area-k', name: 'Kitchen' }),
+      });
+
+      // Pass Kitchen before Bathroom in array — component must sort them
+      renderPanel({ data: makeResponse([kitchenLine, bathroomLine], []) });
+
+      expect(screen.getByText('Bathroom')).toBeInTheDocument();
+      expect(screen.getByText('Kitchen')).toBeInTheDocument();
+
+      const allText = document.body.textContent ?? '';
+      const bathroomPos = allText.indexOf('Bathroom');
+      const kitchenPos = allText.indexOf('Kitchen');
+      expect(bathroomPos).toBeLessThan(kitchenPos);
+    });
+  });
+
+  // ─── Parent item sub-grouping (scenario 9) ───────────────────────────────────
+
+  describe('parent item sub-grouping', () => {
+    it('groups lines under a single parent header when they share parentId', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'p-shared',
+        parentName: 'Bathroom Renovation',
+        description: 'Floor tiles',
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'p-shared',
+        parentName: 'Bathroom Renovation',
+        description: 'Wall tiles',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      // Single parent header for shared parentId
+      expect(screen.getAllByText('Bathroom Renovation')).toHaveLength(1);
+      // Both lines appear under it
+      expect(screen.getByText('Floor tiles')).toBeInTheDocument();
+      expect(screen.getByText('Wall tiles')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Null description → '—' (scenario 10) ───────────────────────────────────
+
+  describe('null description renders dash placeholder', () => {
+    it('shows "—" when line.description is null', () => {
+      const line = makeLine({ description: null });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Confidence badge label (scenario 11) ────────────────────────────────────
+
+  describe('confidence badge', () => {
+    it('shows "Own estimate" badge for own_estimate confidence', () => {
+      const line = makeLine({ confidence: 'own_estimate' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Own estimate')).toBeInTheDocument();
+    });
+
+    it('shows "Pro estimate" badge for professional_estimate confidence', () => {
+      const line = makeLine({ confidence: 'professional_estimate' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Pro estimate')).toBeInTheDocument();
+    });
+
+    it('shows "Quote" badge for quote confidence', () => {
+      const line = makeLine({ confidence: 'quote' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Quote')).toBeInTheDocument();
+    });
+
+    it('shows "Invoice" badge for invoice confidence', () => {
+      const line = makeLine({ confidence: 'invoice' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Invoice')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Invoice badge present (scenario 12) ─────────────────────────────────────
+
+  describe('invoice badge', () => {
+    it('renders "Invoiced" badge when invoiceLink is not null', () => {
+      const line = makeLine({
+        invoiceLink: {
+          invoiceBudgetLineId: 'ibl-1',
+          invoiceId: 'inv-1',
+          invoiceNumber: 'INV-001',
+          invoiceDate: '2026-01-01',
+          invoiceStatus: 'paid',
+          itemizedAmount: 100,
+        },
+      });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Invoiced')).toBeInTheDocument();
+    });
+
+    // ─── Invoice badge absent (scenario 13) ───────────────────────────────────
+
+    it('does NOT render "Invoiced" badge when invoiceLink is null', () => {
+      const line = makeLine({ invoiceLink: null });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.queryByText('Invoiced')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Currency formatting (scenario 14) ───────────────────────────────────────
+
+  describe('currency formatting', () => {
+    it('renders planned amount via formatCurrency', () => {
+      const line = makeLine({ plannedAmount: 2500 });
+      renderPanel({ data: makeResponse([line], []) });
+
+      // Mock formatCurrency produces €2,500.00
+      expect(screen.getByText('€2,500.00')).toBeInTheDocument();
+    });
+
+    it('renders zero amount as €0.00', () => {
+      const line = makeLine({ plannedAmount: 0 });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('€0.00')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Panel root accessibility (scenario 15) ──────────────────────────────────
+
+  describe('panel root accessibility', () => {
+    it('renders panel with role="region"', () => {
+      renderPanel({ data: makeResponse([makeLine()], []) });
+
+      expect(screen.getByRole('region')).toBeInTheDocument();
+    });
+
+    it('region aria-label contains the source name', () => {
+      renderPanel({ data: makeResponse([makeLine()], []), sourceName: 'Primary Loan' });
+
+      const region = screen.getByRole('region');
+      expect(region.getAttribute('aria-label')).toContain('Primary Loan');
+    });
+
+    it('region id is source-lines-{sourceId}', () => {
+      renderPanel({ data: makeResponse([makeLine()], []), sourceId: 'src-99' });
+
+      const region = document.getElementById('source-lines-src-99');
+      expect(region).toBeInTheDocument();
+    });
+  });
+
+  // ─── List roles (scenario 16) ────────────────────────────────────────────────
+
+  describe('list ARIA roles', () => {
+    it('renders ul with role="list"', () => {
+      renderPanel({ data: makeResponse([makeLine()], []) });
+
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('each line is rendered as li with role="listitem"', () => {
+      const line1 = makeLine({ id: 'l1', description: 'First item' });
+      const line2 = makeLine({
+        id: 'l2',
+        description: 'Second item',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    });
+
+    it('each li contains a description span', () => {
+      const line = makeLine({ description: 'Flooring' });
+      renderPanel({ data: makeResponse([line], []) });
+
+      expect(screen.getByText('Flooring')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Area color dot ──────────────────────────────────────────────────────────
+
+  describe('area color dot', () => {
+    it('renders color dot for named area with color', () => {
+      const line = makeLine({ area: makeArea({ color: '#ff0000' }) });
+      renderPanel({ data: makeResponse([line], []) });
+
+      // The color dot has aria-hidden="true" and inline style
+      const dots = document.querySelectorAll('[aria-hidden="true"]');
+      const colorDots = Array.from(dots).filter(
+        (el) => (el as HTMLElement).style.backgroundColor !== '',
+      );
+      expect(colorDots.length).toBeGreaterThan(0);
+    });
+
+    it('renders grey dot for unassigned area', () => {
+      const line = makeLine({ area: null });
+      renderPanel({ data: makeResponse([line], []) });
+
+      // The unassigned dot uses var(--color-text-disabled)
+      const dots = document.querySelectorAll('[aria-hidden="true"]');
+      const unassignedDot = Array.from(dots).find((el) =>
+        (el as HTMLElement).style.backgroundColor?.includes('var(--color-text-disabled)'),
+      );
+      expect(unassignedDot).toBeDefined();
+    });
+  });
+
+  // ─── Area line count ─────────────────────────────────────────────────────────
+
+  describe('area line count', () => {
+    it('shows line count for named area with 2 lines', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'p1',
+        parentName: 'Kitchen',
+        area: makeArea({ id: 'a1', name: 'Main Area' }),
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'p2',
+        parentName: 'Bathroom',
+        area: makeArea({ id: 'a1', name: 'Main Area' }),
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      // areaLineCount_other = "{{count}} lines"
+      expect(screen.getByText('2 lines')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
@@ -1,0 +1,275 @@
+import { useTranslation } from 'react-i18next';
+import type {
+  BudgetSourceBudgetLinesResponse,
+  BudgetSourceBudgetLine,
+  ConfidenceLevel,
+} from '@cornerstone/shared';
+import { useFormatters } from '../../lib/formatters.js';
+import { Badge } from '../Badge/Badge.js';
+import type { BadgeVariantMap } from '../Badge/Badge.js';
+import { Skeleton } from '../Skeleton/Skeleton.js';
+import { EmptyState } from '../EmptyState/EmptyState.js';
+import styles from './SourceBudgetLinePanel.module.css';
+
+interface SourceBudgetLinePanelProps {
+  sourceId: string;
+  sourceName: string;
+  data: BudgetSourceBudgetLinesResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+interface ParentGroup {
+  parentId: string;
+  parentName: string;
+  lines: BudgetSourceBudgetLine[];
+}
+
+interface AreaGroup {
+  areaId: string | null;
+  areaName: string;
+  areaColor: string | null;
+  parentGroups: ParentGroup[];
+  totalLines: number;
+}
+
+// Group lines by parent within an area
+function buildParentGroups(lines: BudgetSourceBudgetLine[]): ParentGroup[] {
+  const parentMap = new Map<string, { name: string; lines: BudgetSourceBudgetLine[] }>();
+
+  for (const line of lines) {
+    const parentKey = line.parentId;
+    if (!parentMap.has(parentKey)) {
+      parentMap.set(parentKey, { name: line.parentName, lines: [] });
+    }
+    parentMap.get(parentKey)!.lines.push(line);
+  }
+
+  // Sort each parent's lines by createdAt ascending
+  for (const pg of parentMap.values()) {
+    pg.lines.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }
+
+  // Return sorted by parent name
+  return Array.from(parentMap.entries())
+    .map(([id, data]) => ({
+      parentId: id,
+      parentName: data.name,
+      lines: data.lines,
+    }))
+    .sort((a, b) => a.parentName.localeCompare(b.parentName));
+}
+
+// Group lines by area, then parent
+function groupLines(lines: BudgetSourceBudgetLine[]): AreaGroup[] {
+  const areaMap = new Map<
+    string | null,
+    { name: string; color: string | null; lines: BudgetSourceBudgetLine[] }
+  >();
+
+  for (const line of lines) {
+    const areaKey = line.area?.id ?? null;
+    if (!areaMap.has(areaKey)) {
+      areaMap.set(areaKey, {
+        name: line.area?.name ?? '',
+        color: line.area?.color ?? null,
+        lines: [],
+      });
+    }
+    areaMap.get(areaKey)!.lines.push(line);
+  }
+
+  // Build area groups: named areas sorted alphabetically, unassigned last
+  const namedAreas = Array.from(areaMap.entries())
+    .filter(([id]) => id !== null)
+    .map(([id, data]) => ({
+      areaId: id,
+      areaName: data.name,
+      areaColor: data.color,
+      parentGroups: buildParentGroups(data.lines),
+      totalLines: data.lines.length,
+    }))
+    .sort((a, b) => a.areaName.localeCompare(b.areaName));
+
+  const unassignedData = areaMap.get(null);
+  if (unassignedData && unassignedData.lines.length > 0) {
+    namedAreas.push({
+      areaId: null,
+      areaName: '',
+      areaColor: null,
+      parentGroups: buildParentGroups(unassignedData.lines),
+      totalLines: unassignedData.lines.length,
+    });
+  }
+
+  return namedAreas;
+}
+
+export function SourceBudgetLinePanel({
+  sourceId,
+  sourceName,
+  data,
+  isLoading,
+  error,
+  onRetry,
+}: SourceBudgetLinePanelProps) {
+  const { t } = useTranslation('budget');
+  const { formatCurrency } = useFormatters();
+
+  // Build confidence and invoice badge variants
+  const confidenceVariants: BadgeVariantMap = {
+    own_estimate: {
+      label: t('sources.lines.confidence.own_estimate'),
+      className: styles.confidenceOwnEstimate,
+    },
+    professional_estimate: {
+      label: t('sources.lines.confidence.professional_estimate'),
+      className: styles.confidenceProEstimate,
+    },
+    quote: {
+      label: t('sources.lines.confidence.quote'),
+      className: styles.confidenceQuote,
+    },
+    invoice: {
+      label: t('sources.lines.confidence.invoice'),
+      className: styles.confidenceInvoice,
+    },
+  };
+
+  const invoiceVariants: BadgeVariantMap = {
+    linked: {
+      label: t('sources.lines.invoiceLinked'),
+      className: styles.invoiceLinked,
+    },
+  };
+
+  const workItemLines = data?.workItemLines ?? [];
+
+  const householdItemLines = data?.householdItemLines ?? [];
+
+  const isEmpty = workItemLines.length === 0 && householdItemLines.length === 0;
+
+  // Render a section (work items or household items)
+  const renderSection = (lines: BudgetSourceBudgetLine[], titleKey: 'workItemSection' | 'householdItemSection') => {
+    if (lines.length === 0) return null;
+
+    const groupedByArea = groupLines(lines);
+
+    return (
+      <div key={titleKey} className={styles.section}>
+        <h4 className={styles.sectionHeader}>{t(`sources.lines.${titleKey}`)}</h4>
+
+        {groupedByArea.map((areaGroup) => (
+          <div key={areaGroup.areaId ?? 'unassigned'} className={styles.areaGroup}>
+            <div className={styles.areaGroupHeader}>
+              {areaGroup.areaColor && (
+                <span
+                  className={styles.areaColorDot}
+                  style={{ backgroundColor: areaGroup.areaColor }}
+                  aria-hidden="true"
+                />
+              )}
+              {!areaGroup.areaColor && areaGroup.areaId === null && (
+                <span
+                  className={styles.areaColorDot}
+                  style={{ backgroundColor: 'var(--color-text-disabled)' }}
+                  aria-hidden="true"
+                />
+              )}
+              <span className={styles.areaName}>
+                {areaGroup.areaId === null
+                  ? t('sources.lines.unassignedArea')
+                  : areaGroup.areaName}
+              </span>
+              <span className={styles.areaLineCount}>
+                {t('sources.lines.areaLineCount', { count: areaGroup.totalLines })}
+              </span>
+            </div>
+
+            {areaGroup.parentGroups.map((parentGroup) => (
+              <div key={parentGroup.parentId}>
+                <p className={styles.parentItemHeader}>{parentGroup.parentName}</p>
+
+                <ul role="list" className={styles.lineList}>
+                  {parentGroup.lines.map((line) => (
+                    <li key={line.id} role="listitem" className={styles.lineRow}>
+                      <span className={styles.lineDescription}>
+                        {line.description ?? '—'}
+                      </span>
+
+                      <div className={styles.lineBadges}>
+                        <Badge
+                          variants={confidenceVariants}
+                          value={line.confidence as ConfidenceLevel}
+                        />
+                        {line.invoiceLink !== null && (
+                          <Badge
+                            variants={invoiceVariants}
+                            value="linked"
+                          />
+                        )}
+                      </div>
+
+                      <span className={styles.linePlannedAmount}>
+                        {formatCurrency(line.plannedAmount)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // Render states
+  if (isLoading) {
+    return (
+      <div id={`source-lines-${sourceId}`} role="region" aria-label={t('sources.lines.loadingLabel')} className={styles.linesPanel}>
+        <Skeleton
+          lines={6}
+          widths={['70%', '45%', '90%', '70%', '90%', '70%']}
+          loadingLabel={t('sources.lines.loadingLabel')}
+        />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div id={`source-lines-${sourceId}`} role="region" aria-label={t('sources.lines.panelAriaLabel', { name: sourceName })} className={styles.linesPanel}>
+        <div className={styles.errorBanner} role="alert">
+          <p>{error}</p>
+          <button
+            type="button"
+            className={styles.retryButton}
+            onClick={onRetry}
+          >
+            {t('sources.lines.retry')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div id={`source-lines-${sourceId}`} role="region" aria-label={t('sources.lines.panelAriaLabel', { name: sourceName })} className={styles.linesPanel}>
+        <EmptyState
+          message={t('sources.lines.empty')}
+          description={t('sources.lines.emptyDescription')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div id={`source-lines-${sourceId}`} role="region" aria-label={t('sources.lines.panelAriaLabel', { name: sourceName })} className={styles.linesPanel}>
+      {renderSection(workItemLines, 'workItemSection')}
+      {renderSection(householdItemLines, 'householdItemSection')}
+    </div>
+  );
+}

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
@@ -192,30 +192,42 @@ export function SourceBudgetLinePanel({
                 <p className={styles.parentItemHeader}>{parentGroup.parentName}</p>
 
                 <ul role="list" className={styles.lineList}>
-                  {parentGroup.lines.map((line) => (
-                    <li key={line.id} role="listitem" className={styles.lineRow}>
-                      <span className={styles.lineDescription}>
-                        {line.description ?? '—'}
-                      </span>
+                  {parentGroup.lines.map((line) => {
+                    const categoryName = line.budgetCategory?.name ?? null;
+                    const vendorName = line.vendor?.name ?? null;
+                    const showSubtext = categoryName || vendorName;
 
-                      <div className={styles.lineBadges}>
-                        <Badge
-                          variants={confidenceVariants}
-                          value={line.confidence as ConfidenceLevel}
-                        />
-                        {line.invoiceLink !== null && (
-                          <Badge
-                            variants={invoiceVariants}
-                            value="linked"
-                          />
+                    return (
+                      <li key={line.id} role="listitem" className={styles.lineRow}>
+                        <span className={styles.lineDescription}>
+                          {line.description ?? '—'}
+                        </span>
+
+                        {showSubtext && (
+                          <span className={styles.lineSubtext}>
+                            {categoryName && vendorName ? `${categoryName} · ${vendorName}` : (categoryName || vendorName)}
+                          </span>
                         )}
-                      </div>
 
-                      <span className={styles.linePlannedAmount}>
-                        {formatCurrency(line.plannedAmount)}
-                      </span>
-                    </li>
-                  ))}
+                        <div className={styles.lineBadges}>
+                          <Badge
+                            variants={confidenceVariants}
+                            value={line.confidence}
+                          />
+                          {line.invoiceLink !== null && (
+                            <Badge
+                              variants={invoiceVariants}
+                              value="linked"
+                            />
+                          )}
+                        </div>
+
+                        <span className={styles.linePlannedAmount}>
+                          {formatCurrency(line.plannedAmount)}
+                        </span>
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             ))}

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -170,7 +170,9 @@
         "quote": "Angebot",
         "invoice": "Rechnung"
       },
-      "invoiceLinked": "Verrechnet"
+      "invoiceLinked": "Verrechnet",
+      "categoryVendorSeparator": " · ",
+      "noCategory": "Keine Kategorie"
     }
   },
   "vendors": {

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -147,6 +147,30 @@
       "ofTotal": "der Summe",
       "remaining": "Verbleibend",
       "overflow": "Überlauf"
+    },
+    "lines": {
+      "expand": "Positionen einblenden",
+      "collapse": "Positionen ausblenden",
+      "loadingLabel": "Budgetpositionen werden geladen…",
+      "empty": "Keine Budgetpositionen zugeordnet",
+      "emptyDescription": "Budgetpositionen aus Arbeitspaketen und Haushaltsartikeln erscheinen hier, wenn sie dieser Quelle zugeordnet sind.",
+      "workItemSection": "Arbeitspaket-Positionen",
+      "householdItemSection": "Haushaltsartikel-Positionen",
+      "unassignedArea": "Nicht zugeordnet",
+      "fetchError": "Budgetpositionen konnten nicht geladen werden.",
+      "retry": "Erneut versuchen",
+      "areaLineCount_one": "{{count}} Position",
+      "areaLineCount_other": "{{count}} Positionen",
+      "expandAriaLabel": "Budgetpositionen für {{name}} einblenden",
+      "collapseAriaLabel": "Budgetpositionen für {{name}} ausblenden",
+      "panelAriaLabel": "Budgetpositionen für {{name}}",
+      "confidence": {
+        "own_estimate": "Eigene Schätzung",
+        "professional_estimate": "Fachschätzung",
+        "quote": "Angebot",
+        "invoice": "Rechnung"
+      },
+      "invoiceLinked": "Verrechnet"
     }
   },
   "vendors": {

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -164,6 +164,7 @@
       "expandAriaLabel": "Expand budget lines for {{name}}",
       "collapseAriaLabel": "Collapse budget lines for {{name}}",
       "panelAriaLabel": "Budget lines for {{name}}",
+      "categoryVendorSeparator": " · ",
       "confidence": {
         "own_estimate": "Own estimate",
         "professional_estimate": "Pro estimate",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -147,6 +147,30 @@
       "ofTotal": "of total",
       "remaining": "Remaining",
       "overflow": "Overflow"
+    },
+    "lines": {
+      "expand": "Show lines",
+      "collapse": "Hide lines",
+      "loadingLabel": "Loading budget lines…",
+      "empty": "No budget lines assigned",
+      "emptyDescription": "Budget lines from work items and household items appear here when assigned to this source.",
+      "workItemSection": "Work Item Lines",
+      "householdItemSection": "Household Item Lines",
+      "unassignedArea": "Unassigned",
+      "fetchError": "Could not load budget lines.",
+      "retry": "Retry",
+      "areaLineCount_one": "{{count}} line",
+      "areaLineCount_other": "{{count}} lines",
+      "expandAriaLabel": "Expand budget lines for {{name}}",
+      "collapseAriaLabel": "Collapse budget lines for {{name}}",
+      "panelAriaLabel": "Budget lines for {{name}}",
+      "confidence": {
+        "own_estimate": "Own estimate",
+        "professional_estimate": "Pro estimate",
+        "quote": "Quote",
+        "invoice": "Invoice"
+      },
+      "invoiceLinked": "Invoiced"
     }
   },
   "vendors": {

--- a/client/src/lib/budgetSourcesApi.test.ts
+++ b/client/src/lib/budgetSourcesApi.test.ts
@@ -5,11 +5,13 @@ import {
   createBudgetSource,
   updateBudgetSource,
   deleteBudgetSource,
+  fetchBudgetLinesForSource,
 } from './budgetSourcesApi.js';
 import type {
   BudgetSource,
   BudgetSourceListResponse,
   BudgetSourceResponse,
+  BudgetSourceBudgetLinesResponse,
 } from '@cornerstone/shared';
 
 describe('budgetSourcesApi', () => {
@@ -500,6 +502,111 @@ describe('budgetSourcesApi', () => {
       } as Response);
 
       await expect(deleteBudgetSource('src-1')).rejects.toThrow();
+    });
+  });
+
+  // ─── fetchBudgetLinesForSource ─────────────────────────────────────────────
+
+  describe('fetchBudgetLinesForSource', () => {
+    const mockLinesResponse: BudgetSourceBudgetLinesResponse = {
+      workItemLines: [],
+      householdItemLines: [],
+    };
+
+    it('calls GET /budget-sources/:sourceId/budget-lines with correct sourceId', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLinesResponse,
+      } as Response);
+
+      await fetchBudgetLinesForSource('src-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/budget-sources/src-1/budget-lines',
+        expect.any(Object),
+      );
+    });
+
+    it('returns the response object from the API call', async () => {
+      const filledResponse: BudgetSourceBudgetLinesResponse = {
+        workItemLines: [
+          {
+            id: 'line-1',
+            parentId: 'p-1',
+            parentName: 'Kitchen Renovation',
+            area: null,
+            description: 'Floor tiles',
+            plannedAmount: 1500,
+            confidence: 'own_estimate',
+            confidenceMargin: 0.2,
+            budgetCategory: null,
+            budgetSource: null,
+            vendor: null,
+            actualCost: 0,
+            actualCostPaid: 0,
+            invoiceCount: 0,
+            invoiceLink: null,
+            quantity: null,
+            unit: null,
+            unitPrice: null,
+            includesVat: null,
+            createdBy: null,
+            hasClaimedInvoice: false,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+        householdItemLines: [],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => filledResponse,
+      } as Response);
+
+      const result = await fetchBudgetLinesForSource('src-1');
+
+      expect(result).toEqual(filledResponse);
+      expect(result.workItemLines).toHaveLength(1);
+      expect(result.workItemLines[0].id).toBe('line-1');
+    });
+
+    it('uses the provided sourceId in the URL path', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLinesResponse,
+      } as Response);
+
+      await fetchBudgetLinesForSource('custom-source-id-999');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/budget-sources/custom-source-id-999/budget-lines',
+        expect.any(Object),
+      );
+    });
+
+    it('throws ApiClientError when server returns 404', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({
+          error: { code: 'NOT_FOUND', message: 'Budget source not found' },
+        }),
+      } as Response);
+
+      await expect(fetchBudgetLinesForSource('nonexistent')).rejects.toThrow();
+    });
+
+    it('throws ApiClientError when server returns 401', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({
+          error: { code: 'UNAUTHORIZED', message: 'Unauthorized' },
+        }),
+      } as Response);
+
+      await expect(fetchBudgetLinesForSource('src-1')).rejects.toThrow();
     });
   });
 });

--- a/client/src/lib/budgetSourcesApi.ts
+++ b/client/src/lib/budgetSourcesApi.ts
@@ -5,6 +5,7 @@ import type {
   BudgetSourceResponse,
   CreateBudgetSourceRequest,
   UpdateBudgetSourceRequest,
+  BudgetSourceBudgetLinesResponse,
 } from '@cornerstone/shared';
 
 /**
@@ -46,4 +47,11 @@ export async function updateBudgetSource(
  */
 export function deleteBudgetSource(id: string): Promise<void> {
   return del<void>(`/budget-sources/${id}`);
+}
+
+/**
+ * Fetches budget lines for a specific budget source, grouped by parent type.
+ */
+export function fetchBudgetLinesForSource(sourceId: string): Promise<BudgetSourceBudgetLinesResponse> {
+  return get<BudgetSourceBudgetLinesResponse>(`/budget-sources/${sourceId}/budget-lines`);
 }

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -425,18 +425,20 @@
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   background-color: transparent;
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
+  color: var(--color-text-muted);
   cursor: pointer;
-  transition: background-color var(--transition-normal), border-color var(--transition-normal);
+  transition: background-color var(--transition-normal), border-color var(--transition-normal), color var(--transition-normal);
   min-height: 44px;
 }
 
 .expandToggle:hover:not(:disabled) {
-  background-color: var(--color-bg-tertiary);
+  background-color: var(--color-bg-secondary);
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
 }
 
 .expandToggle:focus-visible {
@@ -450,19 +452,20 @@
 }
 
 .expandToggleActive {
-  background-color: var(--color-primary);
-  color: white;
+  background-color: var(--color-primary-bg);
+  color: var(--color-primary-badge-text);
   border-color: var(--color-primary);
 }
 
 .expandToggleActive:hover {
-  background-color: var(--color-primary-hover);
-  border-color: var(--color-primary-hover);
+  background-color: var(--color-primary-bg);
+  border-color: var(--color-primary);
+  color: var(--color-primary-badge-text);
 }
 
 .chevronIcon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   transition: transform var(--transition-normal);
   flex-shrink: 0;
 }

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -417,6 +417,66 @@
   flex-wrap: wrap;
 }
 
+/* ---- Expand toggle button ---- */
+
+.expandToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: transparent;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color var(--transition-normal), border-color var(--transition-normal);
+  min-height: 44px;
+}
+
+.expandToggle:hover:not(:disabled) {
+  background-color: var(--color-bg-tertiary);
+}
+
+.expandToggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.expandToggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.expandToggleActive {
+  background-color: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.expandToggleActive:hover {
+  background-color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.chevronIcon {
+  width: 16px;
+  height: 16px;
+  transition: transform var(--transition-normal);
+  flex-shrink: 0;
+}
+
+.chevronExpanded {
+  transform: rotate(90deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevronIcon {
+    transition: none;
+  }
+}
+
 /* ---- Source type badge ---- */
 
 .typeBadge {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -7,7 +7,11 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type * as BudgetSourcesApiTypes from '../../lib/budgetSourcesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
-import type { BudgetSource, BudgetSourceListResponse } from '@cornerstone/shared';
+import type {
+  BudgetSource,
+  BudgetSourceListResponse,
+  BudgetSourceBudgetLinesResponse,
+} from '@cornerstone/shared';
 
 // Mock the API module BEFORE importing the component
 const mockFetchBudgetSources = jest.fn<typeof BudgetSourcesApiTypes.fetchBudgetSources>();
@@ -15,6 +19,8 @@ const mockFetchBudgetSource = jest.fn<typeof BudgetSourcesApiTypes.fetchBudgetSo
 const mockCreateBudgetSource = jest.fn<typeof BudgetSourcesApiTypes.createBudgetSource>();
 const mockUpdateBudgetSource = jest.fn<typeof BudgetSourcesApiTypes.updateBudgetSource>();
 const mockDeleteBudgetSource = jest.fn<typeof BudgetSourcesApiTypes.deleteBudgetSource>();
+const mockFetchBudgetLinesForSource =
+  jest.fn<typeof BudgetSourcesApiTypes.fetchBudgetLinesForSource>();
 
 jest.unstable_mockModule('../../lib/budgetSourcesApi.js', () => ({
   fetchBudgetSources: mockFetchBudgetSources,
@@ -22,6 +28,7 @@ jest.unstable_mockModule('../../lib/budgetSourcesApi.js', () => ({
   createBudgetSource: mockCreateBudgetSource,
   updateBudgetSource: mockUpdateBudgetSource,
   deleteBudgetSource: mockDeleteBudgetSource,
+  fetchBudgetLinesForSource: mockFetchBudgetLinesForSource,
 }));
 
 // ─── Mock: formatters — provides useFormatters() hook ────────────────────────
@@ -155,6 +162,7 @@ describe('BudgetSourcesPage', () => {
     mockCreateBudgetSource.mockReset();
     mockUpdateBudgetSource.mockReset();
     mockDeleteBudgetSource.mockReset();
+    mockFetchBudgetLinesForSource.mockReset();
   });
 
   function renderPage() {
@@ -1814,6 +1822,134 @@ describe('BudgetSourcesPage', () => {
       await waitFor(() => {
         expect(screen.getByText('30-year fixed')).toBeInTheDocument();
       });
+    });
+  });
+
+  // ─── Expand/collapse + cache behaviour (scenario 19) ────────────────────────
+
+  describe('budget lines expand/collapse with cache', () => {
+    const emptyLinesResponse: BudgetSourceBudgetLinesResponse = {
+      workItemLines: [],
+      householdItemLines: [],
+    };
+
+    it('clicking "Show lines" expands the panel and calls fetchBudgetLinesForSource once', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      mockFetchBudgetLinesForSource.mockResolvedValueOnce(emptyLinesResponse);
+
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // Find expand toggle by aria-label
+      const expandButton = screen.getByRole('button', {
+        name: /expand budget lines for home loan/i,
+      });
+      await user.click(expandButton);
+
+      await waitFor(() => {
+        expect(mockFetchBudgetLinesForSource).toHaveBeenCalledTimes(1);
+        expect(mockFetchBudgetLinesForSource).toHaveBeenCalledWith('src-1');
+      });
+
+      // Panel is now visible (the region with id source-lines-src-1 is present)
+      await waitFor(() => {
+        expect(document.getElementById('source-lines-src-1')).toBeInTheDocument();
+      });
+    });
+
+    it('collapse then re-expand does NOT call fetchBudgetLinesForSource a second time', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      mockFetchBudgetLinesForSource.mockResolvedValueOnce(emptyLinesResponse);
+
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // First expand
+      const expandButton = screen.getByRole('button', {
+        name: /expand budget lines for home loan/i,
+      });
+      await user.click(expandButton);
+
+      // Wait for fetch to complete and panel to appear
+      await waitFor(() => {
+        expect(mockFetchBudgetLinesForSource).toHaveBeenCalledTimes(1);
+      });
+
+      await waitFor(() => {
+        expect(document.getElementById('source-lines-src-1')).toBeInTheDocument();
+      });
+
+      // Collapse: button label switches to "collapse"
+      const collapseButton = screen.getByRole('button', {
+        name: /collapse budget lines for home loan/i,
+      });
+      await user.click(collapseButton);
+
+      // Panel should no longer be in DOM
+      await waitFor(() => {
+        expect(document.getElementById('source-lines-src-1')).not.toBeInTheDocument();
+      });
+
+      // Re-expand using the "Show lines" toggle again
+      const reExpandButton = screen.getByRole('button', {
+        name: /expand budget lines for home loan/i,
+      });
+      await user.click(reExpandButton);
+
+      // Panel is visible again
+      await waitFor(() => {
+        expect(document.getElementById('source-lines-src-1')).toBeInTheDocument();
+      });
+
+      // fetchBudgetLinesForSource must still have been called only once (cache hit)
+      expect(mockFetchBudgetLinesForSource).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows "Show lines" toggle button for each source in the list', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({
+        budgetSources: [sampleSource1, sampleSource2],
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /expand budget lines for home loan/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /expand budget lines for savings account/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('toggle button is disabled while another source is being edited', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({
+        budgetSources: [sampleSource1, sampleSource2],
+      });
+
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit home loan/i })).toBeInTheDocument();
+      });
+
+      // Start editing Home Loan
+      await user.click(screen.getByRole('button', { name: /edit home loan/i }));
+
+      // The toggle for Savings Account should be disabled while editing
+      const savingsToggle = screen.getByRole('button', {
+        name: /expand budget lines for savings account/i,
+      });
+      expect(savingsToggle).toBeDisabled();
     });
   });
 });

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -5,12 +5,14 @@ import type {
   BudgetSourceType,
   BudgetSourceStatus,
   CreateBudgetSourceRequest,
+  BudgetSourceBudgetLinesResponse,
 } from '@cornerstone/shared';
 import {
   fetchBudgetSources,
   createBudgetSource,
   updateBudgetSource,
   deleteBudgetSource,
+  fetchBudgetLinesForSource,
 } from '../../lib/budgetSourcesApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import { useFormatters } from '../../lib/formatters.js';
@@ -18,6 +20,7 @@ import { PageLayout } from '../../components/PageLayout/PageLayout.js';
 import { SubNav, type SubNavTab } from '../../components/SubNav/SubNav.js';
 import { BudgetBar } from '../../components/BudgetBar/BudgetBar.js';
 import type { BudgetBarSegment } from '../../components/BudgetBar/BudgetBar.js';
+import { SourceBudgetLinePanel } from '../../components/SourceBudgetLinePanel/SourceBudgetLinePanel.js';
 import styles from './BudgetSourcesPage.module.css';
 
 const BUDGET_TABS: SubNavTab[] = [
@@ -269,6 +272,12 @@ export function BudgetSourcesPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string>('');
 
+  // Budget lines expansion state
+  const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
+  const [linesCache, setLinesCache] = useState<Map<string, BudgetSourceBudgetLinesResponse>>(new Map());
+  const [linesLoading, setLinesLoading] = useState<Set<string>>(new Set());
+  const [linesError, setLinesError] = useState<Map<string, string>>(new Map());
+
   // Translation-dependent label maps
   const SOURCE_TYPE_LABELS: Record<BudgetSourceType, string> = {
     bank_loan: t('sources.sourceTypes.bank_loan'),
@@ -472,6 +481,77 @@ export function BudgetSourcesPage() {
       }
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleToggleLines = async (sourceId: string) => {
+    const isCurrentlyExpanded = expandedSources.has(sourceId);
+
+    if (isCurrentlyExpanded) {
+      // Collapse: just remove from expanded set
+      const newExpanded = new Set(expandedSources);
+      newExpanded.delete(sourceId);
+      setExpandedSources(newExpanded);
+    } else {
+      // Expand: fetch if not cached
+      const isAlreadyCached = linesCache.has(sourceId);
+
+      if (!isAlreadyCached) {
+        setLinesLoading((prev) => new Set(prev).add(sourceId));
+        setLinesError((prev) => {
+          const newErr = new Map(prev);
+          newErr.delete(sourceId);
+          return newErr;
+        });
+
+        try {
+          const data = await fetchBudgetLinesForSource(sourceId);
+          setLinesCache((prev) => new Map(prev).set(sourceId, data));
+        } catch (err) {
+          let errorMsg = t('sources.lines.fetchError');
+          if (err instanceof ApiClientError) {
+            errorMsg = err.error.message;
+          }
+          setLinesError((prev) => new Map(prev).set(sourceId, errorMsg));
+        } finally {
+          setLinesLoading((prev) => {
+            const newLoading = new Set(prev);
+            newLoading.delete(sourceId);
+            return newLoading;
+          });
+        }
+      }
+
+      // Add to expanded set
+      const newExpanded = new Set(expandedSources);
+      newExpanded.add(sourceId);
+      setExpandedSources(newExpanded);
+    }
+  };
+
+  const handleRetryLines = async (sourceId: string) => {
+    setLinesLoading((prev) => new Set(prev).add(sourceId));
+    setLinesError((prev) => {
+      const newErr = new Map(prev);
+      newErr.delete(sourceId);
+      return newErr;
+    });
+
+    try {
+      const data = await fetchBudgetLinesForSource(sourceId);
+      setLinesCache((prev) => new Map(prev).set(sourceId, data));
+    } catch (err) {
+      let errorMsg = t('sources.lines.fetchError');
+      if (err instanceof ApiClientError) {
+        errorMsg = err.error.message;
+      }
+      setLinesError((prev) => new Map(prev).set(sourceId, errorMsg));
+    } finally {
+      setLinesLoading((prev) => {
+        const newLoading = new Set(prev);
+        newLoading.delete(sourceId);
+        return newLoading;
+      });
     }
   };
 
@@ -912,6 +992,33 @@ export function BudgetSourcesPage() {
                             </span>
                           )}
                         </div>
+                        <button
+                          type="button"
+                          className={`${styles.expandToggle} ${expandedSources.has(source.id) ? styles.expandToggleActive : ''}`}
+                          onClick={() => handleToggleLines(source.id)}
+                          disabled={!!editingSource}
+                          aria-expanded={expandedSources.has(source.id)}
+                          aria-controls={`source-lines-${source.id}`}
+                          aria-label={
+                            expandedSources.has(source.id)
+                              ? t('sources.lines.collapseAriaLabel', { name: source.name })
+                              : t('sources.lines.expandAriaLabel', { name: source.name })
+                          }
+                        >
+                          <svg
+                            className={`${styles.chevronIcon} ${expandedSources.has(source.id) ? styles.chevronExpanded : ''}`}
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            aria-hidden="true"
+                          >
+                            <path d="M6 5l4 4-4 4" stroke="currentColor" strokeWidth="2" fill="none" />
+                          </svg>
+                          <span>
+                            {expandedSources.has(source.id)
+                              ? t('sources.lines.collapse')
+                              : t('sources.lines.expand')}
+                          </span>
+                        </button>
                       </div>
 
                       <SourceBarChart
@@ -926,6 +1033,17 @@ export function BudgetSourcesPage() {
                         </p>
                       )}
                     </div>
+
+                    {expandedSources.has(source.id) && (
+                      <SourceBudgetLinePanel
+                        sourceId={source.id}
+                        sourceName={source.name}
+                        data={linesCache.get(source.id) ?? null}
+                        isLoading={linesLoading.has(source.id)}
+                        error={linesError.get(source.id) ?? null}
+                        onRetry={() => handleRetryLines(source.id)}
+                      />
+                    )}
 
                     <div className={styles.sourceActions}>
                       <button

--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -354,4 +354,45 @@ export class BudgetSourcesPage {
   getAmountLabelsInRow(sourceName: string): import('@playwright/test').Locator {
     return this.getSourceRowByName(sourceName).locator('[class*="barLegendLabel"]');
   }
+
+  // ─── Budget Lines Expansion helpers (Story #1247) ────────────────────────────
+
+  /**
+   * Get the expand/collapse toggle button for the named source row.
+   * The button has aria-label "Expand budget lines for <name>" or
+   * "Collapse budget lines for <name>".
+   */
+  getExpandToggle(sourceName: string): import('@playwright/test').Locator {
+    return this.getSourceRowByName(sourceName).getByRole('button', {
+      name: new RegExp(`(Expand|Collapse) budget lines for ${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i'),
+    });
+  }
+
+  /**
+   * Get the lines panel region for a specific source by its ID.
+   * The panel renders as: <div id="source-lines-{sourceId}" role="region">
+   */
+  getLinesPanelById(sourceId: string): import('@playwright/test').Locator {
+    return this.page.locator(`[id="source-lines-${sourceId}"]`);
+  }
+
+  /**
+   * Click the expand toggle for the named source and wait for the panel to appear.
+   * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+   */
+  async expandSourceLines(sourceName: string): Promise<void> {
+    const toggle = this.getExpandToggle(sourceName);
+    await toggle.waitFor({ state: 'visible' });
+    await toggle.click();
+  }
+
+  /**
+   * Click the collapse toggle for the named source and wait for the panel to be hidden.
+   * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+   */
+  async collapseSourceLines(sourceName: string): Promise<void> {
+    const toggle = this.getExpandToggle(sourceName);
+    await toggle.waitFor({ state: 'visible' });
+    await toggle.click();
+  }
 }

--- a/e2e/tests/budget/budget-source-lines.spec.ts
+++ b/e2e/tests/budget/budget-source-lines.spec.ts
@@ -538,8 +538,8 @@ test.describe('Unassigned area grouping', { tag: '@responsive' }, () => {
       await expect(panel.getByText('Unassigned')).toBeVisible();
 
       // The parent item name and line description must be visible
-      await expect(panel.getByText('General Work')).toBeVisible();
-      await expect(panel.getByText('General work item line')).toBeVisible();
+      await expect(panel.getByText('General Work', { exact: true })).toBeVisible();
+      await expect(panel.getByText('General work item line', { exact: true })).toBeVisible();
     } finally {
       if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
       if (sourceId) await deleteSourceViaApi(page, sourceId);

--- a/e2e/tests/budget/budget-source-lines.spec.ts
+++ b/e2e/tests/budget/budget-source-lines.spec.ts
@@ -1,0 +1,604 @@
+/**
+ * E2E tests for Budget Source inline line expansion (Story #1247)
+ *
+ * UAT Scenarios covered:
+ * - Expand shows budget lines panel with grouped Work Item Lines (smoke, all viewports)
+ * - Collapse hides the panel
+ * - Empty source shows EmptyState with "No budget lines assigned"
+ * - Fetch error shows inline error banner with Retry button
+ * - Regression: Edit still works while expand toggle is disabled during edit
+ * - Mobile layout: panel visible with no horizontal scroll
+ *
+ * API mocking strategy:
+ * - Real source created via API for parent ID coherence.
+ * - GET /api/budget-sources/:id/budget-lines is mocked per test to control panel content.
+ * - Route is always unrouted in finally blocks.
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import type { Page } from '@playwright/test';
+import { BudgetSourcesPage } from '../../pages/BudgetSourcesPage.js';
+import { API } from '../../fixtures/testData.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API helpers (same pattern as budget-sources.spec.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface BudgetSourceApiData {
+  name: string;
+  sourceType?: string;
+  totalAmount: number;
+  interestRate?: number | null;
+  terms?: string | null;
+  notes?: string | null;
+  status?: string;
+}
+
+interface BudgetSourceApiResponse {
+  id: string;
+  name: string;
+  sourceType: string;
+  totalAmount: number;
+  usedAmount: number;
+  availableAmount: number;
+  interestRate: number | null;
+  terms: string | null;
+  notes: string | null;
+  status: string;
+}
+
+async function createSourceViaApi(page: Page, data: BudgetSourceApiData): Promise<string> {
+  const response = await page.request.post(API.budgetSources, {
+    data: {
+      sourceType: 'bank_loan',
+      status: 'active',
+      interestRate: null,
+      terms: null,
+      notes: null,
+      ...data,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as { budgetSource: BudgetSourceApiResponse };
+  return body.budgetSource.id;
+}
+
+async function deleteSourceViaApi(page: Page, id: string): Promise<void> {
+  await page.request.delete(`${API.budgetSources}/${id}`);
+}
+
+/**
+ * Build the budget-lines URL glob for a specific source ID.
+ * Used to scope `page.route()` to the correct source's lines endpoint.
+ */
+function budgetLinesUrl(sourceId: string): string {
+  return `**/api/budget-sources/${sourceId}/budget-lines`;
+}
+
+/**
+ * A minimal BudgetSourceBudgetLinesResponse with 2 work item lines in area "Kitchen",
+ * parent name "Flooring".
+ */
+function mockLinesWithWorkItems(sourceId: string) {
+  return {
+    workItemLines: [
+      {
+        id: `wil-1-${sourceId}`,
+        description: 'Hardwood floor installation',
+        plannedAmount: 8000,
+        confidence: 'quote',
+        confidenceMargin: 1.0,
+        invoiceLink: null,
+        createdAt: '2026-01-01T10:00:00.000Z',
+        updatedAt: '2026-01-01T10:00:00.000Z',
+        parentId: `wi-parent-${sourceId}`,
+        parentName: 'Flooring',
+        area: { id: `area-k-${sourceId}`, name: 'Kitchen', color: '#4CAF50' },
+        hasClaimedInvoice: false,
+      },
+      {
+        id: `wil-2-${sourceId}`,
+        description: 'Subfloor preparation',
+        plannedAmount: 1500,
+        confidence: 'own_estimate',
+        confidenceMargin: 1.2,
+        invoiceLink: null,
+        createdAt: '2026-01-02T10:00:00.000Z',
+        updatedAt: '2026-01-02T10:00:00.000Z',
+        parentId: `wi-parent-${sourceId}`,
+        parentName: 'Flooring',
+        area: { id: `area-k-${sourceId}`, name: 'Kitchen', color: '#4CAF50' },
+        hasClaimedInvoice: false,
+      },
+    ],
+    householdItemLines: [],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Expand shows panel — @smoke
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Expand shows budget lines panel', { tag: ['@smoke', '@responsive'] }, () => {
+  test(
+    'expanding a source shows the lines panel with Work Item Lines and area grouping',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const sourcesPage = new BudgetSourcesPage(page);
+      const sourceName = `${testPrefix} Lines Expand Source`;
+      let sourceId: string | null = null;
+
+      try {
+        sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 50000 });
+
+        const linesResponse = mockLinesWithWorkItems(sourceId);
+
+        // Register route BEFORE goto so the intercept is ready when expand fires.
+        await page.route(budgetLinesUrl(sourceId), async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(linesResponse),
+          });
+        });
+
+        await sourcesPage.goto();
+        await sourcesPage.waitForSourcesLoaded();
+
+        // Expand the source
+        const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+        await sourcesPage.expandSourceLines(sourceName);
+        await linesResponsePromise;
+
+        // Panel must be visible
+        const panel = sourcesPage.getLinesPanelById(sourceId);
+        await expect(panel).toBeVisible();
+
+        // "Work Item Lines" section header must be visible
+        await expect(panel.getByRole('heading', { level: 4, name: 'Work Item Lines' })).toBeVisible();
+
+        // "Household Item Lines" section must NOT be visible (no household lines in mock)
+        await expect(
+          panel.getByRole('heading', { level: 4, name: 'Household Item Lines' }),
+        ).not.toBeVisible();
+
+        // Area name "Kitchen" must be visible
+        await expect(panel.getByText('Kitchen')).toBeVisible();
+
+        // Parent item "Flooring" must be visible
+        await expect(panel.getByText('Flooring')).toBeVisible();
+
+        // Both line descriptions must be visible
+        await expect(panel.getByText('Hardwood floor installation')).toBeVisible();
+        await expect(panel.getByText('Subfloor preparation')).toBeVisible();
+      } finally {
+        if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+        if (sourceId) await deleteSourceViaApi(page, sourceId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Collapse hides panel
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Collapse hides budget lines panel', { tag: '@responsive' }, () => {
+  test('collapsing an expanded source hides the lines panel', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Lines Collapse Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 30000 });
+
+      const linesResponse = mockLinesWithWorkItems(sourceId);
+
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(linesResponse),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Expand
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // Collapse — the panel should no longer be in the DOM
+      // (React conditionally renders the SourceBudgetLinePanel)
+      await sourcesPage.collapseSourceLines(sourceName);
+
+      // Panel must not be visible after collapse (may be DOM-absent or CSS-hidden)
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(panel).not.toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Empty source → EmptyState
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Empty source shows EmptyState', { tag: '@responsive' }, () => {
+  test('expanding a source with no budget lines shows "No budget lines assigned"', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Empty Lines Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 20000 });
+
+      // Mock returns empty response
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ workItemLines: [], householdItemLines: [] }),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // EmptyState message must be visible
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(panel.getByText('No budget lines assigned')).toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fetch error → error banner + Retry
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Fetch error shows error banner with Retry', { tag: '@responsive' }, () => {
+  test('expanding a source when the API returns 500 shows error banner and Retry button', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Error Lines Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 15000 });
+
+      let callCount = 0;
+
+      // First call returns 500; second call (retry) returns empty data
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        callCount++;
+        if (callCount === 1) {
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              error: { code: 'INTERNAL_ERROR', message: 'Server error' },
+            }),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ workItemLines: [], householdItemLines: [] }),
+          });
+        }
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // First expand — should trigger error
+      const errorResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await errorResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // Error banner (role="alert") must be visible inside panel
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      const errorBanner = panel.locator('[role="alert"]');
+      await expect(errorBanner).toBeVisible();
+
+      // Retry button must be visible inside the panel
+      const retryButton = panel.getByRole('button', { name: 'Retry' });
+      await expect(retryButton).toBeVisible();
+
+      // Click Retry — should trigger a second fetch
+      const retryResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await retryButton.click();
+      await retryResponsePromise;
+
+      // After successful retry, error banner should be gone
+      // (empty state renders instead)
+      await expect(errorBanner).not.toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression — Edit still works while expand toggle is disabled during edit
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Edit regression — expand toggle disabled during edit', { tag: '@responsive' }, () => {
+  test('expand toggle is disabled while another source is being edited', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Edit Regression Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 10000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Open edit form for the source
+      await sourcesPage.startEdit(sourceName);
+
+      // While edit form is open, the expand toggle must be disabled
+      // (aria-disabled or disabled attr — the button has disabled={!!editingSource})
+      const toggle = sourcesPage.getExpandToggle(sourceName);
+      // The toggle is inside the display portion; when editing, the sourceRow
+      // renders the edit form, hiding the display row. The toggle belongs to the
+      // display part, so it will not be visible.
+      // Confirm: toggle is not visible (display row is replaced by edit form).
+      await expect(toggle).not.toBeVisible();
+
+      // Cancel edit — display row returns
+      await sourcesPage.cancelEdit(sourceName);
+
+      // Toggle is now visible again
+      await expect(toggle).toBeVisible();
+    } finally {
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+
+  test('editing a source succeeds after expanding its lines', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Expand Then Edit Source`;
+    const updatedName = `${testPrefix} Expand Then Edit Updated`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 25000 });
+
+      // Mock lines response for the expand step
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ workItemLines: [], householdItemLines: [] }),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Expand lines first
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      // Now open edit form — expand toggle hides, edit form renders
+      await sourcesPage.startEdit(sourceName);
+
+      // Change name
+      const editForm = sourcesPage.getEditForm(sourceName);
+      const nameInput = editForm.locator(`#edit-name-${sourceId}`);
+      await nameInput.fill(updatedName);
+
+      // Register response listener BEFORE clicking save
+      const saveResponse = page.waitForResponse(
+        (resp) => resp.url().includes('/api/budget-sources') && resp.status() === 200,
+      );
+      await sourcesPage.saveEdit(sourceName);
+      await saveResponse;
+
+      // Updated name must appear in the list
+      const names = await sourcesPage.getSourceNames();
+      expect(names).toContain(updatedName);
+      expect(names).not.toContain(sourceName);
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mobile layout smoke
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Mobile layout — panel visible with no horizontal scroll', { tag: ['@smoke', '@responsive'] }, () => {
+  test(
+    'expanded lines panel is visible with no horizontal scroll on current viewport',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const sourcesPage = new BudgetSourcesPage(page);
+      const sourceName = `${testPrefix} Mobile Lines Source`;
+      let sourceId: string | null = null;
+
+      try {
+        sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 40000 });
+
+        const linesResponse = mockLinesWithWorkItems(sourceId);
+
+        await page.route(budgetLinesUrl(sourceId), async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(linesResponse),
+          });
+        });
+
+        await sourcesPage.goto();
+        await sourcesPage.waitForSourcesLoaded();
+
+        // Expand the source
+        const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+        await sourcesPage.expandSourceLines(sourceName);
+        await linesResponsePromise;
+
+        const panel = sourcesPage.getLinesPanelById(sourceId);
+        await expect(panel).toBeVisible();
+
+        // No horizontal scroll after expansion
+        const hasHorizontalScroll = await page.evaluate(() => {
+          return document.documentElement.scrollWidth > window.innerWidth;
+        });
+        expect(hasHorizontalScroll).toBe(false);
+      } finally {
+        if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+        if (sourceId) await deleteSourceViaApi(page, sourceId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unassigned area grouping
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Unassigned area grouping', { tag: '@responsive' }, () => {
+  test('lines with no area appear under "Unassigned" group', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Unassigned Area Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 10000 });
+
+      // One line with no area (area: null)
+      const linesResponse = {
+        workItemLines: [
+          {
+            id: `wil-unassigned-${sourceId}`,
+            description: 'General work item line',
+            plannedAmount: 5000,
+            confidence: 'own_estimate',
+            confidenceMargin: 1.2,
+            invoiceLink: null,
+            createdAt: '2026-01-01T10:00:00.000Z',
+            updatedAt: '2026-01-01T10:00:00.000Z',
+            parentId: `wi-parent-ua-${sourceId}`,
+            parentName: 'General Work',
+            area: null,
+            hasClaimedInvoice: false,
+          },
+        ],
+        householdItemLines: [],
+      };
+
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(linesResponse),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // "Unassigned" area group header must be visible
+      // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
+      await expect(panel.getByText('Unassigned')).toBeVisible();
+
+      // The parent item name and line description must be visible
+      await expect(panel.getByText('General Work')).toBeVisible();
+      await expect(panel.getByText('General work item line')).toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Second expand uses cache — no additional network request
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Lines cache — second expand does not refetch', { tag: '@responsive' }, () => {
+  test('collapsing then re-expanding does not trigger a second API call', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Cache Lines Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 20000 });
+
+      let fetchCount = 0;
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        fetchCount++;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ workItemLines: [], householdItemLines: [] }),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // First expand — triggers fetch
+      const firstFetch = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await firstFetch;
+
+      expect(fetchCount).toBe(1);
+
+      // Collapse
+      await sourcesPage.collapseSourceLines(sourceName);
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).not.toBeVisible();
+
+      // Re-expand — should NOT trigger a second fetch (served from cache)
+      await sourcesPage.expandSourceLines(sourceName);
+      // Wait a tick for any potential in-flight request
+      await page.waitForTimeout(300);
+
+      expect(fetchCount).toBe(1);
+
+      // Panel is visible again
+      await expect(sourcesPage.getLinesPanelById(sourceId)).toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds expand/collapse toggle per budget source row on `/budget/sources`
- New `SourceBudgetLinePanel` component: budget lines grouped by Area → parent work/household item
- Work Item Lines and Household Item Lines displayed in separate sections; unassigned lines grouped last
- `EmptyState` when source has no lines; `Skeleton` while fetching; fetched lines cached per-session
- Responsive layout, full dark mode support, design tokens only (no hardcoded values)
- German translations for all new `sources.lines.*` i18n keys

Fixes #1247

## Test plan

- [x] 38 unit tests for `SourceBudgetLinePanel` (loading, error, empty, WI/HI sections, grouping, null area, badges, a11y roles)
- [x] 5 new tests for `fetchBudgetLinesForSource` API client
- [x] 4 new tests in `BudgetSourcesPage` for expand/collapse + session cache behavior
- [x] 9 Playwright E2E tests: expand, collapse, empty state, error + retry, edit regression, mobile smoke, unassigned group, cache regression
- [x] 4 new POM methods on `BudgetSourcesPage` E2E page object
- [x] Quality Gates CI must pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>