### PR TITLE
fix(budget-sources): preserve selection, restructure area header, nested tree

### DIFF
--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -54,16 +54,40 @@
 
 .areaGroupHeader {
   display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-2);
+  flex-direction: column;
+  gap: var(--spacing-0-5);
   margin-bottom: var(--spacing-1);
   padding: var(--spacing-1-5) 0;
   border-bottom: 1px solid var(--color-border);
 }
 
+.areaTitleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.areaTitleRow .areaLineCount {
+  margin-left: auto;
+}
+
+.areaSelectAllRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding-left: var(--spacing-3);
+  cursor: pointer;
+}
+
 .areaGroupCheckbox {
   flex-shrink: 0;
   min-height: 2.75rem;
+}
+
+.areaSelectAllLabel {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-normal);
 }
 
 .areaColorDot {
@@ -76,15 +100,12 @@
 }
 
 .areaNameContainer {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-0-5);
-  flex: 1;
+  display: none;
 }
 
 .areaName {
   font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
 }
 

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -299,12 +299,12 @@ describe('SourceBudgetLinePanel', () => {
       // Both area headers should appear — named area and "Unassigned"
       const kitchenHeaders = screen.getAllByText('Kitchen');
       expect(kitchenHeaders.length).toBeGreaterThan(0);
-      expect(screen.getByText('Unassigned')).toBeInTheDocument();
+      expect(screen.getByText('No Area')).toBeInTheDocument();
 
       // Verify order: "Kitchen" should appear before "Unassigned" in the DOM
       const allText = document.body.textContent ?? '';
       const kitchenPos = allText.indexOf('Kitchen');
-      const unassignedPos = allText.indexOf('Unassigned');
+      const unassignedPos = allText.indexOf('No Area');
       expect(kitchenPos).toBeLessThan(unassignedPos);
     });
   });

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
@@ -133,12 +133,13 @@ function buildAreaTree(lines: BudgetSourceBudgetLine[]): AreaNode[] {
     if (!areaMap.has(areaId)) {
       // Find any line that has this area as an ancestor
       for (const line of lines) {
-        if ((line.area?.ancestors ?? []).some((a) => a.id === areaId)) {
-          const ancestor = (line.area!.ancestors ?? []).find((a) => a.id === areaId)!;
+        const chain = line.area?.ancestors ?? [];
+        const idx = chain.findIndex((a) => a.id === areaId);
+        if (idx >= 0) {
           areaMap.set(areaId, {
-            name: ancestor.name,
-            color: ancestor.color,
-            ancestors: [], // We'd need to traverse further; for now, assume these are implicit parents
+            name: chain[idx].name,
+            color: chain[idx].color,
+            ancestors: chain.slice(0, idx),
             lines: [],
           });
           break;
@@ -414,81 +415,68 @@ export function SourceBudgetLinePanel({
         className={styles.areaGroup}
         style={{ paddingLeft: `calc(${node.depth} * var(--spacing-4))` }}
       >
-        <div className={styles.areaGroupHeader}>
-          {isSelectable && selectionState && (
-            <TriStateCheckbox
-              id={`area-${groupKey}-checkbox`}
-              checked={selectionState.allSelected}
-              indeterminate={!selectionState.allSelected && selectionState.someSelected}
-              onChange={(checked) =>
-                handleAreaGroupCheckboxChange(
-                  {
-                    areaId: node.areaId,
-                    areaName: node.areaName,
-                    areaColor: node.areaColor,
-                    depth: node.depth,
-                    ancestors: node.ancestors,
-                    parentGroups: node.parentGroups,
-                    totalLines: node.totalLines,
-                  },
-                  checked,
-                  parentType,
-                )
-              }
-              label={t('sources.budgetLines.move.selectGroupLabel', {
-                name: areaName,
-              })}
-              className={styles.areaGroupCheckbox}
-            />
-          )}
-          {!isSelectable && (
-            <>
-              {node.areaColor && (
-                <span
-                  className={styles.areaColorDot}
-                  style={{ backgroundColor: node.areaColor }}
-                  aria-hidden="true"
-                />
-              )}
-              {!node.areaColor && node.areaId === null && (
-                <span
-                  className={styles.areaColorDot}
-                  style={{ backgroundColor: 'var(--color-text-disabled)' }}
-                  aria-hidden="true"
-                />
-              )}
-            </>
-          )}
-          {isSelectable && !selectionState && (
-            <>
-              {node.areaColor && (
-                <span
-                  className={styles.areaColorDot}
-                  style={{ backgroundColor: node.areaColor }}
-                  aria-hidden="true"
-                />
-              )}
-              {!node.areaColor && node.areaId === null && (
-                <span
-                  className={styles.areaColorDot}
-                  style={{ backgroundColor: 'var(--color-text-disabled)' }}
-                  aria-hidden="true"
-                />
-              )}
-            </>
-          )}
-          <div className={styles.areaNameContainer}>
+        <header className={styles.areaGroupHeader}>
+          <div className={styles.areaTitleRow}>
+            {node.areaColor && (
+              <span
+                className={styles.areaColorDot}
+                style={{ backgroundColor: node.areaColor }}
+                aria-hidden="true"
+              />
+            )}
+            {!node.areaColor && node.areaId === null && (
+              <span
+                className={styles.areaColorDot}
+                style={{ backgroundColor: 'var(--color-text-disabled)' }}
+                aria-hidden="true"
+              />
+            )}
             <span className={styles.areaName}>{areaName}</span>
             {breadcrumb && (
               <span className={styles.areaAncestorHint}>
                 {t('sources.lines.underArea', { breadcrumb })}
               </span>
             )}
+            {!isSelectable && (
+              <span className={styles.areaLineCount}>
+                {t('sources.lines.areaLineCount', { count: node.totalLines })}
+              </span>
+            )}
           </div>
-          <span className={styles.areaLineCount}>
-            {t('sources.lines.areaLineCount', { count: node.totalLines })}
-          </span>
-        </div>
+          {isSelectable && selectionState && (
+            <label className={styles.areaSelectAllRow}>
+              <TriStateCheckbox
+                id={`area-${groupKey}-checkbox`}
+                checked={selectionState.allSelected}
+                indeterminate={!selectionState.allSelected && selectionState.someSelected}
+                onChange={(checked) =>
+                  handleAreaGroupCheckboxChange(
+                    {
+                      areaId: node.areaId,
+                      areaName: node.areaName,
+                      areaColor: node.areaColor,
+                      depth: node.depth,
+                      ancestors: node.ancestors,
+                      parentGroups: node.parentGroups,
+                      totalLines: node.totalLines,
+                    },
+                    checked,
+                    parentType,
+                  )
+                }
+                className={styles.areaGroupCheckbox}
+              />
+              <span className={styles.areaSelectAllLabel}>
+                {t('sources.budgetLines.move.selectGroupLabel', {
+                  name: areaName,
+                })}
+              </span>
+              <span className={styles.areaLineCount}>
+                {t('sources.lines.areaLineCount', { count: node.totalLines })}
+              </span>
+            </label>
+          )}
+        </header>
 
         {node.parentGroups.map((parentGroup) => (
           <div key={parentGroup.parentId} className={styles.parentItemBlock}>

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -164,7 +164,7 @@
       "emptyDescription": "Budgetpositionen aus Arbeitspaketen und Haushaltsartikeln erscheinen hier, wenn sie dieser Quelle zugeordnet sind.",
       "workItemSection": "Arbeitspaket-Positionen",
       "householdItemSection": "Haushaltsartikel-Positionen",
-      "unassignedArea": "Nicht zugeordnet",
+      "unassignedArea": "Kein Bereich",
       "fetchError": "Budgetpositionen konnten nicht geladen werden.",
       "retry": "Erneut versuchen",
       "areaLineCount_one": "{{count}} Position",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -164,7 +164,7 @@
       "emptyDescription": "Budget lines from work items and household items appear here when assigned to this source.",
       "workItemSection": "Work Item Lines",
       "householdItemSection": "Household Item Lines",
-      "unassignedArea": "Unassigned",
+      "unassignedArea": "No Area",
       "fetchError": "Could not load budget lines.",
       "retry": "Retry",
       "areaLineCount_one": "{{count}} line",

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -572,8 +572,7 @@ export function BudgetSourcesPage() {
   const handleSelectionChange = useCallback((sourceId: string, newSet: Set<string>) => {
     setSourceSelections((prev) => {
       const next = new Map(prev);
-      if (newSet.size === 0) next.delete(sourceId);
-      else next.set(sourceId, newSet);
+      next.set(sourceId, newSet);
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary

Follow-up fixes on the source-lines panel:

- **Bug**: selecting and deselecting a line caused all checkboxes to vanish (the entry was deleted from the selection Map, leaving the panel in non-selectable mode). Keep the entry as an empty Set.
- **Area header layout**: two rows — area name prominent on top, muted "Select all in {name}" with tri-state checkbox below.
- **Nested tree**: ancestor-only areas (parents with no direct lines) now inherit the correct prefix of their ancestor chain, so a 3-deep hierarchy renders properly nested.
- **Rename**: "Unassigned" → "No Area" (EN + DE).

## Test plan

- [x] 54 unit tests pass
- [x] Typecheck clean
- [ ] CI Quality Gates green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>