### PR TITLE
feat(household-items): display area tree on household item pages and pickers

### DIFF
--- a/.claude/agent-memory/e2e-test-engineer/MEMORY.md
+++ b/.claude/agent-memory/e2e-test-engineer/MEMORY.md
@@ -3,6 +3,18 @@
 > Detailed notes live in topic files. This index links to them.
 > See: `e2e-pom-patterns.md`, `e2e-parallel-isolation.md`, `story-epic08-e2e.md`, `story-933-dav-vendor-contacts.md`, `milestones-e2e.md`, `story-1248-mass-move.md`
 
+## HI Breadcrumb E2E (Story #1240, 2026-04-17)
+
+- HouseholdItemDetailPage POM: `areaBreadcrumbNav` + `areaBreadcrumb` added (same pattern as WorkItemDetailPage)
+- HouseholdItemsPage list: name column renders `<div class*="titleCell">` → compact AreaBreadcrumb inside — `[class*="compact"]` selector
+- HouseholdItemDetailPage: default breadcrumb in `<div class*="titleBreadcrumb">` below h1 — `getByRole('navigation', { name: /area path/i })`
+- HouseholdItemPicker: `renderSecondary` renders compact breadcrumb in dropdown options — test via InvoiceDetailPage "Add Budget Line" modal
+- InvoiceDetailPage budget line modal: `getByRole('dialog', { name: 'Add Budget Line' })` → HI picker input `getByPlaceholder('Search household items...')`
+- Invoice route is `/budget/invoices/:id` (NOT `/project/budget/invoices/:id`)
+- Invoice API: `POST /api/vendors/:vendorId/invoices` (requires vendor first) → `{ invoice: { id } }`
+- `budget-source-lines.spec.ts` failures on feat/1239 branch: pre-existing, caused by `fix/source-lines-layout-links` feature not yet merged, not a breadcrumb regression
+- CI Shard 5 failure on beta release run (2026-04-16): from concurrent release workflow, not from feature work
+
 ## Embeds/Pickers Breadcrumb E2E (Story #1239, 2026-04-16)
 
 - Gantt bar: `data-testid="gantt-bar-{id}"` on the SVG `<g>` element — use `page.getByTestId()` for hover

--- a/client/src/components/HouseholdItemPicker/HouseholdItemPicker.breadcrumb.test.tsx
+++ b/client/src/components/HouseholdItemPicker/HouseholdItemPicker.breadcrumb.test.tsx
@@ -1,0 +1,344 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Breadcrumb-specific tests for HouseholdItemPicker.tsx (Story #1240).
+ * Verifies that search results render AreaBreadcrumb (compact variant) as
+ * a secondary line via the SearchPicker renderSecondary prop.
+ *
+ * Mocks are identical to HouseholdItemPicker.test.tsx to stay independent.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type * as HouseholdItemsApiTypes from '../../lib/householdItemsApi.js';
+import type { HouseholdItemSummary } from '@cornerstone/shared';
+
+// ─── Mock modules BEFORE importing component ─────────────────────────────────
+
+const mockListHouseholdItems = jest.fn<typeof HouseholdItemsApiTypes.listHouseholdItems>();
+
+jest.unstable_mockModule('../../lib/householdItemsApi.js', () => ({
+  listHouseholdItems: mockListHouseholdItems,
+}));
+
+import type { HouseholdItemPicker as HouseholdItemPickerType } from './HouseholdItemPicker.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal HouseholdItemSummary. The area field is the key variable
+ * across tests (null vs populated AreaSummary).
+ */
+function makeItem(overrides: Partial<HouseholdItemSummary> = {}): HouseholdItemSummary {
+  return {
+    id: 'hi-1',
+    name: 'Sofa',
+    description: null,
+    category: 'hic-furniture',
+    status: 'planned',
+    vendor: null,
+    area: null,
+    quantity: 1,
+    orderDate: null,
+    targetDeliveryDate: null,
+    actualDeliveryDate: null,
+    earliestDeliveryDate: null,
+    latestDeliveryDate: null,
+    isLate: false,
+    url: null,
+    budgetLineCount: 0,
+    totalPlannedAmount: 0,
+    budgetSummary: {
+      totalPlanned: 0,
+      totalActual: 0,
+      subsidyReduction: 0,
+      netCost: 0,
+    },
+    createdBy: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const areaWithAncestors = {
+  id: 'area-kitchen',
+  name: 'Kitchen',
+  color: null,
+  ancestors: [{ id: 'area-gf', name: 'Ground Floor', color: null }],
+};
+
+const areaRootLevel = {
+  id: 'area-garage',
+  name: 'Garage',
+  color: null,
+  ancestors: [],
+};
+
+// ─── Component import (must be after mocks) ──────────────────────────────────
+
+let HouseholdItemPickerModule: {
+  HouseholdItemPicker: typeof HouseholdItemPickerType;
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', () => {
+  beforeEach(async () => {
+    mockListHouseholdItems.mockReset();
+    // Default: return empty list so tests that don't trigger search still render safely.
+    mockListHouseholdItems.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, pageSize: 15, totalItems: 0, totalPages: 0 },
+    });
+
+    if (!HouseholdItemPickerModule) {
+      HouseholdItemPickerModule = await import('./HouseholdItemPicker.js');
+    }
+  });
+
+  function renderPicker(
+    props: Partial<React.ComponentProps<typeof HouseholdItemPickerModule.HouseholdItemPicker>> = {},
+  ) {
+    const { HouseholdItemPicker } = HouseholdItemPickerModule;
+    return render(<HouseholdItemPicker value="" onChange={jest.fn()} excludeIds={[]} {...props} />);
+  }
+
+  // ── Scenario 5: item with area → compact breadcrumb secondary line renders ──
+
+  describe('search results — item with area set', () => {
+    it('renders compact breadcrumb text for an item with a single ancestor', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Sofa', area: areaWithAncestors })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+      });
+
+      // Compact breadcrumb: "Ground Floor › Kitchen"
+      const fullPath = 'Ground Floor \u203a Kitchen';
+      expect(screen.getByText(fullPath)).toBeInTheDocument();
+    });
+
+    it('renders compact breadcrumb text for a root-level area (no ancestors)', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Toolbox', area: areaRootLevel })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Toolbox')).toBeInTheDocument();
+      });
+
+      // Root-level area: breadcrumb text is just "Garage"
+      expect(screen.getByText('Garage')).toBeInTheDocument();
+    });
+
+    it('renders tooltip element containing the full area path', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Chair', area: areaWithAncestors })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      const { container } = renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Chair')).toBeInTheDocument();
+      });
+
+      // Compact variant wraps text in a Tooltip that renders role="tooltip"
+      const tooltips = container.querySelectorAll('[role="tooltip"]');
+      expect(tooltips.length).toBeGreaterThan(0);
+
+      const fullPath = 'Ground Floor \u203a Kitchen';
+      const matchingTooltip = Array.from(tooltips).find((el) => el.textContent === fullPath);
+      expect(matchingTooltip).toBeDefined();
+    });
+
+    it('renders secondary breadcrumbs for multiple results with different areas', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [
+          makeItem({ id: 'hi-1', name: 'Sofa', area: areaWithAncestors }),
+          makeItem({ id: 'hi-2', name: 'Toolbox', area: areaRootLevel }),
+        ],
+        pagination: { page: 1, pageSize: 15, totalItems: 2, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+        expect(screen.getByText('Toolbox')).toBeInTheDocument();
+      });
+
+      // Sofa's area breadcrumb
+      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
+      // Toolbox's area breadcrumb (root-level, no ancestors)
+      expect(screen.getByText('Garage')).toBeInTheDocument();
+    });
+  });
+
+  // ── Scenario 6: item with area: null → "No area" secondary line renders ──
+
+  describe('search results — item with area: null', () => {
+    it('renders "No area" secondary text when item area is null', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Sofa', area: null })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+      });
+
+      // AreaBreadcrumb with area=null renders "No area"
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+
+    it('renders "No area" for every null-area item in the results', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [
+          makeItem({ id: 'hi-1', name: 'Sofa', area: null }),
+          makeItem({ id: 'hi-2', name: 'Chair', area: null }),
+        ],
+        pagination: { page: 1, pageSize: 15, totalItems: 2, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+        expect(screen.getByText('Chair')).toBeInTheDocument();
+      });
+
+      // Both items have null area → two "No area" labels
+      const noAreaEls = screen.getAllByText('No area');
+      expect(noAreaEls).toHaveLength(2);
+    });
+
+    it('does not render a nav element for null-area items in the dropdown', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Sofa', area: null })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      const { container } = renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+      });
+
+      // null area renders a muted <span>, not a <nav>
+      expect(container.querySelector('nav[aria-label="Area path"]')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Mixed results: area items and null-area items together ───────────────
+
+  describe('search results — mixed area / no-area items', () => {
+    it('renders breadcrumb for area items and "No area" for null-area items side by side', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [
+          makeItem({ id: 'hi-1', name: 'Sofa', area: areaWithAncestors }),
+          makeItem({ id: 'hi-2', name: 'Chair', area: null }),
+        ],
+        pagination: { page: 1, pageSize: 15, totalItems: 2, totalPages: 1 },
+      });
+
+      renderPicker({ showItemsOnFocus: true });
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+        expect(screen.getByText('Chair')).toBeInTheDocument();
+      });
+
+      // Sofa shows the compact path
+      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
+      // Chair shows "No area"
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+  });
+
+  // ── Secondary line renders after typing (non-focus-triggered search) ─────
+
+  describe('search-triggered results — area secondary line', () => {
+    it('renders area breadcrumb secondary line after typing a search term', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Sofa', area: areaWithAncestors })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      renderPicker();
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.type(input, 'Sofa');
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
+    });
+
+    it('renders "No area" secondary line after typing when item has null area', async () => {
+      const user = userEvent.setup();
+      mockListHouseholdItems.mockResolvedValue({
+        items: [makeItem({ id: 'hi-1', name: 'Sofa', area: null })],
+        pagination: { page: 1, pageSize: 15, totalItems: 1, totalPages: 1 },
+      });
+
+      renderPicker();
+
+      const input = screen.getByPlaceholderText('Search household items...');
+      await user.type(input, 'Sofa');
+
+      await waitFor(() => {
+        expect(screen.getByText('Sofa')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/HouseholdItemPicker/HouseholdItemPicker.breadcrumb.test.tsx
+++ b/client/src/components/HouseholdItemPicker/HouseholdItemPicker.breadcrumb.test.tsx
@@ -125,8 +125,10 @@ describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', 
       });
 
       // Compact breadcrumb: "Ground Floor › Kitchen"
+      // Tooltip renders the text in both the visible span and in role="tooltip",
+      // so getAllByText is used to avoid "Found multiple elements" errors.
       const fullPath = 'Ground Floor \u203a Kitchen';
-      expect(screen.getByText(fullPath)).toBeInTheDocument();
+      expect(screen.getAllByText(fullPath).length).toBeGreaterThan(0);
     });
 
     it('renders compact breadcrumb text for a root-level area (no ancestors)', async () => {
@@ -146,7 +148,8 @@ describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', 
       });
 
       // Root-level area: breadcrumb text is just "Garage"
-      expect(screen.getByText('Garage')).toBeInTheDocument();
+      // Tooltip renders the text twice (visible span + role="tooltip").
+      expect(screen.getAllByText('Garage').length).toBeGreaterThan(0);
     });
 
     it('renders tooltip element containing the full area path', async () => {
@@ -194,10 +197,10 @@ describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', 
         expect(screen.getByText('Toolbox')).toBeInTheDocument();
       });
 
