### PR TITLE
fix(budget): print polish — page margins, title spacing, nested group boxes (#1325)

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
@@ -598,16 +598,51 @@
   .rowLevel1 td {
     border-top: 3pt solid var(--color-border-strong);
     border-bottom: none;
-    background-color: var(--color-border) !important;
+    background-color: var(--color-bg-secondary) !important;
     font-weight: 600;
   }
 
-  /* Level 2 (item rows): medium bottom border separating items */
-  .rowLevel2 td {
+  /* ========= OUTER (area) BOX — medium gray ========= */
+
+  /* Left edge of outer box — every row in cost section gets left border */
+  .costSection .rowLevel1 td:first-child,
+  .costSection .rowLevel2 td:first-child,
+  .costSection .rowLevel3 td:first-child {
+    border-left: 1.5pt solid var(--color-border-strong);
+  }
+
+  /* Right edge of outer box — every row in cost section gets right border */
+  .costSection .rowLevel1 td:last-child,
+  .costSection .rowLevel2 td:last-child,
+  .costSection .rowLevel3 td:last-child {
+    border-right: 1.5pt solid var(--color-border-strong);
+  }
+
+  /* Bottom edge of outer box — rows before next area or sum get bottom border */
+  .costSection .rowLevel2:has(+ .rowLevel1) td,
+  .costSection .rowLevel3:has(+ .rowLevel1) td,
+  .costSection .rowLevel2:has(+ .rowSum) td,
+  .costSection .rowLevel3:has(+ .rowSum) td,
+  .costSection .rowLevel2:last-child td,
+  .costSection .rowLevel3:last-child td {
     border-bottom: 1.5pt solid var(--color-border-strong);
   }
 
-  /* Level 2 before budget lines: suppress bottom border so item + lines attach visually */
+  /* ========= INNER (item) BOX — lighter gray ========= */
+
+  /* Inner left edge — inset shadow on item and budget-line rows */
+  .costSection .rowLevel2 td:first-child,
+  .costSection .rowLevel3 td:first-child {
+    box-shadow: inset 8pt 0 0 -6pt var(--color-border);
+  }
+
+  /* Inner right edge — inset shadow on item and budget-line rows */
+  .costSection .rowLevel2 td:last-child,
+  .costSection .rowLevel3 td:last-child {
+    box-shadow: inset -8pt 0 0 -6pt var(--color-border);
+  }
+
+  /* Level 2 (item rows): suppress bottom border when followed by budget lines */
   .rowLevel2:has(+ .rowLevel3) td {
     border-bottom: none;
   }

--- a/client/src/components/PageLayout/PageLayout.module.css
+++ b/client/src/components/PageLayout/PageLayout.module.css
@@ -76,3 +76,21 @@
     margin-bottom: var(--spacing-4);
   }
 }
+
+@media print {
+  .container {
+    padding-top: 0;
+    margin-top: 0;
+  }
+
+  .header {
+    padding-top: 0;
+    margin-top: 0;
+    margin-bottom: var(--spacing-3);
+  }
+
+  .title {
+    padding-top: 0;
+    margin-top: 0;
+  }
+}

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
@@ -576,14 +576,9 @@
     --color-warning-text-on-light: #c2410c;
   }
 
-  /* Suppress browser-generated header/footer by zeroing @page margin */
+  /* Apply proper margins to all pages */
   @page {
-    margin: 0;
-  }
-
-  /* Restore readable padding after zeroing @page margin */
-  body {
-    padding: 1cm;
+    margin: 1.5cm 1cm;
   }
 
   /* No scrollable ancestor should reserve scrollbar gutter */


### PR DESCRIPTION
## Summary

- Per-page top/bottom margins via `@page { margin: 1.5cm 1cm }` (works on continuation pages; replaces first-page-only `body { padding }` approach)
- Reduced top spacing before page h1 in print via PageLayout `@media print` overrides
- Nested grayscale visual group boxes: outer medium-gray rectangle around each area + all descendants; inner light-gray rectangle around each item + its budget lines. Uses `:has()` selectors for bottom edges and `box-shadow: inset` for inner edges.

Fixes #1325

## Test plan
- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>