### PR TITLE
ci(release): add Docker Scout compare against latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,20 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
+      - name: Docker Scout compare to latest
+        if: matrix.platform == 'linux/amd64' && github.actor == 'steilerdev'
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
+        with:
+          command: compare,recommendations
+          image: registry://steilerdev/cornerstone@${{ steps.build.outputs.digest }}
+          to: registry://steilerdev/cornerstone:latest
+          organization: steilerdev
+          only-severities: critical,high
+          dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          summary: true
+
       - name: Upload digest
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:


### PR DESCRIPTION
## Summary

- Adds an informational `compare,recommendations` Docker Scout step to the `docker-build` job (amd64 only).
- Runs while `:latest` still points to the previously published image, so the diff is meaningful on every release (the existing `scout` job runs *after* the `docker` manifest job re-tags `:latest`, so adding the compare there would compare the image to itself).
- Guarded with `github.actor == 'steilerdev'` so bot-triggered releases (Dependabot, auto-fix) skip the step.
- Pinned to `docker/scout-action@v1.20.4` to match the existing scout step.

## Test plan

- [ ] On the next beta release, verify the new "Docker Scout compare to latest" step appears in the `Docker Build (linux/amd64)` job and produces a comparison summary.
- [ ] Confirm the step is skipped when a release is triggered by Dependabot or the auto-fix bot.