### PR TITLE
chore(deps): bump production dependencies from PR #1250

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@cornerstone/shared": "*",
-    "i18next": "25.8.20",
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
-    "react-i18next": "16.5.8",
-    "react-router-dom": "7.13.1"
+    "i18next": "26.0.4",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "react-i18next": "17.0.2",
+    "react-router-dom": "7.14.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@docusaurus/preset-classic": "3.10.0",
     "@mdx-js/react": "3.1.1",
     "prism-react-renderer": "2.4.1",
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,18 +69,6 @@
         "webpack-dev-server": "5.2.3"
       }
     },
-    "client/node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.5"
-      }
-    },
     "docs": {
       "name": "@cornerstone/docs",
       "version": "0.1.0",
@@ -91,19 +79,6 @@
         "prism-react-renderer": "2.4.1",
         "react": "19.2.5",
         "react-dom": "19.2.5"
-      }
-    },
-    "docs/node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.5"
       }
     },
     "e2e": {
@@ -29266,16 +29241,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,11 +45,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@cornerstone/shared": "*",
-        "i18next": "25.8.20",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "react-i18next": "16.5.8",
-        "react-router-dom": "7.13.1"
+        "i18next": "26.0.4",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
+        "react-i18next": "17.0.2",
+        "react-router-dom": "7.14.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.0",
@@ -69,6 +69,18 @@
         "webpack-dev-server": "5.2.3"
       }
     },
+    "client/node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
     "docs": {
       "name": "@cornerstone/docs",
       "version": "0.1.0",
@@ -77,8 +89,21 @@
         "@docusaurus/preset-classic": "3.10.0",
         "@mdx-js/react": "3.1.1",
         "prism-react-renderer": "2.4.1",
-        "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
+      }
+    },
+    "docs/node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
       }
     },
     "e2e": {
@@ -5781,9 +5806,9 @@
       }
     },
     "node_modules/@fastify/multipart": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
-      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.0.0.tgz",
+      "integrity": "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==",
       "funding": [
         {
           "type": "github",
@@ -11949,9 +11974,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18645,29 +18670,29 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.8.20",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.20.tgz",
-      "integrity": "sha512-xjo9+lbX/P1tQt3xpO2rfJiBppNfUnNIPKgCvNsTKsvTOCro1Qr/geXVg1N47j5ScOSaXAPq8ET93raK3Rr06A==",
+      "version": "26.0.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
+      "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -20482,9 +20507,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
-      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -26281,13 +26306,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
-      "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.3.tgz",
+      "integrity": "sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==",
       "license": "MIT",
       "dependencies": {
-        "jose": "^6.1.3",
-        "oauth4webapi": "^3.8.4"
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -29232,9 +29257,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29245,6 +29270,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -29279,19 +29305,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.5.8",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.8.tgz",
-      "integrity": "sha512-2ABeHHlakxVY+LSirD+OiERxFL6+zip0PaHo979bgwzeHg27Sqc82xxXWIrSFmfWX0ZkrvXMHwhsi/NGUf5VQg==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
+      "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.29.2",
         "html-parse-stringify": "^3.0.1",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.6.2",
+        "i18next": ">= 26.0.1",
         "react": ">= 16.8.0",
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -29393,12 +29419,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.14.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -29409,9 +29435,9 @@
       }
     },
     "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -34463,10 +34489,13 @@
       }
     },
     "node_modules/vcard-creator": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/vcard-creator/-/vcard-creator-0.7.2.tgz",
-      "integrity": "sha512-DiZpZqie2aPoRec5bPO3WmXy/+Yh1Dl01Go5VyDnn5iV2KhN6d3S16yZoGz9iq27U6l+o6m68Ub8JQz8TnbNYA==",
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vcard-creator/-/vcard-creator-1.0.0.tgz",
+      "integrity": "sha512-LunDOSct5saY+XhaA/fal/GYphrQXuQB5wa0YDy0C9NUMMwOhOaSriY/LseAPQFlh8EpB6vRX7hVxPdNvTzMbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -35671,19 +35700,19 @@
         "@fastify/compress": "8.3.1",
         "@fastify/cookie": "11.0.2",
         "@fastify/helmet": "13.0.2",
-        "@fastify/multipart": "9.4.0",
+        "@fastify/multipart": "10.0.0",
         "@fastify/rate-limit": "10.3.0",
         "@fastify/static": "9.1.1",
-        "better-sqlite3": "12.8.0",
+        "better-sqlite3": "12.9.0",
         "drizzle-orm": "0.45.2",
         "fastify": "5.8.5",
         "fastify-plugin": "5.1.0",
         "ical-generator": "10.1.0",
         "node-cron": "4.2.1",
-        "openid-client": "6.8.2",
+        "openid-client": "6.8.3",
         "sharp": "0.34.5",
         "tar": "^7.5.13",
