### PR TITLE
chore(server): adopt TS 6 using/Disposable for test cleanup and migrate FK pragma

### DIFF
--- a/server/src/db/disposables.ts
+++ b/server/src/db/disposables.ts
@@ -1,0 +1,24 @@
+/**
+ * Database-layer disposable helpers.
+ *
+ * Implements the Disposable protocol (Symbol.dispose) for SQLite database
+ * operations that need guaranteed cleanup on scope exit, including on thrown
+ * exceptions. Safe for production and test code.
+ */
+
+import type { Database } from 'better-sqlite3';
+
+/**
+ * Disables SQLite foreign key enforcement for the duration of a `using` scope.
+ * FK is OFF on construction, ON on dispose. On any exit path (including throw)
+ * FK is re-enabled. Matches the existing migrate.ts convention of unconditionally
+ * re-enabling FK at the end of each migration.
+ */
+export function foreignKeysDisabled(db: Database): Disposable {
+  db.pragma('foreign_keys = OFF');
+  return {
+    [Symbol.dispose](): void {
+      db.pragma('foreign_keys = ON');
+    },
+  };
+}

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { foreignKeysDisabled } from './disposables.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -34,17 +35,13 @@ export function runMigrations(db: Database.Database, customMigrationsDir?: strin
     if (applied.has(file)) continue;
     const sql = readFileSync(join(migrationsDir, file), 'utf-8');
 
-    // Disable FK enforcement OUTSIDE the transaction (PRAGMA is a no-op inside transactions).
-    // This prevents CASCADE deletes during table-recreation migrations.
-    db.pragma('foreign_keys = OFF');
-
-    db.transaction(() => {
-      db.exec(sql);
-      db.prepare('INSERT INTO _migrations (name) VALUES (?)').run(file);
-    })();
-
-    // Re-enable FK enforcement after migration completes
-    db.pragma('foreign_keys = ON');
+    {
+      using _fk = foreignKeysDisabled(db);
+      db.transaction(() => {
+        db.exec(sql);
+        db.prepare('INSERT INTO _migrations (name) VALUES (?)').run(file);
+      })();
+    } // FK re-enabled here even if transaction throws
 
     console.warn(`Applied migration: ${file}`);
   }

--- a/server/src/routes/backups.test.ts
+++ b/server/src/routes/backups.test.ts
@@ -11,34 +11,33 @@
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { writeFileSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildApp } from '../app.js';
 import * as userService from '../services/userService.js';
 import * as sessionService from '../services/sessionService.js';
+import { disposableTempDir } from '../test-helpers/disposables.js';
 import type { FastifyInstance } from 'fastify';
 import type { ApiErrorResponse, BackupListResponse, BackupResponse } from '@cornerstone/shared';
+import type { DisposableTempDir } from '../test-helpers/disposables.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 describe('Backup Routes', () => {
   let app: FastifyInstance;
