### PR TITLE
fix(e2e): update budget overview subnav tabs after Vendors→Settings move

### DIFF
--- a/e2e/tests/budget/budget-overview.spec.ts
+++ b/e2e/tests/budget/budget-overview.spec.ts
@@ -107,8 +107,8 @@ test.describe('Page heading and navigation', { tag: '@responsive' }, () => {
     // Then: The sub-navigation is visible
     await expect(overviewPage.subNav).toBeVisible();
 
-    // And: All four budget tabs are present (Categories moved to Manage page)
-    const expectedTabs = ['Overview', 'Vendors', 'Sources', 'Subsidies'];
+    // And: All four budget tabs are present (Vendors moved to Settings in #1286, Categories to Manage page)
+    const expectedTabs = ['Overview', 'Invoices', 'Sources', 'Subsidies'];
     for (const tab of expectedTabs) {
       await expect(overviewPage.subNav.getByRole('link', { name: tab })).toBeVisible();
     }


### PR DESCRIPTION
## Summary

Partner fix to #1293. After PR #1286 moved Vendors to Settings and added Invoices to the Budget subnav, `budget-overview.spec.ts:101` still asserted the old tab list. Updated to the current set: `['Overview', 'Invoices', 'Sources', 'Subsidies']`.

Unblocks PR #1215.

## Test plan
- [ ] `Quality Gates` passes
- [ ] `E2E Gates` on #1215 after this lands