### PR TITLE
fix(budget): suppress browser print chrome and render inner item separators (#1328)

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
@@ -630,16 +630,10 @@
 
   /* ========= INNER (item) BOX — lighter gray ========= */
 
-  /* Inner left edge — inset shadow on item and budget-line rows */
-  .costSection .rowLevel2 td:first-child,
-  .costSection .rowLevel3 td:first-child {
-    box-shadow: inset 8pt 0 0 -6pt var(--color-border);
-  }
-
-  /* Inner right edge — inset shadow on item and budget-line rows */
-  .costSection .rowLevel2 td:last-child,
-  .costSection .rowLevel3 td:last-child {
-    box-shadow: inset -8pt 0 0 -6pt var(--color-border);
+  /* Inner (item) box — light gray top border on every item row creates a visible
+   * boundary between items. Item's left/right edges inherit from the outer area box. */
+  .costSection .rowLevel2 td {
+    border-top: 1pt solid var(--color-border);
   }
 
   /* Level 2 (item rows): suppress bottom border when followed by budget lines */

--- a/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
+++ b/client/src/pages/BudgetOverviewPage/BudgetOverviewPage.module.css
@@ -577,8 +577,41 @@
   }
 
   /* Apply proper margins to all pages */
+  /* stylelint-disable-next-line -- CSS Paged Media @top-* / @bottom-* margin boxes required to suppress browser-injected chrome */
   @page {
     margin: 1.5cm 1cm;
+
+    /* Explicitly empty all 10 margin boxes to suppress browser-injected header/footer */
+    @top-left-corner {
+      content: '';
+    }
+    @top-left {
+      content: '';
+    }
+    @top-center {
+      content: '';
+    }
+    @top-right {
+      content: '';
+    }
+    @top-right-corner {
+      content: '';
+    }
+    @bottom-left-corner {
+      content: '';
+    }
+    @bottom-left {
+      content: '';
+    }
+    @bottom-center {
+      content: '';
+    }
+    @bottom-right {
+      content: '';
+    }
+    @bottom-right-corner {
+      content: '';
+    }
   }
 
   /* No scrollable ancestor should reserve scrollbar gutter */


### PR DESCRIPTION
## Summary
- Expanded `@page` rule in `BudgetOverviewPage.module.css` with explicit empty content for all 10 CSS Paged Media margin boxes (`@top-*`/`@bottom-*`) — suppresses Chrome's injected header (date, page title) and footer (URL, page number) while preserving `@page { margin: 1.5cm 1cm }` for per-page whitespace
- Replaced non-rendering `box-shadow: inset` inner-box edges in `CostBreakdownTable.module.css` with `border-top: 1pt solid var(--color-border)` on `.rowLevel2 td` — creates visible item-group separators nested inside the outer area box

Fixes #1328

## Test plan
- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>