### PR TITLE
fix(budget-sources): stack lines panel below source info + add item links

### DIFF
--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -93,6 +93,21 @@
   color: var(--color-text-secondary);
   margin: var(--spacing-2) 0 var(--spacing-1) 0;
   padding: 0 0 var(--spacing-1) 0;
+  text-decoration: none;
+  transition: color var(--transition-normal);
+  display: inline-block;
+  border-radius: var(--radius-sm);
+}
+
+.parentItemHeader:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.parentItemHeader:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
 }
 
 .lineList {

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -4,6 +4,8 @@
 import type React from 'react';
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LocaleProvider } from '../../contexts/LocaleContext.js';
 import type { BudgetSourceBudgetLine, BudgetSourceBudgetLinesResponse } from '@cornerstone/shared';
 
 // ─── Mock: formatters ──────────────────────────────────────────────────────────
@@ -30,6 +32,19 @@ jest.unstable_mockModule('../../lib/formatters.js', () => {
       formatDateTime: () => '—',
       formatPercent: (n: number) => `${n.toFixed(2)}%`,
     }),
+  };
+});
+
+// ─── Mock: react-i18next ───────────────────────────────────────────────────────
+
+jest.unstable_mockModule('react-i18next', async () => {
+  const actual = await jest.requireActual<typeof import('react-i18next')>(
+    'react-i18next',
+  );
+  return {
+    ...actual,
+    // useTranslation is already provided by the actual module
+    // which reads from the i18next instance initialized in setupTests.ts
   };
 });
 
@@ -114,7 +129,13 @@ describe('SourceBudgetLinePanel', () => {
       error: null,
       onRetry: jest.fn(),
     };
-    return render(<SourceBudgetLinePanel {...defaultProps} {...props} />);
+    return render(
+      <MemoryRouter>
+        <LocaleProvider>
+          <SourceBudgetLinePanel {...defaultProps} {...props} />
+        </LocaleProvider>
+      </MemoryRouter>,
+    );
   }
 
   // ─── Loading state (scenario 1) ─────────────────────────────────────────────
@@ -818,6 +839,36 @@ describe('SourceBudgetLinePanel', () => {
       fireEvent.click(moveButton);
 
       expect(onMoveLines).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Parent item links (scenario 23) ───────────────────────────────────────────
+
+  describe('parent item header links', () => {
+    it('renders parent item name as link with href to work item detail for work item lines', () => {
+      const line = makeLine({
+        id: 'l1',
+        parentId: 'work-item-42',
+        parentName: 'Kitchen Renovation',
+      });
+      renderPanel({ data: makeResponse([line], []) });
+
+      const link = screen.getByRole('link', { name: /Kitchen Renovation/i }) as HTMLAnchorElement;
+      expect(link).toBeInTheDocument();
+      expect(link.getAttribute('href')).toBe('/project/work-items/work-item-42');
+    });
+
+    it('renders parent item name as link with href to household item detail for household item lines', () => {
+      const line = makeLine({
+        id: 'l1',
+        parentId: 'household-item-99',
+        parentName: 'Sofa Purchase',
+      });
+      renderPanel({ data: makeResponse([], [line]) });
+
+      const link = screen.getByRole('link', { name: /Sofa Purchase/i }) as HTMLAnchorElement;
+      expect(link).toBeInTheDocument();
+      expect(link.getAttribute('href')).toBe('/project/household-items/household-item-99');
     });
   });
 });

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -35,18 +35,11 @@ jest.unstable_mockModule('../../lib/formatters.js', () => {
   };
 });
 
