### PR TITLE
fix(budget-sources): resolve area ancestor chain in budget-lines response

### DIFF
--- a/server/src/services/budgetSourceService.budgetLines.test.ts
+++ b/server/src/services/budgetSourceService.budgetLines.test.ts
@@ -84,7 +84,7 @@ describe('budgetSourceService.getBudgetSourceBudgetLines()', () => {
     return id;
   }
 
-  function createArea(name: string, color = '#ff0000'): string {
+  function createArea(name: string, color = '#ff0000', parentId: string | null = null): string {
     const id = uid('area');
     const ts = nowTs();
     app.db
@@ -93,7 +93,7 @@ describe('budgetSourceService.getBudgetSourceBudgetLines()', () => {
         id,
         name,
         color,
-        parentId: null,
+        parentId,
         description: null,
         sortOrder: 0,
         createdAt: ts,
@@ -669,5 +669,93 @@ describe('budgetSourceService.getBudgetSourceBudgetLines()', () => {
 
     const result = getBudgetSourceBudgetLines(app.db, sourceId);
     expect(result.householdItemLines[0].parentId).toBe(hiId);
+  });
+
+  // Area ancestors: root-level area has empty ancestor chain
+  it('area ancestors: root-level area has empty ancestor chain', () => {
+    const sourceId = createSource();
+    const rootArea = createArea('Kitchen', '#aabbcc');
+    const wiId = createWorkItem(rootArea);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(rootArea);
+    expect(line.area?.ancestors).toEqual([]);
+  });
+
+  // Area ancestors: 2-level hierarchy (Parent -> Child)
+  it('area ancestors: 2-level hierarchy resolves parent as ancestor', () => {
+    const sourceId = createSource();
+    const parentArea = createArea('House', '#111111');
+    const childArea = createArea('Kitchen', '#222222', parentArea);
+    const wiId = createWorkItem(childArea);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(childArea);
+    expect(line.area?.ancestors).toHaveLength(1);
+    expect(line.area?.ancestors[0].id).toBe(parentArea);
+    expect(line.area?.ancestors[0].name).toBe('House');
+  });
+
+  // Area ancestors: 3-level hierarchy (Grandparent -> Parent -> Child)
+  it('area ancestors: 3-level hierarchy resolves all ancestors in root-first order', () => {
+    const sourceId = createSource();
+    const grandparent = createArea('House', '#111111');
+    const parent = createArea('First Floor', '#222222', grandparent);
+    const child = createArea('Kitchen', '#333333', parent);
+    const wiId = createWorkItem(child);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(child);
+    expect(line.area?.ancestors).toHaveLength(2);
+    // Root-first order: House, then First Floor
+    expect(line.area?.ancestors[0].id).toBe(grandparent);
+    expect(line.area?.ancestors[0].name).toBe('House');
+    expect(line.area?.ancestors[1].id).toBe(parent);
+    expect(line.area?.ancestors[1].name).toBe('First Floor');
+  });
+
+  // Area ancestors: household item with 2-level hierarchy
+  it('area ancestors: household item with 2-level hierarchy resolves ancestors', () => {
+    const sourceId = createSource();
+    const parentArea = createArea('House', '#444444');
+    const childArea = createArea('Living Room', '#555555', parentArea);
+    const hiId = createHouseholdItem(childArea, 'Sofa');
+    createHouseholdItemBudgetLine(hiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.householdItemLines[0];
+
+    expect(line.area).not.toBeNull();
+    expect(line.area?.id).toBe(childArea);
+    expect(line.area?.ancestors).toHaveLength(1);
+    expect(line.area?.ancestors[0].id).toBe(parentArea);
+    expect(line.area?.ancestors[0].name).toBe('House');
+  });
+
+  // Area ancestors: area color is preserved in ancestors
+  it('area ancestors: ancestor color is preserved in ancestor objects', () => {
+    const sourceId = createSource();
+    const parentArea = createArea('House', '#ff0000');
+    const childArea = createArea('Kitchen', '#00ff00', parentArea);
+    const wiId = createWorkItem(childArea);
+    createWorkItemBudgetLine(wiId, sourceId);
+
+    const result = getBudgetSourceBudgetLines(app.db, sourceId);
+    const line = result.workItemLines[0];
+
+    expect(line.area?.ancestors).toHaveLength(1);
+    expect(line.area?.ancestors[0].color).toBe('#ff0000');
   });
 });

--- a/server/src/services/budgetSourceService.ts
+++ b/server/src/services/budgetSourceService.ts
@@ -37,6 +37,7 @@ import {
   toVendorSummary,
   toUserSummary,
 } from './shared/converters.js';
+import { loadAreaMap, resolveAreaAncestors, type AreaMapEntry } from './areaService.js';
 import {
   NotFoundError,
   ValidationError,
@@ -677,6 +678,7 @@ function getHouseholdItemLineInvoiceLink(db: DbType, lineId: string): BudgetLine
 function buildWorkItemBudgetLine(
   db: DbType,
   line: typeof workItemBudgets.$inferSelect,
+  areaMap: Map<string, AreaMapEntry>,
 ): BudgetSourceBudgetLine {
   const workItem = db.select().from(workItems).where(eq(workItems.id, line.workItemId)).get();
   const area =
@@ -721,7 +723,7 @@ function buildWorkItemBudgetLine(
     updatedAt: line.updatedAt,
     parentId: line.workItemId,
     parentName: workItem?.title ?? '(Unknown Work Item)',
-    area: toAreaSummary(area),
+    area: toAreaSummary(area, area ? resolveAreaAncestors(area.id, areaMap) : []),
     hasClaimedInvoice: invoiceData.hasClaimedInvoice,
   };
 }
@@ -733,6 +735,7 @@ function buildWorkItemBudgetLine(
 function buildHouseholdItemBudgetLine(
   db: DbType,
   line: typeof householdItemBudgets.$inferSelect,
+  areaMap: Map<string, AreaMapEntry>,
 ): BudgetSourceBudgetLine {
   const householdItem = db
     .select()
@@ -781,7 +784,7 @@ function buildHouseholdItemBudgetLine(
     updatedAt: line.updatedAt,
     parentId: line.householdItemId,
     parentName: householdItem?.name ?? '(Unknown Household Item)',
-    area: toAreaSummary(area),
+    area: toAreaSummary(area, area ? resolveAreaAncestors(area.id, areaMap) : []),
     hasClaimedInvoice: invoiceData.hasClaimedInvoice,
   };
 }
@@ -822,6 +825,9 @@ export function getBudgetSourceBudgetLines(
     throw new NotFoundError('Budget source not found');
   }
 
+  // Load area map once for efficient ancestor resolution
+  const areaMap = loadAreaMap(db);
+
   // Fetch work item budget lines
   const wibRows = db
     .select()
@@ -829,7 +835,7 @@ export function getBudgetSourceBudgetLines(
     .where(eq(workItemBudgets.budgetSourceId, sourceId))
     .all();
   const workItemLines = wibRows
-    .map((line) => buildWorkItemBudgetLine(db, line))
+    .map((line) => buildWorkItemBudgetLine(db, line, areaMap))
     .sort(compareBudgetSourceLines);
 
   // Fetch household item budget lines
@@ -839,7 +845,7 @@ export function getBudgetSourceBudgetLines(
     .where(eq(householdItemBudgets.budgetSourceId, sourceId))
     .all();
   const householdItemLines = hibRows
-    .map((line) => buildHouseholdItemBudgetLine(db, line))
+    .map((line) => buildHouseholdItemBudgetLine(db, line, areaMap))
     .sort(compareBudgetSourceLines);
 
   return {


### PR DESCRIPTION
## Summary

The budget-lines read endpoint was always returning `area.ancestors: []` (the converter default), so the frontend's hierarchical area tree could never see top-level parent areas that didn't directly contain lines. Example: items under "Ground Floor" and "Upper Floor" children of "House" → "House" never showed up.

## Changes

- Load the area map once per request in `getBudgetSourceBudgetLines`
- Resolve each line's area ancestor chain via `resolveAreaAncestors` and pass it to `toAreaSummary`
- 5 new unit tests for root / 2-level / 3-level hierarchies

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>