### PR TITLE
feat(list-filters): add "No Area" option to area filter on Work Items and Household Items lists (#1277)

### DIFF
--- a/client/src/components/DataTable/DataTable.tsx
+++ b/client/src/components/DataTable/DataTable.tsx
@@ -47,6 +47,11 @@ export interface ColumnDef<T> {
   filterParamKey?: string;
   enumOptions?: EnumOption[];
   enumHierarchy?: EnumHierarchyItem[];
+  enumIncludeNone?: boolean;
+  /** Already-translated label shown in the "none" sentinel row */
+  enumNoneLabel?: string;
+  /** Used as aria-label on the sentinel checkbox (already translated) */
+  enumNoneDescription?: string;
   entitySearchFn?: SearchPickerProps<unknown>['searchFn'];
   entityRenderItem?: SearchPickerProps<unknown>['renderItem'];
   entityPlaceholder?: string;

--- a/client/src/components/DataTable/DataTableFilterPopover.tsx
+++ b/client/src/components/DataTable/DataTableFilterPopover.tsx
@@ -81,6 +81,9 @@ export function DataTableFilterPopover<T>({
               onChange={handleChange}
               options={column.enumOptions}
               hierarchy={column.enumHierarchy}
+              enumIncludeNone={column.enumIncludeNone}
+              enumNoneLabel={column.enumNoneLabel}
+              enumNoneDescription={column.enumNoneDescription}
             />
           )
         );

--- a/client/src/components/DataTable/filters/EnumFilter.sentinel.test.tsx
+++ b/client/src/components/DataTable/filters/EnumFilter.sentinel.test.tsx
@@ -1,0 +1,391 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { EnumOption } from '../DataTable.js';
+import { EnumFilter, ENUM_NONE_SENTINEL } from './EnumFilter.js';
+
+/**
+ * Unit tests for the __none__ sentinel row in EnumFilter.
+ *
+ * Story #1277 — No Area sentinel filter.
+ * Covers rendering, interaction, aria attributes, Select All/None behaviour.
+ */
+
+const OPTIONS: EnumOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+  { value: 'pending', label: 'Pending' },
+];
+
+const NONE_LABEL = 'No Area';
+const NONE_DESCRIPTION = 'Items with no area assigned';
+
+describe('EnumFilter — sentinel row', () => {
+  // ─── Scenario 1: enumIncludeNone=false / undefined → no sentinel rendered ───
+
+  describe('sentinel not rendered when enumIncludeNone is falsy', () => {
+    it('does not render sentinel row when enumIncludeNone is not set', () => {
+      render(<EnumFilter value="" onChange={jest.fn()} options={OPTIONS} />);
+      expect(screen.queryByRole('checkbox', { name: /no area/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render sentinel row when enumIncludeNone=false', () => {
+      render(
+        <EnumFilter
+          value=""
+          onChange={jest.fn()}
+          options={OPTIONS}
+          enumIncludeNone={false}
+          enumNoneLabel={NONE_LABEL}
+        />,
+      );
+      expect(screen.queryByText(NONE_LABEL)).not.toBeInTheDocument();
+    });
+
+    it('does not render sentinel row when enumIncludeNone=true but enumNoneLabel is missing', () => {
+      // The component guards: `enumIncludeNone && enumNoneLabel` — label is required
+      render(
+        <EnumFilter
+          value=""
+          onChange={jest.fn()}
+          options={OPTIONS}
+          enumIncludeNone={true}
+          enumNoneLabel={undefined}
+        />,
+      );
+      // Only the 3 option checkboxes should exist
+      expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    });
+
+    it('total checkbox count equals option count when sentinel is absent', () => {
+      render(<EnumFilter value="" onChange={jest.fn()} options={OPTIONS} />);
+      expect(screen.getAllByRole('checkbox')).toHaveLength(OPTIONS.length);
+    });
+  });
+
+  // ─── Scenario 2: Sentinel rendered with enumIncludeNone=true ────────────────
+
+  describe('sentinel rendered when enumIncludeNone=true and label provided', () => {
+    it('renders the sentinel checkbox when enumIncludeNone=true and enumNoneLabel set', () => {
+      render(
+        <EnumFilter
+          value=""
+          onChange={jest.fn()}
+          options={OPTIONS}
+          enumIncludeNone={true}
+          enumNoneLabel={NONE_LABEL}
+        />,
+      );
+      expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeInTheDocument();
+    });
+
+    it('sentinel checkbox has id="enum-__none__"', () => {
+      render(
+        <EnumFilter
+          value=""
+          onChange={jest.fn()}
+          options={OPTIONS}
+          enumIncludeNone={true}
+          enumNoneLabel={NONE_LABEL}
+        />,
+      );
+      // The label element links via htmlFor="enum-__none__"
+      const sentinel = document.getElementById(`enum-${ENUM_NONE_SENTINEL}`);
+      expect(sentinel).not.toBeNull();
+      expect(sentinel?.tagName).toBe('INPUT');
+      expect(sentinel).toHaveAttribute('type', 'checkbox');
+    });
+
+    it('total checkbox count is options.length + 1 (sentinel included)', () => {
+      render(
+        <EnumFilter
+          value=""
+          onChange={jest.fn()}
+          options={OPTIONS}
+          enumIncludeNone={true}
+          enumNoneLabel={NONE_LABEL}
+        />,
+      );
+      expect(screen.getAllByRole('checkbox')).toHaveLength(OPTIONS.length + 1);
+    });
+  });
+
+  // ─── Scenario 3: aria-label = enumNoneDescription when provided ─────────────
+
+  it('sentinel checkbox aria-label equals enumNoneDescription when provided', () => {
+    render(
+      <EnumFilter
+        value=""
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+        enumNoneDescription={NONE_DESCRIPTION}
+      />,
+    );
+    const sentinel = screen.getByRole('checkbox', { name: NONE_DESCRIPTION });
+    expect(sentinel).toBeInTheDocument();
+  });
+
+  // ─── Scenario 4: aria-label = enumNoneLabel when description not provided ───
+
+  it('sentinel checkbox aria-label falls back to enumNoneLabel when enumNoneDescription is absent', () => {
+    render(
+      <EnumFilter
+        value=""
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    const sentinel = screen.getByRole('checkbox', { name: NONE_LABEL });
+    expect(sentinel).toBeInTheDocument();
+  });
+
+  // ─── Scenario 5: Sentinel label text visible in DOM ─────────────────────────
+
+  it('sentinel label text is visible in the DOM', () => {
+    render(
+      <EnumFilter
+        value=""
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    expect(screen.getByText(NONE_LABEL)).toBeInTheDocument();
+  });
+
+  // ─── Scenario 6: Selecting sentinel alone → onChange("__none__") ─────────────
+
+  it('clicking unchecked sentinel calls onChange with "__none__"', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value=""
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    await user.click(screen.getByRole('checkbox', { name: NONE_LABEL }));
+    expect(mockOnChange).toHaveBeenCalledWith('__none__');
+  });
+
+  // ─── Scenario 7: Selecting sentinel + option → value contains both ───────────
+
+  it('selecting sentinel then an option produces onChange value containing both', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value=""
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: NONE_LABEL }));
+    await user.click(screen.getByRole('checkbox', { name: 'Active' }));
+
+    const lastCall = (mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1] as [string])[0];
+    const parts = lastCall.split(',');
+    expect(parts).toContain(ENUM_NONE_SENTINEL);
+    expect(parts).toContain('active');
+    expect(parts).toHaveLength(2);
+  });
+
+  it('selecting an option then sentinel produces onChange value containing both', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value=""
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Active' }));
+    await user.click(screen.getByRole('checkbox', { name: NONE_LABEL }));
+
+    const lastCall = (mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1] as [string])[0];
+    const parts = lastCall.split(',');
+    expect(parts).toContain(ENUM_NONE_SENTINEL);
+    expect(parts).toContain('active');
+    expect(parts).toHaveLength(2);
+  });
+
+  // ─── Scenario 8: Unselecting sentinel removes __none__, preserves others ─────
+
+  it('unselecting the sentinel removes __none__ but preserves other selected values', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value={`${ENUM_NONE_SENTINEL},active`}
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    // Sentinel should be checked initially
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+
+    await user.click(screen.getByRole('checkbox', { name: NONE_LABEL }));
+
+    const lastCall = (mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1] as [string])[0];
+    expect(lastCall).not.toContain(ENUM_NONE_SENTINEL);
+    expect(lastCall).toContain('active');
+  });
+
+  // ─── Scenario 9: Select All does NOT include __none__ ────────────────────────
+
+  it('clicking Select All does not include __none__ in the onChange value', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value=""
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /select all/i }));
+
+    const callArg = (mockOnChange.mock.calls[0] as [string])[0];
+    expect(callArg).not.toContain(ENUM_NONE_SENTINEL);
+    // Should contain all regular option values
+    const parts = callArg.split(',');
+    expect(parts).toContain('active');
+    expect(parts).toContain('inactive');
+    expect(parts).toContain('pending');
+  });
+
+  it('clicking Select All does not check the sentinel checkbox', async () => {
+    const user = userEvent.setup();
+    render(
+      <EnumFilter
+        value=""
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /select all/i }));
+
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).not.toBeChecked();
+  });
+
+  // ─── Scenario 10: Select None clears everything including sentinel ────────────
+
+  it('clicking Select None calls onChange with empty string (clears all including sentinel)', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(
+      <EnumFilter
+        value={`${ENUM_NONE_SENTINEL},active,pending`}
+        onChange={mockOnChange}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /select none/i }));
+
+    expect(mockOnChange).toHaveBeenCalledWith('');
+  });
+
+  it('clicking Select None unchecks sentinel when it was checked', async () => {
+    const user = userEvent.setup();
+    render(
+      <EnumFilter
+        value={`${ENUM_NONE_SENTINEL},active`}
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /select none/i }));
+
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).not.toBeChecked();
+  });
+
+  // ─── Scenario 11: Initial value="__none__" → sentinel appears checked ────────
+
+  it('sentinel checkbox is checked when initial value is "__none__"', () => {
+    render(
+      <EnumFilter
+        value="__none__"
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeChecked();
+    // Regular options should be unchecked
+    expect(screen.getByRole('checkbox', { name: 'Active' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Inactive' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Pending' })).not.toBeChecked();
+  });
+
+  // ─── Scenario 12: Initial value="__none__,active" → both sentinel + "active" checked
+
+  it('sentinel and "active" are both checked when initial value is "__none__,active"', () => {
+    render(
+      <EnumFilter
+        value={`${ENUM_NONE_SENTINEL},active`}
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Inactive' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Pending' })).not.toBeChecked();
+  });
+
+  it('initial value "active,__none__" (sentinel last) checks both sentinel and "active"', () => {
+    render(
+      <EnumFilter
+        value={`active,${ENUM_NONE_SENTINEL}`}
+        onChange={jest.fn()}
+        options={OPTIONS}
+        enumIncludeNone={true}
+        enumNoneLabel={NONE_LABEL}
+      />,
+    );
+    expect(screen.getByRole('checkbox', { name: NONE_LABEL })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+  });
+
+  // ─── ENUM_NONE_SENTINEL constant is correct ───────────────────────────────────
+
+  it('ENUM_NONE_SENTINEL export equals "__none__"', () => {
+    expect(ENUM_NONE_SENTINEL).toBe('__none__');
+  });
+});

