### PR TITLE
feat(budget): clickable tiles select all budget lines (#1323)

### DIFF
--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.module.css
@@ -77,24 +77,6 @@
   margin-left: auto;
 }
 
-.areaSelectAllRow {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding-left: var(--spacing-3);
-  cursor: pointer;
-}
-
-.areaGroupCheckbox {
-  flex-shrink: 0;
-  min-height: 2.75rem;
-}
-
-.areaSelectAllLabel {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  font-weight: var(--font-weight-normal);
-}
 
 .areaColorDot {
   display: inline-block;
@@ -136,24 +118,100 @@
 }
 
 .parentItemHeader {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
   margin-bottom: var(--spacing-2);
   padding-bottom: var(--spacing-2);
   border-bottom: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+}
+
+.parentItemHeaderLink {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  flex: 1;
   transition: color var(--transition-normal);
 }
 
-.parentItemHeader:hover {
+.parentItemHeaderLink:hover {
   color: var(--color-primary);
   text-decoration: underline;
 }
 
-.parentItemHeader:focus-visible {
+.parentItemHeaderLink:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
+.parentItemName {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.parentItemNavLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-normal);
+}
+
+.parentItemNavLink:hover {
+  color: var(--color-primary);
+}
+
+.parentItemNavLink:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.parentItemBlockMixed {
+  background-color: var(--color-primary-bg);
+  border-color: var(--color-border-strong);
+}
+
+.parentItemBlockChecked {
+  background-color: var(--color-primary-bg);
+  border-color: var(--color-primary);
+}
+
+.parentItemBlock[role="checkbox"] {
+  cursor: pointer;
+}
+
+.parentItemBlock[role="checkbox"]:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.areaNameClickable {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: color var(--transition-normal);
+}
+
+.areaNameClickable:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.areaNameClickable:focus-visible {
   outline: none;
   box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
@@ -299,7 +357,10 @@
   }
   .retryButton,
   .actionBarButton,
-  .lineRow {
+  .lineRow,
+  .areaNameClickable,
+  .parentItemNavLink,
+  .parentItemHeaderLink {
     transition: none;
   }
 }
@@ -357,10 +418,6 @@
 @media (max-width: 767px) {
   .checkbox {
     min-width: 2.75rem;
-    min-height: 2.75rem;
-  }
-
-  .areaGroupCheckbox {
     min-height: 2.75rem;
   }
 

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.test.tsx
@@ -731,6 +731,10 @@ describe('SourceBudgetLinePanel', () => {
   });
 
   // ─── Selection mode: area group checkbox (scenario 21) ───────────────────────
+  //
+  // After the tile-click refactor, the area name itself carries role="checkbox"
+  // (as a <div>) instead of the old TriStateCheckbox <input> inside
+  // .areaSelectAllRow. Assertions target aria-checked instead of .indeterminate.
 
   describe('area group checkbox', () => {
     it('clicking all-unchecked area group checkbox adds all area line ids to selection', () => {
@@ -755,9 +759,10 @@ describe('SourceBudgetLinePanel', () => {
         onMoveLines: jest.fn(),
       });
 
-      // Area group checkbox has aria-label containing the area name
-      const areaCheckbox = screen.getByRole('checkbox', { name: /Select all in Main/i });
-      fireEvent.click(areaCheckbox);
+      // Area name <div role="checkbox"> carries the area-group selection state
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      expect(areaName.getAttribute('aria-checked')).toBe('false');
+      fireEvent.click(areaName);
 
       expect(onSelectionChange).toHaveBeenCalledTimes(1);
       const newSet = onSelectionChange.mock.calls[0]![0];
@@ -787,8 +792,9 @@ describe('SourceBudgetLinePanel', () => {
         onMoveLines: jest.fn(),
       });
 
-      const areaCheckbox = screen.getByRole('checkbox', { name: /Select all in Main/i });
-      fireEvent.click(areaCheckbox);
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      expect(areaName.getAttribute('aria-checked')).toBe('true');
+      fireEvent.click(areaName);
 
       expect(onSelectionChange).toHaveBeenCalledTimes(1);
       const newSet = onSelectionChange.mock.calls[0]![0];
@@ -796,7 +802,7 @@ describe('SourceBudgetLinePanel', () => {
       expect(newSet.has('l2')).toBe(false);
     });
 
-    it('area group checkbox has indeterminate=true when only some lines are selected', () => {
+    it('area group checkbox has aria-checked="mixed" when only some lines are selected', () => {
       const line1 = makeLine({
         id: 'l1',
         parentId: 'p1',
@@ -817,10 +823,408 @@ describe('SourceBudgetLinePanel', () => {
         onMoveLines: jest.fn(),
       });
 
-      const areaCheckbox = screen.getByRole('checkbox', {
-        name: /Select all in Main/i,
-      }) as HTMLInputElement;
-      expect(areaCheckbox.indeterminate).toBe(true);
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      // The area name div uses aria-checked="mixed" for the indeterminate state
+      expect(areaName.getAttribute('aria-checked')).toBe('mixed');
+    });
+  });
+
+  // ─── Area name ARIA tri-state (scenario B) ───────────────────────────────────
+
+  describe('area name ARIA tri-state', () => {
+    function makeMainAreaLines() {
+      return [
+        makeLine({
+          id: 'l1',
+          parentId: 'p1',
+          parentName: 'Kitchen',
+          area: makeArea({ id: 'a1', name: 'Main' }),
+        }),
+        makeLine({
+          id: 'l2',
+          parentId: 'p1',
+          parentName: 'Kitchen',
+          area: makeArea({ id: 'a1', name: 'Main' }),
+          createdAt: '2026-01-02T00:00:00.000Z',
+        }),
+      ];
+    }
+
+    it('has aria-checked="false" when no lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeMainAreaLines(), []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      expect(areaName.getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('has aria-checked="true" when all area lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeMainAreaLines(), []),
+        selectedLineIds: new Set<string>(['l1', 'l2']),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      expect(areaName.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('has aria-checked="mixed" when only some lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeMainAreaLines(), []),
+        selectedLineIds: new Set<string>(['l1']),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      expect(areaName.getAttribute('aria-checked')).toBe('mixed');
+    });
+  });
+
+  // ─── Area name keyboard toggle (scenario C) ──────────────────────────────────
+
+  describe('area name keyboard interaction', () => {
+    function renderAreaWithTwoLines() {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse(
+          [
+            makeLine({
+              id: 'l1',
+              parentId: 'p1',
+              parentName: 'Kitchen',
+              area: makeArea({ id: 'a1', name: 'Main' }),
+            }),
+            makeLine({
+              id: 'l2',
+              parentId: 'p1',
+              parentName: 'Kitchen',
+              area: makeArea({ id: 'a1', name: 'Main' }),
+              createdAt: '2026-01-02T00:00:00.000Z',
+            }),
+          ],
+          [],
+        ),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+      return onSelectionChange;
+    }
+
+    it('pressing Enter on area name selects all descendant lines', () => {
+      const onSelectionChange = renderAreaWithTwoLines();
+
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      fireEvent.keyDown(areaName, { key: 'Enter' });
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      expect(newSet.has('l1')).toBe(true);
+      expect(newSet.has('l2')).toBe(true);
+    });
+
+    it('pressing Space on area name selects all descendant lines', () => {
+      const onSelectionChange = renderAreaWithTwoLines();
+
+      const areaName = screen.getByRole('checkbox', { name: /Select all in Main/i });
+      fireEvent.keyDown(areaName, { key: ' ' });
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      expect(newSet.has('l1')).toBe(true);
+      expect(newSet.has('l2')).toBe(true);
+    });
+  });
+
+  // ─── Non-selectable mode: area name is plain span (scenario D) ───────────────
+
+  describe('non-selectable mode: area name rendering', () => {
+    it('renders area name as <span> (not checkbox div) when not in selectable mode', () => {
+      const line = makeLine({
+        id: 'l1',
+        parentId: 'p1',
+        parentName: 'Kitchen',
+        area: makeArea({ id: 'a1', name: 'Main' }),
+      });
+      // Render without selectedLineIds / onSelectionChange
+      renderPanel({ data: makeResponse([line], []) });
+
+      const areaCheckbox = screen.queryByRole('checkbox', { name: /Select all in/i });
+      expect(areaCheckbox).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Parent card tri-state behavior (scenario E) ─────────────────────────────
+
+  describe('parent item card tri-state', () => {
+    function makeKitchenLines() {
+      return [
+        makeLine({ id: 'line-1', parentId: 'parent-kitchen', parentName: 'Kitchen Renovation' }),
+        makeLine({
+          id: 'line-2',
+          parentId: 'parent-kitchen',
+          parentName: 'Kitchen Renovation',
+          createdAt: '2026-01-02T00:00:00.000Z',
+        }),
+      ];
+    }
+
+    it('renders with role="checkbox" in selectable mode', () => {
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      expect(parentCard).toBeInTheDocument();
+    });
+
+    it('aria-checked is "false" when no lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      expect(parentCard.getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('aria-checked is "true" when all card lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(['line-1', 'line-2']),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      expect(parentCard.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('aria-checked is "mixed" when some card lines selected', () => {
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(['line-1']),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      expect(parentCard.getAttribute('aria-checked')).toBe('mixed');
+    });
+
+    it('clicking parent card selects all its lines when none selected', () => {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      fireEvent.click(parentCard);
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      expect(newSet.size).toBe(2);
+      expect(newSet.has('line-1')).toBe(true);
+      expect(newSet.has('line-2')).toBe(true);
+    });
+
+    it('clicking parent card deselects all when all selected', () => {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(['line-1', 'line-2']),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      fireEvent.click(parentCard);
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      expect(newSet.size).toBe(0);
+    });
+
+    it('clicking parent card in mixed state selects remaining lines', () => {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse(makeKitchenLines(), []),
+        selectedLineIds: new Set<string>(['line-1']),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      fireEvent.click(parentCard);
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      expect(newSet.has('line-1')).toBe(true);
+      expect(newSet.has('line-2')).toBe(true);
+    });
+  });
+
+  // ─── Parent card keyboard toggle (scenario F) ────────────────────────────────
+
+  describe('parent item card keyboard toggle', () => {
+    function renderKitchenCard() {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse(
+          [
+            makeLine({ id: 'line-1', parentId: 'parent-kitchen', parentName: 'Kitchen Renovation' }),
+            makeLine({
+              id: 'line-2',
+              parentId: 'parent-kitchen',
+              parentName: 'Kitchen Renovation',
+              createdAt: '2026-01-02T00:00:00.000Z',
+            }),
+          ],
+          [],
+        ),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+      return onSelectionChange;
+    }
+
+    it('pressing Enter on parent card toggles selection', () => {
+      const onSelectionChange = renderKitchenCard();
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      fireEvent.keyDown(parentCard, { key: 'Enter' });
+
+      expect(onSelectionChange).toHaveBeenCalled();
+    });
+
+    it('pressing Space on parent card toggles selection', () => {
+      const onSelectionChange = renderKitchenCard();
+
+      const parentCard = screen.getByRole('checkbox', {
+        name: /Select all under Kitchen Renovation/i,
+      });
+      fireEvent.keyDown(parentCard, { key: ' ' });
+
+      expect(onSelectionChange).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Nav icon link (scenario G) ──────────────────────────────────────────────
+
+  describe('nav icon link', () => {
+    it('has aria-label="Open {parentName}" pointing to work item detail', () => {
+      const line = makeLine({
+        id: 'l1',
+        parentId: 'work-item-42',
+        parentName: 'Kitchen Renovation',
+      });
+      renderPanel({
+        data: makeResponse([line], []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange: jest.fn(),
+        onMoveLines: jest.fn(),
+      });
+
+      const navLink = screen.getByRole('link', {
+        name: /Open Kitchen Renovation/i,
+      }) as HTMLAnchorElement;
+      expect(navLink).toBeInTheDocument();
+      expect(navLink.getAttribute('href')).toBe('/project/work-items/work-item-42');
+    });
+
+    it('clicking nav icon does NOT trigger card selection', () => {
+      const line = makeLine({
+        id: 'l1',
+        parentId: 'work-item-42',
+        parentName: 'Kitchen Renovation',
+      });
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      renderPanel({
+        data: makeResponse([line], []),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+
+      const navLink = screen.getByRole('link', { name: /Open Kitchen Renovation/i });
+      fireEvent.click(navLink);
+
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Individual line checkbox does not bubble (scenario H) ───────────────────
+
+  describe('individual line checkbox stopPropagation', () => {
+    it('clicking individual line checkbox does not trigger parent card select-all', () => {
+      const onSelectionChange = jest.fn<(s: Set<string>) => void>();
+      // Two lines under the same parent — if propagation occurred, clicking one
+      // would trigger the parent's handleParentGroupToggle and add both.
+      renderPanel({
+        data: makeResponse(
+          [
+            makeLine({
+              id: 'line-floor',
+              parentId: 'p1',
+              parentName: 'Kitchen Renovation',
+              description: 'Floor tiles',
+            }),
+            makeLine({
+              id: 'line-wall',
+              parentId: 'p1',
+              parentName: 'Kitchen Renovation',
+              description: 'Wall tiles',
+              createdAt: '2026-01-02T00:00:00.000Z',
+            }),
+          ],
+          [],
+        ),
+        selectedLineIds: new Set<string>(),
+        onSelectionChange,
+        onMoveLines: jest.fn(),
+      });
+
+      const lineCheckbox = screen.getByRole('checkbox', { name: /Select Floor tiles/i });
+      fireEvent.click(lineCheckbox);
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      const newSet = onSelectionChange.mock.calls[0]![0];
+      // Only the clicked line should be in the set — not both lines
+      expect(newSet.size).toBe(1);
+      expect(newSet.has('line-floor')).toBe(true);
+      expect(newSet.has('line-wall')).toBe(false);
     });
   });
 
@@ -1046,32 +1450,104 @@ describe('SourceBudgetLinePanel', () => {
   });
 
   // ─── Parent item links (scenario 23) ───────────────────────────────────────────
+  //
+  // In selectable mode the parent name is no longer a <Link> — the whole card
+  // is a <div role="checkbox"> and navigation is provided by a separate nav icon
+  // <Link aria-label="Open {name}">.  In non-selectable mode the original Link
+  // wrapping the parent name is still rendered.
 
   describe('parent item header links', () => {
-    it('renders parent item name as link with href to work item detail for work item lines', () => {
-      const line = makeLine({
-        id: 'l1',
-        parentId: 'work-item-42',
-        parentName: 'Kitchen Renovation',
-      });
-      renderPanel({ data: makeResponse([line], []) });
+    describe('non-selectable mode', () => {
+      it('renders parent item name as link with href to work item detail for work item lines', () => {
+        const line = makeLine({
+          id: 'l1',
+          parentId: 'work-item-42',
+          parentName: 'Kitchen Renovation',
+        });
+        renderPanel({ data: makeResponse([line], []) });
 
-      const link = screen.getByRole('link', { name: /Kitchen Renovation/i }) as HTMLAnchorElement;
-      expect(link).toBeInTheDocument();
-      expect(link.getAttribute('href')).toBe('/project/work-items/work-item-42');
+        const link = screen.getByRole('link', { name: /Kitchen Renovation/i }) as HTMLAnchorElement;
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute('href')).toBe('/project/work-items/work-item-42');
+      });
+
+      it('renders parent item name as link with href to household item detail for household item lines', () => {
+        const line = makeLine({
+          id: 'l1',
+          parentId: 'household-item-99',
+          parentName: 'Sofa Purchase',
+        });
+        renderPanel({ data: makeResponse([], [line]) });
+
+        const link = screen.getByRole('link', { name: /Sofa Purchase/i }) as HTMLAnchorElement;
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute('href')).toBe('/project/household-items/household-item-99');
+      });
     });
 
-    it('renders parent item name as link with href to household item detail for household item lines', () => {
-      const line = makeLine({
-        id: 'l1',
-        parentId: 'household-item-99',
-        parentName: 'Sofa Purchase',
-      });
-      renderPanel({ data: makeResponse([], [line]) });
+    describe('selectable mode', () => {
+      it('renders nav icon link with aria-label "Open {name}" in selectable mode', () => {
+        const line = makeLine({
+          id: 'l1',
+          parentId: 'work-item-42',
+          parentName: 'Kitchen Renovation',
+        });
+        renderPanel({
+          data: makeResponse([line], []),
+          selectedLineIds: new Set<string>(),
+          onSelectionChange: jest.fn(),
+          onMoveLines: jest.fn(),
+        });
 
-      const link = screen.getByRole('link', { name: /Sofa Purchase/i }) as HTMLAnchorElement;
-      expect(link).toBeInTheDocument();
-      expect(link.getAttribute('href')).toBe('/project/household-items/household-item-99');
+        const navLink = screen.getByRole('link', {
+          name: /Open Kitchen Renovation/i,
+        }) as HTMLAnchorElement;
+        expect(navLink).toBeInTheDocument();
+        expect(navLink.getAttribute('href')).toBe('/project/work-items/work-item-42');
+      });
+
+      it('renders parent card with role="checkbox" and aria-label "Select all under {name}"', () => {
+        const line = makeLine({
+          id: 'l1',
+          parentId: 'work-item-42',
+          parentName: 'Kitchen Renovation',
+        });
+        renderPanel({
+          data: makeResponse([line], []),
+          selectedLineIds: new Set<string>(),
+          onSelectionChange: jest.fn(),
+          onMoveLines: jest.fn(),
+        });
+
+        const parentCard = screen.getByRole('checkbox', {
+          name: /Select all under Kitchen Renovation/i,
+        });
+        expect(parentCard).toBeInTheDocument();
+      });
+
+      it('does NOT render a plain text link with the parent name in selectable mode', () => {
+        const line = makeLine({
+          id: 'l1',
+          parentId: 'work-item-42',
+          parentName: 'Kitchen Renovation',
+        });
+        renderPanel({
+          data: makeResponse([line], []),
+          selectedLineIds: new Set<string>(),
+          onSelectionChange: jest.fn(),
+          onMoveLines: jest.fn(),
+        });
+
+        // The old link wrapping the parent name text should not be present in selectable mode
+        // (only the nav icon link with "Open Kitchen Renovation" label exists)
+        const links = screen.getAllByRole('link');
+        const plainNameLink = links.find(
+          (l) =>
+            l.textContent?.trim() === 'Kitchen Renovation' &&
+            l.getAttribute('aria-label') === null,
+        );
+        expect(plainNameLink).toBeUndefined();
+      });
     });
   });
 });

--- a/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
+++ b/client/src/components/SourceBudgetLinePanel/SourceBudgetLinePanel.tsx
@@ -4,15 +4,11 @@ import { useTranslation } from 'react-i18next';
 import type {
   BudgetSourceBudgetLinesResponse,
   BudgetSourceBudgetLine,
-  ConfidenceLevel,
 } from '@cornerstone/shared';
 import type { AreaAncestor } from '@cornerstone/shared';
 import { useFormatters } from '../../lib/formatters.js';
-import { Badge } from '../Badge/Badge.js';
-import type { BadgeVariantMap } from '../Badge/Badge.js';
 import { Skeleton } from '../Skeleton/Skeleton.js';
 import { EmptyState } from '../EmptyState/EmptyState.js';
-import { TriStateCheckbox } from '../TriStateCheckbox/TriStateCheckbox.js';
 import styles from './SourceBudgetLinePanel.module.css';
 
 interface SourceBudgetLinePanelProps {
@@ -401,11 +397,34 @@ export function SourceBudgetLinePanel({
     [isSelectable, selectedLineIds, onSelectionChange],
   );
 
+  // Handle parent group (work item / household item) checkbox toggle
+  const handleParentGroupToggle = useCallback(
+    (lineIds: string[], allSelected: boolean) => {
+      if (!isSelectable || !onSelectionChange) return;
+      const newSelection = new Set(selectedLineIds);
+      if (allSelected) {
+        lineIds.forEach((id) => newSelection.delete(id));
+      } else {
+        lineIds.forEach((id) => newSelection.add(id));
+      }
+      onSelectionChange(newSelection);
+    },
+    [isSelectable, selectedLineIds, onSelectionChange],
+  );
+
   // Render an area hierarchy recursively
   const renderAreaNode = (node: AreaNode, parentType: 'work-item' | 'household-item') => {
     const groupKey = node.areaId ?? 'unassigned';
     const selectionState = areaGroupSelectionStates.get(groupKey);
     const areaName = node.areaId === null ? t('sources.lines.unassignedArea') : node.areaName;
+
+    // Get all line IDs in this area's subtree (for clickable area name in selectable mode)
+    const selectableLineIdsInArea = Array.from(
+      getAreaSubtreeLineIds(
+        parentType === 'work-item' ? workItemAreaTree : householdItemAreaTree,
+        node.areaId,
+      ),
+    );
 
     return (
       <div
@@ -429,20 +448,20 @@ export function SourceBudgetLinePanel({
                 aria-hidden="true"
               />
             )}
-            <span className={styles.areaName}>{areaName}</span>
-            {!isSelectable && (
-              <span className={styles.areaLineCount}>
-                {t('sources.lines.areaLineCount', { count: node.totalLines })}
-              </span>
-            )}
-          </div>
-          {isSelectable && selectionState && (
-            <label className={styles.areaSelectAllRow}>
-              <TriStateCheckbox
-                id={`area-${groupKey}-checkbox`}
-                checked={selectionState.allSelected}
-                indeterminate={!selectionState.allSelected && selectionState.someSelected}
-                onChange={(checked) =>
+            {isSelectable && selectableLineIdsInArea.length > 0 ? (
+              <div
+                role="checkbox"
+                aria-checked={
+                  selectionState?.allSelected
+                    ? true
+                    : selectionState?.someSelected
+                      ? 'mixed'
+                      : false
+                }
+                aria-label={t('sources.budgetLines.move.selectGroupLabel', { name: areaName })}
+                tabIndex={0}
+                className={styles.areaNameClickable}
+                onClick={() =>
                   handleAreaGroupCheckboxChange(
                     {
                       areaId: node.areaId,
@@ -453,72 +472,196 @@ export function SourceBudgetLinePanel({
                       parentGroups: node.parentGroups,
                       totalLines: node.totalLines,
                     },
-                    checked,
+                    !(selectionState?.allSelected ?? false),
                     parentType,
                   )
                 }
-                className={styles.areaGroupCheckbox}
-              />
-              <span className={styles.areaSelectAllLabel}>
-                {t('sources.budgetLines.move.selectGroupLabel', {
-                  name: areaName,
-                })}
-              </span>
-              <span className={styles.areaLineCount}>
-                {t('sources.lines.areaLineCount', { count: node.totalLines })}
-              </span>
-            </label>
-          )}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleAreaGroupCheckboxChange(
+                      {
+                        areaId: node.areaId,
+                        areaName: node.areaName,
+                        areaColor: node.areaColor,
+                        depth: node.depth,
+                        ancestors: node.ancestors,
+                        parentGroups: node.parentGroups,
+                        totalLines: node.totalLines,
+                      },
+                      !(selectionState?.allSelected ?? false),
+                      parentType,
+                    );
+                  }
+                }}
+              >
+                {areaName}
+              </div>
+            ) : (
+              <span className={styles.areaName}>{areaName}</span>
+            )}
+            <span className={styles.areaLineCount}>
+              {t('sources.lines.areaLineCount', { count: node.totalLines })}
+            </span>
+          </div>
         </header>
 
-        {node.parentGroups.map((parentGroup) => (
-          <div key={parentGroup.parentId} className={styles.parentItemBlock}>
-            <Link
-              to={`/project/${parentType === 'work-item' ? 'work-items' : 'household-items'}/${parentGroup.parentId}`}
-              className={styles.parentItemHeader}
-            >
-              {parentGroup.parentName}
-            </Link>
+        {node.parentGroups.map((parentGroup) => {
+          const selectableLineIdsInParent = parentGroup.lines.map((l) => l.id);
+          const parentSelectedCount = isSelectable
+            ? selectableLineIdsInParent.filter((id) => selectedLineIds!.has(id)).length
+            : 0;
+          const parentAllSelected =
+            parentSelectedCount === selectableLineIdsInParent.length &&
+            selectableLineIdsInParent.length > 0;
+          const parentSomeSelected =
+            parentSelectedCount > 0 && !parentAllSelected;
 
-            <ul role="list" className={isSelectable ? styles.lineListSelectable : styles.lineList}>
-              {parentGroup.lines.map((line) => {
-                const isSelected = selectedLineIds?.has(line.id) ?? false;
-                const confidenceLabel = getConfidenceLabel(line, t);
-                const invoiceStatusLabel = getInvoiceStatusLabel(line, t);
-
-                return (
-                  <li
-                    key={line.id}
-                    role="listitem"
-                    className={`${styles.lineRow} ${isSelectable && isSelected ? styles.lineRowSelected : ''}`}
+          if (isSelectable) {
+            return (
+              <div
+                key={parentGroup.parentId}
+                className={`${styles.parentItemBlock} ${
+                  parentAllSelected
+                    ? styles.parentItemBlockChecked
+                    : parentSomeSelected
+                      ? styles.parentItemBlockMixed
+                      : ''
+                }`}
+                role="checkbox"
+                aria-checked={
+                  parentAllSelected ? true : parentSomeSelected ? 'mixed' : false
+                }
+                aria-label={t('sources.budgetLines.move.selectItemLabel', {
+                  name: parentGroup.parentName,
+                })}
+                tabIndex={0}
+                onClick={() =>
+                  handleParentGroupToggle(
+                    selectableLineIdsInParent,
+                    parentAllSelected,
+                  )
+                }
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleParentGroupToggle(
+                      selectableLineIdsInParent,
+                      parentAllSelected,
+                    );
+                  }
+                }}
+              >
+                <div className={styles.parentItemHeader}>
+                  <span className={styles.parentItemName}>{parentGroup.parentName}</span>
+                  <Link
+                    to={`/project/${parentType === 'work-item' ? 'work-items' : 'household-items'}/${parentGroup.parentId}`}
+                    className={styles.parentItemNavLink}
+                    aria-label={t('sources.budgetLines.move.navigateToItem', {
+                      name: parentGroup.parentName,
+                    })}
+                    onClick={(e) => e.stopPropagation()}
                   >
-                    {isSelectable && (
-                      <input
-                        type="checkbox"
-                        className={styles.checkbox}
-                        checked={isSelected}
-                        onChange={(e) => handleLineCheckboxChange(line.id, e.target.checked)}
-                        aria-label={t('sources.budgetLines.move.checkboxLabel', {
-                          description: line.description ?? '—',
-                        })}
-                      />
-                    )}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                      <polyline points="15 3 21 3 21 9" />
+                      <line x1="10" y1="14" x2="21" y2="3" />
+                    </svg>
+                  </Link>
+                </div>
 
-                    <span className={styles.lineDescription}>{line.description ?? '—'}</span>
+                <ul role="list" className={styles.lineListSelectable}>
+                  {parentGroup.lines.map((line) => {
+                    const isSelected = selectedLineIds?.has(line.id) ?? false;
+                    const confidenceLabel = getConfidenceLabel(line, t);
+                    const invoiceStatusLabel = getInvoiceStatusLabel(line, t);
 
-                    <span className={styles.lineType}>{confidenceLabel}</span>
+                    return (
+                      <li
+                        key={line.id}
+                        role="listitem"
+                        className={`${styles.lineRow} ${isSelected ? styles.lineRowSelected : ''}`}
+                      >
+                        <input
+                          type="checkbox"
+                          className={styles.checkbox}
+                          checked={isSelected}
+                          onClick={(e) => e.stopPropagation()}
+                          onChange={(e) => {
+                            e.stopPropagation();
+                            handleLineCheckboxChange(line.id, e.target.checked);
+                          }}
+                          aria-label={t('sources.budgetLines.move.checkboxLabel', {
+                            description: line.description ?? '—',
+                          })}
+                        />
 
-                    <span className={styles.lineStatus}>{invoiceStatusLabel}</span>
+                        <span className={styles.lineDescription}>{line.description ?? '—'}</span>
 
-                    <span className={styles.linePlannedAmount}>
-                      {formatCurrency(line.plannedAmount)}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        ))}
+                        <span className={styles.lineType}>{confidenceLabel}</span>
+
+                        <span className={styles.lineStatus}>{invoiceStatusLabel}</span>
+
+                        <span className={styles.linePlannedAmount}>
+                          {formatCurrency(line.plannedAmount)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          } else {
+            // Non-selectable mode: render as before with Link wrapper
+            return (
+              <div key={parentGroup.parentId} className={styles.parentItemBlock}>
+                <Link
+                  to={`/project/${parentType === 'work-item' ? 'work-items' : 'household-items'}/${parentGroup.parentId}`}
+                  className={`${styles.parentItemHeader} ${styles.parentItemHeaderLink}`}
+                >
+                  {parentGroup.parentName}
+                </Link>
+
+                <ul role="list" className={styles.lineList}>
+                  {parentGroup.lines.map((line) => {
+                    const confidenceLabel = getConfidenceLabel(line, t);
+                    const invoiceStatusLabel = getInvoiceStatusLabel(line, t);
+
+                    return (
+                      <li
+                        key={line.id}
+                        role="listitem"
+                        className={styles.lineRow}
+                      >
+                        <span className={styles.lineDescription}>{line.description ?? '—'}</span>
+
+                        <span className={styles.lineType}>{confidenceLabel}</span>
+
+                        <span className={styles.lineStatus}>{invoiceStatusLabel}</span>
+
+                        <span className={styles.linePlannedAmount}>
+                          {formatCurrency(line.plannedAmount)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          }
+        })}
 
         {/* Render child areas */}
         {node.children.map((childNode) => renderAreaNode(childNode, parentType))}

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -192,6 +192,8 @@
       "move": {
         "checkboxLabel": "{{description}} auswählen",
         "selectGroupLabel": "Alle in {{name}} auswählen",
+        "selectItemLabel": "Alle unter {{name}} auswählen",
+        "navigateToItem": "{{name}} öffnen",
         "selectedCount_one": "{{count}} Position ausgewählt",
         "selectedCount_other": "{{count}} Positionen ausgewählt",
         "openModalButton": "In andere Quelle verschieben…",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -194,6 +194,8 @@
       "move": {
         "checkboxLabel": "Select {{description}}",
         "selectGroupLabel": "Select all in {{name}}",
+        "selectItemLabel": "Select all under {{name}}",
+        "navigateToItem": "Open {{name}}",
         "selectedCount_one": "{{count}} line selected",
         "selectedCount_other": "{{count}} lines selected",
         "openModalButton": "Move to another source…",

--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -415,15 +415,53 @@ export class BudgetSourcesPage {
   }
 
   /**
-   * Get the area group tri-state checkbox inside a lines panel.
-   * The checkbox has aria-label "Select all in {areaName}".
+   * Get the area name element that acts as a tri-state select-all toggle.
+   * The element has role="checkbox" and aria-label "Select all in {areaName}".
+   *
+   * After Issue #1323 the dedicated .areaSelectAllRow checkbox row was removed;
+   * the area name itself is now the clickable tri-state toggle.
    *
    * @param sourceId  The numeric source ID used to scope to the correct panel.
-   * @param areaName  The area name displayed in the group header (or the i18n "No Area" label).
+   * @param areaName  The area name displayed in the group header.
    */
-  getAreaGroupCheckbox(sourceId: string, areaName: string): import('@playwright/test').Locator {
+  getAreaNameSelector(sourceId: string, areaName: string): import('@playwright/test').Locator {
     return this.getLinesPanelById(sourceId).getByRole('checkbox', {
       name: `Select all in ${areaName}`,
+    });
+  }
+
+  /**
+   * @deprecated Use getAreaNameSelector instead.
+   * Kept as an alias so existing callers continue to compile during the transition.
+   */
+  getAreaGroupCheckbox(sourceId: string, areaName: string): import('@playwright/test').Locator {
+    return this.getAreaNameSelector(sourceId, areaName);
+  }
+
+  /**
+   * Get the parent item card that acts as a tri-state select-all toggle.
+   * The card has role="checkbox" and aria-label "Select all under {parentName}".
+   *
+   * @param sourceId    The numeric source ID used to scope to the correct panel.
+   * @param parentName  The parent work/household item name.
+   */
+  getParentItemCard(sourceId: string, parentName: string): import('@playwright/test').Locator {
+    return this.getLinesPanelById(sourceId).getByRole('checkbox', {
+      name: `Select all under ${parentName}`,
+    });
+  }
+
+  /**
+   * Get the nav icon link inside the parent item card header.
+   * The link has aria-label "Open {parentName}" and navigates to the parent item detail page.
+   * Its click handler calls stopPropagation so the card selection is not triggered.
+   *
+   * @param sourceId    The numeric source ID used to scope to the correct panel.
+   * @param parentName  The parent work/household item name.
+   */
+  getParentItemNavIcon(sourceId: string, parentName: string): import('@playwright/test').Locator {
+    return this.getLinesPanelById(sourceId).getByRole('link', {
+      name: `Open ${parentName}`,
     });
   }
 

--- a/e2e/tests/budget/budget-source-move.spec.ts
+++ b/e2e/tests/budget/budget-source-move.spec.ts
@@ -8,8 +8,10 @@
  * 4. Happy path (no claimed invoices) — move succeeds, toast shown  (@smoke)
  * 5. Claimed invoice warning gates confirm button
  * 6. API 409 STALE_OWNERSHIP → FormError visible, modal stays open, cancel closes
- * 7. Area group "select all" tri-state checkbox — selects all lines in the group
+ * 7. Area name tri-state click selects all lines in the group  (#1323)
  * 8. Mobile viewport — select line, action bar visible  (@smoke)
+ * 9. Parent item card select-all + toggle back  (#1323)
+ * 10. Mixed aria-checked + nav icon isolation  (#1323)
  *
  * API mocking strategy:
  * - Real sources created via API for stable IDs.
@@ -655,10 +657,10 @@ test.describe('API error → FormError in modal', { tag: '@responsive' }, () => 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 7: Area group "select all" tri-state checkbox
+// Scenario 7: Area name tri-state click selects all lines (#1323)
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Area group tri-state checkbox selects all lines', { tag: '@responsive' }, () => {
-  test('clicking the area group checkbox selects all 3 lines in the group and shows "3 lines selected" in the action bar', async ({
+test.describe('Area name tri-state click selects all lines', { tag: '@responsive' }, () => {
+  test('clicking the area name selects all 3 lines and shows correct action bar count', async ({
     page,
     testPrefix,
   }) => {
@@ -684,28 +686,28 @@ test.describe('Area group tri-state checkbox selects all lines', { tag: '@respon
       await sourcesPage.expandSourceLines(sourceName);
       await expandResponse;
 
-      // The area group checkbox for "Bathroom"
-      const areaCheckbox = sourcesPage.getAreaGroupCheckbox(sourceId, 'Bathroom');
-      await areaCheckbox.waitFor({ state: 'visible' });
+      // The area name element (role="checkbox", aria-label="Select all in Bathroom")
+      const areaNameEl = sourcesPage.getAreaNameSelector(sourceId, 'Bathroom');
+      await areaNameEl.waitFor({ state: 'visible' });
 
-      // Initially unchecked
-      await expect(areaCheckbox).not.toBeChecked();
+      // Initially unchecked (aria-checked="false")
+      await expect(areaNameEl).toHaveAttribute('aria-checked', 'false');
 
-      // Click the area checkbox — should select all 3 lines
-      await areaCheckbox.check();
+      // Click the area name — should select all 3 lines
+      await areaNameEl.click();
 
       // All 3 individual line checkboxes must be checked
-      const cb1 = sourcesPage.getLineCheckbox(sourceId, 'Tile installation');
-      const cb2 = sourcesPage.getLineCheckbox(sourceId, 'Plumbing fixtures');
-      const cb3 = sourcesPage.getLineCheckbox(sourceId, 'Vanity cabinet');
-      await expect(cb1).toBeChecked();
-      await expect(cb2).toBeChecked();
-      await expect(cb3).toBeChecked();
+      await expect(sourcesPage.getLineCheckbox(sourceId, 'Tile installation')).toBeChecked();
+      await expect(sourcesPage.getLineCheckbox(sourceId, 'Plumbing fixtures')).toBeChecked();
+      await expect(sourcesPage.getLineCheckbox(sourceId, 'Vanity cabinet')).toBeChecked();
 
       // Action bar shows "3 lines selected"
       const actionBar = sourcesPage.getActionBar(sourceId);
       await expect(actionBar).toBeVisible();
       await expect(actionBar).toContainText('3 lines selected');
+
+      // aria-checked must reflect fully selected state
+      await expect(areaNameEl).toHaveAttribute('aria-checked', 'true');
     } finally {
       if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
       if (sourceId) await deleteSourceViaApi(page, sourceId);
@@ -763,4 +765,125 @@ test.describe('Mobile — select line shows action bar', { tag: ['@smoke', '@res
       }
     },
   );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 9: Parent item card select-all + toggle back (#1323)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Parent item card tri-state click', { tag: '@responsive' }, () => {
+  test('clicking the parent item card selects all its lines and toggling back deselects them', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} ParentCard Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 30000 });
+
+      // mockTwoLines uses "Flooring" as the parentName for both lines in "Kitchen" area
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockTwoLines(sourceId!)),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const expandResponse = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await expandResponse;
+
+      // The parent item card for "Flooring" (role="checkbox", aria-label="Select all under Flooring")
+      const parentCard = sourcesPage.getParentItemCard(sourceId, 'Flooring');
+      await parentCard.waitFor({ state: 'visible' });
+
+      // Initially unchecked (aria-checked="false")
+      await expect(parentCard).toHaveAttribute('aria-checked', 'false');
+
+      // Click the parent card — should select both lines under "Flooring"
+      await parentCard.click();
+
+      await expect(
+        sourcesPage.getLineCheckbox(sourceId, 'Hardwood floor installation'),
+      ).toBeChecked();
+      await expect(sourcesPage.getLineCheckbox(sourceId, 'Subfloor preparation')).toBeChecked();
+
+      const actionBar = sourcesPage.getActionBar(sourceId);
+      await expect(actionBar).toBeVisible();
+      await expect(actionBar).toContainText('2 lines selected');
+      await expect(parentCard).toHaveAttribute('aria-checked', 'true');
+
+      // Toggle off — click again to deselect all
+      await parentCard.click();
+
+      await expect(
+        sourcesPage.getLineCheckbox(sourceId, 'Hardwood floor installation'),
+      ).not.toBeChecked();
+      await expect(actionBar).not.toBeVisible();
+      await expect(parentCard).toHaveAttribute('aria-checked', 'false');
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 10: Mixed aria-checked + nav icon isolation (#1323)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Mixed aria-checked and nav icon isolation', { tag: '@responsive' }, () => {
+  test('selecting one of two lines yields aria-checked="mixed" on parent card; nav icon has correct aria-label and href', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} MixedState Source`;
+    let sourceId: string | null = null;
+
+    try {
+      sourceId = await createSourceViaApi(page, { name: sourceName, totalAmount: 30000 });
+
+      // mockTwoLines: both lines share parentName "Flooring"
+      await page.route(budgetLinesUrl(sourceId), async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockTwoLines(sourceId!)),
+        });
+      });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      const expandResponse = page.waitForResponse(budgetLinesUrl(sourceId));
+      await sourcesPage.expandSourceLines(sourceName);
+      await expandResponse;
+
+      // Select only one of the two lines under "Flooring"
+      const cb = sourcesPage.getLineCheckbox(sourceId, 'Hardwood floor installation');
+      await cb.waitFor({ state: 'visible' });
+      await cb.check();
+
+      // Parent card must show "mixed" when only a subset of its lines are selected
+      const parentCard = sourcesPage.getParentItemCard(sourceId, 'Flooring');
+      await expect(parentCard).toHaveAttribute('aria-checked', 'mixed');
+
+      // Nav icon verification — do not click (would navigate away from the test page)
+      const navIcon = sourcesPage.getParentItemNavIcon(sourceId, 'Flooring');
+      await expect(navIcon).toBeVisible();
+      await expect(navIcon).toHaveAttribute('aria-label', 'Open Flooring');
+
+      // The href must point to a work-item or household-item detail page
+      const href = await navIcon.getAttribute('href');
+      expect(href).toMatch(/\/project\/(work-items|household-items)\//);
+    } finally {
+      if (sourceId) await page.unroute(budgetLinesUrl(sourceId));
+      if (sourceId) await deleteSourceViaApi(page, sourceId);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- **Whole parent item card** (work-item / household-item) is now a tri-state toggle that selects/deselects all its budget lines. Navigation to the item's detail page is preserved via a dedicated icon link in the card header.
- **Area name** becomes the tri-state select-all trigger for all descendants — the previously separate "Select all" checkbox row is removed.
- Tri-state state is announced via `role="checkbox"` + `aria-checked="true|mixed|false"` on both controls. Keyboard (Enter / Space) toggles both.
- Mixed / checked visuals on parent cards use existing `--color-primary-bg` and `--color-border-strong` tokens — no new tokens.
- Individual line checkbox clicks `stopPropagation` so they don't trigger the card select-all.
- New English keys `sources.budgetLines.move.selectItemLabel` and `navigateToItem`, translated in `de/budget.json`.

Fixes #1323

## Test plan
- [x] Unit tests updated + new scenarios for area name tri-state, parent card tri-state, keyboard toggling, nav icon isolation, line checkbox stopPropagation
- [x] E2E scenario 7 rewritten; scenarios 9/10 added (parent card select-all + mixed aria-checked + nav icon assertions)
- [x] `BudgetSourcesPage` POM updated with `getAreaNameSelector`, `getParentItemCard`, `getParentItemNavIcon`; `getAreaGroupCheckbox` kept as deprecated alias
- [x] Dark mode validated via existing tokens (no new dark-mode overrides needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)