### PR TITLE
feat(vendors): move vendors to settings section

### DIFF
--- a/.claude/agent-memory/e2e-test-engineer/MEMORY.md
+++ b/.claude/agent-memory/e2e-test-engineer/MEMORY.md
@@ -9,6 +9,16 @@
 - `checkbox.uncheck()` timeout: sticky `actionBar` (position:sticky; bottom:0) covers the checkbox on narrow viewports after Playwright's internal `scrollIntoViewIfNeeded()` positions the element under the bar. Fix: use `checkbox.click({ force: true })` to bypass coverage check.
 - `waitForURL('**/project/work-items/**')` resolves immediately on `/new` — glob `**` matches `new`. Fix: use UUID regex `waitForURL(/\/project\/work-items\/[0-9a-f]{8}-...-[0-9a-f]{12}$/)`.
 
+## Vendors to Settings Migration E2E (Story #1283, 2026-04-18)
+
+- Vendors moved from `/budget/vendors` to `/settings/vendors`; legacy redirects via React Router `<Navigate replace>`
+- `VENDORS_ROUTE` in VendorsPage POM = `/settings/vendors`; `ROUTES.budgetVendors` renamed to `ROUTES.settingsVendors` in testData.ts
+- `vendors.title` i18n key still = "Budget" — h1 heading on VendorsPage remains "Budget" (not "Vendors")
+- VendorsPage SubNav: `ariaLabel="Settings section navigation"` (was "Budget section navigation")
+- i18n.spec.ts German vendors test: updated SubNav aria-label + route constant
+- `e2e/tests/budget/vendors.spec.ts` deleted; moved to `e2e/tests/vendors/vendors.spec.ts`
+- Pre-existing CI failure on shard 5 (run 24531406436): milestones `getErrorBannerText()` returning null — not vendors-related
+
 ## HI Breadcrumb E2E (Story #1240, 2026-04-17)
 
 - HouseholdItemDetailPage POM: `areaBreadcrumbNav` + `areaBreadcrumb` added (same pattern as WorkItemDetailPage)

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -96,9 +96,10 @@ jest.unstable_mockModule('./lib/householdItemsApi.js', () => ({
 }));
 
 const mockFetchVendors = jest.fn<typeof VendorsApiTypes.fetchVendors>();
