### PR TITLE
fix(budget): polish print output for Budget Overview (#1317)

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
@@ -538,6 +538,7 @@
     overflow: visible;
     overflow-x: visible;
     -webkit-overflow-scrolling: auto;
+    scrollbar-width: none;
   }
 
   .table {
@@ -589,5 +590,29 @@
 
   .nameLink::after {
     content: none !important;
+  }
+
+  /* --- Three-level visual hierarchy for print --- */
+
+  /* Level 1 (area rows): strong top border + tinted background */
+  .rowLevel1 td {
+    border-top: 2pt solid var(--color-border-strong);
+    border-bottom: none;
+    background-color: var(--color-bg-tertiary) !important;
+  }
+
+  /* Level 2 (item rows): medium bottom border separating items */
+  .rowLevel2 td {
+    border-bottom: 1.5pt solid var(--color-border-strong);
+  }
+
+  /* Level 2 before budget lines: suppress bottom border so item + lines attach visually */
+  .rowLevel2:has(+ .rowLevel3) td {
+    border-bottom: none;
+  }
+
+  /* Level 3 (budget line rows): light dotted border — grouped under parent */
+  .rowLevel3 td {
+    border-bottom: 1pt dotted var(--color-border);
   }
 }

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
@@ -575,5 +575,24 @@
     --color-danger-text-on-light: #991b1b;
     --color-warning-text-on-light: #c2410c;
   }
+
+  /* Suppress browser-generated header/footer by zeroing @page margin */
+  @page {
+    margin: 0;
+  }
+
+  /* Restore readable padding after zeroing @page margin */
+  body {
+    padding: 1cm;
+  }
+
+  /* No scrollable ancestor should reserve scrollbar gutter */
+  html,
+  body,
+  main,
+  #root,
+  #root > * {
+    overflow: visible !important;
+  }
 }
 /* stylelint-enable color-no-hex */


### PR DESCRIPTION
## Summary

- Suppress scrollbars on `CostBreakdownTable` in print via `scrollbar-width: none` so the table renders flush without ghost scroll gutters
- Add `@page { margin: 0 }` + `body { padding: 1cm }` inside `:global(@media print)` on `BudgetOverviewPage` to suppress browser-injected URL/date header/footer and restore a clean 1 cm page margin
- Apply three-tier visual border hierarchy (area rows → item rows → budget-line rows) in the print stylesheet so the printed table mirrors the on-screen layout

Fixes #1317

## Test plan

- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>