### PR TITLE
fix(e2e): drop Vendors from Budget subnav assertion

### DIFF
--- a/e2e/tests/invoices/invoices.spec.ts
+++ b/e2e/tests/invoices/invoices.spec.ts
@@ -169,7 +169,6 @@ test.describe('Invoices list page load (Scenario 1)', { tag: '@responsive' }, ()
     const subNav = page.getByRole('navigation', { name: 'Budget section navigation' });
     await expect(subNav.getByRole('link', { name: 'Overview' })).toBeVisible();
     await expect(subNav.getByRole('link', { name: 'Invoices' })).toBeVisible();
-    await expect(subNav.getByRole('link', { name: 'Vendors' })).toBeVisible();
     await expect(subNav.getByRole('link', { name: 'Sources' })).toBeVisible();
     await expect(subNav.getByRole('link', { name: 'Subsidies' })).toBeVisible();
   });


### PR DESCRIPTION
## Summary

PR #1286 moved Vendors from the Budget subnav to the Settings sidebar. The invoices E2E at line 162 still asserted Vendors in the Budget navigation, causing desktop/tablet/mobile fail-fast on PR #1215's E2E Gates.

One-line removal of the stale assertion. Other 4 Budget tabs (Overview, Invoices, Sources, Subsidies) remain asserted.

Unblocks #1215.

## Test plan
- [ ] `E2E Gates` passes