+const mockFetchVendor = jest.fn<typeof VendorsApiTypes.fetchVendor>();
 jest.unstable_mockModule('./lib/vendorsApi.js', () => ({
   fetchVendors: mockFetchVendors,
-  fetchVendor: jest.fn<typeof VendorsApiTypes.fetchVendor>(),
+  fetchVendor: mockFetchVendor,
   createVendor: jest.fn<typeof VendorsApiTypes.createVendor>(),
   updateVendor: jest.fn<typeof VendorsApiTypes.updateVendor>(),
   deleteVendor: jest.fn<typeof VendorsApiTypes.deleteVendor>(),
@@ -230,6 +231,7 @@ describe('App', () => {
     mockListWorkItems.mockReset();
     mockListHouseholdItems.mockReset();
     mockFetchVendors.mockReset();
+    mockFetchVendor.mockReset();
     mockListUsers.mockReset();
     mockFetchAllInvoices.mockReset();
     mockFetchWorkItemBudgets.mockReset();
@@ -303,6 +305,10 @@ describe('App', () => {
       items: [],
       pagination: { page: 1, pageSize: 25, totalItems: 0, totalPages: 0 },
     });
+
+    // Default: fetchVendor stays pending — keeps VendorDetailPage in loading state
+    // when the /settings/vendors/:id route is tested via App.test.tsx
+    mockFetchVendor.mockReturnValue(new Promise(() => {}));
 
     // Default: vendors returns empty list (used by HouseholdItemsPage vendor filter)
     mockFetchVendors.mockResolvedValue({
@@ -460,5 +466,67 @@ describe('App', () => {
       { timeout: 5000 },
     );
     expect(heading).toBeInTheDocument();
+  });
+
+  it('navigates to VendorsPage at /settings/vendors', async () => {
+    window.history.pushState({}, 'Vendors', '/settings/vendors');
+    render(<App />);
+
+    // VendorsPage shows a Settings SubNav — the nav aria-label is "Settings section navigation"
+    // Wait for lazy-loaded VendorsPage to resolve and render the SubNav
+    const nav = await screen.findByRole(
+      'navigation',
+      { name: /settings section navigation/i },
+      { timeout: 5000 },
+    );
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('navigates to VendorDetailPage at /settings/vendors/:id', async () => {
+    window.history.pushState({}, 'Vendor Detail', '/settings/vendors/vendor-1');
+    render(<App />);
+
+    // VendorDetailPage shows a "loading vendor" text immediately and then the
+    // "Back to Vendors" button once the loading state settles.
+    // Since the API is mocked to never resolve (no fetchVendor mock), we check
+    // that the page renders without crashing by verifying the loading indicator.
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    // VendorDetailPage is the active route — the loading vendor text appears
+    // from the page itself (before the API call settles)
+    // The page title is set dynamically; confirm the route rendered (no 404)
+    expect(screen.queryByRole('heading', { name: /404.*not found/i })).not.toBeInTheDocument();
+  });
+
+  it('redirects /budget/vendors to /settings/vendors', async () => {
+    window.history.pushState({}, 'Budget Vendors', '/budget/vendors');
+    render(<App />);
+
+    // After redirect, VendorsPage at /settings/vendors renders the Settings SubNav
+    const nav = await screen.findByRole(
+      'navigation',
+      { name: /settings section navigation/i },
+      { timeout: 5000 },
+    );
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('redirects /budget/vendors/:id to /settings/vendors/:id (preserves id param)', async () => {
+    window.history.pushState({}, 'Budget Vendor Detail', '/budget/vendors/vendor-42');
+    render(<App />);
+
+    // After ParamRedirect, VendorDetailPage at /settings/vendors/vendor-42 renders
+    // without crashing and without showing a 404
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    expect(screen.queryByRole('heading', { name: /404.*not found/i })).not.toBeInTheDocument();
   });
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -153,8 +153,6 @@ export function App() {
                         path="categories"
                         element={<Navigate to="/settings/manage?tab=budget-categories" replace />}
                       />
-                      <Route path="vendors" element={<VendorsPage />} />
-                      <Route path="vendors/:id" element={<VendorDetailPage />} />
                       <Route path="sources" element={<BudgetSourcesPage />} />
                       <Route path="subsidies" element={<SubsidyProgramsPage />} />
                       <Route path="invoices" element={<InvoicesPage />} />
@@ -209,6 +207,8 @@ export function App() {
                       <Route index element={<Navigate to="profile" replace />} />
                       <Route path="profile" element={<ProfilePage />} />
                       <Route path="manage" element={<ManagePage />} />
+                      <Route path="vendors" element={<VendorsPage />} />
+                      <Route path="vendors/:id" element={<VendorDetailPage />} />
                       <Route path="users" element={<UserManagementPage />} />
                       <Route path="backups" element={<BackupsPage />} />
                     </Route>
@@ -252,6 +252,14 @@ export function App() {
                     <Route path="tags" element={<Navigate to="/settings/manage" replace />} />
                     <Route path="profile" element={<Navigate to="/settings/profile" replace />} />
                     <Route path="admin/users" element={<Navigate to="/settings/users" replace />} />
+                    <Route
+                      path="budget/vendors"
+                      element={<Navigate to="/settings/vendors" replace />}
+                    />
+                    <Route
+                      path="budget/vendors/:id"
+                      element={<ParamRedirect to="/settings/vendors/:id" />}
+                    />
 
                     <Route path="*" element={<NotFoundPage />} />
                   </Route>

--- a/client/src/components/QuickActionsCard/QuickActionsCard.test.tsx
+++ b/client/src/components/QuickActionsCard/QuickActionsCard.test.tsx
@@ -77,7 +77,7 @@ describe('QuickActionsCard', () => {
 
     const link = screen.getByRole('link', { name: /^vendors$/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/budget/vendors');
+    expect(link).toHaveAttribute('href', '/settings/vendors');
   });
 
   // ── Test 7: All links are keyboard accessible ─────────────────────────────

--- a/client/src/components/QuickActionsCard/QuickActionsCard.tsx
+++ b/client/src/components/QuickActionsCard/QuickActionsCard.tsx
@@ -48,7 +48,7 @@ export function QuickActionsCard() {
           {t('cards.quickActions.invoices')}
         </Link>
         <Link
-          to="/budget/vendors"
+          to="/settings/vendors"
           className={styles.quickLink}
           aria-label={t('cards.quickActions.vendors')}
         >

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -217,7 +217,7 @@
     }
   },
   "vendors": {
-    "title": "Budget",
+    "title": "Auftragnehmer",
     "sectionTitle": "Auftragnehmer",
     "addVendor": "Auftragnehmer Hinzufügen",
     "addFirstVendor": "Ersten Auftragnehmer Hinzufügen",

--- a/client/src/i18n/de/common.json
+++ b/client/src/i18n/de/common.json
@@ -101,13 +101,13 @@
     "budget": {
       "overview": "Übersicht",
       "invoices": "Rechnungen",
-      "vendors": "Auftragnehmer",
       "sources": "Geldquellen",
       "subsidies": "Zuschüsse"
     },
     "settings": {
       "profile": "Profil",
       "manage": "Verwalten",
+      "vendors": "Auftragnehmer",
       "userManagement": "Benutzerverwaltung",
       "backups": "Sicherungen"
     }

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -226,7 +226,7 @@
     }
   },
   "vendors": {
-    "title": "Budget",
+    "title": "Vendors",
     "sectionTitle": "Vendors",
     "addVendor": "Add Vendor",
     "addFirstVendor": "Add First Vendor",

--- a/client/src/i18n/en/common.json
+++ b/client/src/i18n/en/common.json
@@ -101,13 +101,13 @@
     "budget": {
       "overview": "Overview",
       "invoices": "Invoices",
-      "vendors": "Vendors",
       "sources": "Sources",
       "subsidies": "Subsidies"
     },
     "settings": {
       "profile": "Profile",
       "manage": "Manage",
+      "vendors": "Vendors",
       "userManagement": "User Management",
       "backups": "Backups"
     }

--- a/client/src/pages/BackupsPage/BackupsPage.tsx
+++ b/client/src/pages/BackupsPage/BackupsPage.tsx
@@ -32,6 +32,7 @@ export function BackupsPage() {
   const settingsTabs: SubNavTab[] = [
     { labelKey: 'subnav.settings.profile', to: '/settings/profile', ns: 'common' },
     { labelKey: 'subnav.settings.manage', to: '/settings/manage', ns: 'common' },
+    { labelKey: 'subnav.settings.vendors', to: '/settings/vendors', ns: 'common' },
     {
       labelKey: 'subnav.settings.userManagement',
       to: '/settings/users',

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.test.tsx
@@ -1103,7 +1103,7 @@ describe('BudgetOverviewPage', () => {
       expect(screen.getByTestId('location')).toHaveTextContent('/budget/invoices');
     });
 
-    it('clicking Add Vendor menu item navigates to /budget/vendors', async () => {
+    it('clicking Add Vendor menu item navigates to /settings/vendors', async () => {
       const user = userEvent.setup();
       mockFetchBudgetOverview.mockReturnValueOnce(new Promise(() => {}));
 
@@ -1113,7 +1113,7 @@ describe('BudgetOverviewPage', () => {
       await user.click(screen.getByTestId('budget-overview-add-button'));
       await user.click(screen.getByTestId('budget-overview-add-vendor'));
 
-      expect(screen.getByTestId('location')).toHaveTextContent('/budget/vendors');
+      expect(screen.getByTestId('location')).toHaveTextContent('/settings/vendors');
     });
   });
 });

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.tsx
@@ -18,7 +18,6 @@ import styles from './BudgetOverviewPage.module.css';
 const BUDGET_TABS: SubNavTab[] = [
   { labelKey: 'subnav.budget.overview', to: '/budget/overview' },
   { labelKey: 'subnav.budget.invoices', to: '/budget/invoices' },
-  { labelKey: 'subnav.budget.vendors', to: '/budget/vendors' },
   { labelKey: 'subnav.budget.sources', to: '/budget/sources' },
   { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies' },
 ];
@@ -288,7 +287,7 @@ export function BudgetOverviewPage() {
             role="menuitem"
             onClick={() => {
               setAddOpen(false);
-              void navigate('/budget/vendors');
+              void navigate('/settings/vendors');
             }}
             data-testid="budget-overview-add-vendor"
           >

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -28,7 +28,6 @@ import styles from './BudgetSourcesPage.module.css';
 const BUDGET_TABS: SubNavTab[] = [
   { labelKey: 'subnav.budget.overview', to: '/budget/overview' },
   { labelKey: 'subnav.budget.invoices', to: '/budget/invoices' },
-  { labelKey: 'subnav.budget.vendors', to: '/budget/vendors' },
   { labelKey: 'subnav.budget.sources', to: '/budget/sources' },
   { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies' },
 ];

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
@@ -535,7 +535,7 @@ describe('HouseholdItemDetailPage', () => {
       await waitFor(() => {
         const vendorLink = screen.getByRole('link', { name: 'IKEA' });
         expect(vendorLink).toBeInTheDocument();
-        expect(vendorLink).toHaveAttribute('href', '/budget/vendors/vendor-1');
+        expect(vendorLink).toHaveAttribute('href', '/settings/vendors/vendor-1');
       });
     });
 

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -802,7 +802,7 @@ export function HouseholdItemDetailPage() {
               <dt className={styles.infoLabel}>{t('detail.details.vendor')}</dt>
               <dd className={styles.infoValue}>
                 {item.vendor ? (
-                  <Link to={`/budget/vendors/${item.vendor.id}`} className={styles.infoLink}>
+                  <Link to={`/settings/vendors/${item.vendor.id}`} className={styles.infoLink}>
                     {item.vendor.name}
                   </Link>
                 ) : (

--- a/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
@@ -243,7 +243,7 @@ export function InvoiceDetailPage() {
             <div className={styles.infoRow}>
               <dt className={styles.infoLabel}>{t('invoiceDetail.detailFields.vendor')}</dt>
               <dd className={styles.infoValue}>
-                <Link to={`/budget/vendors/${invoice.vendorId}`} className={styles.infoLink}>
+                <Link to={`/settings/vendors/${invoice.vendorId}`} className={styles.infoLink}>
                   {invoice.vendorName}
                 </Link>
               </dd>

--- a/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
@@ -211,7 +211,7 @@ describe('InvoicesPage', () => {
         <Routes>
           <Route path="/budget/invoices" element={<InvoicesPageModule.InvoicesPage />} />
           <Route path="/budget/invoices/:id" element={<div>Invoice Detail</div>} />
-          <Route path="/budget/vendors/:id" element={<div>Vendor Detail</div>} />
+          <Route path="/settings/vendors/:id" element={<div>Vendor Detail</div>} />
         </Routes>
         <LocationDisplay />
       </MemoryRouter>,

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -19,7 +19,6 @@ import styles from './InvoicesPage.module.css';
 const BUDGET_TABS: SubNavTab[] = [
   { labelKey: 'subnav.budget.overview', to: '/budget/overview' },
   { labelKey: 'subnav.budget.invoices', to: '/budget/invoices' },
-  { labelKey: 'subnav.budget.vendors', to: '/budget/vendors' },
   { labelKey: 'subnav.budget.sources', to: '/budget/sources' },
   { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies' },
 ];
@@ -297,7 +296,7 @@ export function InvoicesPage() {
         filterParamKey: 'vendorId',
         enumOptions: vendors.map((v) => ({ value: v.id, label: v.name })),
         render: (inv) => (
-          <Link to={`/budget/vendors/${inv.vendorId}`} className={styles.vendorLink}>
+          <Link to={`/settings/vendors/${inv.vendorId}`} className={styles.vendorLink}>
             {inv.vendorName}
           </Link>
         ),

--- a/client/src/pages/ManagePage/ManagePage.tsx
+++ b/client/src/pages/ManagePage/ManagePage.tsx
@@ -2139,6 +2139,7 @@ export function ManagePage() {
   const settingsTabs: SubNavTab[] = [
     { labelKey: 'subnav.settings.profile', to: '/settings/profile', ns: 'common' },
     { labelKey: 'subnav.settings.manage', to: '/settings/manage', ns: 'common' },
+    { labelKey: 'subnav.settings.vendors', to: '/settings/vendors', ns: 'common' },
     {
       labelKey: 'subnav.settings.userManagement',
       to: '/settings/users',

--- a/client/src/pages/ProfilePage/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage/ProfilePage.tsx
@@ -25,6 +25,7 @@ export function ProfilePage() {
   const settingsTabs: SubNavTab[] = [
     { labelKey: 'subnav.settings.profile', to: '/settings/profile', ns: 'common' },
     { labelKey: 'subnav.settings.manage', to: '/settings/manage', ns: 'common' },
+    { labelKey: 'subnav.settings.vendors', to: '/settings/vendors', ns: 'common' },
     {
       labelKey: 'subnav.settings.userManagement',
       to: '/settings/users',

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
@@ -25,7 +25,6 @@ import styles from './SubsidyProgramsPage.module.css';
 const BUDGET_TABS: SubNavTab[] = [
   { labelKey: 'subnav.budget.overview', to: '/budget/overview', ns: 'common' },
   { labelKey: 'subnav.budget.invoices', to: '/budget/invoices', ns: 'common' },
-  { labelKey: 'subnav.budget.vendors', to: '/budget/vendors', ns: 'common' },
   { labelKey: 'subnav.budget.sources', to: '/budget/sources', ns: 'common' },
   { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies', ns: 'common' },
 ];

--- a/client/src/pages/UserManagementPage/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage/UserManagementPage.tsx
@@ -43,6 +43,7 @@ export function UserManagementPage() {
   const settingsTabs: SubNavTab[] = [
     { labelKey: 'subnav.settings.profile', to: '/settings/profile', ns: 'common' },
     { labelKey: 'subnav.settings.manage', to: '/settings/manage', ns: 'common' },
+    { labelKey: 'subnav.settings.vendors', to: '/settings/vendors', ns: 'common' },
     {
       labelKey: 'subnav.settings.userManagement',
       to: '/settings/users',

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.test.tsx
@@ -196,10 +196,10 @@ describe('VendorDetailPage', () => {
    */
   function renderPage(vendorId: string = 'vendor-1') {
     return render(
-      <MemoryRouter initialEntries={[`/budget/vendors/${vendorId}`]}>
+      <MemoryRouter initialEntries={[`/settings/vendors/${vendorId}`]}>
         <Routes>
-          <Route path="/budget/vendors/:id" element={<VendorDetailPage />} />
-          <Route path="/budget/vendors" element={<div>Vendors List Page</div>} />
+          <Route path="/settings/vendors/:id" element={<VendorDetailPage />} />
+          <Route path="/settings/vendors" element={<div>Vendors List Page</div>} />
           <Route
             path="/budget/invoices/:id"
             element={<div data-testid="invoice-detail-page">Invoice Detail</div>}

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
@@ -184,7 +184,7 @@ export function VendorDetailPage() {
 
     try {
       await deleteVendor(id);
-      navigate('/budget/vendors');
+      navigate('/settings/vendors');
     } catch (err) {
       if (err instanceof ApiClientError) {
         if (err.statusCode === 409) {
@@ -338,7 +338,7 @@ export function VendorDetailPage() {
             <button
               type="button"
               className={styles.secondaryButton}
-              onClick={() => navigate('/budget/vendors')}
+              onClick={() => navigate('/settings/vendors')}
             >
               {t('vendorDetail.backToVendors')}
             </button>
@@ -359,7 +359,7 @@ export function VendorDetailPage() {
           <button
             type="button"
             className={styles.backButton}
-            onClick={() => navigate('/budget/vendors')}
+            onClick={() => navigate('/settings/vendors')}
           >
             ← {t('vendorDetail.backToVendors')}
           </button>

--- a/client/src/pages/VendorsPage/VendorsPage.test.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.test.tsx
@@ -145,7 +145,7 @@ let VendorsPage: any;
 
 function renderPage() {
   return render(
-    <MemoryRouter initialEntries={['/budget/vendors']}>
+    <MemoryRouter initialEntries={['/settings/vendors']}>
       <VendorsPage />
     </MemoryRouter>,
   );
@@ -200,6 +200,19 @@ describe('VendorsPage', () => {
       await waitFor(() => {
         expect(screen.queryByRole('status')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('settings subnav', () => {
+    it('renders the Settings section SubNav with correct aria-label', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Settings section navigation' });
+      expect(nav).toBeInTheDocument();
     });
   });
 
@@ -465,6 +478,38 @@ describe('VendorsPage', () => {
       fireEvent.click(screen.getAllByTestId('vendor-menu-button-vendor-1')[0]);
 
       expect(screen.getAllByTestId('vendor-delete-vendor-1').length).toBeGreaterThan(0);
+    });
+
+    it('vendor name link points to /settings/vendors/:id', async () => {
+      const vendor = makeVendor({ id: 'vendor-1', name: 'Acme Construction' });
+      mockFetchVendors.mockResolvedValueOnce(defaultFetchResponse([vendor]));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Acme Construction').length).toBeGreaterThan(0);
+      });
+
+      // The vendor name rendered by the DataTable name column is a <Link to="/settings/vendors/:id">
+      const vendorLinks = screen.getAllByRole('link', { name: 'Acme Construction' });
+      expect(vendorLinks.length).toBeGreaterThan(0);
+      expect(vendorLinks[0]).toHaveAttribute('href', '/settings/vendors/vendor-1');
+    });
+
+    it('action menu "View" button navigates to /settings/vendors/:id', async () => {
+      const vendor = makeVendor({ id: 'vendor-1', name: 'Acme Construction' });
+      mockFetchVendors.mockResolvedValueOnce(defaultFetchResponse([vendor]));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('vendor-menu-button-vendor-1').length).toBeGreaterThan(0);
+      });
+
+      fireEvent.click(screen.getAllByTestId('vendor-menu-button-vendor-1')[0]);
+
+      // vendor-view-vendor-1 button calls navigate('/settings/vendors/vendor-1')
+      expect(screen.getAllByTestId('vendor-view-vendor-1').length).toBeGreaterThan(0);
     });
 
     it('opens delete confirmation modal when delete action is clicked', async () => {

--- a/client/src/pages/VendorsPage/VendorsPage.test.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.test.tsx
@@ -11,10 +11,18 @@ import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import type * as VendorsApiTypes from '../../lib/vendorsApi.js';
 import type * as UseTradesTypes from '../../hooks/useTrades.js';
+import type * as AuthContextTypes from '../../contexts/AuthContext.js';
 import type { Vendor } from '@cornerstone/shared';
 import { ApiClientError } from '../../lib/apiClient.js';
 
 // ─── Mock modules BEFORE importing component ────────────────────────────────
+
+// Mock AuthContext — VendorsPage uses useAuth() to compute isAdmin for Settings SubNav visibility
+const mockUseAuth = jest.fn<typeof AuthContextTypes.useAuth>();
+jest.unstable_mockModule('../../contexts/AuthContext.js', () => ({
+  useAuth: mockUseAuth,
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
 
 // Mock preferencesApi — DataTable calls useColumnPreferences -> usePreferences -> listPreferences
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -161,10 +169,30 @@ describe('VendorsPage', () => {
     }
     // Reset mocks to clear call history AND queued Once implementations from prior tests.
     // mockClear only clears call history; mockReset also drains the Once queue.
+    mockUseAuth.mockReset();
     mockFetchVendors.mockReset();
     mockCreateVendor.mockReset();
     mockDeleteVendor.mockReset();
     mockListPreferencesVendors.mockReset();
+
+    // Default: admin user so all Settings SubNav tabs are visible
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-admin',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin' as const,
+        authProvider: 'local' as const,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        deactivatedAt: null,
+      },
+      oidcEnabled: false,
+      isLoading: false,
+      error: null,
+      refreshAuth: jest.fn(async () => Promise.resolve()),
+      logout: jest.fn(async () => Promise.resolve()),
+    });
     mockListPreferencesVendors.mockResolvedValue([]);
     mockUseTrades.mockReturnValue({
       trades: [],

--- a/client/src/pages/VendorsPage/VendorsPage.tsx
+++ b/client/src/pages/VendorsPage/VendorsPage.tsx
@@ -8,6 +8,7 @@ import { Modal } from '../../components/Modal/Modal.js';
 import { PageLayout } from '../../components/PageLayout/PageLayout.js';
 import { SubNav, type SubNavTab } from '../../components/SubNav/SubNav.js';
 import { TradePicker } from '../../components/TradePicker/TradePicker.js';
+import { useAuth } from '../../contexts/AuthContext.js';
 import { useTrades } from '../../hooks/useTrades.js';
 import { useTableState } from '../../hooks/useTableState.js';
 import { useFormatters } from '../../lib/formatters.js';
@@ -17,20 +18,31 @@ import { ApiClientError } from '../../lib/apiClient.js';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './VendorsPage.module.css';
 
-const BUDGET_TABS: SubNavTab[] = [
-  { labelKey: 'subnav.budget.overview', to: '/budget/overview' },
-  { labelKey: 'subnav.budget.invoices', to: '/budget/invoices' },
-  { labelKey: 'subnav.budget.vendors', to: '/budget/vendors' },
-  { labelKey: 'subnav.budget.sources', to: '/budget/sources' },
-  { labelKey: 'subnav.budget.subsidies', to: '/budget/subsidies' },
-];
-
 export function VendorsPage() {
   const { t } = useTranslation('budget');
   const { t: tSettings } = useTranslation('settings');
   const navigate = useNavigate();
+  const { user } = useAuth();
   const { trades } = useTrades();
   const { formatDate } = useFormatters();
+
+  const settingsTabs: SubNavTab[] = [
+    { labelKey: 'subnav.settings.profile', to: '/settings/profile', ns: 'common' },
+    { labelKey: 'subnav.settings.manage', to: '/settings/manage', ns: 'common' },
+    { labelKey: 'subnav.settings.vendors', to: '/settings/vendors', ns: 'common' },
+    {
+      labelKey: 'subnav.settings.userManagement',
+      to: '/settings/users',
+      ns: 'common',
+      visible: user?.role === 'admin',
+    },
+    {
+      labelKey: 'subnav.settings.backups',
+      to: '/settings/backups',
+      ns: 'common',
+      visible: user?.role === 'admin',
+    },
+  ];
 
   // Data state
   const [vendors, setVendors] = useState<Vendor[]>([]);
@@ -233,7 +245,7 @@ export function VendorsPage() {
         sortKey: 'name',
         defaultVisible: true,
         render: (v) => (
-          <Link to={`/budget/vendors/${v.id}`} className={styles.vendorLink}>
+          <Link to={`/settings/vendors/${v.id}`} className={styles.vendorLink}>
             {v.name}
           </Link>
         ),
@@ -352,7 +364,7 @@ export function VendorsPage() {
           <button
             type="button"
             className={styles.menuItem}
-            onClick={() => navigate(`/budget/vendors/${vendor.id}`)}
+            onClick={() => navigate(`/settings/vendors/${vendor.id}`)}
             data-testid={`vendor-view-${vendor.id}`}
           >
             {t('vendors.buttons.view')}
@@ -383,7 +395,7 @@ export function VendorsPage() {
           {t('vendors.addVendor')}
         </button>
       }
-      subNav={<SubNav tabs={BUDGET_TABS} ariaLabel="Budget section navigation" />}
+      subNav={<SubNav tabs={settingsTabs} ariaLabel="Settings section navigation" />}
     >
       <DataTable<Vendor>
         pageKey="vendors"
@@ -395,7 +407,7 @@ export function VendorsPage() {
         isLoading={isLoading}
         error={error}
         getRowKey={(v) => v.id}
-        onRowClick={(v) => navigate(`/budget/vendors/${v.id}`)}
+        onRowClick={(v) => navigate(`/settings/vendors/${v.id}`)}
         renderActions={renderActions}
         tableState={tableState}
         onStateChange={handleStateChange}

--- a/e2e/fixtures/apiHelpers.ts
+++ b/e2e/fixtures/apiHelpers.ts
@@ -7,7 +7,7 @@
  * succeeds so that test setup failures surface with a clear message rather
  * than a cryptic null-reference error later in the test.
  *
- * Pattern mirrors the inline helpers in e2e/tests/budget/vendors.spec.ts but
+ * Pattern mirrors the inline helpers in e2e/tests/vendors/vendors.spec.ts but
  * lives here so multiple spec files can share them without duplication.
  */
 

--- a/e2e/fixtures/testData.ts
+++ b/e2e/fixtures/testData.ts
@@ -22,7 +22,7 @@ export const ROUTES = {
   workItemsNew: '/project/work-items/new',
   budget: '/budget/overview',
   budgetCategories: '/settings/manage?tab=budget-categories',
-  budgetVendors: '/budget/vendors',
+  settingsVendors: '/settings/vendors',
   budgetSources: '/budget/sources',
   budgetSubsidies: '/budget/subsidies',
   manage: '/settings/manage',

--- a/e2e/pages/VendorDetailPage.ts
+++ b/e2e/pages/VendorDetailPage.ts
@@ -1,5 +1,8 @@
 /**
- * Page Object Model for the Vendor Detail page (/budget/vendors/:id)
+ * Page Object Model for the Vendor Detail page (/settings/vendors/:id)
+ *
+ * Vendors moved from Budget section to Settings section in Story #1283.
+ * Legacy route /budget/vendors/:id redirects to /settings/vendors/:id via React Router.
  *
  * The page renders:
  * - A back button navigation ("← Back to Vendors")
@@ -204,7 +207,7 @@ export class VendorDetailPage {
   }
 
   async goto(vendorId: string): Promise<void> {
-    await this.page.goto(`/budget/vendors/${vendorId}`);
+    await this.page.goto(`/settings/vendors/${vendorId}`);
     await this.pageTitle.waitFor({ state: 'visible' });
   }
 
@@ -213,7 +216,7 @@ export class VendorDetailPage {
    */
   async goBackToVendors(): Promise<void> {
     await this.backToVendorsButton.click();
-    await this.page.waitForURL('**/budget/vendors');
+    await this.page.waitForURL('**/settings/vendors');
   }
 
   /**
@@ -271,7 +274,7 @@ export class VendorDetailPage {
   }
 
   /**
-   * Confirm deletion in the modal. The page navigates away to /budget/vendors on success.
+   * Confirm deletion in the modal. The page navigates away to /settings/vendors on success.
    */
   async confirmDelete(): Promise<void> {
     await this.deleteConfirmButton.click();

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -1,7 +1,11 @@
 /**
- * Page Object Model for the Vendors list page (/budget/vendors)
+ * Page Object Model for the Vendors list page (/settings/vendors)
+ *
+ * Vendors moved from Budget section to Settings section in Story #1283.
+ * Legacy route /budget/vendors redirects to /settings/vendors via React Router.
  *
  * The page renders:
+ * - A Settings SubNav (ariaLabel="Settings section navigation") with Vendors tab active
  * - A page header with an "Add Vendor" button
  * - A search input and sort controls
  * - A data table (desktop) / card list (mobile) of vendors
@@ -13,7 +17,7 @@
 
 import type { Page, Locator } from '@playwright/test';
 
-export const VENDORS_ROUTE = '/budget/vendors';
+export const VENDORS_ROUTE = '/settings/vendors';
 
 export interface CreateVendorData {
   name: string;

--- a/e2e/pages/VendorsPage.ts
+++ b/e2e/pages/VendorsPage.ts
@@ -83,7 +83,7 @@ export class VendorsPage {
     this.page = page;
 
     // Page header
-    this.heading = page.getByRole('heading', { level: 1, name: 'Budget', exact: true });
+    this.heading = page.getByRole('heading', { level: 1, name: 'Vendors', exact: true });
     this.addVendorButton = page.getByRole('button', { name: 'Add Vendor', exact: true });
 
     // Search / sort

--- a/e2e/tests/i18n/i18n.spec.ts
+++ b/e2e/tests/i18n/i18n.spec.ts
@@ -232,8 +232,10 @@ test.describe('i18n: German Locale — Responsive Layout', () => {
 
     // When: User navigates to vendors (moved to Settings in Story #1283)
     await page.goto(ROUTES.settingsVendors);
-    // German: "Budget" heading stays "Budget" in German (same word)
-    await page.getByRole('heading', { level: 1, name: 'Budget' }).waitFor({ state: 'visible' });
+    // German heading is "Auftragnehmer" (plural form of Vendor)
+    await page
+      .getByRole('heading', { level: 1, name: 'Auftragnehmer' })
+      .waitFor({ state: 'visible' });
 
     // Then: The Settings sub-nav shows "Auftragnehmer" (German for Vendors/Contractors)
     // Vendors moved from Budget section to Settings section (Story #1283).

--- a/e2e/tests/i18n/i18n.spec.ts
+++ b/e2e/tests/i18n/i18n.spec.ts
@@ -226,19 +226,19 @@ test.describe('i18n: German Locale — Responsive Layout', () => {
     await expect(sidebar.getByText('Einstellungen')).toBeVisible();
   });
 
-  test('German text renders on budget vendors page without breaking layout', async ({ page }) => {
+  test('German text renders on vendors page without breaking layout', async ({ page }) => {
     // Given: Language is set to German
     await setLanguage(page, 'de');
 
-    // When: User navigates to budget vendors
-    await page.goto(ROUTES.budgetVendors);
+    // When: User navigates to vendors (moved to Settings in Story #1283)
+    await page.goto(ROUTES.settingsVendors);
     // German: "Budget" heading stays "Budget" in German (same word)
     await page.getByRole('heading', { level: 1, name: 'Budget' }).waitFor({ state: 'visible' });
 
-    // Then: The Budget sub-nav shows "Auftragnehmer" (German for Vendors/Contractors)
-    // Visual cleanup #1185: the h2 "Vendors" section heading was removed from VendorsPage.
-    // The sub-nav link is the reliable indicator that the page is in German and loaded.
-    const subNav = page.getByRole('navigation', { name: 'Budget section navigation' });
+    // Then: The Settings sub-nav shows "Auftragnehmer" (German for Vendors/Contractors)
+    // Vendors moved from Budget section to Settings section (Story #1283).
+    // The Settings sub-nav link is the reliable indicator that the page is in German and loaded.
+    const subNav = page.getByRole('navigation', { name: 'Settings section navigation' });
     await expect(subNav.getByRole('link', { name: 'Auftragnehmer' })).toBeVisible();
   });
 

--- a/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
+++ b/e2e/tests/screenshots/capture-docs-screenshots.spec.ts
@@ -594,7 +594,7 @@ test.describe('Documentation screenshots', () => {
       return;
     }
 
-    await page.goto(`${baseUrl}${ROUTES.budgetVendors}/${vendorId}`);
+    await page.goto(`${baseUrl}${ROUTES.settingsVendors}/${vendorId}`);
     await page.waitForLoadState('networkidle');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
     await page.waitForTimeout(500);
@@ -613,7 +613,7 @@ test.describe('Documentation screenshots', () => {
       return;
     }
 
-    await page.goto(`${baseUrl}${ROUTES.budgetVendors}/${vendorId}`);
+    await page.goto(`${baseUrl}${ROUTES.settingsVendors}/${vendorId}`);
     await page.waitForLoadState('networkidle');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 

--- a/e2e/tests/vendors/vendors.spec.ts
+++ b/e2e/tests/vendors/vendors.spec.ts
@@ -1,5 +1,10 @@
 /**
- * E2E tests for Vendor/Contractor Management (Story #143)
+ * E2E tests for Vendor/Contractor Management (Story #143, migrated Story #1283)
+ *
+ * Story #1283: Vendors moved from Budget section to Settings section.
+ * - New canonical URL: /settings/vendors (and /settings/vendors/:id)
+ * - Legacy redirects: /budget/vendors → /settings/vendors
+ *                     /budget/vendors/:id → /settings/vendors/:id
  *
  * UAT Scenarios covered:
  * - Scenario 1:  Empty state when no vendors exist
@@ -17,11 +22,13 @@
  * - Scenario 17: Responsive layout on mobile/tablet/desktop (no horizontal scroll)
  * - Navigation:  Vendors → Detail → Back to Vendors
  * - Dark mode:   Page renders without layout breakage in dark mode
+ * - Redirect:    Legacy /budget/vendors → /settings/vendors (Story #1283)
+ * - SubNav:      Settings section navigation shows Vendors tab active (Story #1283)
  */
 
 import { test, expect } from '../../fixtures/auth.js';
 import type { Page } from '@playwright/test';
-import { VendorsPage } from '../../pages/VendorsPage.js';
+import { VendorsPage, VENDORS_ROUTE } from '../../pages/VendorsPage.js';
 import { VendorDetailPage } from '../../pages/VendorDetailPage.js';
 import { API } from '../../fixtures/testData.js';
 
@@ -147,7 +154,7 @@ test.describe('Create vendor — full details (Scenario 2)', { tag: '@responsive
     const vendorName = `${testPrefix} Apex Construction LLC`;
 
     try {
-      // Given: I am on the Budget > Vendors page
+      // Given: I am on the Settings > Vendors page
       await vendorsPage.goto();
       await vendorsPage.waitForVendorsLoaded();
 
@@ -370,11 +377,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
       await vendorsPage.clickView(vendorName);
 
       // Then: I am on the vendor detail page (wait for URL, not h1 which matches list page too)
-      await page.waitForURL(`**/budget/vendors/${createdId}`, { timeout: 15000 });
-
-      // Wait for the loading state to clear — CI runners can be slow and the
-      // fetch + render may take longer than the default 7s timeout
-      await expect(page.getByText('Loading vendor...')).not.toBeVisible({ timeout: 15000 });
+      await page.waitForURL(`**/settings/vendors/${createdId}`, { timeout: 15000 });
 
       // Wait for the loading state to clear — CI runners can be slow and the
       // fetch + render may take longer than the default 7s timeout
@@ -442,7 +445,7 @@ test.describe('Vendor detail page (Scenario 5)', { tag: '@responsive' }, () => {
   test('Navigating to unknown vendor ID shows error state', async ({ page }) => {
     const detailPage = new VendorDetailPage(page);
 
-    await page.goto('/budget/vendors/nonexistent-vendor-id-12345');
+    await page.goto('/settings/vendors/nonexistent-vendor-id-12345');
 
     // Then: An error card is shown
     await expect(detailPage.errorCard).toBeVisible({ timeout: 8000 });
@@ -566,7 +569,7 @@ test.describe('Delete vendor — no references (Scenario 8)', { tag: '@responsiv
     // Given: A vendor exists with no invoices
     const createdId = await createVendorViaApi(page, { name: vendorName });
 
-    // When: I navigate to Budget > Vendors and search for this vendor
+    // When: I navigate to Settings > Vendors and search for this vendor
     await vendorsPage.goto();
     await vendorsPage.waitForVendorsLoaded();
     await vendorsPage.search(vendorName);
@@ -643,9 +646,9 @@ test.describe('Delete vendor — no references (Scenario 8)', { tag: '@responsiv
     // And: I confirm
     await detailPage.confirmDelete();
 
-    // Then: I am redirected to the vendors list
-    await page.waitForURL('/budget/vendors', { timeout: 15000 });
-    expect(page.url()).toContain('/budget/vendors');
+    // Then: I am redirected to the vendors list (new canonical URL)
+    await page.waitForURL('**/settings/vendors', { timeout: 15000 });
+    expect(page.url()).toContain('/settings/vendors');
 
     // Note: vendor was deleted via UI — no API cleanup needed
     void createdId;
@@ -752,8 +755,8 @@ test.describe('Delete blocked by 409 (Scenario 9)', { tag: '@responsive' }, () =
       expect(errorText).toBeTruthy();
       expect(errorText?.toLowerCase()).toMatch(/cannot be deleted|invoices/);
 
-      // Still on detail page
-      expect(page.url()).toContain(`/budget/vendors/${createdId}`);
+      // Still on detail page (new canonical URL)
+      expect(page.url()).toContain(`/settings/vendors/${createdId}`);
 
       // Confirm button hidden
       await expect(detailPage.deleteConfirmButton).not.toBeVisible({ timeout: 3000 });
@@ -1021,10 +1024,7 @@ test.describe('List shows key info (Scenario 14)', { tag: '@responsive' }, () =>
     }
   });
 
-  test('Table has correct column headers: Name, Phone, Email, Actions', async ({
-    page,
-    testPrefix,
-  }) => {
+  test('Table has correct column headers: Name, Trade, Contact', async ({ page, testPrefix }) => {
     // Table is hidden on mobile (< 768px) — cards are shown instead
     const viewport = page.viewportSize();
     if (viewport && viewport.width < 768) {
@@ -1080,26 +1080,26 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
 
       // Navigate to detail (wait for URL change, not h1 which matches list page too)
       await vendorsPage.clickView(vendorName);
-      await page.waitForURL('**/budget/vendors/*', { timeout: 15000 });
+      await page.waitForURL('**/settings/vendors/*', { timeout: 15000 });
 
       // Wait for detail page to fully render before interacting with back button
       await expect(detailPage.infoCard).toBeVisible({ timeout: 15000 });
 
       // Navigate back via back button
       await detailPage.goBackToVendors();
-      expect(page.url()).toContain('/budget/vendors');
+      expect(page.url()).toContain('/settings/vendors');
       await vendorsPage.heading.waitFor({ state: 'visible', timeout: 15000 });
     } finally {
       if (createdId) await deleteVendorViaApi(page, createdId);
     }
   });
 
-  test('Page URL is /budget/vendors', async ({ page }) => {
+  test('Page URL is /settings/vendors', async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
     await vendorsPage.goto();
-    await page.waitForURL('/budget/vendors', { timeout: 15000 });
-    expect(page.url()).toContain('/budget/vendors');
+    await page.waitForURL(VENDORS_ROUTE, { timeout: 15000 });
+    expect(page.url()).toContain('/settings/vendors');
   });
 
   test('Page heading is "Budget" (h1)', { tag: '@smoke' }, async ({ page }) => {
@@ -1109,10 +1109,81 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
     await expect(vendorsPage.heading).toBeVisible();
     await expect(vendorsPage.heading).toHaveText('Budget');
 
-    // Visual cleanup #1185: the h2 "Vendors" section heading was removed.
-    // Verify correct sub-page loaded via the BudgetSubNav "Vendors" tab being visible.
-    const subNav = page.getByRole('navigation', { name: 'Budget section navigation' });
+    // Verify correct sub-page loaded via the SettingsSubNav "Vendors" tab being visible and active.
+    const subNav = page.getByRole('navigation', { name: 'Settings section navigation' });
     await expect(subNav.getByRole('link', { name: 'Vendors' })).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Story #1283: Legacy redirect tests
+// /budget/vendors → /settings/vendors
+// /budget/vendors/:id → /settings/vendors/:id
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Legacy redirect: /budget/vendors → /settings/vendors (Story #1283)', () => {
+  test('Navigating to /budget/vendors redirects to /settings/vendors', async ({ page }) => {
+    const vendorsPage = new VendorsPage(page);
+
+    // When: the user navigates to the old Budget > Vendors URL
+    await page.goto('/budget/vendors');
+
+    // Then: they are redirected to the new canonical Settings > Vendors URL
+    await page.waitForURL('**/settings/vendors', { timeout: 15000 });
+    expect(page.url()).toContain('/settings/vendors');
+    expect(page.url()).not.toContain('/budget/vendors');
+
+    // And: The vendors page heading is visible (page loaded correctly)
+    await expect(vendorsPage.heading).toBeVisible({ timeout: 8000 });
+  });
+
+  test('Navigating to /budget/vendors/:id redirects to /settings/vendors/:id', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new VendorDetailPage(page);
+    let createdId: string | null = null;
+
+    try {
+      // Given: A vendor exists (real ID needed for the redirect to resolve correctly)
+      createdId = await createVendorViaApi(page, {
+        name: `${testPrefix} Redirect Detail Vendor`,
+      });
+
+      // When: the user navigates to the old /budget/vendors/:id URL
+      await page.goto(`/budget/vendors/${createdId}`);
+
+      // Then: they are redirected to the new canonical /settings/vendors/:id URL
+      await page.waitForURL(`**/settings/vendors/${createdId}`, { timeout: 15000 });
+      expect(page.url()).toContain(`/settings/vendors/${createdId}`);
+      expect(page.url()).not.toContain('/budget/vendors');
+
+      // And: The vendor detail page loads correctly
+      await expect(detailPage.pageTitle).toBeVisible({ timeout: 8000 });
+      await expect(detailPage.pageTitle).toHaveText(`${testPrefix} Redirect Detail Vendor`);
+    } finally {
+      if (createdId) await deleteVendorViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Story #1283: Settings SubNav presence
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Settings SubNav shows Vendors tab active (Story #1283)', () => {
+  test('Settings section navigation is visible with Vendors tab marked active', async ({
+    page,
+  }) => {
+    // When: the user is on the Settings > Vendors page
+    await page.goto(VENDORS_ROUTE);
+
+    // Then: The Settings SubNav is present
+    const subNav = page.getByRole('navigation', { name: 'Settings section navigation' });
+    await expect(subNav).toBeVisible({ timeout: 8000 });
+
+    // And: The "Vendors" tab within it has aria-current="page" (active state)
+    const vendorsTab = subNav.getByRole('link', { name: 'Vendors' });
+    await expect(vendorsTab).toBeVisible();
+    await expect(vendorsTab).toHaveAttribute('aria-current', 'page');
   });
 });
 
@@ -1243,7 +1314,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
   test('Vendors list page renders correctly in dark mode', async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
-    await page.goto('/budget/vendors');
+    await page.goto(VENDORS_ROUTE);
     await page.evaluate(() => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
@@ -1263,7 +1334,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
   test('Add Vendor modal is usable in dark mode', async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
-    await page.goto('/budget/vendors');
+    await page.goto(VENDORS_ROUTE);
     await page.evaluate(() => {
       document.documentElement.setAttribute('data-theme', 'dark');
     });
@@ -1288,7 +1359,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
         name: `${testPrefix} Dark Mode Detail Vendor`,
       });
 
-      await page.goto(`/budget/vendors/${createdId}`);
+      await page.goto(`/settings/vendors/${createdId}`);
       await page.evaluate(() => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
@@ -1316,7 +1387,7 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
     try {
       createdId = await createVendorViaApi(page, { name: vendorName });
 
-      await page.goto('/budget/vendors');
+      await page.goto(VENDORS_ROUTE);
       await page.evaluate(() => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });

--- a/e2e/tests/vendors/vendors.spec.ts
+++ b/e2e/tests/vendors/vendors.spec.ts
@@ -1102,12 +1102,12 @@ test.describe('Navigation between list and detail pages', { tag: '@responsive' }
     expect(page.url()).toContain('/settings/vendors');
   });
 
-  test('Page heading is "Budget" (h1)', { tag: '@smoke' }, async ({ page }) => {
+  test('Page heading is "Vendors" (h1)', { tag: '@smoke' }, async ({ page }) => {
     const vendorsPage = new VendorsPage(page);
 
     await vendorsPage.goto();
     await expect(vendorsPage.heading).toBeVisible();
-    await expect(vendorsPage.heading).toHaveText('Budget');
+    await expect(vendorsPage.heading).toHaveText('Vendors');
 
     // Verify correct sub-page loaded via the SettingsSubNav "Vendors" tab being visible and active.
     const subNav = page.getByRole('navigation', { name: 'Settings section navigation' });


### PR DESCRIPTION
## Summary

- Vendors page and vendor detail pages are moved from the `/budget/` section to `/settings/` section
- Legacy `/budget/vendors` and `/budget/vendors/:id` paths redirect to their new locations
- Settings SubNav is added to VendorsPage consistent with other settings pages

## Test Changes (qa-integration-tester)

- **App.test.tsx**: 4 new route/redirect tests covering `/settings/vendors`, `/settings/vendors/:id`, and legacy redirects from `/budget/vendors`
- **VendorsPage.test.tsx**: Updated MemoryRouter URL to `/settings/vendors`; added Settings SubNav `aria-label` assertion; added vendor link `href` and action-menu view button assertions
- **VendorDetailPage.test.tsx**: Updated `renderPage` helper routes from `/budget/vendors` to `/settings/vendors` so Back/delete-success navigation works correctly
- **InvoicesPage.test.tsx**: Updated vendor detail route stub path
- **HouseholdItemDetailPage.test.tsx**: Updated vendor link `href` assertion
- **BudgetOverviewPage.test.tsx**: Updated Add Vendor navigation assertion
- **QuickActionsCard.test.tsx**: Updated Vendors link `href` assertion

## Test plan

- [ ] Quality Gates CI passes (typecheck + jest unit/integration tests + build)
- [ ] No test failures in any of the 7 modified test files
- [ ] `/settings/vendors` route renders VendorsPage with Settings SubNav
- [ ] `/budget/vendors` redirects to `/settings/vendors`
- [ ] `/budget/vendors/:id` redirects to `/settings/vendors/:id` (ParamRedirect preserves `:id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)