### PR TITLE
fix(budget): strengthen print area grouping and suppress AppShell scrollbar (#1320)

### DIFF
--- a/client/src/components/AppShell/AppShell.module.css
+++ b/client/src/components/AppShell/AppShell.module.css
@@ -83,3 +83,10 @@
     transition: none;
   }
 }
+
+@media print {
+  .mainContent {
+    overflow: visible !important;
+    overflow-y: visible !important;
+  }
+}

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
@@ -596,9 +596,10 @@
 
   /* Level 1 (area rows): strong top border + tinted background */
   .rowLevel1 td {
-    border-top: 2pt solid var(--color-border-strong);
+    border-top: 3pt solid var(--color-border-strong);
     border-bottom: none;
-    background-color: var(--color-bg-tertiary) !important;
+    background-color: var(--color-border) !important;
+    font-weight: 600;
   }
 
   /* Level 2 (item rows): medium bottom border separating items */


### PR DESCRIPTION
## Summary

- Added `@media print` override on `.mainContent` in `AppShell.module.css` to suppress the scrollbar area bleeding into print output — the CSS Module scoped class was not covered by the previous global `overflow: visible` rule
- Strengthened area row visual grouping in print output: bumped `.rowLevel1 td` top border to 3pt, applied `var(--color-border)` background tint (renders on paper), and set `font-weight: 600` for semi-bold text

Fixes #1320

## Test plan
- [ ] Print the Budget page and verify no scrollbar ghost column appears in the output
- [ ] Verify area rows (level 1) print with a visible top border, background tint, and semi-bold text
- [ ] Unit tests pass (95%+ coverage)
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>