-        "vcard-creator": "0.7.2"
+        "vcard-creator": "1.0.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "typescript-eslint": "8.58.1"
   },
   "overrides": {
-    "minimatch@>=10.0.0 <10.2.3": "10.2.4"
+    "minimatch@>=10.0.0 <10.2.3": "10.2.4",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -16,19 +16,19 @@
     "@fastify/compress": "8.3.1",
     "@fastify/cookie": "11.0.2",
     "@fastify/helmet": "13.0.2",
-    "@fastify/multipart": "9.4.0",
+    "@fastify/multipart": "10.0.0",
     "@fastify/rate-limit": "10.3.0",
     "@fastify/static": "9.1.1",
-    "better-sqlite3": "12.8.0",
+    "better-sqlite3": "12.9.0",
     "drizzle-orm": "0.45.2",
     "fastify": "5.8.5",
     "fastify-plugin": "5.1.0",
     "ical-generator": "10.1.0",
     "node-cron": "4.2.1",
-    "openid-client": "6.8.2",
+    "openid-client": "6.8.3",
     "sharp": "0.34.5",
     "tar": "^7.5.13",
-    "vcard-creator": "0.7.2"
+    "vcard-creator": "1.0.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13"

--- a/server/src/services/vendorVcard.ts
+++ b/server/src/services/vendorVcard.ts
@@ -61,19 +61,19 @@ export function buildVendorVcard(
 ): string {
   const vcard = new VCardCreator();
   // For organizations: FN is the company name, N is minimal
-  vcard.addName('', vendor.name);
-  vcard.addCompany(vendor.name);
+  vcard.addName({ familyName: vendor.name });
+  vcard.addCompany({ name: vendor.name });
 
   if (vendor.email) {
-    vcard.addEmail(vendor.email, 'WORK');
+    vcard.addEmail({ address: vendor.email, type: ['work'] });
   }
 
   if (vendor.phone) {
-    vcard.addPhoneNumber(vendor.phone as unknown as number, 'WORK');
+    vcard.addPhoneNumber({ number: vendor.phone, type: ['work'] });
   }
 
   if (vendor.address) {
-    vcard.addAddress('', '', vendor.address, '', '', '', '', 'WORK');
+    vcard.addAddress({ street: vendor.address, type: ['work'] });
   }
 
   if (vendor.notes) {
@@ -81,7 +81,7 @@ export function buildVendorVcard(
   }
 
   if (baseUrl) {
-    vcard.addURL(`${baseUrl}/budget/vendors/${vendor.id}`, 'WORK');
+    vcard.addUrl({ url: `${baseUrl}/budget/vendors/${vendor.id}`, type: ['work'] });
   }
 
   let vcardStr = vcard.toString();
@@ -117,19 +117,19 @@ export function buildContactVcard(
   baseUrl?: string,
 ): string {
   const vcard = new VCardCreator();
-  // addName(lastName, firstName) — maps to N:lastName;firstName;;;
-  vcard.addName(contact.lastName ?? '', contact.firstName ?? '');
+  // addName({ familyName, givenName }) — maps to N:familyName;givenName;;;
+  vcard.addName({ familyName: contact.lastName ?? '', givenName: contact.firstName ?? '' });
 
   if (contact.role) {
     vcard.addJobtitle(contact.role);
   }
 
   if (contact.email) {
-    vcard.addEmail(contact.email, 'WORK');
+    vcard.addEmail({ address: contact.email, type: ['work'] });
   }
 
   if (contact.phone) {
-    vcard.addPhoneNumber(contact.phone as unknown as number, 'WORK');
+    vcard.addPhoneNumber({ number: contact.phone, type: ['work'] });
   }
 
   if (contact.notes) {
@@ -137,10 +137,10 @@ export function buildContactVcard(
   }
 
   // Add organization (vendor name)
-  vcard.addCompany(vendorName);
+  vcard.addCompany({ name: vendorName });
 
   if (baseUrl) {
-    vcard.addURL(`${baseUrl}/budget/vendors/${contact.vendorId}`, 'WORK');
+    vcard.addUrl({ url: `${baseUrl}/budget/vendors/${contact.vendorId}`, type: ['work'] });
   }
 
   let vcardStr = vcard.toString();


### PR DESCRIPTION
## Summary

Re-applies the 9 version bumps from the failed Dependabot grouped PR #1250. The original PR was closed due to merge conflicts + test failures caused by the `vcard-creator` major bump; this PR resolves both.

Skipped vs. #1250:
- `@fastify/static` — already at `9.1.1` on beta (ahead of the `9.1.0` target)
- `drizzle-orm` — already at `0.45.2` on beta

### Bumps applied

| Package | From | To |
| --- | --- | --- |
| `@fastify/multipart` | 9.4.0 | 10.0.0 |
| `better-sqlite3` | 12.8.0 | 12.9.0 |
| `openid-client` | 6.8.2 | 6.8.3 |
| `vcard-creator` | 0.7.2 | **1.0.0** (breaking) |
| `i18next` | 25.8.20 | 26.0.4 |
| `react` | 19.2.4 | 19.2.5 |
| `react-dom` | 19.2.4 | 19.2.5 |
| `react-i18next` | 16.5.8 | 17.0.2 |
| `react-router-dom` | 7.13.1 | 7.14.0 |

### Breaking change: vcard-creator 1.0.0

Migrated `server/src/services/vendorVcard.ts` to the new options-object API:

- `addName(lastName, firstName)` → `addName({ familyName, givenName })`
- `addCompany(name)` → `addCompany({ name })`
- `addEmail(addr, 'WORK')` → `addEmail({ address, type: ['work'] })`
- `addPhoneNumber(num, 'WORK')` → `addPhoneNumber({ number, type: ['work'] })`
- `addAddress('', '', street, '', '', '', '', 'WORK')` → `addAddress({ street, type: ['work'] })`
- `addURL(url, 'WORK')` → `addUrl({ url, type: ['work'] })`

The `KIND:org` / `UID` / `REV` post-processing is preserved unchanged. Existing tests use substring `toContain` assertions that remain valid under the new output format.

## Test plan

- [ ] Quality Gates (typecheck + unit/integration tests + build) pass
- [ ] vCard output still validated by existing `vendorVcard.test.ts` suite
- [ ] `dav.test.ts` (address book consumer) still passes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>