--- a/client/src/components/DataTable/filters/EnumFilter.tsx
+++ b/client/src/components/DataTable/filters/EnumFilter.tsx
@@ -3,11 +3,18 @@ import { useTranslation } from 'react-i18next';
 import type { EnumOption, EnumHierarchyItem } from '../DataTable.js';
 import styles from './Filter.module.css';
 
+export const ENUM_NONE_SENTINEL = '__none__';
+
 export interface EnumFilterProps {
   value: string;
   onChange: (value: string) => void;
   options: EnumOption[];
   hierarchy?: EnumHierarchyItem[];
+  enumIncludeNone?: boolean;
+  /** Already-translated label shown in the "none" sentinel row */
+  enumNoneLabel?: string;
+  /** Used as aria-label on the sentinel checkbox (already translated) */
+  enumNoneDescription?: string;
 }
 
 /**
@@ -15,8 +22,17 @@ export interface EnumFilterProps {
  * Stores as comma-separated values
  * Auto-applies on checkbox change
  * Supports hierarchical options (parent-child relationships)
+ * Optionally includes a "none" sentinel option for filtering items with null values
  */
-export function EnumFilter({ value, onChange, options, hierarchy }: EnumFilterProps) {
+export function EnumFilter({
+  value,
+  onChange,
+  options,
+  hierarchy,
+  enumIncludeNone,
+  enumNoneLabel,
+  enumNoneDescription,
+}: EnumFilterProps) {
   const { t } = useTranslation('common');
 
   const parseValue = (v: string) => new Set(v ? v.split(',') : []);
@@ -78,6 +94,7 @@ export function EnumFilter({ value, onChange, options, hierarchy }: EnumFilterPr
   );
 
   const handleSelectAll = useCallback(() => {
+    // Note: sentinel is excluded from "select all" — it has no hierarchy and is semantically distinct
     const allValues = options.map((opt) => opt.value);
     setSelected(new Set(allValues));
     onChange(allValues.join(','));
@@ -143,6 +160,26 @@ export function EnumFilter({ value, onChange, options, hierarchy }: EnumFilterPr
           {t('dataTable.filter.selectNone')}
         </button>
       </div>
+      {enumIncludeNone && enumNoneLabel && (
+        <div className={styles.filterCheckboxSentinel}>
+          <label
+            className={styles.filterCheckboxItem}
+            htmlFor={`enum-${ENUM_NONE_SENTINEL}`}
+          >
+            <input
+              type="checkbox"
+              checked={selected.has(ENUM_NONE_SENTINEL)}
+              onChange={() => handleToggle(ENUM_NONE_SENTINEL)}
+              className={styles.filterCheckbox}
+              id={`enum-${ENUM_NONE_SENTINEL}`}
+              aria-label={enumNoneDescription ?? enumNoneLabel}
+            />
+            <span className={`${styles.filterCheckboxLabel} ${styles.filterCheckboxLabelNone}`}>
+              {enumNoneLabel}
+            </span>
+          </label>
+        </div>
+      )}
       <div className={styles.filterCheckboxGroup}>
         {sortedOptions.map(({ option, isChild }) => {
           const isParent = allParents.has(option.value);

--- a/client/src/components/DataTable/filters/Filter.module.css
+++ b/client/src/components/DataTable/filters/Filter.module.css
@@ -277,6 +277,17 @@
   box-shadow: var(--shadow-focus);
 }
 
+.filterCheckboxSentinel {
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--spacing-2);
+  margin-bottom: var(--spacing-1);
+}
+
+.filterCheckboxLabelNone {
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .filterInput,
   .filterDateInput,

--- a/client/src/i18n/de/common.json
+++ b/client/src/i18n/de/common.json
@@ -7,6 +7,8 @@
     "settings": "Einstellungen"
   },
   "name": "Name",
+  "noArea": "Kein Bereich",
+  "noAreaDescription": "Kein Bereich — Elemente ohne Bereichszuweisung anzeigen",
   "button": {
     "logout": "Abmelden",
     "close": "Schließen",

--- a/client/src/i18n/en/common.json
+++ b/client/src/i18n/en/common.json
@@ -7,6 +7,8 @@
     "settings": "Settings"
   },
   "name": "Name",
+  "noArea": "No Area",
+  "noAreaDescription": "No Area — show items without an area assignment",
   "button": {
     "logout": "Logout",
     "close": "Close",

--- a/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
+++ b/client/src/pages/HouseholdItemsPage/HouseholdItemsPage.tsx
@@ -30,6 +30,7 @@ const PROJECT_TABS: SubNavTab[] = [
 export function HouseholdItemsPage() {
   const { t } = useTranslation('householdItems');
   const { t: tSettings } = useTranslation('settings');
+  const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
   const { formatCurrency, formatDate } = useFormatters();
   const { areas } = useAreas();
@@ -276,6 +277,9 @@ export function HouseholdItemsPage() {
         filterParamKey: 'areaId',
         enumOptions: areas.map((a) => ({ value: a.id, label: a.name })),
         enumHierarchy: areas.map((a) => ({ id: a.id, parentId: a.parentId ?? null })),
+        enumIncludeNone: true,
+        enumNoneLabel: tCommon('noArea'),
+        enumNoneDescription: tCommon('noAreaDescription'),
         render: (item) => item.area?.name || '—',
       },
       {
@@ -380,7 +384,7 @@ export function HouseholdItemsPage() {
         render: (item) => item.budgetLineCount,
       },
     ],
-    [t, categories, formatCurrency, formatDate, hiStatusVariants, vendors, areas],
+    [t, tCommon, categories, formatCurrency, formatDate, hiStatusVariants, vendors, areas],
   );
 
   // Close action menu on outside click and Escape key

--- a/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
+++ b/client/src/pages/WorkItemsPage/WorkItemsPage.tsx
@@ -30,6 +30,7 @@ const PROJECT_TABS: SubNavTab[] = [
 
 export function WorkItemsPage() {
   const { t } = useTranslation('workItems');
+  const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
   const { formatDate } = useFormatters();
   const { areas } = useAreas();
@@ -278,6 +279,9 @@ export function WorkItemsPage() {
         filterParamKey: 'areaId',
         enumOptions: areas.map((a) => ({ value: a.id, label: a.name })),
         enumHierarchy: areas.map((a) => ({ id: a.id, parentId: a.parentId ?? null })),
+        enumIncludeNone: true,
+        enumNoneLabel: tCommon('noArea'),
+        enumNoneDescription: tCommon('noAreaDescription'),
         render: (item) => item.area?.name || '—',
       },
       {
@@ -315,7 +319,7 @@ export function WorkItemsPage() {
         render: (item) => item.budgetLineCount,
       },
     ],
-    [t, formatDate, wiStatusVariants, users, vendors, areas],
+    [t, tCommon, formatDate, wiStatusVariants, users, vendors, areas],
   );
 
   // Close action menu on outside click and Escape key

--- a/e2e/pages/HouseholdItemsPage.ts
+++ b/e2e/pages/HouseholdItemsPage.ts
@@ -266,6 +266,26 @@ export class HouseholdItemsPage {
   }
 
   /**
+   * The "No Area" sentinel checkbox in the area filter popover.
+   * Only visible after the area filter popover is opened.
+   * The Area column has defaultVisible: true on Household Items, so the filter button
+   * is always visible in the table header (on tablet/desktop).
+   */
+  get noneAreaSentinelCheckbox(): Locator {
+    return this.page.locator('#enum-__none__');
+  }
+
+  /**
+   * Open the area filter popover by clicking the "Filter by Area" column header button.
+   * The Area column has defaultVisible: true on Household Items — the button is always
+   * present in the table header on desktop/tablet (CSS-hidden on mobile < 768px).
+   */
+  async openAreaFilter(): Promise<void> {
+    await this.areaFilterContainer.waitFor({ state: 'visible' });
+    await this.areaFilterContainer.click();
+  }
+
+  /**
    * Get pagination info text (e.g. "Showing 1 to 25 of 30 items"), or null if not visible.
    */
   async getPaginationInfoText(): Promise<string | null> {

--- a/e2e/pages/WorkItemsPage.ts
+++ b/e2e/pages/WorkItemsPage.ts
@@ -395,6 +395,49 @@ export class WorkItemsPage {
   }
 
   /**
+   * The "No Area" sentinel checkbox in the area filter popover.
+   * Only visible after the area filter popover is opened AND the Area column is visible
+   * (Area column has defaultVisible: false on Work Items — enable it via column settings first).
+   */
+  get noneAreaSentinelCheckbox(): Locator {
+    return this.page.locator('#enum-__none__');
+  }
+
+  /**
+   * Open the area filter popover by clicking the "Filter by Area" column header button.
+   *
+   * IMPORTANT: The Area column has defaultVisible: false on Work Items. The filter button
+   * only renders for visible columns, so this method requires the Area column to be enabled
+   * via the column settings gear icon before calling. If the column is not visible, this
+   * method will time out waiting for the button.
+   */
+  async openAreaFilter(): Promise<void> {
+    await this.areaFilter.waitFor({ state: 'visible' });
+    await this.areaFilter.click();
+  }
+
+  /**
+   * Enable the Area column via the column settings gear icon so the filter button appears.
+   * Opens the column settings popover, checks the "Area" checkbox, and closes the popover.
+   */
+  async enableAreaColumn(): Promise<void> {
+    const columnSettingsBtn = this.page.getByRole('button', { name: 'Column settings', exact: true });
+    await columnSettingsBtn.waitFor({ state: 'visible' });
+    await columnSettingsBtn.click();
+    // The column settings popover renders a checkbox for each column by label
+    const areaCheckbox = this.page.getByRole('checkbox', { name: /^Area$/i });
+    await areaCheckbox.waitFor({ state: 'visible' });
+    const checked = await areaCheckbox.isChecked();
+    if (!checked) {
+      await areaCheckbox.click();
+    }
+    // Close popover by pressing Escape
+    await this.page.keyboard.press('Escape');
+    // Wait for Area filter button to appear in the header
+    await this.areaFilter.waitFor({ state: 'visible' });
+  }
+
+  /**
    * Get pagination info text (e.g. "Showing 1 to 25 of 30 items"), or null if not visible.
    */
   async getPaginationInfoText(): Promise<string | null> {

--- a/e2e/tests/household-items/no-area-filter.spec.ts
+++ b/e2e/tests/household-items/no-area-filter.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E tests for the "No Area" sentinel filter on the Household Items list page (Issue #1277)
+ *
+ * The area filter popover now has a "No Area" sentinel checkbox (`id="enum-__none__"`)
+ * pinned above the scrollable option list. Selecting it filters for items where
+ * areaId IS NULL (`?areaId=__none__`). The sentinel is combinable with named areas via
+ * CSV: `?areaId=__none__,<parentId>` returns the union.
+ *
+ * NOTE: The Household Items Area column has defaultVisible: true — the "Filter by Area"
+ * button is always present in the table header on desktop/tablet. Interactive scenarios
+ * (1) can open the popover directly without enabling the column first.
+ * URL-based scenarios (2, 3, 4) bypass the UI entirely and navigate directly.
+ *
+ * Scenarios covered:
+ * 1.  Sentinel renders at top of popover (desktop/tablet; mobile skip)
+ * 2.  ?areaId=__none__ shows only unassigned items
+ * 3.  ?areaId=__none__,<areaId> shows union of unassigned + named area items
+ * 4.  Empty state when no unassigned items exist and ?areaId=__none__ applied
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { HouseholdItemsPage, HOUSEHOLD_ITEMS_ROUTE } from '../../pages/HouseholdItemsPage.js';
+import {
+  createAreaViaApi,
+  deleteAreaViaApi,
+  createHouseholdItemViaApi,
+  deleteHouseholdItemViaApi,
+} from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Sentinel renders at top of area filter popover
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'No Area sentinel renders at top of area filter popover (Scenario 1)',
+  { tag: '@responsive' },
+  () => {
+    test('Area filter popover contains #enum-__none__ sentinel checkbox', async ({ page }) => {
+      const listPage = new HouseholdItemsPage(page);
+
+      const viewport = page.viewportSize();
+      // On mobile the table header (and filter button) is CSS-hidden — skip interactive check
+      if (viewport && viewport.width < 768) {
+        await listPage.goto();
+        await expect(listPage.heading).toBeVisible();
+        return;
+      }
+
+      await listPage.goto();
+
+      // Area column has defaultVisible: true on Household Items — filter button is present
+      await listPage.openAreaFilter();
+
+      // Sentinel checkbox must be visible inside the popover
+      await expect(listPage.noneAreaSentinelCheckbox).toBeVisible();
+
+      // Verify sentinel renders above the scrollable group — check its label text
+      const sentinelLabel = listPage.noneAreaSentinelCheckbox
+        .locator('..')
+        .locator('[class*="filterCheckboxLabelNone"], [class*="filterCheckboxLabel"]');
+      const labelText = await sentinelLabel.first().textContent();
+      expect(labelText?.trim()).toBe('No Area');
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: ?areaId=__none__ shows only unassigned household items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__ shows only household items with no area assignment (Scenario 2)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Navigating with ?areaId=__none__ shows only unassigned items and URL is preserved', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new HouseholdItemsPage(page);
+      const areaIds: string[] = [];
+      const itemIds: string[] = [];
+
+      const areaName = `${testPrefix} HI NoArea Sc2 Area`;
+      const itemInAreaName = `${testPrefix} HI NoArea Sc2 InArea`;
+      const itemNoAreaName = `${testPrefix} HI NoArea Sc2 NoArea`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemInAreaName, areaId }));
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemNoAreaName }));
+
+        await page.goto(`${HOUSEHOLD_ITEMS_ROUTE}?areaId=__none__`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must preserve the sentinel value
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe('__none__');
+
+        // Only the unassigned item must appear
+        await expect(async () => {
+          const names = await listPage.getItemNames();
+          expect(names).toContain(itemNoAreaName);
+          expect(names).not.toContain(itemInAreaName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of itemIds) {
+          await deleteHouseholdItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: ?areaId=__none__,<areaId> shows union of unassigned + area items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__,<areaId> shows union of unassigned and named-area household items (Scenario 3)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('CSV sentinel+area filter shows unassigned and Alpha items; Beta item excluded', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new HouseholdItemsPage(page);
+      const areaIds: string[] = [];
+      const itemIds: string[] = [];
+
+      const areaAlphaName = `${testPrefix} HI NoArea Sc3 Alpha`;
+      const areaBetaName = `${testPrefix} HI NoArea Sc3 Beta`;
+      const itemAlphaName = `${testPrefix} HI NoArea Sc3 InAlpha`;
+      const itemUnassignedName = `${testPrefix} HI NoArea Sc3 NoArea`;
+      const itemBetaName = `${testPrefix} HI NoArea Sc3 InBeta`;
+
+      try {
+        const areaAlphaId = await createAreaViaApi(page, { name: areaAlphaName });
+        areaIds.push(areaAlphaId);
+        const areaBetaId = await createAreaViaApi(page, { name: areaBetaName });
+        areaIds.push(areaBetaId);
+
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemAlphaName, areaId: areaAlphaId }));
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemUnassignedName }));
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemBetaName, areaId: areaBetaId }));
+
+        const csvFilter = `__none__,${areaAlphaId}`;
+        await page.goto(`${HOUSEHOLD_ITEMS_ROUTE}?areaId=${encodeURIComponent(csvFilter)}`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must contain the CSV filter value
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe(csvFilter);
+
+        // Alpha and unassigned items visible; Beta item excluded
+        await expect(async () => {
+          const names = await listPage.getItemNames();
+          expect(names).toContain(itemAlphaName);
+          expect(names).toContain(itemUnassignedName);
+          expect(names).not.toContain(itemBetaName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of itemIds) {
+          await deleteHouseholdItemViaApi(page, id);
+        }
+        for (const id of [...areaIds].reverse()) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Empty state when no unassigned items and ?areaId=__none__ applied
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__ shows filtered empty state when no unassigned household items exist (Scenario 4)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Empty state with Clear Filters button when all items are area-assigned', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new HouseholdItemsPage(page);
+      const areaIds: string[] = [];
+      const itemIds: string[] = [];
+
+      const areaName = `${testPrefix} HI NoArea Sc4 Area`;
+      const itemAssignedName = `${testPrefix} HI NoArea Sc4 Assigned`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+        itemIds.push(await createHouseholdItemViaApi(page, { name: itemAssignedName, areaId }));
+
+        await page.goto(`${HOUSEHOLD_ITEMS_ROUTE}?areaId=__none__`);
+        await listPage.heading.waitFor({ state: 'visible' });
+
+        // Wait for the filter empty state
+        await expect(async () => {
+          await expect(listPage.emptyState).toBeVisible();
+        }).toPass({ timeout: 30_000 });
+
+        // Empty state message must indicate filtered no-results
+        const emptyText = await listPage.emptyState.textContent();
+        expect(emptyText?.toLowerCase()).toMatch(/no items match the current filters/);
+
+        // "Clear Filters" button must be visible (DataTable renders it in the empty state action)
+        const clearButton = listPage.emptyState.getByRole('button', {
+          name: /Clear Filters/i,
+        });
+        await expect(clearButton).toBeVisible();
+      } finally {
+        for (const id of itemIds) {
+          await deleteHouseholdItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);

--- a/e2e/tests/work-items/no-area-filter.spec.ts
+++ b/e2e/tests/work-items/no-area-filter.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * E2E tests for the "No Area" sentinel filter on the Work Items list page (Issue #1277)
+ *
+ * The area filter popover now has a "No Area" sentinel checkbox (`id="enum-__none__"`)
+ * pinned above the scrollable option list. Selecting it filters for items where
+ * areaId IS NULL (`?areaId=__none__`). The sentinel is combinable with named areas via
+ * CSV: `?areaId=__none__,<parentId>` returns the union.
+ *
+ * NOTE: The Work Items Area column has defaultVisible: false — the "Filter by Area"
+ * button only appears after the Area column is enabled via column settings. Interactive
+ * scenarios (1, 5, 6) enable the column via enableAreaColumn() before opening the popover.
+ * URL-based scenarios (2, 3, 4) bypass the UI entirely and navigate directly.
+ *
+ * Scenarios covered:
+ * 1.  Sentinel renders at top of popover (desktop/tablet; mobile skip)
+ * 2.  ?areaId=__none__ shows only unassigned items
+ * 3.  ?areaId=__none__,<areaId> shows union of unassigned + named area items
+ * 4.  Empty state when no unassigned items exist and ?areaId=__none__ applied
+ * 5.  Interactive sentinel click filters to unassigned items (desktop only)
+ * 6.  Select All excludes sentinel — sentinel stays unchecked after Select All (desktop only)
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { WorkItemsPage, WORK_ITEMS_ROUTE } from '../../pages/WorkItemsPage.js';
+import {
+  createAreaViaApi,
+  deleteAreaViaApi,
+  createWorkItemViaApi,
+  deleteWorkItemViaApi,
+} from '../../fixtures/apiHelpers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Sentinel renders at top of area filter popover
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'No Area sentinel renders at top of area filter popover (Scenario 1)',
+  { tag: '@responsive' },
+  () => {
+    test('Area filter popover contains #enum-__none__ sentinel checkbox', async ({ page }) => {
+      const listPage = new WorkItemsPage(page);
+
+      const viewport = page.viewportSize();
+      // On mobile the table header (and filter button) is CSS-hidden — skip interactive check
+      if (viewport && viewport.width < 768) {
+        await listPage.goto();
+        await expect(listPage.heading).toBeVisible();
+        return;
+      }
+
+      await listPage.goto();
+
+      // Area column is hidden by default on Work Items — enable it first
+      await listPage.enableAreaColumn();
+
+      // Open the area filter popover
+      await listPage.openAreaFilter();
+
+      // Sentinel checkbox must be visible inside the popover
+      await expect(listPage.noneAreaSentinelCheckbox).toBeVisible();
+
+      // Sentinel must render ABOVE the scrollable checkbox group
+      // Verify by checking the sentinel's DOM position: filterCheckboxSentinel container
+      // wraps the sentinel; filterCheckboxGroup wraps named area options.
+      // The sentinel div must precede the group in the DOM — check it is visible and has
+      // the correct label text.
+      const sentinelLabel = listPage.noneAreaSentinelCheckbox.locator('..').locator('[class*="filterCheckboxLabelNone"], [class*="filterCheckboxLabel"]');
+      const labelText = await sentinelLabel.first().textContent();
+      expect(labelText?.trim()).toBe('No Area');
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: ?areaId=__none__ shows only unassigned work items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__ shows only items with no area assignment (Scenario 2)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Navigating with ?areaId=__none__ shows only unassigned items and URL is preserved', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaName = `${testPrefix} WI NoArea Sc2 Area`;
+      const wiInAreaName = `${testPrefix} WI NoArea Sc2 InArea`;
+      const wiNoAreaName = `${testPrefix} WI NoArea Sc2 NoArea`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiInAreaName, areaId }));
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiNoAreaName }));
+
+        await page.goto(`${WORK_ITEMS_ROUTE}?areaId=__none__`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must preserve the sentinel value
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe('__none__');
+
+        // Only the unassigned item must appear
+        await expect(async () => {
+          const titles = await listPage.getWorkItemTitles();
+          expect(titles).toContain(wiNoAreaName);
+          expect(titles).not.toContain(wiInAreaName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: ?areaId=__none__,<areaId> shows union of unassigned + area items
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__,<areaId> shows union of unassigned and named-area items (Scenario 3)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('CSV sentinel+area filter shows unassigned and Alpha items; Beta item excluded', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaAlphaName = `${testPrefix} WI NoArea Sc3 Alpha`;
+      const areaBetaName = `${testPrefix} WI NoArea Sc3 Beta`;
+      const wiAlphaName = `${testPrefix} WI NoArea Sc3 WiAlpha`;
+      const wiUnassignedName = `${testPrefix} WI NoArea Sc3 WiNone`;
+      const wiBetaName = `${testPrefix} WI NoArea Sc3 WiBeta`;
+
+      try {
+        const areaAlphaId = await createAreaViaApi(page, { name: areaAlphaName });
+        areaIds.push(areaAlphaId);
+        const areaBetaId = await createAreaViaApi(page, { name: areaBetaName });
+        areaIds.push(areaBetaId);
+
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiAlphaName, areaId: areaAlphaId }));
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiUnassignedName }));
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiBetaName, areaId: areaBetaId }));
+
+        const csvFilter = `__none__,${areaAlphaId}`;
+        await page.goto(`${WORK_ITEMS_ROUTE}?areaId=${encodeURIComponent(csvFilter)}`);
+        await listPage.heading.waitFor({ state: 'visible' });
+        await listPage.waitForLoaded();
+
+        // URL must contain the CSV filter value
+        const url = new URL(page.url());
+        expect(url.searchParams.get('areaId')).toBe(csvFilter);
+
+        // Alpha and unassigned items visible; Beta item excluded
+        await expect(async () => {
+          const titles = await listPage.getWorkItemTitles();
+          expect(titles).toContain(wiAlphaName);
+          expect(titles).toContain(wiUnassignedName);
+          expect(titles).not.toContain(wiBetaName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of [...areaIds].reverse()) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Empty state when no unassigned items and ?areaId=__none__ applied
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  '?areaId=__none__ shows filtered empty state when no unassigned items exist (Scenario 4)',
+  { tag: '@responsive' },
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Empty state with Clear Filters button when all items are area-assigned', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaName = `${testPrefix} WI NoArea Sc4 Area`;
+      const wiAssignedName = `${testPrefix} WI NoArea Sc4 Assigned`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiAssignedName, areaId }));
+
+        await page.goto(`${WORK_ITEMS_ROUTE}?areaId=__none__`);
+        await listPage.heading.waitFor({ state: 'visible' });
+
+        // Wait for the filter empty state
+        await expect(async () => {
+          await expect(listPage.emptyState).toBeVisible();
+        }).toPass({ timeout: 30_000 });
+
+        // Empty state message must indicate filtered no-results
+        const emptyText = await listPage.emptyState.textContent();
+        expect(emptyText?.toLowerCase()).toMatch(/no items match the current filters/);
+
+        // "Clear Filters" button must be visible (DataTable renders it in the empty state action)
+        const clearButton = listPage.emptyState.getByRole('button', {
+          name: /Clear Filters/i,
+        });
+        await expect(clearButton).toBeVisible();
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: Interactive sentinel click filters to unassigned items (desktop only)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Clicking the No Area sentinel checkbox interactively filters to unassigned items (Scenario 5)',
+  () => {
+    // Desktop-only: Area column must be enabled + popover clicked interactively
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Clicking #enum-__none__ in the popover adds areaId=__none__ to URL and filters list', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaName = `${testPrefix} WI NoArea Sc5 Area`;
+      const wiInAreaName = `${testPrefix} WI NoArea Sc5 InArea`;
+      const wiNoAreaName = `${testPrefix} WI NoArea Sc5 NoArea`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiInAreaName, areaId }));
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiNoAreaName }));
+
+        await listPage.goto();
+        await listPage.waitForLoaded();
+
+        // Enable Area column (defaultVisible: false on Work Items)
+        await listPage.enableAreaColumn();
+
+        // Open the area filter popover
+        await listPage.openAreaFilter();
+        await expect(listPage.noneAreaSentinelCheckbox).toBeVisible();
+
+        // Register response listener BEFORE clicking the sentinel
+        const responsePromise = page.waitForResponse(
+          (resp) => {
+            if (!resp.url().includes('/api/work-items') || resp.status() !== 200) return false;
+            try {
+              const url = new URL(resp.url());
+              return url.searchParams.get('areaId') === '__none__';
+            } catch {
+              return false;
+            }
+          },
+          { timeout: 15_000 },
+        );
+
+        // Click the sentinel — uses force: true to bypass any sticky UI coverage
+        await listPage.noneAreaSentinelCheckbox.click({ force: true });
+
+        // Wait for API response with areaId=__none__
+        await responsePromise;
+
+        // URL must contain sentinel value
+        await page.waitForURL((url) => url.searchParams.get('areaId') === '__none__', {
+          timeout: 10_000,
+        });
+
+        // Only the unassigned item must be visible
+        await expect(async () => {
+          const titles = await listPage.getWorkItemTitles();
+          expect(titles).toContain(wiNoAreaName);
+          expect(titles).not.toContain(wiInAreaName);
+        }).toPass({ timeout: 30_000 });
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: Select All excludes the sentinel (desktop only)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe(
+  'Select All in area filter popover excludes the No Area sentinel (Scenario 6)',
+  () => {
+    test.describe.configure({ timeout: 90_000 });
+
+    test('Clicking Select All does not check the #enum-__none__ sentinel checkbox', async ({
+      page,
+      testPrefix,
+    }) => {
+      const listPage = new WorkItemsPage(page);
+      const areaIds: string[] = [];
+      const workItemIds: string[] = [];
+
+      const areaName = `${testPrefix} WI NoArea Sc6 Area`;
+      const wiName = `${testPrefix} WI NoArea Sc6 Item`;
+
+      try {
+        const areaId = await createAreaViaApi(page, { name: areaName });
+        areaIds.push(areaId);
+        workItemIds.push(await createWorkItemViaApi(page, { title: wiName, areaId }));
+
+        await listPage.goto();
+        await listPage.waitForLoaded();
+
+        // Enable Area column (defaultVisible: false on Work Items)
+        await listPage.enableAreaColumn();
+
+        // Open the area filter popover
+        await listPage.openAreaFilter();
+        await expect(listPage.noneAreaSentinelCheckbox).toBeVisible();
+
+        // The sentinel must start unchecked
+        await expect(listPage.noneAreaSentinelCheckbox).not.toBeChecked();
+
+        // Click "Select All" (quick action button above the checkbox list)
+        const selectAllButton = page.getByRole('button', { name: 'Select All', exact: true });
+        await selectAllButton.click();
+
+        // The sentinel must remain unchecked — Select All excludes the sentinel by design
+        await expect(listPage.noneAreaSentinelCheckbox).not.toBeChecked();
+      } finally {
+        for (const id of workItemIds) {
+          await deleteWorkItemViaApi(page, id);
+        }
+        for (const id of areaIds) {
+          await deleteAreaViaApi(page, id);
+        }
+      }
+    });
+  },
+);

