### PR TITLE
fix(budget-sources): add horizontal divider between work item groups (#1309)

### DIFF
--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -129,6 +129,12 @@
   padding-left: var(--spacing-3);
 }
 
+.parentItemBlock + .parentItemBlock {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-2);
+  margin-top: var(--spacing-2);
+}
+
 .parentItemHeader {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -844,6 +844,103 @@ describe('SourceBudgetLinePanel', () => {
     });
   });
 
+  // ─── Inter-group divider structure (scenario 24) ────────────────────────────
+  //
+  // Jest + JSDOM does not parse *.module.css, so getComputedStyle cannot verify
+  // the border-top value added by the adjacent-sibling CSS selector.  These
+  // tests assert the DOM contract that the CSS selector depends on instead.
+  // Visual verification belongs to the E2E spec (e2e-test-engineer).
+
+  describe('inter-group divider structure', () => {
+    it('multiple parent groups produce multiple .parentItemBlock siblings', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'parent-1',
+        parentName: 'Kitchen Renovation',
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'parent-2',
+        parentName: 'Bathroom Renovation',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      // identity-obj-proxy returns the key name as the class value, so
+      // styles.parentItemBlock resolves to the literal string "parentItemBlock".
+      expect(document.querySelectorAll('[class*="parentItemBlock"]').length).toBe(2);
+    });
+
+    it('single parent group produces exactly one .parentItemBlock', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'parent-shared',
+        parentName: 'Kitchen Renovation',
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'parent-shared',
+        parentName: 'Kitchen Renovation',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      expect(document.querySelectorAll('[class*="parentItemBlock"]').length).toBe(1);
+    });
+
+    it('.parentItemBlock elements are siblings inside the same parent container', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'parent-1',
+        parentName: 'Kitchen Renovation',
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'parent-2',
+        parentName: 'Bathroom Renovation',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      const blocks = document.querySelectorAll('[class*="parentItemBlock"]');
+      expect(blocks.length).toBe(2);
+      // Both blocks must share the same parent — required for the CSS
+      // adjacent-sibling combinator (.parentItemBlock + .parentItemBlock) to
+      // apply the divider border-top.
+      expect(blocks[0]!.parentElement).toBe(blocks[1]!.parentElement);
+    });
+
+    it('intra-group lineRow elements are unaffected when multiple groups exist', () => {
+      const line1 = makeLine({
+        id: 'l1',
+        parentId: 'parent-1',
+        parentName: 'Kitchen Renovation',
+      });
+      const line2 = makeLine({
+        id: 'l2',
+        parentId: 'parent-2',
+        parentName: 'Bathroom Renovation',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      renderPanel({ data: makeResponse([line1, line2], []) });
+
+      const blocks = document.querySelectorAll('[class*="parentItemBlock"]');
+      expect(blocks.length).toBe(2);
+
+      // Each group must still contain at least one lineRow descendant — this is
+      // a regression guard confirming the divider change did not affect the
+      // intra-group row structure.
+      blocks.forEach((block) => {
+        const lineRows = block.querySelectorAll('[class*="lineRow"]');
+        expect(lineRows.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+
   // ─── Parent item links (scenario 23) ───────────────────────────────────────────
 
   describe('parent item header links', () => {

--- a/e2e/tests/budget/budget-source-lines.spec.ts
+++ b/e2e/tests/budget/budget-source-lines.spec.ts
@@ -115,6 +115,49 @@ function mockLinesWithWorkItems(sourceId: string) {
   };
 }
 
+/**
+ * A BudgetSourceBudgetLinesResponse with 2 work item lines belonging to TWO
+ * different parent work items (different parentId values) but sharing the same
+ * area "Kitchen".  Used to verify that the adjacent-sibling divider CSS rule
+ * (.parentItemBlock + .parentItemBlock) produces a visible border-top on the
+ * second block.
+ */
+function mockLinesWithMultipleWorkItems(sourceId: string) {
+  return {
+    workItemLines: [
+      {
+        id: `wil-a1-${sourceId}`,
+        description: 'Hardwood floor installation',
+        plannedAmount: 8000,
+        confidence: 'quote',
+        confidenceMargin: 1.0,
+        invoiceLink: null,
+        createdAt: '2026-01-01T10:00:00.000Z',
+        updatedAt: '2026-01-01T10:00:00.000Z',
+        parentId: `wi-a-${sourceId}`,
+        parentName: 'Flooring',
+        area: { id: `area-k-${sourceId}`, name: 'Kitchen', color: '#4CAF50', ancestors: [] },
+        hasClaimedInvoice: false,
+      },
+      {
+        id: `wil-b1-${sourceId}`,
+        description: 'Kitchen cabinetry',
+        plannedAmount: 12000,
+        confidence: 'own_estimate',
+        confidenceMargin: 1.2,
+        invoiceLink: null,
+        createdAt: '2026-01-02T10:00:00.000Z',
+        updatedAt: '2026-01-02T10:00:00.000Z',
+        parentId: `wi-b-${sourceId}`,
+        parentName: 'Cabinetry',
+        area: { id: `area-k-${sourceId}`, name: 'Kitchen', color: '#4CAF50', ancestors: [] },
+        hasClaimedInvoice: false,
+      },
+    ],
+    householdItemLines: [],
+  };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Expand shows panel — @smoke
 // ─────────────────────────────────────────────────────────────────────────────
@@ -612,6 +655,109 @@ test.describe('Lines cache — second expand does not refetch', { tag: '@respons
 
       // Panel is visible again
       await expect(sourcesPage.getLinesPanelById(sourceId)).toBeVisible();
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inter-work-item divider (Story #1309)
+// Validates that .parentItemBlock + .parentItemBlock { border-top: 1px solid }
+// is applied by the browser when two distinct parent groups render side-by-side.
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('inter-work-item divider', { tag: '@responsive' }, () => {
+  test('divider is visible between two work item groups', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Divider Multi Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 20000 });
+
+      const linesResponse = mockLinesWithMultipleWorkItems(sourceId);
+
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(linesResponse),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // Two distinct parent groups must be rendered.
+      const blocks = panel.locator('[class*="parentItemBlock"]');
+      await expect(blocks).toHaveCount(2);
+
+      // Second block must have a solid border-top (the CSS adjacent-sibling divider).
+      const secondBlockBorderStyle = await blocks.nth(1).evaluate((el) => {
+        return getComputedStyle(el).borderTopStyle;
+      });
+      const secondBlockBorderWidth = await blocks.nth(1).evaluate((el) => {
+        return getComputedStyle(el).borderTopWidth;
+      });
+      expect(secondBlockBorderStyle).toBe('solid');
+      expect(secondBlockBorderWidth).not.toBe('0px');
+
+      // First block must NOT have a border-top (no preceding sibling).
+      const firstBlockBorderStyle = await blocks.nth(0).evaluate((el) => {
+        return getComputedStyle(el).borderTopStyle;
+      });
+      expect(['none', '']).toContain(firstBlockBorderStyle);
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+
+  test('no divider when only one work item group is present', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Divider Single Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 10000 });
+
+      const linesResponse = mockLinesWithWorkItems(sourceId);
+
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(linesResponse),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const linesResponsePromise = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await linesResponsePromise;
+
+      const panel = sourcesPage.getLinesPanelById(sourceId);
+      await expect(panel).toBeVisible();
+
+      // Only one parent group must be rendered.
+      const blocks = panel.locator('[class*="parentItemBlock"]');
+      await expect(blocks).toHaveCount(1);
+
+      // The single block must NOT have a border-top.
+      const borderStyle = await blocks.nth(0).evaluate((el) => {
+        return getComputedStyle(el).borderTopStyle;
+      });
+      expect(['none', '']).toContain(borderStyle);
     } finally {
       if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
       if (sourceId) await deleteSourceViaApi(page, sourceId);


### PR DESCRIPTION
## Summary

- Add a horizontal `border-top` between consecutive `.parentItemBlock` siblings in `SourceBudgetLinePanel` so work-item groups are visually separated in the Budget > Sources list.
- Uses adjacent-sibling selector `.parentItemBlock + .parentItemBlock` with `--color-border` + `--spacing-2` tokens (auto-themed for dark mode, no trailing divider after the last group).
- Unit tests document the DOM contract the CSS selector depends on; E2E tests assert the computed `border-top` across desktop/tablet/mobile viewports.

Fixes #1309

## Test plan

- [x] Unit tests: structural DOM contract in \`SourceBudgetLinePanel.test.tsx\`
- [x] E2E tests: computed-style assertions in \`e2e/tests/budget/budget-source-lines.spec.ts\` (\`@responsive\`)
- [x] Stylelint: tokens only, no hardcoded colors/spacing
- [ ] Quality Gates CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>