-// ─── Mock: react-i18next ───────────────────────────────────────────────────────
-
-jest.unstable_mockModule('react-i18next', async () => {
-  const actual = await jest.requireActual<typeof import('react-i18next')>(
-    'react-i18next',
-  );
-  return {
-    ...actual,
-    // useTranslation is already provided by the actual module
-    // which reads from the i18next instance initialized in setupTests.ts
-  };
-});
+// react-i18next is not mocked — the real module is used against the
+// i18next instance initialized by setupTests.ts. Mocking via
+// jest.unstable_mockModule + jest.requireActual creates a separate module
+// reference that does not share the initialized instance, so keys come
+// back unresolved.
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────────
 

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type {
   BudgetSourceBudgetLinesResponse,
@@ -222,6 +223,7 @@ export function SourceBudgetLinePanel({
   const renderSection = (
     lines: BudgetSourceBudgetLine[],
     titleKey: 'workItemSection' | 'householdItemSection',
+    parentType: 'work-item' | 'household-item',
   ) => {
     if (lines.length === 0) return null;
 
@@ -298,7 +300,12 @@ export function SourceBudgetLinePanel({
 
               {areaGroup.parentGroups.map((parentGroup) => (
                 <div key={parentGroup.parentId}>
-                  <p className={styles.parentItemHeader}>{parentGroup.parentName}</p>
+                  <Link
+                    to={`/project/${parentType === 'work-item' ? 'work-items' : 'household-items'}/${parentGroup.parentId}`}
+                    className={styles.parentItemHeader}
+                  >
+                    {parentGroup.parentName}
+                  </Link>
 
                   <ul
                     role="list"
@@ -420,8 +427,8 @@ export function SourceBudgetLinePanel({
       aria-label={t('sources.lines.panelAriaLabel', { name: sourceName })}
       className={styles.linesPanel}
     >
-      {renderSection(workItemLines, 'workItemSection')}
-      {renderSection(householdItemLines, 'householdItemSection')}
+      {renderSection(workItemLines, 'workItemSection', 'work-item')}
+      {renderSection(householdItemLines, 'householdItemSection', 'household-item')}
       {isSelectable && selectedLineIds.size > 0 && (
         <div className={styles.actionBar}>
           <span className={styles.actionBarCount} role="status" aria-atomic="true">

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -375,8 +375,7 @@
 
 .sourceRow {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  flex-direction: column;
   padding: var(--spacing-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -386,6 +385,13 @@
 
 .sourceRow:hover {
   background-color: var(--color-bg-secondary);
+}
+
+.sourceRowHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-4);
 }
 
 /* ---- Source info (left side) ---- */
@@ -849,8 +855,8 @@
     text-align: center;
   }
 
-  /* Source row becomes a column on mobile */
-  .sourceRow {
+  /* Source row is already a column; sourceRowHeader adapts on mobile */
+  .sourceRowHeader {
     flex-direction: column;
     align-items: stretch;
     gap: var(--spacing-3);

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -894,12 +894,13 @@ export function BudgetSourcesPage() {
           <div className={styles.sourcesList}>
             {sources.map((source) => (
               <div key={source.id} className={styles.sourceRow}>
-                {editingSource?.id === source.id ? (
-                  <form
-                    onSubmit={handleUpdateSource}
-                    className={styles.editForm}
-                    aria-label={`Edit ${source.name}`}
-                  >
+                <div className={styles.sourceRowHeader}>
+                  {editingSource?.id === source.id ? (
+                    <form
+                      onSubmit={handleUpdateSource}
+                      className={styles.editForm}
+                      aria-label={`Edit ${source.name}`}
+                    >
                     {updateError && (
                       <div className={styles.errorBanner} role="alert">
                         {updateError}
@@ -1141,20 +1142,6 @@ export function BudgetSourcesPage() {
                       )}
                     </div>
 
-                    {expandedSources.has(source.id) && (
-                      <SourceBudgetLinePanel
-                        sourceId={source.id}
-                        sourceName={source.name}
-                        data={linesCache.get(source.id) ?? null}
-                        isLoading={linesLoading.has(source.id)}
-                        error={linesError.get(source.id) ?? null}
-                        onRetry={() => handleRetryLines(source.id)}
-                        selectedLineIds={sourceSelections.get(source.id)}
-                        onSelectionChange={(newSet) => handleSelectionChange(source.id, newSet)}
-                        onMoveLines={() => handleOpenMoveModal(source.id)}
-                      />
-                    )}
-
                     <div className={styles.sourceActions}>
                       <button
                         type="button"
@@ -1178,6 +1165,20 @@ export function BudgetSourcesPage() {
                       )}
                     </div>
                   </>
+                )}
+                </div>
+                {editingSource?.id !== source.id && expandedSources.has(source.id) && (
+                  <SourceBudgetLinePanel
+                    sourceId={source.id}
+                    sourceName={source.name}
+                    data={linesCache.get(source.id) ?? null}
+                    isLoading={linesLoading.has(source.id)}
+                    error={linesError.get(source.id) ?? null}
+                    onRetry={() => handleRetryLines(source.id)}
+                    selectedLineIds={sourceSelections.get(source.id)}
+                    onSelectionChange={(newSet) => handleSelectionChange(source.id, newSet)}
+                    onMoveLines={() => handleOpenMoveModal(source.id)}
+                  />
                 )}
               </div>
             ))}

--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -175,7 +175,7 @@ export class BudgetSourcesPage {
    */
   async waitForSourcesLoaded(): Promise<void> {
     await Promise.race([
-      this.sourcesList.locator('[class*="sourceRow"]').first().waitFor({ state: 'visible' }),
+      this.sourcesList.locator('[class*="sourceRow_"]').first().waitFor({ state: 'visible' }),
       this.emptyState.waitFor({ state: 'visible' }),
     ]);
   }
@@ -184,7 +184,7 @@ export class BudgetSourcesPage {
    * Get all source row locators from the sources list.
    */
   async getSourceRows(): Promise<Locator[]> {
-    return await this.page.locator('[class*="sourceRow"]').all();
+    return await this.page.locator('[class*="sourceRow_"]').all();
   }
 
   /**
@@ -208,7 +208,7 @@ export class BudgetSourcesPage {
    */
   async getSourceRow(name: string): Promise<Locator | null> {
     try {
-      await this.page.locator('[class*="sourceRow"]').first().waitFor({ state: 'visible' });
+      await this.page.locator('[class*="sourceRow_"]').first().waitFor({ state: 'visible' });
     } catch {
       return null;
     }
@@ -329,7 +329,7 @@ export class BudgetSourcesPage {
    * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
    */
   getSourceRowByName(name: string): import('@playwright/test').Locator {
-    return this.page.locator('[class*="sourceRow"]').filter({ hasText: name });
+    return this.page.locator('[class*="sourceRow_"]').filter({ hasText: name });
   }
 
   /**


### PR DESCRIPTION
## Summary

User feedback on the just-landed mini-epic (#1245–#1248):

- The expanded budget-lines panel was rendering as a middle column beside the source info and actions. Restructured the row so the panel drops below the header as a full-width block.
- Parent item names (Work Item / Household Item) in the lines panel are now hyperlinks to the detail page.

## Changes

- `BudgetSourcesPage.tsx` / CSS — wrap info+actions in a new `.sourceRowHeader`; panel renders beneath
- `SourceBudgetLinePanel.tsx` / CSS — render parent item names as `<Link>` to `/project/work-items/:id` or `/project/household-items/:id`
- Panel tests wrapped in `MemoryRouter` + `LocaleProvider`; 2 new tests for the hyperlinks

## Test plan

- [x] Typecheck clean
- [x] Stylelint clean
- [x] 52 unit tests pass (including 2 new)
- [ ] CI Quality Gates green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>