--- a/server/src/services/areaService.resolveAreaFilter.test.ts
+++ b/server/src/services/areaService.resolveAreaFilter.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import * as schema from '../db/schema.js';
+import { resolveAreaFilter } from './areaService.js';
+
+/**
+ * Unit tests for resolveAreaFilter().
+ *
+ * Story #1277 — No Area sentinel filter.
+ * Covers: empty input, single leaf, parent+child expansion, __none__ sentinel
+ * alone, sentinel+area, array input, unknown IDs, whitespace CSV segments.
+ */
+describe('resolveAreaFilter()', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  /** Insert a test area and return its ID. */
+  function insertArea(name: string, parentId: string | null = null): string {
+    const now = new Date(Date.now() + idCounter++).toISOString();
+    const id = `area-${idCounter++}-${Math.random().toString(36).substring(7)}`;
+    db.insert(schema.areas)
+      .values({
+        id,
+        name,
+        parentId,
+        color: null,
+        description: null,
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  beforeEach(() => {
+    idCounter = 0;
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Scenario 1: Empty string ───────────────────────────────────────────────
+
+  it('returns empty areaIds and includeNull=false for empty string input', () => {
+    const result = resolveAreaFilter(db, '');
+    expect(result.areaIds).toHaveLength(0);
+    expect(result.includeNull).toBe(false);
+  });
+
+  // ─── Scenario 2: Single leaf area (no children) ─────────────────────────────
+
+  it('returns just the leaf area ID for a single leaf area; includeNull=false', () => {
+    const leafId = insertArea('Bathroom');
+
+    const result = resolveAreaFilter(db, leafId);
+
+    expect(result.areaIds).toEqual([leafId]);
+    expect(result.includeNull).toBe(false);
+  });
+
+  it('returns only the area itself when the area has no children (no descendant expansion)', () => {
+    const areaA = insertArea('Kitchen');
+    const areaB = insertArea('Living Room');
+
+    const result = resolveAreaFilter(db, areaA);
+
+    // areaA has no children — result should only contain areaA, not areaB
+    expect(result.areaIds).toContain(areaA);
+    expect(result.areaIds).not.toContain(areaB);
+    expect(result.areaIds).toHaveLength(1);
+  });
+
+  // ─── Scenario 3: Parent with one child (descendant expansion) ───────────────
+
+  it('expands parent ID to include parent + child IDs; includeNull=false', () => {
+    const parentId = insertArea('Floor 1');
+    const childId = insertArea('Bedroom', parentId);
+
+    const result = resolveAreaFilter(db, parentId);
+
+    expect(result.areaIds).toContain(parentId);
+    expect(result.areaIds).toContain(childId);
+    expect(result.areaIds).toHaveLength(2);
+    expect(result.includeNull).toBe(false);
+  });
+
+  it('expands parent to all descendants recursively (grandchild included)', () => {
+    const grandparentId = insertArea('House');
+    const parentId = insertArea('Floor 1', grandparentId);
+    const childId = insertArea('Bedroom', parentId);
+
+    const result = resolveAreaFilter(db, grandparentId);
+
+    expect(result.areaIds).toContain(grandparentId);
+    expect(result.areaIds).toContain(parentId);
+    expect(result.areaIds).toContain(childId);
+    expect(result.areaIds).toHaveLength(3);
+  });
+
+  // ─── Scenario 4: __none__ sentinel alone ────────────────────────────────────
+
+  it('returns empty areaIds and includeNull=true for "__none__" alone', () => {
+    const result = resolveAreaFilter(db, '__none__');
+    expect(result.areaIds).toHaveLength(0);
+    expect(result.includeNull).toBe(true);
+  });
+
+  // ─── Scenario 5: __none__ combined with an area ID (CSV string) ─────────────
+
+  it('returns includeNull=true and expanded area IDs for "__none__,<areaId>" CSV', () => {
+    const parentId = insertArea('Zone A');
+    const childId = insertArea('Room 1', parentId);
+
+    const result = resolveAreaFilter(db, `__none__,${parentId}`);
+
+    expect(result.includeNull).toBe(true);
+    expect(result.areaIds).toContain(parentId);
+    expect(result.areaIds).toContain(childId);
+    expect(result.areaIds).not.toContain('__none__');
+  });
+
+  it('returns includeNull=true and expanded area IDs for "<areaId>,__none__" CSV (sentinel last)', () => {
+    const areaId = insertArea('Garage');
+
+    const result = resolveAreaFilter(db, `${areaId},__none__`);
+
+    expect(result.includeNull).toBe(true);
+    expect(result.areaIds).toContain(areaId);
+    expect(result.areaIds).not.toContain('__none__');
+  });
+
+  // ─── Scenario 6: Array input with ["__none__", "<areaId>"] ──────────────────
+
+  it('accepts array input: ["__none__", "<areaId>"] and returns same as CSV form', () => {
+    const parentId = insertArea('Floor 2');
+    const childId = insertArea('Bathroom', parentId);
+
+    const result = resolveAreaFilter(db, ['__none__', parentId]);
+
+    expect(result.includeNull).toBe(true);
+    expect(result.areaIds).toContain(parentId);
+    expect(result.areaIds).toContain(childId);
+    expect(result.areaIds).not.toContain('__none__');
+  });
+
+  it('accepts array input with only one area ID (no sentinel)', () => {
+    const leafId = insertArea('Study');
+
+    const result = resolveAreaFilter(db, [leafId]);
+
+    expect(result.includeNull).toBe(false);
+    expect(result.areaIds).toEqual([leafId]);
+  });
+
+  it('accepts array input with only ["__none__"]', () => {
+    const result = resolveAreaFilter(db, ['__none__']);
+    expect(result.includeNull).toBe(true);
+    expect(result.areaIds).toHaveLength(0);
+  });
+
+  // ─── Scenario 7: Unknown UUIDs silently ignored ──────────────────────────────
+
+  it('ignores unknown area IDs silently — returns empty areaIds, no throw', () => {
+    const result = resolveAreaFilter(db, 'non-existent-area-id-xyz');
+    expect(result.areaIds).toHaveLength(0);
+    expect(result.includeNull).toBe(false);
+  });
+
+  it('ignores unknown IDs in CSV and still processes valid ones', () => {
+    const knownId = insertArea('Valid Area');
+
+    const result = resolveAreaFilter(db, `unknown-id-abc,${knownId}`);
+
+    expect(result.areaIds).toContain(knownId);
+    expect(result.areaIds).not.toContain('unknown-id-abc');
+  });
+
+  it('ignores unknown IDs in array and still processes valid ones', () => {
+    const knownId = insertArea('Known Area');
+
+    const result = resolveAreaFilter(db, ['does-not-exist', knownId]);
+
+    expect(result.areaIds).toContain(knownId);
+    expect(result.areaIds).not.toContain('does-not-exist');
+  });
+
+  // ─── Scenario 8: Whitespace-only CSV segments dropped ───────────────────────
+
+  it('drops whitespace-only segments in CSV string', () => {
+    const result = resolveAreaFilter(db, '  ,   ,  ');
+    expect(result.areaIds).toHaveLength(0);
+    expect(result.includeNull).toBe(false);
+  });
+
+  it('trims whitespace around valid area IDs in CSV', () => {
+    const areaId = insertArea('Pantry');
+
+    const result = resolveAreaFilter(db, `  ${areaId}  `);
+
+    expect(result.areaIds).toContain(areaId);
+  });
+
+  it('handles mixed whitespace segments and valid IDs in CSV', () => {
+    const areaId = insertArea('Utility Room');
+
+    const result = resolveAreaFilter(db, `  ,${areaId},  `);
+
+    expect(result.areaIds).toContain(areaId);
+    expect(result.areaIds).toHaveLength(1);
+  });
+
+  // ─── Deduplication ──────────────────────────────────────────────────────────
+
+  it('deduplicates expanded area IDs when same area appears multiple times', () => {
+    const areaId = insertArea('Duplicated');
+
+    const result = resolveAreaFilter(db, `${areaId},${areaId}`);
+
+    // Despite appearing twice, areaId should appear only once in the result
+    const count = result.areaIds.filter((id) => id === areaId).length;
+    expect(count).toBe(1);
+  });
+});

--- a/server/src/services/areaService.ts
+++ b/server/src/services/areaService.ts
@@ -163,6 +163,50 @@ export function resolveAreaAncestors(
 }
 
 /**
+ * Result of parsing an areaId filter query parameter.
+ */
+export interface AreaFilterResult {
+  /** Expanded, deduplicated area IDs (includes descendants of each supplied ID). */
+  areaIds: string[];
+  /** When true, caller must also include items with area_id IS NULL. */
+  includeNull: boolean;
+}
+
+/**
+ * Parse the areaId filter (single ID, CSV string, or array) into an expanded,
+ * deduplicated array of area IDs and a flag for null inclusion.
+ *
+ * Supports the `__none__` sentinel: when present in the CSV, sets includeNull=true.
+ * Empty segments and unknown IDs are silently ignored.
+ */
+export function resolveAreaFilter(db: DbType, areaId: string | string[]): AreaFilterResult {
+  const NONE_SENTINEL = '__none__';
+  const raw = Array.isArray(areaId)
+    ? areaId
+    : areaId
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+  let includeNull = false;
+  const expanded = new Set<string>();
+  for (const id of raw) {
+    if (id === NONE_SENTINEL) {
+      includeNull = true;
+    } else {
+      const exists = db.select({ id: areas.id }).from(areas).where(eq(areas.id, id)).get();
+      if (exists) {
+        for (const descendant of getDescendantIds(db, id)) {
+          expanded.add(descendant);
+        }
+      }
+      // unknown IDs are silently dropped
+    }
+  }
+  return { areaIds: [...expanded], includeNull };
+}
+
+/**
  * List all areas, sorted by sort_order ascending, then name ascending.
  * Optionally filter by name search (case-insensitive).
  */

--- a/server/src/services/areaService.ts
+++ b/server/src/services/areaService.ts
@@ -170,6 +170,8 @@ export interface AreaFilterResult {
   areaIds: string[];
   /** When true, caller must also include items with area_id IS NULL. */
   includeNull: boolean;
+  /** true when the raw input had at least one non-empty segment (after trim). */
+  hasInput: boolean;
 }
 
 /**
@@ -178,15 +180,18 @@ export interface AreaFilterResult {
  *
  * Supports the `__none__` sentinel: when present in the CSV, sets includeNull=true.
  * Empty segments and unknown IDs are silently ignored.
+ * Returns hasInput=true only when the raw input had at least one non-empty segment.
  */
 export function resolveAreaFilter(db: DbType, areaId: string | string[]): AreaFilterResult {
   const NONE_SENTINEL = '__none__';
   const raw = Array.isArray(areaId)
-    ? areaId
+    ? areaId.filter((s) => s.trim().length > 0).map((s) => s.trim())
     : areaId
         .split(',')
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
+
+  const hasInput = raw.length > 0;
 
   let includeNull = false;
   const expanded = new Set<string>();
@@ -203,7 +208,7 @@ export function resolveAreaFilter(db: DbType, areaId: string | string[]): AreaFi
       // unknown IDs are silently dropped
     }
   }
-  return { areaIds: [...expanded], includeNull };
+  return { areaIds: [...expanded], includeNull, hasInput };
 }
 
 /**

--- a/server/src/services/householdItemService.areaFilter.test.ts
+++ b/server/src/services/householdItemService.areaFilter.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import * as schema from '../db/schema.js';
+import { listHouseholdItems } from './householdItemService.js';
+import type { HouseholdItemListQuery } from '@cornerstone/shared';
+
+/**
+ * Integration tests for listHouseholdItems() — area filter behavior introduced by
+ * story #1277 (No Area sentinel filter).
+ *
+ * Covers:
+ *   - __none__ sentinel returns only unassigned (null-area) household items
+ *   - __none__ + named area returns union of null-area + named-area items
+ *   - __none__ when all items have areas returns empty
+ *   - Regression: named parentId expands to include descendant-area items
+ *   - Regression: CSV of multiple area IDs returns union
+ */
+describe('listHouseholdItems() — area filter', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  /** Insert a test area, returns its ID. */
+  function insertArea(name: string, parentId: string | null = null): string {
+    const now = new Date(Date.now() + idCounter++).toISOString();
+    const id = `area-${idCounter++}-${Math.random().toString(36).substring(7)}`;
+    db.insert(schema.areas)
+      .values({
+        id,
+        name,
+        parentId,
+        color: null,
+        description: null,
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  /**
+   * Insert a household item. Uses the seeded 'hic-furniture' categoryId which
+   * is required (NOT NULL FK). Returns the item ID.
+   */
+  function insertHouseholdItem(name: string, areaId: string | null = null): string {
+    const now = new Date(Date.now() + idCounter++).toISOString();
+    const id = `hi-${idCounter++}-${Math.random().toString(36).substring(7)}`;
+    db.insert(schema.householdItems)
+      .values({
+        id,
+        name,
+        categoryId: 'hic-furniture',
+        areaId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  /** Build a minimal HouseholdItemListQuery. */
+  function buildQuery(overrides: Partial<HouseholdItemListQuery> = {}): HouseholdItemListQuery {
+    return { page: 1, pageSize: 100, ...overrides };
+  }
+
+  beforeEach(() => {
+    idCounter = 0;
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Scenario 1: __none__ returns only unassigned items ─────────────────────
+
+  it('?areaId=__none__ returns only household items with null areaId', () => {
+    const areaId = insertArea('Living Room');
+    const assigned = insertHouseholdItem('Sofa', areaId);
+    const unassigned = insertHouseholdItem('No-area lamp');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: '__none__' }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(unassigned);
+    expect(ids).not.toContain(assigned);
+  });
+
+  it('?areaId=__none__ includes ALL unassigned items', () => {
+    const areaId = insertArea('Bedroom');
+    insertHouseholdItem('Bed frame', areaId);
+    const u1 = insertHouseholdItem('Box 1');
+    const u2 = insertHouseholdItem('Box 2');
+    const u3 = insertHouseholdItem('Box 3');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: '__none__' }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(u1);
+    expect(ids).toContain(u2);
+    expect(ids).toContain(u3);
+    expect(result.items).toHaveLength(3);
+  });
+
+  // ─── Scenario 2: __none__ + named area = union ──────────────────────────────
+
+  it('?areaId=__none__,<areaId> returns union: null-area items + named-area items', () => {
+    const area1Id = insertArea('Kitchen');
+    const area2Id = insertArea('Office');
+
+    const inArea1 = insertHouseholdItem('Kitchen table', area1Id);
+    const inArea2 = insertHouseholdItem('Office chair', area2Id);
+    const unassigned = insertHouseholdItem('Storage box');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: `__none__,${area1Id}` }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea1);
+    expect(ids).toContain(unassigned);
+    expect(ids).not.toContain(inArea2);
+  });
+
+  it('?areaId=<areaId>,__none__ (sentinel last) also returns correct union', () => {
+    const areaId = insertArea('Bathroom');
+    const inArea = insertHouseholdItem('Mirror', areaId);
+    const unassigned = insertHouseholdItem('Floating item');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: `${areaId},__none__` }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea);
+    expect(ids).toContain(unassigned);
+  });
+
+  // ─── Scenario 3: __none__ when all items have areas returns empty ────────────
+
+  it('?areaId=__none__ returns empty result when all household items have an assigned area', () => {
+    const areaId = insertArea('Garage');
+    insertHouseholdItem('Tool cabinet', areaId);
+    insertHouseholdItem('Bike rack', areaId);
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: '__none__' }));
+
+    expect(result.items).toHaveLength(0);
+    expect(result.pagination.totalItems).toBe(0);
+  });
+
+  // ─── Scenario 4: Regression — parentId expands to descendants ───────────────
+
+  it('?areaId=<parentId> returns items in parent AND all descendant areas', () => {
+    const parentId = insertArea('Upper Floor');
+    const childId = insertArea('Master Bedroom', parentId);
+
+    const parentItem = insertHouseholdItem('Hallway rug', parentId);
+    const childItem = insertHouseholdItem('King bed', childId);
+    const unrelated = insertHouseholdItem('Unrelated item');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: parentId }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(parentItem);
+    expect(ids).toContain(childItem);
+    expect(ids).not.toContain(unrelated);
+  });
+
+  it('?areaId=<grandparentId> expands recursively through all descendants', () => {
+    const grandparentId = insertArea('House');
+    const parentId = insertArea('Floor 1', grandparentId);
+    const childId = insertArea('Living Room', parentId);
+
+    const gpItem = insertHouseholdItem('Entrance mat', grandparentId);
+    const pItem = insertHouseholdItem('Floor lamp', parentId);
+    const cItem = insertHouseholdItem('Sectional sofa', childId);
+    const unrelated = insertHouseholdItem('No area item');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: grandparentId }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(gpItem);
+    expect(ids).toContain(pItem);
+    expect(ids).toContain(cItem);
+    expect(ids).not.toContain(unrelated);
+  });
+
+  // ─── Scenario 5: Regression — CSV of multiple area IDs returns union ─────────
+
+  it('?areaId=<areaA>,<areaB> returns union of items from both areas', () => {
+    const areaA = insertArea('Bedroom A');
+    const areaB = insertArea('Bedroom B');
+    const areaC = insertArea('Utility Room');
+
+    const itemA = insertHouseholdItem('Bed A', areaA);
+    const itemB = insertHouseholdItem('Bed B', areaB);
+    const itemC = insertHouseholdItem('Washing machine', areaC);
+    const unassigned = insertHouseholdItem('No area item');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: `${areaA},${areaB}` }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(itemA);
+    expect(ids).toContain(itemB);
+    expect(ids).not.toContain(itemC);
+    expect(ids).not.toContain(unassigned);
+  });
+
+  it('?areaId=<parentId>,<unrelated> returns union of descendant items from both areas', () => {
+    const parentId = insertArea('Zone A');
+    const childId = insertArea('Room A1', parentId);
+    const otherAreaId = insertArea('Zone B');
+
+    const parentItem = insertHouseholdItem('Zone A item', parentId);
+    const childItem = insertHouseholdItem('Room A1 item', childId);
+    const otherItem = insertHouseholdItem('Zone B item', otherAreaId);
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: `${parentId},${otherAreaId}` }));
+    const ids = result.items.map((i) => i.id);
+
+    // parentId expands to include childId
+    expect(ids).toContain(parentItem);
+    expect(ids).toContain(childItem);
+    expect(ids).toContain(otherItem);
+  });
+
+  // ─── Single leaf area ID (regression) ───────────────────────────────────────
+
+  it('?areaId=<leafId> returns only items for that exact leaf area', () => {
+    const areaA = insertArea('Garden');
+    const areaB = insertArea('Terrace');
+
+    const itemA = insertHouseholdItem('Garden chair', areaA);
+    const itemB = insertHouseholdItem('Outdoor heater', areaB);
+    const unassigned = insertHouseholdItem('No area');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: areaA }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(itemA);
+    expect(ids).not.toContain(itemB);
+    expect(ids).not.toContain(unassigned);
+    expect(result.items).toHaveLength(1);
+  });
+
+  // ─── No areaId filter — returns all items ───────────────────────────────────
+
+  it('omitting areaId returns all household items regardless of area assignment', () => {
+    const areaId = insertArea('Study');
+    const inArea = insertHouseholdItem('Desk lamp', areaId);
+    const noArea = insertHouseholdItem('Spare item');
+
+    const result = listHouseholdItems(db, buildQuery({}));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea);
+    expect(ids).toContain(noArea);
+  });
+
+  // ─── Pagination metadata reflects filter ────────────────────────────────────
+
+  it('pagination.totalItems reflects __none__ sentinel filter count accurately', () => {
+    const areaId = insertArea('Workshop');
+    insertHouseholdItem('Workbench', areaId);
+    insertHouseholdItem('Floating 1');
+    insertHouseholdItem('Floating 2');
+
+    const result = listHouseholdItems(db, buildQuery({ areaId: '__none__' }));
+
+    expect(result.pagination.totalItems).toBe(2);
+  });
+});