-      // Sofa's area breadcrumb
-      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
-      // Toolbox's area breadcrumb (root-level, no ancestors)
-      expect(screen.getByText('Garage')).toBeInTheDocument();
+      // Sofa's area breadcrumb — Tooltip duplicates text into role="tooltip".
+      expect(screen.getAllByText('Ground Floor \u203a Kitchen').length).toBeGreaterThan(0);
+      // Toolbox's area breadcrumb (root-level, no ancestors) — same Tooltip duplication.
+      expect(screen.getAllByText('Garage').length).toBeGreaterThan(0);
     });
   });
 
@@ -293,8 +296,8 @@ describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', 
         expect(screen.getByText('Chair')).toBeInTheDocument();
       });
 
-      // Sofa shows the compact path
-      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
+      // Sofa shows the compact path — Tooltip renders text twice (span + role="tooltip").
+      expect(screen.getAllByText('Ground Floor \u203a Kitchen').length).toBeGreaterThan(0);
       // Chair shows "No area"
       expect(screen.getByText('No area')).toBeInTheDocument();
     });
@@ -319,7 +322,8 @@ describe('HouseholdItemPicker — AreaBreadcrumb secondary line (Story #1240)', 
         expect(screen.getByText('Sofa')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('Ground Floor \u203a Kitchen')).toBeInTheDocument();
+      // Tooltip renders text twice (visible span + role="tooltip").
+      expect(screen.getAllByText('Ground Floor \u203a Kitchen').length).toBeGreaterThan(0);
     });
 
     it('renders "No area" secondary line after typing when item has null area', async () => {

--- a/client/src/components/HouseholdItemPicker/HouseholdItemPicker.tsx
+++ b/client/src/components/HouseholdItemPicker/HouseholdItemPicker.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import type { HouseholdItemSummary, HouseholdItemStatus } from '@cornerstone/shared';
 import { listHouseholdItems } from '../../lib/householdItemsApi.js';
 import { SearchPicker } from '../SearchPicker/index.js';
+import { AreaBreadcrumb } from '../AreaBreadcrumb/index.js';
 
 /** Maps household item status values to their CSS custom property for the left-border color. */
 const STATUS_BORDER_COLORS: Record<HouseholdItemStatus, string> = {
@@ -62,6 +63,7 @@ export function HouseholdItemPicker({
         return response.items.filter((item) => !ids.includes(item.id));
       }}
       renderItem={(item) => ({ id: item.id, label: item.name })}
+      renderSecondary={(item) => <AreaBreadcrumb area={item.area ?? null} variant="compact" />}
       getStatusBorderColor={(item) => STATUS_BORDER_COLORS[item.status]}
       showItemsOnFocus={showItemsOnFocus}
       initialTitle={initialTitle}

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.breadcrumb.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.breadcrumb.test.tsx
@@ -1,0 +1,530 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Breadcrumb-specific tests for HouseholdItemDetailPage.tsx (Story #1240).
+ * Verifies that the detail page header renders AreaBreadcrumb (default variant)
+ * below the item h1 — including the nav/aria-label for items with an area
+ * and the "No area" fallback for items with area: null.
+ *
+ * All mocks replicate those in HouseholdItemDetailPage.test.tsx to stay
+ * independent and avoid module-registry conflicts.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type * as HouseholdItemsApiTypes from '../../lib/householdItemsApi.js';
+import type * as HouseholdItemDetailPageTypes from './HouseholdItemDetailPage.js';
+import type {
+  HouseholdItemDetail,
+  HouseholdItemStatus,
+  HouseholdItemCategory,
+  AreaSummary,
+} from '@cornerstone/shared';
+import type React from 'react';
+import type * as WorkItemsApiTypes from '../../lib/workItemsApi.js';
+import type * as HouseholdItemDepsApiTypes from '../../lib/householdItemDepsApi.js';
+import type * as MilestonesApiTypes from '../../lib/milestonesApi.js';
+import type * as InvoicesApiTypes from '../../lib/invoicesApi.js';
+import type { HouseholdItemDepDetail } from '@cornerstone/shared';
+
+// ─── API mock handles ─────────────────────────────────────────────────────────
+
+const mockGetHouseholdItem = jest.fn<typeof HouseholdItemsApiTypes.getHouseholdItem>();
+const mockUpdateHouseholdItem = jest.fn<typeof HouseholdItemsApiTypes.updateHouseholdItem>();
+const mockDeleteHouseholdItem = jest.fn<typeof HouseholdItemsApiTypes.deleteHouseholdItem>();
+const mockShowToast = jest.fn();
+const mockListWorkItems = jest.fn<typeof WorkItemsApiTypes.listWorkItems>();
+const mockFetchHouseholdItemDeps =
+  jest.fn<typeof HouseholdItemDepsApiTypes.fetchHouseholdItemDeps>();
+const mockCreateHouseholdItemDep =
+  jest.fn<typeof HouseholdItemDepsApiTypes.createHouseholdItemDep>();
+const mockDeleteHouseholdItemDep =
+  jest.fn<typeof HouseholdItemDepsApiTypes.deleteHouseholdItemDep>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchHouseholdItemBudgets = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchBudgetCategories = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchBudgetSources = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchVendors = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchSubsidyPrograms = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchHouseholdItemSubsidies = jest.fn() as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchHouseholdItemSubsidyPayback = jest.fn() as any;
+const mockListMilestones = jest.fn<typeof MilestonesApiTypes.listMilestones>();
+const mockFetchInvoices = jest.fn<typeof InvoicesApiTypes.fetchInvoices>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchHouseholdItemCategories = jest.fn() as any;
+
+// Mock ApiClientError so instanceof checks work in the component
+class MockApiClientError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly error: { code: string; message: string },
+  ) {
+    super(error.message);
+    this.name = 'ApiClientError';
+  }
+}
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../lib/householdItemsApi.js', () => ({
+  createHouseholdItem: jest.fn<typeof HouseholdItemsApiTypes.createHouseholdItem>(),
+  getHouseholdItem: mockGetHouseholdItem,
+  updateHouseholdItem: mockUpdateHouseholdItem,
+  listHouseholdItems: jest.fn<typeof HouseholdItemsApiTypes.listHouseholdItems>(),
+  deleteHouseholdItem: mockDeleteHouseholdItem,
+}));
+
+jest.unstable_mockModule('../../lib/apiClient.js', () => ({
+  ApiClientError: MockApiClientError,
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../components/Toast/ToastContext.js', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+  useToast: () => ({
+    toasts: [],
+    showToast: mockShowToast,
+    dismissToast: jest.fn(),
+  }),
+}));
+
+jest.unstable_mockModule('../../lib/householdItemWorkItemsApi.js', () => ({
+  fetchLinkedHouseholdItems: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/workItemsApi.js', () => ({
+  listWorkItems: mockListWorkItems,
+  getWorkItem: jest.fn(),
+  createWorkItem: jest.fn(),
+  updateWorkItem: jest.fn(),
+  deleteWorkItem: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/householdItemBudgetsApi.js', () => ({
+  fetchHouseholdItemBudgets: mockFetchHouseholdItemBudgets,
+  createHouseholdItemBudget: jest.fn(),
+  updateHouseholdItemBudget: jest.fn(),
+  deleteHouseholdItemBudget: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/budgetCategoriesApi.js', () => ({
+  fetchBudgetCategories: mockFetchBudgetCategories,
+  createBudgetCategory: jest.fn(),
+  updateBudgetCategory: jest.fn(),
+  deleteBudgetCategory: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/budgetSourcesApi.js', () => ({
+  fetchBudgetSources: mockFetchBudgetSources,
+  fetchBudgetSource: jest.fn(),
+  createBudgetSource: jest.fn(),
+  updateBudgetSource: jest.fn(),
+  deleteBudgetSource: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/vendorsApi.js', () => ({
+  fetchVendors: mockFetchVendors,
+  fetchVendor: jest.fn(),
+  createVendor: jest.fn(),
+  updateVendor: jest.fn(),
+  deleteVendor: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/subsidyProgramsApi.js', () => ({
+  fetchSubsidyPrograms: mockFetchSubsidyPrograms,
+  fetchSubsidyProgram: jest.fn(),
+  createSubsidyProgram: jest.fn(),
+  updateSubsidyProgram: jest.fn(),
+  deleteSubsidyProgram: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../lib/householdItemSubsidiesApi.js', () => ({
+  fetchHouseholdItemSubsidies: mockFetchHouseholdItemSubsidies,
+  linkHouseholdItemSubsidy: jest.fn(),
+  unlinkHouseholdItemSubsidy: jest.fn(),
+  fetchHouseholdItemSubsidyPayback: mockFetchHouseholdItemSubsidyPayback,
+}));
+
+jest.unstable_mockModule('../../lib/householdItemDepsApi.js', () => ({
+  fetchHouseholdItemDeps: mockFetchHouseholdItemDeps,
+  createHouseholdItemDep: mockCreateHouseholdItemDep,
+  deleteHouseholdItemDep: mockDeleteHouseholdItemDep,
+}));
+
+jest.unstable_mockModule('../../lib/milestonesApi.js', () => ({
+  listMilestones: mockListMilestones,
+  getMilestone: jest.fn<typeof MilestonesApiTypes.getMilestone>(),
+  createMilestone: jest.fn<typeof MilestonesApiTypes.createMilestone>(),
+  updateMilestone: jest.fn<typeof MilestonesApiTypes.updateMilestone>(),
+  deleteMilestone: jest.fn<typeof MilestonesApiTypes.deleteMilestone>(),
+  linkWorkItem: jest.fn<typeof MilestonesApiTypes.linkWorkItem>(),
+  unlinkWorkItem: jest.fn<typeof MilestonesApiTypes.unlinkWorkItem>(),
+  addDependentWorkItem: jest.fn<typeof MilestonesApiTypes.addDependentWorkItem>(),
+  removeDependentWorkItem: jest.fn<typeof MilestonesApiTypes.removeDependentWorkItem>(),
+}));
+
+jest.unstable_mockModule('../../lib/invoicesApi.js', () => ({
+  fetchInvoices: mockFetchInvoices,
+  fetchAllInvoices: jest.fn<typeof InvoicesApiTypes.fetchAllInvoices>(),
+  fetchInvoiceById: jest.fn<typeof InvoicesApiTypes.fetchInvoiceById>(),
+  createInvoice: jest.fn<typeof InvoicesApiTypes.createInvoice>(),
+  updateInvoice: jest.fn<typeof InvoicesApiTypes.updateInvoice>(),
+  deleteInvoice: jest.fn<typeof InvoicesApiTypes.deleteInvoice>(),
+}));
+
+jest.unstable_mockModule('../../lib/householdItemCategoriesApi.js', () => ({
+  fetchHouseholdItemCategories: mockFetchHouseholdItemCategories,
+  createHouseholdItemCategory: jest.fn(),
+  updateHouseholdItemCategory: jest.fn(),
+  deleteHouseholdItemCategory: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../hooks/useAreas.js', () => ({
+  useAreas: jest.fn(() => ({
+    areas: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    createArea: jest.fn(),
+    updateArea: jest.fn(),
+    deleteArea: jest.fn(),
+  })),
+}));
+
+jest.unstable_mockModule('../../components/documents/LinkedDocumentsSection.js', () => ({
+  LinkedDocumentsSection: function MockLinkedDocumentsSection(props: {
+    entityType: string;
+    entityId: string;
+  }) {
+    return (
+      <section data-testid="linked-documents-section">
+        <h2>Documents</h2>
+        <span data-testid="entity-type">{props.entityType}</span>
+        <span data-testid="entity-id">{props.entityId}</span>
+      </section>
+    );
+  },
+}));
+
+jest.unstable_mockModule('../../lib/formatters.js', () => {
+  const fmtCurrency = (n: number) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(n);
+  const fmtDate = (d: string | null | undefined, fallback = '—') => {
+    if (!d) return fallback;
+    const [year, month, day] = d.slice(0, 10).split('-').map(Number);
+    if (!year || !month || !day) return fallback;
+    return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+  const fmtTime = (ts: string | null | undefined, fallback = '—') => ts ?? fallback;
+  const fmtDateTime = (ts: string | null | undefined, fallback = '—') => ts ?? fallback;
+  return {
+    formatCurrency: fmtCurrency,
+    formatDate: fmtDate,
+    formatTime: fmtTime,
+    formatDateTime: fmtDateTime,
+    formatPercent: (n: number) => `${n.toFixed(2)}%`,
+    computeActualDuration: () => null,
+    useFormatters: () => ({
+      formatCurrency: fmtCurrency,
+      formatDate: fmtDate,
+      formatTime: fmtTime,
+      formatDateTime: fmtDateTime,
+      formatPercent: (n: number) => `${n.toFixed(2)}%`,
+    }),
+  };
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeItem(overrides: Partial<HouseholdItemDetail> = {}): HouseholdItemDetail {
+  return {
+    id: 'item-1',
+    name: 'Standing Desk',
+    description: 'Electric height-adjustable desk',
+    category: 'furniture' as HouseholdItemCategory,
+    status: 'purchased' as HouseholdItemStatus,
+    vendor: { id: 'vendor-1', name: 'IKEA', trade: null },
+    area: null,
+    quantity: 2,
+    orderDate: '2026-02-15',
+    targetDeliveryDate: '2026-03-01',
+    actualDeliveryDate: null,
+    earliestDeliveryDate: '2026-03-01',
+    latestDeliveryDate: '2026-03-10',
+    isLate: false,
+    url: 'https://example.com/desk',
+    budgetLineCount: 1,
+    totalPlannedAmount: 599.99,
+    budgetSummary: { totalPlanned: 599.99, totalActual: 0, subsidyReduction: 0, netCost: 599.99 },
+    createdBy: { id: 'user-1', displayName: 'John Doe', email: 'john@example.com' },
+    createdAt: '2026-01-15T10:00:00Z',
+    updatedAt: '2026-02-15T14:30:00Z',
+    dependencies: [],
+    subsidies: [],
+    ...overrides,
+  };
+}
+
+const areaWithAncestor: AreaSummary = {
+  id: 'area-kitchen',
+  name: 'Kitchen',
+  color: null,
+  ancestors: [{ id: 'area-gf', name: 'Ground Floor', color: null }],
+};
+
+const areaRootLevel: AreaSummary = {
+  id: 'area-garage',
+  name: 'Garage',
+  color: null,
+  ancestors: [],
+};
+
+const areaDeepNested: AreaSummary = {
+  id: 'area-pantry',
+  name: 'Pantry',
+  color: null,
+  ancestors: [
+    { id: 'area-gf', name: 'Ground Floor', color: null },
+    { id: 'area-kitchen', name: 'Kitchen', color: null },
+  ],
+};
+
+// ─── Component import (must be after mocks) ──────────────────────────────────
+
+let HouseholdItemDetailPageModule: typeof HouseholdItemDetailPageTypes;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPage(itemId = 'item-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/project/household-items/${itemId}`]}>
+      <Routes>
+        <Route
+          path="/project/household-items/:id"
+          element={<HouseholdItemDetailPageModule.default />}
+        />
+        <Route path="/project/household-items" element={<div>Household Items List</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('HouseholdItemDetailPage — AreaBreadcrumb in header (Story #1240)', () => {
+  beforeEach(async () => {
+    if (!HouseholdItemDetailPageModule) {
+      HouseholdItemDetailPageModule = await import('./HouseholdItemDetailPage.js');
+    }
+
+    mockGetHouseholdItem.mockReset();
+    mockUpdateHouseholdItem.mockReset();
+    mockDeleteHouseholdItem.mockReset();
+    mockShowToast.mockReset();
+    mockListWorkItems.mockReset();
+    mockFetchHouseholdItemBudgets.mockReset();
+    mockFetchBudgetCategories.mockReset();
+    mockFetchBudgetSources.mockReset();
+    mockFetchVendors.mockReset();
+    mockFetchSubsidyPrograms.mockReset();
+    mockFetchHouseholdItemSubsidies.mockReset();
+    mockFetchHouseholdItemSubsidyPayback.mockReset();
+    mockFetchHouseholdItemDeps.mockReset();
+    mockCreateHouseholdItemDep.mockReset();
+    mockDeleteHouseholdItemDep.mockReset();
+    mockListMilestones.mockReset();
+    mockFetchInvoices.mockReset();
+    mockFetchHouseholdItemCategories.mockReset();
+
+    // Default API responses
+    mockListWorkItems.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
+    });
+    mockFetchHouseholdItemBudgets.mockResolvedValue([]);
+    mockFetchBudgetCategories.mockResolvedValue({ categories: [] });
+    mockFetchBudgetSources.mockResolvedValue({ budgetSources: [] });
+    mockFetchVendors.mockResolvedValue({
+      vendors: [],
+      pagination: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
+    });
+    mockFetchSubsidyPrograms.mockResolvedValue({ subsidyPrograms: [] });
+    mockFetchHouseholdItemSubsidies.mockResolvedValue([]);
+    mockFetchHouseholdItemSubsidyPayback.mockResolvedValue({
+      householdItemId: 'item-1',
+      minTotalPayback: 0,
+      maxTotalPayback: 0,
+      subsidies: [],
+    });
+    mockFetchHouseholdItemDeps.mockResolvedValue([]);
+    mockCreateHouseholdItemDep.mockResolvedValue({
+      householdItemId: 'item-1',
+      predecessorType: 'work_item',
+      predecessorId: 'wi-1',
+      predecessor: { id: 'wi-1', title: 'Work Item', status: 'not_started', endDate: null },
+    } as HouseholdItemDepDetail);
+    mockDeleteHouseholdItemDep.mockResolvedValue(undefined);
+    mockListMilestones.mockResolvedValue([]);
+    mockFetchInvoices.mockResolvedValue([]);
+    mockFetchHouseholdItemCategories.mockResolvedValue({
+      categories: [
+        {
+          id: 'furniture',
+          name: 'Furniture',
+          color: '#8B5CF6',
+          sortOrder: 0,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  // ── Scenario 3: area set → nav element with aria-label visible ──────────
+
+  describe('header — item with area set', () => {
+    it('renders nav with aria-label "Area path" when area is set', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaWithAncestor }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('navigation', { name: 'Area path' })).toBeInTheDocument();
+    });
+
+    it('renders ancestor name inside the nav breadcrumb', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaWithAncestor }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Area path' });
+      expect(nav).toBeInTheDocument();
+      // The nav contains list items: ancestor name + separator + leaf name
+      expect(nav.textContent).toContain('Ground Floor');
+      expect(nav.textContent).toContain('Kitchen');
+    });
+
+    it('renders leaf area name inside the nav breadcrumb', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaRootLevel }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Area path' });
+      expect(nav.textContent).toContain('Garage');
+    });
+
+    it('renders correct separator count for multi-level ancestors', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaDeepNested }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Area path' });
+      // 3 segments → 2 separators
+      const separators = nav.querySelectorAll('[aria-hidden="true"]');
+      expect(separators).toHaveLength(2);
+    });
+
+    it('renders all ancestor and leaf names in the nav for deeply nested area', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaDeepNested }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Area path' });
+      expect(nav.textContent).toContain('Ground Floor');
+      expect(nav.textContent).toContain('Kitchen');
+      expect(nav.textContent).toContain('Pantry');
+    });
+
+    it('does not render "No area" text when area is set', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: areaWithAncestor }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('No area')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Scenario 4: area: null → "No area" visible, no nav ──────────────────
+
+  describe('header — item with area: null', () => {
+    it('renders "No area" text when area is null', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: null }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      // AreaBreadcrumb renders "No area" muted span when area is null
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+
+    it('does not render a nav with "Area path" label when area is null', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ area: null }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('navigation', { name: 'Area path' })).not.toBeInTheDocument();
+    });
+
+    it('still renders the item heading h1 when area is null', async () => {
+      mockGetHouseholdItem.mockResolvedValue(makeItem({ name: 'My Item', area: null }));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1, name: 'My Item' })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('No area')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.module.css
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.module.css
@@ -178,6 +178,10 @@
   word-break: break-word;
 }
 