-  let tempDir: string;
-  let backupTempDir: string;
-  let backupDir: string;
+  let tempDir: DisposableTempDir;
+  let backupTempDir: DisposableTempDir;
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(async () => {
     originalEnv = { ...process.env };
 
     // App data directory (DB lives here)
-    tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-routes-test-'));
+    tempDir = disposableTempDir('cornerstone-backup-routes-test-');
     // Backup directory MUST be outside the app data directory (config validation)
-    backupTempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-backups-test-'));
-    backupDir = backupTempDir;
+    backupTempDir = disposableTempDir('cornerstone-backup-backups-test-');
 
-    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    process.env.DATABASE_URL = join(tempDir.path, 'test.db');
     process.env.SECURE_COOKIES = 'false';
 
     app = await buildApp();
@@ -51,16 +50,8 @@ describe('Backup Routes', () => {
 
     process.env = originalEnv;
 
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    try {
-      rmSync(backupTempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
+    tempDir[Symbol.dispose]();
+    backupTempDir[Symbol.dispose]();
   });
 
   /**
@@ -223,7 +214,7 @@ describe('Backup Routes', () => {
 
     beforeEach(async () => {
       // Set BACKUP_DIR before building the app
-      process.env.BACKUP_DIR = backupDir;
+      process.env.BACKUP_DIR = backupTempDir.path;
       appWithBackup = await buildApp();
     });
 
@@ -264,13 +255,13 @@ describe('Backup Routes', () => {
 
       // Create backup dir and write fake backup files
       const { mkdirSync } = await import('node:fs');
-      mkdirSync(backupDir, { recursive: true });
+      mkdirSync(backupTempDir.path, { recursive: true });
       writeFileSync(
-        join(backupDir, 'cornerstone-backup-2026-03-22T020000Z.tar.gz'),
+        join(backupTempDir.path, 'cornerstone-backup-2026-03-22T020000Z.tar.gz'),
         'backup content',
       );
       writeFileSync(
-        join(backupDir, 'cornerstone-backup-2026-01-01T000000Z.tar.gz'),
+        join(backupTempDir.path, 'cornerstone-backup-2026-01-01T000000Z.tar.gz'),
         'older backup',
       );
 
@@ -321,9 +312,9 @@ describe('Backup Routes', () => {
     it('DELETE /api/backups/:filename returns 204 for an existing backup', async () => {
       const cookie = await createAdminWithSession();
       const { mkdirSync } = await import('node:fs');
-      mkdirSync(backupDir, { recursive: true });
+      mkdirSync(backupTempDir.path, { recursive: true });
       const filename = 'cornerstone-backup-2026-03-22T020000Z.tar.gz';
-      writeFileSync(join(backupDir, filename), 'backup content');
+      writeFileSync(join(backupTempDir.path, filename), 'backup content');
 
       const response = await appWithBackup.inject({
         method: 'DELETE',
@@ -337,9 +328,9 @@ describe('Backup Routes', () => {
     it('POST /api/backups/:filename/restore returns 202 Accepted when file exists (async response)', async () => {
       const cookie = await createAdminWithSession();
       const { mkdirSync } = await import('node:fs');
-      mkdirSync(backupDir, { recursive: true });
+      mkdirSync(backupTempDir.path, { recursive: true });
       const filename = 'cornerstone-backup-2026-03-22T020000Z.tar.gz';
-      writeFileSync(join(backupDir, filename), 'backup content');
+      writeFileSync(join(backupTempDir.path, filename), 'backup content');
 
       const response = await appWithBackup.inject({
         method: 'POST',
@@ -362,7 +353,7 @@ describe('Backup Routes', () => {
       const cookie = await createAdminWithSession();
 
       // Make the backup directory read-only so the writability probe fails
-      chmodSync(backupDir, 0o444);
+      chmodSync(backupTempDir.path, 0o444);
 
       try {
         const response = await appWithBackup.inject({
@@ -376,7 +367,7 @@ describe('Backup Routes', () => {
         expect(body.error.code).toBe('BACKUP_FAILED');
       } finally {
         // Restore permissions so afterEach cleanup can delete the directory
-        chmodSync(backupDir, 0o755);
+        chmodSync(backupTempDir.path, 0o755);
       }
     });
   });

--- a/server/src/services/backupService.test.ts
+++ b/server/src/services/backupService.test.ts
@@ -5,11 +5,11 @@
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { writeFileSync, chmodSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { disposableTempDir, disposableDb } from '../test-helpers/disposables.js';
+import type { DisposableTempDir } from '../test-helpers/disposables.js';
 
 // ─── Import service functions ───────────────────────────────────────────────
 
@@ -199,37 +199,33 @@ describe('backupService', () => {
   // ─── listBackups ──────────────────────────────────────────────────────────
 
   describe('listBackups()', () => {
-    let tempDir: string;
+    let tempDir: DisposableTempDir;
 
     beforeEach(() => {
-      tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-list-test-'));
+      tempDir = disposableTempDir('cornerstone-backup-list-test-');
     });
 
     afterEach(() => {
-      try {
-        rmSync(tempDir, { recursive: true, force: true });
-      } catch {
-        // ignore cleanup errors
-      }
+      tempDir[Symbol.dispose]();
     });
 
     it('returns empty array for an empty directory', async () => {
-      const result = await listBackups(tempDir);
+      const result = await listBackups(tempDir.path);
       expect(result).toEqual([]);
     });
 
     it('returns empty array when the directory does not exist (ENOENT)', async () => {
-      const result = await listBackups(join(tempDir, 'nonexistent-dir'));
+      const result = await listBackups(join(tempDir.path, 'nonexistent-dir'));
       expect(result).toEqual([]);
     });
 
     it('returns backup files sorted newest-first by timestamp', async () => {
       const olderFilename = 'cornerstone-backup-2026-01-01T000000Z.tar.gz';
       const newerFilename = 'cornerstone-backup-2026-06-15T120000Z.tar.gz';
-      writeFileSync(join(tempDir, olderFilename), 'older content');
-      writeFileSync(join(tempDir, newerFilename), 'newer content');
+      writeFileSync(join(tempDir.path, olderFilename), 'older content');
+      writeFileSync(join(tempDir.path, newerFilename), 'newer content');
 
-      const result = await listBackups(tempDir);
+      const result = await listBackups(tempDir.path);
 
       expect(result).toHaveLength(2);
       expect(result[0].filename).toBe(newerFilename);
@@ -238,9 +234,9 @@ describe('backupService', () => {
 
     it('returns correct BackupMeta shape for a backup file', async () => {
       const filename = 'cornerstone-backup-2026-03-22T020000Z.tar.gz';
-      writeFileSync(join(tempDir, filename), 'test content');
+      writeFileSync(join(tempDir.path, filename), 'test content');
 
-      const result = await listBackups(tempDir);
+      const result = await listBackups(tempDir.path);
 
       expect(result).toHaveLength(1);
       expect(result[0].filename).toBe(filename);
@@ -250,11 +246,11 @@ describe('backupService', () => {
     });
 
     it('ignores non-backup files in the directory', async () => {
-      writeFileSync(join(tempDir, 'README.txt'), 'readme');
-      writeFileSync(join(tempDir, 'some-other-archive.tar.gz'), 'other');
-      writeFileSync(join(tempDir, 'cornerstone-backup-2026-03-22T020000Z.tar.gz'), 'backup');
+      writeFileSync(join(tempDir.path, 'README.txt'), 'readme');
+      writeFileSync(join(tempDir.path, 'some-other-archive.tar.gz'), 'other');
+      writeFileSync(join(tempDir.path, 'cornerstone-backup-2026-03-22T020000Z.tar.gz'), 'backup');
 
-      const result = await listBackups(tempDir);
+      const result = await listBackups(tempDir.path);
 
       expect(result).toHaveLength(1);
       expect(result[0].filename).toBe('cornerstone-backup-2026-03-22T020000Z.tar.gz');
@@ -267,10 +263,10 @@ describe('backupService', () => {
         'cornerstone-backup-2026-02-10T150000Z.tar.gz',
       ];
       for (const f of files) {
-        writeFileSync(join(tempDir, f), 'content');
+        writeFileSync(join(tempDir.path, f), 'content');
       }
 
-      const result = await listBackups(tempDir);
+      const result = await listBackups(tempDir.path);
 
       expect(result).toHaveLength(3);
       // Sorted newest-first
@@ -283,56 +279,52 @@ describe('backupService', () => {
   // ─── deleteBackup ─────────────────────────────────────────────────────────
 
   describe('deleteBackup()', () => {
-    let tempDir: string;
+    let tempDir: DisposableTempDir;
 
     beforeEach(() => {
-      tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-delete-test-'));
+      tempDir = disposableTempDir('cornerstone-backup-delete-test-');
     });
 
     afterEach(() => {
-      try {
-        rmSync(tempDir, { recursive: true, force: true });
-      } catch {
-        // ignore cleanup errors
-      }
+      tempDir[Symbol.dispose]();
     });
 
     it('deletes an existing backup file successfully', async () => {
       const filename = 'cornerstone-backup-2026-03-22T020000Z.tar.gz';
-      writeFileSync(join(tempDir, filename), 'backup content');
+      writeFileSync(join(tempDir.path, filename), 'backup content');
 
-      await expect(deleteBackup(tempDir, filename)).resolves.toBeUndefined();
+      await expect(deleteBackup(tempDir.path, filename)).resolves.toBeUndefined();
 
       // Verify the file was actually removed
-      const remaining = await listBackups(tempDir);
+      const remaining = await listBackups(tempDir.path);
       expect(remaining).toHaveLength(0);
     });
 
     it('throws BackupNotFoundError (code BACKUP_NOT_FOUND) when file does not exist', async () => {
       await expect(
-        deleteBackup(tempDir, 'cornerstone-backup-2099-01-01T000000Z.tar.gz'),
+        deleteBackup(tempDir.path, 'cornerstone-backup-2099-01-01T000000Z.tar.gz'),
       ).rejects.toMatchObject({
         code: 'BACKUP_NOT_FOUND',
       });
     });
 
     it('throws BackupNotFoundError for path traversal filename (../../etc/passwd)', async () => {
-      await expect(deleteBackup(tempDir, '../../etc/passwd')).rejects.toMatchObject({
+      await expect(deleteBackup(tempDir.path, '../../etc/passwd')).rejects.toMatchObject({
         code: 'BACKUP_NOT_FOUND',
       });
     });
 
     it('throws BackupNotFoundError for filename with backslash', async () => {
       await expect(
-        deleteBackup(tempDir, 'cornerstone-backup-2026\\T000000Z.tar.gz'),
+        deleteBackup(tempDir.path, 'cornerstone-backup-2026\\T000000Z.tar.gz'),
       ).rejects.toMatchObject({
         code: 'BACKUP_NOT_FOUND',
       });
     });
 
     it('throws BackupNotFoundError for a random non-backup filename', async () => {
-      writeFileSync(join(tempDir, 'random-file.txt'), 'content');
-      await expect(deleteBackup(tempDir, 'random-file.txt')).rejects.toMatchObject({
+      writeFileSync(join(tempDir.path, 'random-file.txt'), 'content');
+      await expect(deleteBackup(tempDir.path, 'random-file.txt')).rejects.toMatchObject({
         code: 'BACKUP_NOT_FOUND',
       });
     });
@@ -340,12 +332,12 @@ describe('backupService', () => {
     it('only deletes the targeted file, leaving others intact', async () => {
       const file1 = 'cornerstone-backup-2026-01-01T000000Z.tar.gz';
       const file2 = 'cornerstone-backup-2026-06-01T000000Z.tar.gz';
-      writeFileSync(join(tempDir, file1), 'content1');
-      writeFileSync(join(tempDir, file2), 'content2');
+      writeFileSync(join(tempDir.path, file1), 'content1');
+      writeFileSync(join(tempDir.path, file2), 'content2');
 
-      await deleteBackup(tempDir, file1);
+      await deleteBackup(tempDir.path, file1);
 
-      const remaining = await listBackups(tempDir);
+      const remaining = await listBackups(tempDir.path);
       expect(remaining).toHaveLength(1);
       expect(remaining[0].filename).toBe(file2);
     });
@@ -367,51 +359,34 @@ describe('backupService', () => {
   // ─── createBackup — execution path ───────────────────────────────────────
 
   describe('createBackup() — execution path', () => {
-    let tempDir: string;
-    let backupTempDir: string;
-    let rawDb: Database.Database;
+    let tempDir: DisposableTempDir;
+    let backupTempDir: DisposableTempDir;
 
     beforeEach(() => {
       // App data directory (DB lives here) — separate from backup directory
-      tempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-exec-appdata-'));
+      tempDir = disposableTempDir('cornerstone-backup-exec-appdata-');
       // Backup directory MUST be outside the app data directory (config validation)
-      backupTempDir = mkdtempSync(join(tmpdir(), 'cornerstone-backup-exec-backups-'));
+      backupTempDir = disposableTempDir('cornerstone-backup-exec-backups-');
     });
 
     afterEach(() => {
-      // Close DB connection if open
-      try {
-        if (rawDb && rawDb.open) {
-          rawDb.close();
-        }
-      } catch {
-        // ignore
-      }
       // Restore writable permissions before cleanup (in case a test made the dir read-only)
       try {
-        chmodSync(backupTempDir, 0o755);
+        chmodSync(backupTempDir.path, 0o755);
       } catch {
         // ignore
       }
-      try {
-        rmSync(tempDir, { recursive: true, force: true });
-      } catch {
-        // ignore cleanup errors
-      }
-      try {
-        rmSync(backupTempDir, { recursive: true, force: true });
-      } catch {
-        // ignore cleanup errors
-      }
+      tempDir[Symbol.dispose]();
+      backupTempDir[Symbol.dispose]();
     });
 
     it('createBackup succeeds with a real DB and real tar: returns valid BackupMeta and writes the .tar.gz file', async () => {
-      rawDb = new Database(join(tempDir, 'test.db'));
+      using rawDb = disposableDb(join(tempDir.path, 'test.db'));
       const db = drizzle(rawDb);
 
       const config = makeConfig({
-        databaseUrl: join(tempDir, 'test.db'),
-        backupDir: backupTempDir,
+        databaseUrl: join(tempDir.path, 'test.db'),
+        backupDir: backupTempDir.path,
         backupEnabled: true,
         backupRetention: undefined,
       });
@@ -425,7 +400,7 @@ describe('backupService', () => {
       expect(result.sizeBytes).toBeGreaterThan(0);
 
       // The archive file must exist on disk
-      const archivePath = join(backupTempDir, result.filename);
+      const archivePath = join(backupTempDir.path, result.filename);
       expect(existsSync(archivePath)).toBe(true);
     });
 
@@ -435,15 +410,15 @@ describe('backupService', () => {
         return;
       }
 
-      rawDb = new Database(join(tempDir, 'test.db'));
+      using rawDb = disposableDb(join(tempDir.path, 'test.db'));
       const db = drizzle(rawDb);
 
       // Make the backup directory read-only
-      chmodSync(backupTempDir, 0o444);
+      chmodSync(backupTempDir.path, 0o444);
 
       const config = makeConfig({
-        databaseUrl: join(tempDir, 'test.db'),
-        backupDir: backupTempDir,
+        databaseUrl: join(tempDir.path, 'test.db'),
+        backupDir: backupTempDir.path,
         backupEnabled: true,
       });
 
@@ -464,8 +439,8 @@ describe('backupService', () => {
       } as any;
 
       const config = makeConfig({
-        databaseUrl: join(tempDir, 'test.db'),
-        backupDir: backupTempDir,
+        databaseUrl: join(tempDir.path, 'test.db'),
+        backupDir: backupTempDir.path,
         backupEnabled: true,
       });
 
@@ -475,12 +450,12 @@ describe('backupService', () => {
     });
 
     it('createBackup enforces retention policy and deletes oldest backups when limit is exceeded', async () => {
-      rawDb = new Database(join(tempDir, 'test.db'));
+      using rawDb = disposableDb(join(tempDir.path, 'test.db'));
       const db = drizzle(rawDb);
 
       const config = makeConfig({
-        databaseUrl: join(tempDir, 'test.db'),
-        backupDir: backupTempDir,
+        databaseUrl: join(tempDir.path, 'test.db'),
+        backupDir: backupTempDir.path,
         backupEnabled: true,
         backupRetention: 2,
       });
@@ -488,14 +463,14 @@ describe('backupService', () => {
       // Pre-seed two older backup stubs with valid filenames
       const stub1 = 'cornerstone-backup-2026-01-01T000000Z.tar.gz';
       const stub2 = 'cornerstone-backup-2026-01-02T000000Z.tar.gz';
-      writeFileSync(join(backupTempDir, stub1), 'stub content 1');
-      writeFileSync(join(backupTempDir, stub2), 'stub content 2');
+      writeFileSync(join(backupTempDir.path, stub1), 'stub content 1');
+      writeFileSync(join(backupTempDir.path, stub2), 'stub content 2');
 
       // Third backup created for real — this should push total to 3, triggering retention
       await createBackup(db, config);
 
       // After retention enforcement, only 2 files should remain
-      const remaining = await listBackups(backupTempDir);
+      const remaining = await listBackups(backupTempDir.path);
       expect(remaining).toHaveLength(2);
 
       // The two oldest stubs should have been deleted; only the 2 newest remain

--- a/server/src/test-helpers/disposables.ts
+++ b/server/src/test-helpers/disposables.ts
@@ -1,0 +1,56 @@
+/**
+ * Disposable helpers for test resource cleanup.
+ *
+ * Implements the Disposable protocol so tests can use `using` declarations
+ * for guaranteed cleanup on scope exit, including when exceptions are thrown.
+ */
+
+import BetterSqlite3 from 'better-sqlite3';
+import type { Database } from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export type DisposableDatabase = Database & Disposable;
+
+/**
+ * Opens a better-sqlite3 database and returns it as a Disposable.
+ * Close errors are swallowed (better-sqlite3 throws on double-close,
+ * which is harmless in cleanup).
+ */
+export function disposableDb(filename: string = ':memory:'): DisposableDatabase {
+  const db = new BetterSqlite3(filename) as DisposableDatabase;
+  db[Symbol.dispose] = () => {
+    try {
+      if (db.open) {
+        db.close();
+      }
+    } catch {
+      // Ignore: already closed or non-actionable error
+    }
+  };
+  return db;
+}
+
+export type DisposableTempDir = { readonly path: string } & Disposable;
+
+/**
+ * Creates a temporary directory via mkdtempSync. On dispose, recursively deletes it.
+ * Deletion errors are swallowed (ENOENT is already handled by force: true; other
+ * errors are non-actionable in a test cleanup context).
+ */
+export function disposableTempDir(prefix: string = 'cornerstone-test-'): DisposableTempDir {
+  const dirPath = mkdtempSync(join(tmpdir(), prefix));
+  return {
+    get path(): string {
+      return dirPath;
+    },
+    [Symbol.dispose](): void {
+      try {
+        rmSync(dirPath, { recursive: true, force: true });
+      } catch {
+        // Ignore
+      }
+    },
+  };
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "./src",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ES2024", "DOM", "DOM.Iterable", "esnext.disposable"],
     "types": ["node", "better-sqlite3"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

Adopt TypeScript 6's Explicit Resource Management (`using` declarations) in three concrete high-value sites identified during the TS 6 migration (#1266). Eliminates a class of bugs where thrown exceptions bypass manual cleanup, and establishes the pattern for future test authors.

**Adoption sites:**
- `server/src/routes/backups.test.ts` — `tempDir` / `backupTempDir` now `DisposableTempDir`; `afterEach` calls `[Symbol.dispose]()` instead of bare try/catch rmSync
- `server/src/services/backupService.test.ts` — same across three nested describe blocks; `rawDb` in `createBackup` tests becomes per-test `using rawDb = disposableDb(...)`
- `server/src/db/migrate.ts` — FK pragma sandwich wrapped in `using _fk = foreignKeysDisabled(db)`, guaranteeing `foreign_keys=ON` even if the migration transaction throws (**production correctness improvement**)

**New utility modules:**
- `server/src/db/disposables.ts` — production-safe `foreignKeysDisabled`
- `server/src/test-helpers/disposables.ts` — `disposableDb` and `disposableTempDir`

**Configuration:**
- `server/tsconfig.json` adds `lib: ["ES2024", "DOM", "DOM.Iterable", "esnext.disposable"]` — scoped to the workspace doing the adoption; no change to `tsconfig.base.json` or `jest.config.ts`

Follow-ups tracked in #1281 (remaining ~60 test files, `noUncheckedIndexedAccess`, `await using`).

Fixes #1280

## Test plan
- [x] `npm run typecheck` clean across all workspaces
- [x] backups.test.ts 15/15 pass
- [x] backupService.test.ts 40/40 pass
- [x] schema.test.ts (exercises migrate.ts) 70/70 pass
- [ ] `Quality Gates` passes on CI