--- a/server/src/services/householdItemService.ts
+++ b/server/src/services/householdItemService.ts
@@ -536,18 +536,18 @@ export function listHouseholdItems(
   }
 
   if (query.areaId) {
-    const { areaIds, includeNull } = resolveAreaFilter(db, query.areaId);
+    const { areaIds, includeNull, hasInput } = resolveAreaFilter(db, query.areaId);
     if (includeNull && areaIds.length > 0) {
       baseConditions.push(or(isNull(householdItems.areaId), inArray(householdItems.areaId, areaIds))!);
     } else if (includeNull) {
       baseConditions.push(isNull(householdItems.areaId));
     } else if (areaIds.length > 0) {
       baseConditions.push(inArray(householdItems.areaId, areaIds));
-    } else {
-      // Filter param was provided but contained only unknown IDs (no sentinel).
-      // Preserve the contract: return empty result rather than silently dropping the filter.
+    } else if (hasInput) {
+      // User supplied ID(s) but all were unknown — yield empty result
       baseConditions.push(sql`1 = 0`);
     }
+    // else: no meaningful input (empty/whitespace-only CSV) — skip filter
   }
 
   if (query.q) {

--- a/server/src/services/householdItemService.ts
+++ b/server/src/services/householdItemService.ts
@@ -543,6 +543,10 @@ export function listHouseholdItems(
       baseConditions.push(isNull(householdItems.areaId));
     } else if (areaIds.length > 0) {
       baseConditions.push(inArray(householdItems.areaId, areaIds));
+    } else {
+      // Filter param was provided but contained only unknown IDs (no sentinel).
+      // Preserve the contract: return empty result rather than silently dropping the filter.
+      baseConditions.push(sql`1 = 0`);
     }
   }
 