+.titleBreadcrumb {
+  margin-top: var(--spacing-2);
+}
+
 .headerBadges {
   display: flex;
   gap: var(--spacing-2);

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
@@ -1820,7 +1820,10 @@ describe('HouseholdItemDetailPage', () => {
         expect(screen.getByText('Foundation Excavation')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('No area')).toBeInTheDocument();
+      // The page header also renders "No area" via AreaBreadcrumb (item.area is null),
+      // so scope the assertion to the dropdown button containing the work item title.
+      const wiDropdownButton = screen.getByRole('button', { name: /Foundation Excavation/ });
+      expect(within(wiDropdownButton).getByText('No area')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -763,6 +763,9 @@ export function HouseholdItemDetailPage() {
         <div className={styles.headerRow}>
           <div className={styles.pageHeading}>
             <h1 className={styles.pageTitle}>{item.name}</h1>
+            <div className={styles.titleBreadcrumb}>
+              <AreaBreadcrumb area={item.area ?? null} variant="default" />
+            </div>
             <div className={styles.headerBadges}>
               <span className={styles.categoryBadge}>
                 {(() => {

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.breadcrumb.test.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.breadcrumb.test.tsx
@@ -1,0 +1,411 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Breadcrumb-specific tests for HouseholdItemsPage.tsx (Story #1240).
+ * Verifies that the name column renders AreaBreadcrumb (compact variant)
+ * below the item link, both for items with an area and items with area: null.
+ *
+ * All mocks are identical to HouseholdItemsPage.test.tsx to avoid
+ * module-registry conflicts between test files.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type * as HouseholdItemsApiTypes from '../../lib/householdItemsApi.js';
+import type * as VendorsApiTypes from '../../lib/vendorsApi.js';
+import type * as HouseholdItemCategoriesApiTypes from '../../lib/householdItemCategoriesApi.js';
+import type * as UseAreasTypes from '../../hooks/useAreas.js';
+import type { HouseholdItemSummary } from '@cornerstone/shared';
+
+// ─── Mock modules BEFORE importing component ────────────────────────────────
+
+// Mock preferencesApi — DataTable calls useColumnPreferences -> usePreferences -> listPreferences
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockListPreferences = jest.fn<any>().mockResolvedValue([]);
+jest.unstable_mockModule('../../lib/preferencesApi.js', () => ({
+  listPreferences: mockListPreferences,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  upsertPreference: jest.fn<any>().mockResolvedValue({ key: '', value: '', updatedAt: '' }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deletePreference: jest.fn<any>().mockResolvedValue(undefined),
+}));
+
+const mockListHouseholdItems = jest.fn<typeof HouseholdItemsApiTypes.listHouseholdItems>();
+const mockDeleteHouseholdItem = jest.fn<typeof HouseholdItemsApiTypes.deleteHouseholdItem>();
+
+jest.unstable_mockModule('../../lib/householdItemsApi.js', () => ({
+  listHouseholdItems: mockListHouseholdItems,
+  deleteHouseholdItem: mockDeleteHouseholdItem,
+  getHouseholdItem: jest.fn(),
+  createHouseholdItem: jest.fn(),
+  updateHouseholdItem: jest.fn(),
+}));
+
+const mockFetchVendors = jest.fn<typeof VendorsApiTypes.fetchVendors>();
+
+jest.unstable_mockModule('../../lib/vendorsApi.js', () => ({
+  fetchVendors: mockFetchVendors,
+  fetchVendor: jest.fn(),
+  createVendor: jest.fn(),
+  updateVendor: jest.fn(),
+  deleteVendor: jest.fn(),
+}));
+
+const mockFetchHouseholdItemCategories =
+  jest.fn<typeof HouseholdItemCategoriesApiTypes.fetchHouseholdItemCategories>();
+
+jest.unstable_mockModule('../../lib/householdItemCategoriesApi.js', () => ({
+  fetchHouseholdItemCategories: mockFetchHouseholdItemCategories,
+  createHouseholdItemCategory: jest.fn(),
+  updateHouseholdItemCategory: jest.fn(),
+  deleteHouseholdItemCategory: jest.fn(),
+}));
+
+const mockUseAreas = jest.fn<typeof UseAreasTypes.useAreas>();
+
+jest.unstable_mockModule('../../hooks/useAreas.js', () => ({
+  useAreas: mockUseAreas,
+}));
+
+// Mock useTableState with a stable Map to prevent infinite re-renders.
+const stableFilters = new Map();
+jest.unstable_mockModule('../../hooks/useTableState.js', () => ({
+  useTableState: () => ({
+    tableState: {
+      search: '',
+      filters: stableFilters,
+      sortBy: null,
+      sortDir: null,
+      page: 1,
+      pageSize: 25,
+    },
+    searchInput: '',
+    setSearch: jest.fn(),
+    toApiParams: jest.fn(() => ({})),
+    setFilter: jest.fn(),
+  }),
+}));
+
+// Mock formatters
+jest.unstable_mockModule('../../lib/formatters.js', () => ({
+  useFormatters: () => ({
+    formatDate: (d: string | null | undefined) => (d ? '01/01/2026' : '—'),
+    formatCurrency: (n: number) => `€${n.toFixed(2)}`,
+    formatPercent: (n: number) => `${n}%`,
+  }),
+  formatDate: (d: string | null | undefined) => (d ? '01/01/2026' : '—'),
+  formatCurrency: (n: number) => `€${n.toFixed(2)}`,
+  formatPercent: (n: number) => `${n}%`,
+}));
+
+// Mock categoryUtils
+jest.unstable_mockModule('../../lib/categoryUtils.js', () => ({
+  getCategoryDisplayName: (_t: unknown, name: string) => name,
+}));
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const makeHouseholdItem = (
+  overrides: Partial<HouseholdItemSummary> = {},
+): HouseholdItemSummary => ({
+  id: 'hi-1',
+  name: 'Living Room Sofa',
+  description: null,
+  category: 'hic-furniture',
+  status: 'planned',
+  vendor: null,
+  area: null,
+  quantity: 1,
+  orderDate: null,
+  actualDeliveryDate: null,
+  earliestDeliveryDate: null,
+  latestDeliveryDate: null,
+  targetDeliveryDate: null,
+  isLate: false,
+  url: null,
+  budgetLineCount: 0,
+  totalPlannedAmount: 1500,
+  budgetSummary: {
+    totalPlanned: 1500,
+    totalActual: 0,
+    subsidyReduction: 0,
+    netCost: 1500,
+  },
+  createdBy: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makePagination = (overrides = {}) => ({
+  page: 1,
+  pageSize: 25,
+  totalItems: 0,
+  totalPages: 1,
+  ...overrides,
+});
+
+const defaultListResponse = (items: HouseholdItemSummary[] = []) => ({
+  items,
+  pagination: makePagination({ totalItems: items.length }),
+  filterMeta: {},
+});
+
+// ─── Component import (must be after mocks) ──────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let HouseholdItemsPage: any;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/project/household-items']}>
+      <HouseholdItemsPage />
+    </MemoryRouter>,
+  );
+}
+
+function makeDefaultAreasHook(): ReturnType<typeof UseAreasTypes.useAreas> {
+  return {
+    areas: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    createArea: jest.fn<UseAreasTypes.UseAreasResult['createArea']>(),
+    updateArea: jest.fn<UseAreasTypes.UseAreasResult['updateArea']>(),
+    deleteArea: jest.fn<UseAreasTypes.UseAreasResult['deleteArea']>(),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('HouseholdItemsPage — AreaBreadcrumb in name column (Story #1240)', () => {
+  beforeEach(async () => {
+    if (!HouseholdItemsPage) {
+      const module = await import('./HouseholdItemsPage.js');
+      HouseholdItemsPage = module.HouseholdItemsPage;
+    }
+
+    mockListHouseholdItems.mockReset();
+    mockDeleteHouseholdItem.mockReset();
+    mockFetchVendors.mockReset();
+    mockFetchHouseholdItemCategories.mockReset();
+    mockListPreferences.mockReset();
+    mockListPreferences.mockResolvedValue([]);
+
+    mockUseAreas.mockReturnValue(makeDefaultAreasHook());
+
+    mockListHouseholdItems.mockResolvedValue(defaultListResponse());
+    mockFetchVendors.mockResolvedValue({
+      vendors: [],
+      pagination: makePagination(),
+    });
+    mockFetchHouseholdItemCategories.mockResolvedValue({
+      categories: [],
+    });
+    mockDeleteHouseholdItem.mockResolvedValue(undefined);
+  });
+
+  // ── Scenario 1: item with area → compact breadcrumb text visible ──────────
+
+  describe('name column — item with area set', () => {
+    it('renders the leaf area name in the compact breadcrumb below the item link', async () => {
+      const item = makeHouseholdItem({
+        id: 'hi-1',
+        name: 'Living Room Sofa',
+        area: {
+          id: 'area-kitchen',
+          name: 'Kitchen',
+          color: null,
+          ancestors: [{ id: 'area-gf', name: 'Ground Floor', color: null }],
+        },
+      });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      renderPage();
+
+      // DataTable renders both table rows and mobile cards — use getAllByText.
+      await waitFor(() => {
+        // The item name link should be present
+        expect(screen.getAllByText('Living Room Sofa').length).toBeGreaterThan(0);
+      });
+
+      // Compact breadcrumb renders the full path as "Ground Floor › Kitchen"
+      // The separator is U+203A (›) with spaces.
+      const breadcrumbEls = screen.getAllByText('Ground Floor \u203a Kitchen');
+      expect(breadcrumbEls.length).toBeGreaterThan(0);
+    });
+
+    it('renders a tooltip element containing the full area path when area has ancestors', async () => {
+      const item = makeHouseholdItem({
+        id: 'hi-1',
+        name: 'Bookshelf',
+        area: {
+          id: 'area-study',
+          name: 'Study',
+          color: null,
+          ancestors: [{ id: 'area-upper', name: 'Upper Floor', color: null }],
+        },
+      });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      const { container } = renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Bookshelf').length).toBeGreaterThan(0);
+      });
+
+      // Compact variant wraps text in a Tooltip that renders role="tooltip"
+      const tooltips = container.querySelectorAll('[role="tooltip"]');
+      expect(tooltips.length).toBeGreaterThan(0);
+
+      // At least one tooltip should contain the full path
+      const fullPath = 'Upper Floor \u203a Study';
+      const matchingTooltip = Array.from(tooltips).find(
+        (el) => el.textContent === fullPath,
+      );
+      expect(matchingTooltip).toBeDefined();
+    });
+
+    it('renders both the item link and the breadcrumb within the name column', async () => {
+      const item = makeHouseholdItem({
+        id: 'hi-2',
+        name: 'Dining Table',
+        area: {
+          id: 'area-dining',
+          name: 'Dining Room',
+          color: null,
+          ancestors: [],
+        },
+      });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Dining Table').length).toBeGreaterThan(0);
+        // Root area: no ancestors → breadcrumb shows just "Dining Room"
+        expect(screen.getAllByText('Dining Room').length).toBeGreaterThan(0);
+      });
+    });
+
+    it('renders breadcrumb for item with multiple ancestor levels', async () => {
+      const item = makeHouseholdItem({
+        id: 'hi-3',
+        name: 'Cabinet',
+        area: {
+          id: 'area-cabinet',
+          name: 'Kitchen Cabinet',
+          color: null,
+          ancestors: [
+            { id: 'area-gf', name: 'Ground Floor', color: null },
+            { id: 'area-kitchen', name: 'Kitchen', color: null },
+          ],
+        },
+      });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Cabinet').length).toBeGreaterThan(0);
+      });
+
+      // Full path: "Ground Floor › Kitchen › Kitchen Cabinet"
+      const fullPath = 'Ground Floor \u203a Kitchen \u203a Kitchen Cabinet';
+      const breadcrumbs = screen.getAllByText(fullPath);
+      expect(breadcrumbs.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Scenario 2: item with area: null → "No area" text ────────────────────
+
+  describe('name column — item with area: null', () => {
+    it('renders "No area" text when item area is null', async () => {
+      const item = makeHouseholdItem({
+        id: 'hi-1',
+        name: 'Living Room Sofa',
+        area: null,
+      });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Living Room Sofa').length).toBeGreaterThan(0);
+      });
+
+      // AreaBreadcrumb with area=null renders "No area"
+      const noAreaEls = screen.getAllByText('No area');
+      expect(noAreaEls.length).toBeGreaterThan(0);
+    });
+
+    it('does not render a nav element when area is null', async () => {
+      const item = makeHouseholdItem({ area: null });
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse([item]));
+
+      const { container } = renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Living Room Sofa').length).toBeGreaterThan(0);
+      });
+
+      // null area renders a <span>, not a <nav>
+      expect(container.querySelector('nav[aria-label="Area path"]')).not.toBeInTheDocument();
+    });
+
+    it('renders "No area" for every null-area item in a multi-item list', async () => {
+      const items = [
+        makeHouseholdItem({ id: 'hi-1', name: 'Sofa', area: null }),
+        makeHouseholdItem({ id: 'hi-2', name: 'Chair', area: null }),
+      ];
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse(items));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Sofa').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Chair').length).toBeGreaterThan(0);
+      });
+
+      // DataTable renders table rows + mobile cards, so we expect at least 2 "No area" per item
+      const noAreaEls = screen.getAllByText('No area');
+      expect(noAreaEls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── Mixed list: some items with area, some without ───────────────────────
+
+  describe('name column — mixed area / no-area list', () => {
+    it('renders breadcrumb for area items and "No area" for null-area items side by side', async () => {
+      const items = [
+        makeHouseholdItem({
+          id: 'hi-1',
+          name: 'Sofa',
+          area: {
+            id: 'area-lr',
+            name: 'Living Room',
+            color: null,
+            ancestors: [],
+          },
+        }),
+        makeHouseholdItem({ id: 'hi-2', name: 'Chair', area: null }),
+      ];
+      mockListHouseholdItems.mockResolvedValueOnce(defaultListResponse(items));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Sofa').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Chair').length).toBeGreaterThan(0);
+      });
+
+      // Area item shows leaf name as compact breadcrumb
+      expect(screen.getAllByText('Living Room').length).toBeGreaterThan(0);
+      // Null-area item shows "No area"
+      expect(screen.getAllByText('No area').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.module.css
@@ -1,3 +1,9 @@
+.titleCell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
 .errorBanner {
   background-color: var(--color-danger-bg);
   border: 1px solid var(--color-danger-border);

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -16,6 +16,7 @@ import { fetchHouseholdItemCategories } from '../../lib/householdItemCategoriesA
 import { getCategoryDisplayName } from '../../lib/categoryUtils.js';
 import { useAreas } from '../../hooks/useAreas.js';
 import { ApiClientError } from '../../lib/apiClient.js';
+import { AreaBreadcrumb } from '../../components/AreaBreadcrumb/index.js';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './HouseholdItemsPage.module.css';
 
@@ -220,9 +221,12 @@ export function HouseholdItemsPage() {
         sortKey: 'name',
         defaultVisible: true,
         render: (item) => (
-          <Link to={`/project/household-items/${item.id}`} className={styles.itemLink}>
-            {item.name}
-          </Link>
+          <div className={styles.titleCell}>
+            <Link to={`/project/household-items/${item.id}`} className={styles.itemLink}>
+              {item.name}
+            </Link>
+            <AreaBreadcrumb area={item.area ?? null} variant="compact" />
+          </div>
         ),
       },
       {

--- a/e2e/pages/HouseholdItemDetailPage.ts
+++ b/e2e/pages/HouseholdItemDetailPage.ts
@@ -21,6 +21,10 @@
  * - Delete confirmation modal uses role="dialog"
  * - Budget section h2: "Budget" (rendered conditionally based on budget lines)
  * - Documents section uses LinkedDocumentsSection (same as work items, invoices)
+ *
+ * Story #1240 additions:
+ * - areaBreadcrumbNav: <nav aria-label="Area path"> rendered in .titleBreadcrumb div when area is set
+ * - areaBreadcrumb: covers both nav (area set) and muted "No area" span (area null)
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -32,6 +36,13 @@ export class HouseholdItemDetailPage {
   readonly heading: Locator;
   readonly backLink: Locator;
   readonly editButton: Locator;
+
+  // Area breadcrumb — default variant (i18n key areas.pathLabel = "Area path")
+  // When area is set: renders <nav aria-label="Area path"> inside .titleBreadcrumb div
+  // When area is null: renders <span class*="muted">No area</span>
+  readonly areaBreadcrumbNav: Locator;
+  // Covers both cases (nav or muted span)
+  readonly areaBreadcrumb: Locator;
 
   // Content sections
   readonly budgetSection: Locator;
@@ -58,6 +69,16 @@ export class HouseholdItemDetailPage {
     // Edit button — located in the pageActions area; class="editButton"
     // Multiple "Edit" buttons may exist (budget line edit). Use first() to get the page-level one.
     this.editButton = page.locator('[class*="editButton"]').first();
+
+    // Area breadcrumb — default variant rendered inside .titleBreadcrumb div below h1
+    // When area is set: <nav aria-label="Area path"> (i18n key areas.pathLabel)
+    // When area is null: <span class*="muted">No area</span>
+    this.areaBreadcrumbNav = page.getByRole('navigation', { name: /area path/i });
+    // Covers both cases (nav or muted span)
+    this.areaBreadcrumb = page
+      .getByRole('navigation', { name: /area path/i })
+      .or(page.locator('[class*="muted"]').first())
+      .first();
 
     // Budget section
     this.budgetSection = page.locator('[class*="budgetSection"], [class*="budget"]').first();

--- a/e2e/tests/budget/budget-source-lines.spec.ts
+++ b/e2e/tests/budget/budget-source-lines.spec.ts
@@ -545,7 +545,7 @@ test.describe('Unassigned area grouping', { tag: '@responsive' }, () => {
 
       // "Unassigned" area group header must be visible
       // No explicit timeout — uses project-level expect.timeout (15s for WebKit).
-      await expect(panel.getByText('Unassigned')).toBeVisible();
+      await expect(panel.getByText('Unassigned', { exact: true })).toBeVisible();
 
       // The parent item name and line description must be visible
       await expect(panel.getByText('General Work', { exact: true })).toBeVisible();

--- a/e2e/tests/household-items/household-item-breadcrumb.spec.ts
+++ b/e2e/tests/household-items/household-item-breadcrumb.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * E2E tests for AreaBreadcrumb on household-item pages (Story #1240)
+ *
+ * Validates that the AreaBreadcrumb component renders correctly on:
+ *  - Household Items list page  (compact variant — tooltip span with full path)
+ *  - Household Item detail page (default variant — <nav aria-label="Area path">)
+ *  - HouseholdItemPicker dropdown (renderSecondary compact breadcrumb in search results)
+ *
+ * Scenarios covered:
+ * 1. List page — breadcrumb with ancestors shows ancestor + area name (desktop, tablet, mobile)
+ * 2. Detail page — breadcrumb nav shows ancestor + area name segments
+ * 3. Mobile list — tooltip becomes visible on focus (any viewport — scoped to compact span)
+ * 4. List page — null area shows "No area" text in row
+ * 5. Detail page — null area shows "No area" text; nav NOT visible
+ * 6. HouseholdItemPicker — renderSecondary breadcrumb visible in search dropdown (smoke)
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { HouseholdItemsPage } from '../../pages/HouseholdItemsPage.js';
+import { HouseholdItemDetailPage } from '../../pages/HouseholdItemDetailPage.js';
+import {
+  createAreaViaApi,
+  deleteAreaViaApi,
+  createHouseholdItemViaApi,
+  deleteHouseholdItemViaApi,
+} from '../../fixtures/apiHelpers.js';
+import { API } from '../../fixtures/testData.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: List page — breadcrumb with ancestors
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'List page — breadcrumb with area ancestors (Scenario 1)',
+  { tag: '@responsive' },
+  () => {
+    test('Household item row shows compact breadcrumb with ancestor and area name', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new HouseholdItemsPage(page);
+      let rootAreaId: string | null = null;
+      let childAreaId: string | null = null;
+      let itemId: string | null = null;
+      const rootName = `${testPrefix} Ground Floor`;
+      const childName = `${testPrefix} Kitchen`;
+      const itemName = `${testPrefix} Breadcrumb List HI`;
+
+      try {
+        // Create parent → child area chain
+        rootAreaId = await createAreaViaApi(page, { name: rootName });
+        childAreaId = await createAreaViaApi(page, { name: childName, parentId: rootAreaId });
+        itemId = await createHouseholdItemViaApi(page, { name: itemName, areaId: childAreaId });
+
+        // Navigate directly with search query in URL — avoids debounce/race issues
+        await listPage.search(itemName);
+
+        const viewport = page.viewportSize();
+        const tableVisible = viewport ? viewport.width >= 768 : true;
+
+        if (tableVisible) {
+          const row = listPage.tableBody.locator('tr').filter({ hasText: itemName });
+          // The name column renders <div class*="titleCell"> containing compact AreaBreadcrumb
+          const breadcrumbSpan = row.locator('[class*="compact"]');
+          await expect(breadcrumbSpan).toBeVisible();
+          const breadcrumbText = await breadcrumbSpan.textContent();
+          expect(breadcrumbText).toContain(rootName);
+          expect(breadcrumbText).toContain(childName);
+        } else {
+          const card = listPage.cardsContainer
+            .locator('[class*="card"]')
+            .filter({ hasText: itemName });
+          const breadcrumbSpan = card.locator('[class*="compact"]');
+          await expect(breadcrumbSpan).toBeVisible();
+          const breadcrumbText = await breadcrumbSpan.textContent();
+          expect(breadcrumbText).toContain(rootName);
+          expect(breadcrumbText).toContain(childName);
+        }
+      } finally {
+        if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+        if (childAreaId) await deleteAreaViaApi(page, childAreaId);
+        if (rootAreaId) await deleteAreaViaApi(page, rootAreaId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Detail page — breadcrumb nav with ancestors
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Detail page — area path breadcrumb nav (Scenario 2)', { tag: '@responsive' }, () => {
+  test('Detail header shows nav "Area path" with ancestor and area name segments', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new HouseholdItemDetailPage(page);
+    let rootAreaId: string | null = null;
+    let childAreaId: string | null = null;
+    let itemId: string | null = null;
+    const rootName = `${testPrefix} GF HI Detail`;
+    const childName = `${testPrefix} Bathroom HI Detail`;
+    const itemName = `${testPrefix} Breadcrumb Detail HI`;
+
+    try {
+      rootAreaId = await createAreaViaApi(page, { name: rootName });
+      childAreaId = await createAreaViaApi(page, { name: childName, parentId: rootAreaId });
+      itemId = await createHouseholdItemViaApi(page, { name: itemName, areaId: childAreaId });
+
+      await detailPage.goto(itemId);
+
+      // Default variant renders <nav aria-label="Area path"> inside .titleBreadcrumb div
+      await expect(detailPage.areaBreadcrumbNav).toBeVisible();
+
+      // Verify both ancestor and area name appear inside the nav
+      const navText = await detailPage.areaBreadcrumbNav.textContent();
+      expect(navText).toContain(rootName);
+      expect(navText).toContain(childName);
+
+      // Verify individual segments via list items (li[class*="segment"])
+      const segments = detailPage.areaBreadcrumbNav.locator('[class*="segment"]');
+      const segmentTexts = await segments.allTextContents();
+      expect(segmentTexts).toContain(rootName);
+      expect(segmentTexts).toContain(childName);
+    } finally {
+      if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+      if (childAreaId) await deleteAreaViaApi(page, childAreaId);
+      if (rootAreaId) await deleteAreaViaApi(page, rootAreaId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Compact breadcrumb tooltip on focus
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Compact breadcrumb tooltip on focus (Scenario 3)', () => {
+  test('Focusing the compact breadcrumb span reveals the tooltip with full path', async ({
+    page,
+    testPrefix,
+  }) => {
+    // This test validates the tooltip focus interaction.
+    // The Tooltip component shows on onFocus (and onMouseEnter).
+    // Tooltip content = the full path string (e.g. "Root › Child › Grandchild").
+    // Tooltip uses CSS opacity: 0 → 1 (not display:none), so toBeVisible() works.
+    const listPage = new HouseholdItemsPage(page);
+    let rootAreaId: string | null = null;
+    let child1Id: string | null = null;
+    let child2Id: string | null = null;
+    let child3Id: string | null = null;
+    let itemId: string | null = null;
+
+    const rootName = `${testPrefix} HI Property`;
+    const houseName = `${testPrefix} HI House`;
+    const floorName = `${testPrefix} HI Floor`;
+    const kitchenName = `${testPrefix} HI Kitchen`;
+    const itemName = `${testPrefix} Tooltip HI Test`;
+
+    try {
+      rootAreaId = await createAreaViaApi(page, { name: rootName });
+      child1Id = await createAreaViaApi(page, { name: houseName, parentId: rootAreaId });
+      child2Id = await createAreaViaApi(page, { name: floorName, parentId: child1Id });
+      child3Id = await createAreaViaApi(page, { name: kitchenName, parentId: child2Id });
+      itemId = await createHouseholdItemViaApi(page, { name: itemName, areaId: child3Id });
+
+      await listPage.search(itemName);
+
+      // Find the compact breadcrumb span (tabIndex=0) for this item.
+      // Works in both table rows (desktop/tablet) and cards (mobile).
+      const viewport = page.viewportSize();
+      const tableVisible = viewport ? viewport.width >= 768 : true;
+
+      let breadcrumbSpan;
+      if (tableVisible) {
+        const row = listPage.tableBody.locator('tr').filter({ hasText: itemName });
+        breadcrumbSpan = row.locator('[tabIndex="0"][class*="compact"]');
+      } else {
+        const card = listPage.cardsContainer
+          .locator('[class*="card"]')
+          .filter({ hasText: itemName });
+        breadcrumbSpan = card.locator('[tabIndex="0"][class*="compact"]');
+      }
+
+      await expect(breadcrumbSpan).toBeVisible();
+
+      // Scroll into view and focus — this triggers the Tooltip onFocus handler
+      await breadcrumbSpan.scrollIntoViewIfNeeded();
+      await breadcrumbSpan.focus();
+
+      // The tooltip element (role="tooltip") should become visible (opacity: 1)
+      // The tooltip content is the full path: "HI Property › HI House › HI Floor › HI Kitchen"
+      const tooltip = page.getByRole('tooltip');
+      await expect(tooltip).toBeVisible();
+
+      const tooltipText = await tooltip.textContent();
+      expect(tooltipText).toContain(rootName);
+      expect(tooltipText).toContain(kitchenName);
+    } finally {
+      if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+      if (child3Id) await deleteAreaViaApi(page, child3Id);
+      if (child2Id) await deleteAreaViaApi(page, child2Id);
+      if (child1Id) await deleteAreaViaApi(page, child1Id);
+      if (rootAreaId) await deleteAreaViaApi(page, rootAreaId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: List page — null area shows "No area"
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'List page — null area shows "No area" (Scenario 4)',
+  { tag: '@responsive' },
+  () => {
+    test('Household item with no area assigned shows "No area" text in list row', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new HouseholdItemsPage(page);
+      let itemId: string | null = null;
+      const itemName = `${testPrefix} No Area HI List`;
+
+      try {
+        // Create household item with no areaId
+        itemId = await createHouseholdItemViaApi(page, { name: itemName });
+
+        await listPage.search(itemName);
+
+        // Null area renders <span class*="muted">No area</span> inside the name column's titleCell
+        // Works in both table rows and mobile cards
+        const viewport = page.viewportSize();
+        const tableVisible = viewport ? viewport.width >= 768 : true;
+
+        if (tableVisible) {
+          const row = listPage.tableBody.locator('tr').filter({ hasText: itemName });
+          await expect(row.getByText('No area', { exact: true })).toBeVisible();
+        } else {
+          const card = listPage.cardsContainer
+            .locator('[class*="card"]')
+            .filter({ hasText: itemName });
+          await expect(card.getByText('No area', { exact: true })).toBeVisible();
+        }
+      } finally {
+        if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: Detail page — null area shows "No area"
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Detail page — null area shows "No area" (Scenario 5)',
+  { tag: '@responsive' },
+  () => {
+    test('Household item with no area assigned shows "No area" text in detail header', async ({
+      page,
+      testPrefix,
+    }) => {
+      const detailPage = new HouseholdItemDetailPage(page);
+      let itemId: string | null = null;
+      const itemName = `${testPrefix} No Area HI Detail`;
+
+      try {
+        itemId = await createHouseholdItemViaApi(page, { name: itemName });
+
+        await detailPage.goto(itemId);
+
+        // Null area renders <span class*="muted">No area</span> (no nav)
+        // Use .first() to pick the first occurrence in case multiple muted spans exist
+        await expect(page.getByText('No area', { exact: true }).first()).toBeVisible();
+
+        // The nav element should NOT be present (area is null → no nav rendered)
+        await expect(detailPage.areaBreadcrumbNav).not.toBeVisible();
+      } finally {
+        if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: HouseholdItemPicker — renderSecondary breadcrumb in dropdown
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('HouseholdItemPicker — renderSecondary breadcrumb in search dropdown (Scenario 6)', () => {
+  test('Opening the HI picker and searching shows compact area breadcrumb in dropdown result', async ({
+    page,
+    testPrefix,
+  }) => {
+    // The HouseholdItemPicker is used on the InvoiceDetailPage to link household items
+    // to invoice budget lines. We create a vendor and invoice via API, navigate to the
+    // invoice detail page, open the "Add Budget Line" modal, and confirm the compact
+    // AreaBreadcrumb renders for the result in the HouseholdItemPicker dropdown.
+    //
+    // Note: showItemsOnFocus=true means the picker populates results on focus without
+    // needing to type — we focus then also fill the query to narrow results reliably.
+
+    let rootAreaId: string | null = null;
+    let childAreaId: string | null = null;
+    let itemId: string | null = null;
+    let vendorId: string | null = null;
+    let invoiceId: string | null = null;
+
+    const rootName = `${testPrefix} Picker Root`;
+    const childName = `${testPrefix} Picker Child`;
+    const itemName = `${testPrefix} Picker HI`;
+
+    try {
+      rootAreaId = await createAreaViaApi(page, { name: rootName });
+      childAreaId = await createAreaViaApi(page, { name: childName, parentId: rootAreaId });
+      itemId = await createHouseholdItemViaApi(page, { name: itemName, areaId: childAreaId });
+
+      // Create vendor and invoice via inline API calls (no shared helper for these yet)
+      const vendorResp = await page.request.post(API.vendors, {
+        data: { name: `${testPrefix} Picker Vendor` },
+      });
+      expect(vendorResp.ok()).toBeTruthy();
+      const vendorBody = (await vendorResp.json()) as { vendor: { id: string } };
+      vendorId = vendorBody.vendor.id;
+
+      const invoiceResp = await page.request.post(`${API.vendors}/${vendorId}/invoices`, {
+        data: { amount: 100, date: '2026-01-15', status: 'draft' },
+      });
+      expect(invoiceResp.ok()).toBeTruthy();
+      const invoiceBody = (await invoiceResp.json()) as { invoice: { id: string } };
+      invoiceId = invoiceBody.invoice.id;
+
+      // Navigate to invoice detail page where HouseholdItemPicker is rendered in the
+      // "Add Budget Line" modal
+      await page.goto(`/budget/invoices/${invoiceId}`);
+      await page.getByRole('heading', { level: 1 }).waitFor({ state: 'visible' });
+
+      // Open the "Add Budget Line" modal
+      const addBudgetLineButton = page.getByRole('button', { name: '+ Add Budget Line', exact: true });
+      await addBudgetLineButton.waitFor({ state: 'visible' });
+      await addBudgetLineButton.click();
+
+      // The modal (role=dialog aria-labelledby="picker-title") opens with Step 1
+      const modal = page.getByRole('dialog', { name: 'Add Budget Line' });
+      await expect(modal).toBeVisible();
+
+      // The HouseholdItemPicker is rendered in the "Household Item" tab with
+      // placeholder="Search household items..." and showItemsOnFocus=true.
+      const pickerInput = modal.getByPlaceholder('Search household items...');
+      await pickerInput.waitFor({ state: 'visible' });
+
+      // Fill the query to find the specific item
+      await pickerInput.fill(itemName);
+
+      // Wait for the listbox to appear
+      const listbox = page.getByRole('listbox');
+      await expect(listbox).toBeVisible();
+
+      // Find the option matching our item
+      const option = listbox.getByRole('option', { name: new RegExp(itemName) });
+      await expect(option).toBeVisible();
+
+      // The renderSecondary prop renders a compact AreaBreadcrumb inside each option.
+      // The compact variant renders a <span class*="compact"> containing the area path text.
+      // Verify the breadcrumb text appears in the option — both ancestor and leaf name.
+      const secondaryBreadcrumb = option.locator('[class*="compact"]');
+      await expect(secondaryBreadcrumb).toBeVisible();
+      const breadcrumbText = await secondaryBreadcrumb.textContent();
+      expect(breadcrumbText).toContain(rootName);
+      expect(breadcrumbText).toContain(childName);
+    } finally {
+      // Invoice is deleted with vendor (cascade) — delete invoice first, then vendor
+      if (invoiceId && vendorId) {
+        await page.request.delete(`${API.vendors}/${vendorId}/invoices/${invoiceId}`);
+      }
+      if (vendorId) await page.request.delete(`${API.vendors}/${vendorId}`);
+      if (itemId) await deleteHouseholdItemViaApi(page, itemId);
+      if (childAreaId) await deleteAreaViaApi(page, childAreaId);
+      if (rootAreaId) await deleteAreaViaApi(page, rootAreaId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Compact `AreaBreadcrumb` wired into **HouseholdItemsPage** list rows, showing each item's full area ancestry inline
- Default `AreaBreadcrumb` added below the title in **HouseholdItemDetailPage** header for at-a-glance location context
- **HouseholdItemPicker** `renderSecondary` slot populated with compact `AreaBreadcrumb`, surfacing area context in search/pick results

Fixes #1240

## Test plan

- [x] 28 new unit tests across 3 breadcrumb test files (HouseholdItemsPage, HouseholdItemDetailPage, HouseholdItemPicker)
- [x] 6 new E2E scenarios in `household-item-breadcrumb.spec.ts` + POM locator additions
- [x] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>