--- a/server/src/services/householdItemService.ts
+++ b/server/src/services/householdItemService.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { eq, sql, and, or, desc, asc, inArray } from 'drizzle-orm';
+import { eq, sql, and, or, desc, asc, inArray, isNull } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
 import type { areas } from '../db/schema.js';
@@ -28,7 +28,7 @@ import {
 import { deleteLinksForEntity } from './documentLinkService.js';
 import { listDeps } from './householdItemDepService.js';
 import { autoReschedule } from './schedulingEngine.js';
-import { getDescendantIds, loadAreaMap, resolveAreaAncestors } from './areaService.js';
+import { getDescendantIds, loadAreaMap, resolveAreaAncestors, resolveAreaFilter } from './areaService.js';
 import type { AreaMapEntry } from './areaService.js';
 import { toUserSummary, toAreaSummary, toVendorSummaryWithTrade } from './shared/converters.js';
 import { validateVendorId, validateAreaId } from './shared/validators.js';
@@ -536,8 +536,14 @@ export function listHouseholdItems(
   }
 
   if (query.areaId) {
-    const areaIds = getDescendantIds(db, query.areaId);
-    baseConditions.push(inArray(householdItems.areaId, areaIds));
+    const { areaIds, includeNull } = resolveAreaFilter(db, query.areaId);
+    if (includeNull && areaIds.length > 0) {
+      baseConditions.push(or(isNull(householdItems.areaId), inArray(householdItems.areaId, areaIds))!);
+    } else if (includeNull) {
+      baseConditions.push(isNull(householdItems.areaId));
+    } else if (areaIds.length > 0) {
+      baseConditions.push(inArray(householdItems.areaId, areaIds));
+    }
   }
 
   if (query.q) {

--- a/server/src/services/workItemService.areaFilter.test.ts
+++ b/server/src/services/workItemService.areaFilter.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import * as schema from '../db/schema.js';
+import { listWorkItems } from './workItemService.js';
+import type { WorkItemListQuery } from '@cornerstone/shared';
+
+/**
+ * Integration tests for listWorkItems() — area filter behavior introduced by
+ * story #1277 (No Area sentinel filter).
+ *
+ * Covers:
+ *   - __none__ sentinel returns only unassigned (null-area) work items
+ *   - __none__ + named area returns union of null-area + named-area items
+ *   - __none__ when all items have areas returns empty
+ *   - Regression: named parentId expands to include descendant-area items
+ *   - Regression: single leaf areaId returns only that area's items
+ */
+describe('listWorkItems() — area filter', () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database<typeof schema>;
+
+  let idCounter = 0;
+
+  function createTestDb() {
+    const sqliteDb = new Database(':memory:');
+    sqliteDb.pragma('journal_mode = WAL');
+    sqliteDb.pragma('foreign_keys = ON');
+    runMigrations(sqliteDb);
+    return { sqlite: sqliteDb, db: drizzle(sqliteDb, { schema }) };
+  }
+
+  /** Insert a test area, returns its ID. */
+  function insertArea(name: string, parentId: string | null = null): string {
+    const now = new Date(Date.now() + idCounter++).toISOString();
+    const id = `area-${idCounter++}-${Math.random().toString(36).substring(7)}`;
+    db.insert(schema.areas)
+      .values({
+        id,
+        name,
+        parentId,
+        color: null,
+        description: null,
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  /** Insert a work item, returns its ID. */
+  function insertWorkItem(title: string, areaId: string | null = null): string {
+    const now = new Date(Date.now() + idCounter++).toISOString();
+    const id = `wi-${idCounter++}-${Math.random().toString(36).substring(7)}`;
+    db.insert(schema.workItems)
+      .values({
+        id,
+        title,
+        status: 'not_started',
+        areaId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  /** Build a minimal WorkItemListQuery. */
+  function buildQuery(overrides: Partial<WorkItemListQuery> = {}): WorkItemListQuery {
+    return { page: 1, pageSize: 100, ...overrides };
+  }
+
+  beforeEach(() => {
+    idCounter = 0;
+    const testDb = createTestDb();
+    sqlite = testDb.sqlite;
+    db = testDb.db;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  // ─── Scenario 1: __none__ returns only unassigned items ─────────────────────
+
+  it('?areaId=__none__ returns only work items with null areaId', () => {
+    const areaId = insertArea('Kitchen');
+    const assignedId = insertWorkItem('Tile floor', areaId);
+    const unassignedId = insertWorkItem('Unassigned task');
+
+    const result = listWorkItems(db, buildQuery({ areaId: '__none__' }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(unassignedId);
+    expect(ids).not.toContain(assignedId);
+  });
+
+  it('?areaId=__none__ includes ALL unassigned items (multiple)', () => {
+    const areaId = insertArea('Garage');
+    insertWorkItem('In garage', areaId);
+    const u1 = insertWorkItem('Unassigned 1');
+    const u2 = insertWorkItem('Unassigned 2');
+    const u3 = insertWorkItem('Unassigned 3');
+
+    const result = listWorkItems(db, buildQuery({ areaId: '__none__' }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(u1);
+    expect(ids).toContain(u2);
+    expect(ids).toContain(u3);
+    expect(result.items).toHaveLength(3);
+  });
+
+  // ─── Scenario 2: __none__ + named area = union ──────────────────────────────
+
+  it('?areaId=__none__,<areaId> returns union: null-area items + named-area items', () => {
+    const area1Id = insertArea('Bathroom');
+    const area2Id = insertArea('Kitchen');
+
+    const inArea1 = insertWorkItem('Install sink', area1Id);
+    const inArea2 = insertWorkItem('Install cooktop', area2Id);
+    const unassigned = insertWorkItem('No area task');
+
+    const result = listWorkItems(db, buildQuery({ areaId: `__none__,${area1Id}` }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea1);
+    expect(ids).toContain(unassigned);
+    expect(ids).not.toContain(inArea2);
+  });
+
+  it('?areaId=<areaId>,__none__ (sentinel last) also returns correct union', () => {
+    const areaId = insertArea('Study');
+    const inArea = insertWorkItem('Paint walls', areaId);
+    const unassigned = insertWorkItem('Floating task');
+
+    const result = listWorkItems(db, buildQuery({ areaId: `${areaId},__none__` }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea);
+    expect(ids).toContain(unassigned);
+  });
+
+  // ─── Scenario 3: __none__ when all items have areas returns empty ────────────
+
+  it('?areaId=__none__ returns empty result when all work items have an assigned area', () => {
+    const areaId = insertArea('Living Room');
+    insertWorkItem('Hang curtains', areaId);
+    insertWorkItem('Lay flooring', areaId);
+
+    const result = listWorkItems(db, buildQuery({ areaId: '__none__' }));
+
+    expect(result.items).toHaveLength(0);
+    expect(result.pagination.totalItems).toBe(0);
+  });
+
+  // ─── Scenario 4: Regression — parentId expands to descendants ───────────────
+
+  it('?areaId=<parentId> (no sentinel) returns items for parent AND descendant areas', () => {
+    const parentId = insertArea('Floor 1');
+    const childId = insertArea('Bedroom 1', parentId);
+
+    const parentItem = insertWorkItem('Floor works', parentId);
+    const childItem = insertWorkItem('Bedroom decoration', childId);
+    const unrelated = insertWorkItem('Unrelated task');
+
+    const result = listWorkItems(db, buildQuery({ areaId: parentId }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(parentItem);
+    expect(ids).toContain(childItem);
+    expect(ids).not.toContain(unrelated);
+  });
+
+  it('?areaId=<grandparentId> expands recursively through all descendants', () => {
+    const grandparentId = insertArea('House');
+    const parentId = insertArea('Ground Floor', grandparentId);
+    const childId = insertArea('Kitchen', parentId);
+
+    const gpItem = insertWorkItem('Foundation work', grandparentId);
+    const pItem = insertWorkItem('Floor tiling', parentId);
+    const cItem = insertWorkItem('Install cabinets', childId);
+    const unrelated = insertWorkItem('No area');
+
+    const result = listWorkItems(db, buildQuery({ areaId: grandparentId }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(gpItem);
+    expect(ids).toContain(pItem);
+    expect(ids).toContain(cItem);
+    expect(ids).not.toContain(unrelated);
+  });
+
+  // ─── Scenario 5: Regression — single leaf areaId ────────────────────────────
+
+  it('?areaId=<leafId> returns only items for that exact leaf area', () => {
+    const areaA = insertArea('Bathroom');
+    const areaB = insertArea('Kitchen');
+
+    const itemA = insertWorkItem('Tile bathroom', areaA);
+    const itemB = insertWorkItem('Install oven', areaB);
+    const unassigned = insertWorkItem('Unassigned');
+
+    const result = listWorkItems(db, buildQuery({ areaId: areaA }));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(itemA);
+    expect(ids).not.toContain(itemB);
+    expect(ids).not.toContain(unassigned);
+    expect(result.items).toHaveLength(1);
+  });
+
+  // ─── No areaId filter — returns all items ───────────────────────────────────
+
+  it('omitting areaId returns all work items regardless of area assignment', () => {
+    const areaId = insertArea('Garden');
+    const inArea = insertWorkItem('Fence installation', areaId);
+    const noArea = insertWorkItem('General planning');
+
+    const result = listWorkItems(db, buildQuery({}));
+    const ids = result.items.map((i) => i.id);
+
+    expect(ids).toContain(inArea);
+    expect(ids).toContain(noArea);
+  });
+
+  // ─── Pagination metadata reflects filter ────────────────────────────────────
+
+  it('pagination.totalItems reflects __none__ sentinel filter count accurately', () => {
+    const areaId = insertArea('Office');
+    insertWorkItem('Paint office', areaId);
+    insertWorkItem('Unassigned 1');
+    insertWorkItem('Unassigned 2');
+
+    const result = listWorkItems(db, buildQuery({ areaId: '__none__' }));
+
+    expect(result.pagination.totalItems).toBe(2);
+    expect(result.pagination.totalPages).toBe(1);
+  });
+});

--- a/server/src/services/workItemService.ts
+++ b/server/src/services/workItemService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { eq, sql, and, or, desc, asc, inArray } from 'drizzle-orm';
+import { eq, sql, and, or, desc, asc, inArray, isNull } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
 import type { areas } from '../db/schema.js';
@@ -16,7 +16,7 @@ import {
 import { listWorkItemBudgets } from './workItemBudgetService.js';
 import { autoReschedule } from './schedulingEngine.js';
 import { deleteLinksForEntity } from './documentLinkService.js';
-import { getDescendantIds, loadAreaMap, resolveAreaAncestors } from './areaService.js';
+import { getDescendantIds, loadAreaMap, resolveAreaAncestors, resolveAreaFilter } from './areaService.js';
 import type { AreaMapEntry } from './areaService.js';
 import {
   onWorkItemStatusChanged,
@@ -41,28 +41,6 @@ import type {
 import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
-
-/**
- * Parse the areaId filter (single ID, CSV string, or array) into an expanded,
- * deduplicated array of area IDs including each supplied ID's descendants.
- * Empty segments and unknown IDs are silently ignored (inArray on unknown IDs returns no rows).
- */
-function resolveAreaIds(db: DbType, areaId: string | string[]): string[] {
-  const raw = Array.isArray(areaId)
-    ? areaId
-    : areaId
-        .split(',')
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-
-  const expanded = new Set<string>();
-  for (const id of raw) {
-    for (const descendant of getDescendantIds(db, id)) {
-      expanded.add(descendant);
-    }
-  }
-  return [...expanded];
-}
 
 /**
  * Count budget lines for a work item.
@@ -656,8 +634,12 @@ export function listWorkItems(
   }
 
   if (query.areaId) {
-    const areaIds = resolveAreaIds(db, query.areaId);
-    if (areaIds.length > 0) {
+    const { areaIds, includeNull } = resolveAreaFilter(db, query.areaId);
+    if (includeNull && areaIds.length > 0) {
+      baseConditions.push(or(isNull(workItems.areaId), inArray(workItems.areaId, areaIds))!);
+    } else if (includeNull) {
+      baseConditions.push(isNull(workItems.areaId));
+    } else if (areaIds.length > 0) {
       baseConditions.push(inArray(workItems.areaId, areaIds));
     }
   }

--- a/server/src/services/workItemService.ts
+++ b/server/src/services/workItemService.ts
@@ -641,6 +641,10 @@ export function listWorkItems(
       baseConditions.push(isNull(workItems.areaId));
     } else if (areaIds.length > 0) {
       baseConditions.push(inArray(workItems.areaId, areaIds));
+    } else {
+      // Filter param was provided but contained only unknown IDs (no sentinel).
+      // Preserve the contract: return empty result rather than silently dropping the filter.
+      baseConditions.push(sql`1 = 0`);
     }
   }
 

--- a/server/src/services/workItemService.ts
+++ b/server/src/services/workItemService.ts
@@ -634,18 +634,18 @@ export function listWorkItems(
   }
 
   if (query.areaId) {
-    const { areaIds, includeNull } = resolveAreaFilter(db, query.areaId);
+    const { areaIds, includeNull, hasInput } = resolveAreaFilter(db, query.areaId);
     if (includeNull && areaIds.length > 0) {
       baseConditions.push(or(isNull(workItems.areaId), inArray(workItems.areaId, areaIds))!);
     } else if (includeNull) {
       baseConditions.push(isNull(workItems.areaId));
     } else if (areaIds.length > 0) {
       baseConditions.push(inArray(workItems.areaId, areaIds));
-    } else {
-      // Filter param was provided but contained only unknown IDs (no sentinel).
-      // Preserve the contract: return empty result rather than silently dropping the filter.
+    } else if (hasInput) {
+      // User supplied ID(s) but all were unknown — yield empty result
       baseConditions.push(sql`1 = 0`);
     }
+    // else: no meaningful input (empty/whitespace-only CSV) — skip filter
   }
 
   if (query.assignedVendorId) {

--- a/shared/src/types/householdItem.ts
+++ b/shared/src/types/householdItem.ts
@@ -256,6 +256,13 @@ export interface HouseholdItemListQuery {
   q?: string;
   category?: HouseholdItemCategory;
   status?: HouseholdItemStatus;
+  /**
+   * Filter by area UUID or comma-separated list of area UUIDs.
+   * For each supplied ID the server expands descendants server-side;
+   * results are the union of all matching subtrees.
+   * Use the sentinel value `__none__` to include items with no area assignment.
+   * `__none__` can be combined with UUIDs (e.g., `__none__,kitchen-uuid`) for union.
+   */
   areaId?: string;
   vendorId?: string;
   plannedCostMin?: number;

--- a/shared/src/types/workItem.ts
+++ b/shared/src/types/workItem.ts
@@ -174,6 +174,13 @@ export interface WorkItemListQuery {
   status?: WorkItemStatus;
   assignedUserId?: string;
   assignedVendorId?: string;
+  /**
+   * Filter by area UUID or comma-separated list of area UUIDs.
+   * For each supplied ID the server expands descendants server-side;
+   * results are the union of all matching subtrees.
+   * Use the sentinel value `__none__` to include items with no area assignment.
+   * `__none__` can be combined with UUIDs (e.g., `__none__,kitchen-uuid`) for union.
+   */
   areaId?: string;
   q?: string;
   budgetLinesMin?: number;


### PR DESCRIPTION
## Summary
- Add `__none__` sentinel to `EnumFilter`; opt-in via `enumIncludeNone` column prop
- Work Items + Household Items lists expose a "No Area" row pinned above the named-area list
- Backend: lift `resolveAreaFilter` to `areaService`; accept sentinel (OR null-area); upgrade household items to CSV + descendant expansion
- 62 unit/integration tests + 10 E2E scenarios
- Wiki API contract updated for both endpoints

Fixes #1277

## Test plan
- [ ] Quality Gates green on beta

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>