### PR TITLE
fix(budget-sources): render en-dash and label remaining amounts (#1333)

### DIFF
--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -219,6 +219,9 @@
         "successToast_other": "{{count}} Positionen wurden nach {{targetName}} verschoben",
         "genericError": "Positionen konnten nicht verschoben werden. Bitte versuchen Sie es erneut."
       }
+    },
+    "summary": {
+      "remainingLabel": "Verbleibend"
     }
   },
   "vendors": {

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -161,6 +161,9 @@
       "summaryClaimedLabel": "Claimed",
       "srOnly": "Claimed {{claimed}}, Paid {{paid}}, Projected {{projectedMin}} to {{projectedMax}}, of total {{total}}"
     },
+    "summary": {
+      "remainingLabel": "Remaining"
+    },
     "lines": {
       "expand": "Show lines",
       "collapse": "Hide lines",

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -1887,14 +1887,57 @@ describe('BudgetSourcesPage', () => {
         expect(screen.getByText('Home Loan')).toBeInTheDocument();
       });
 
-      // The primary value for the Projected row shows both min and max amounts.
-      // In JSX raw text (outside {}), \u2013 is the literal characters \u2013, not en-dash.
-      // We verify both formatted values appear in the first summaryPrimary element.
+      // The primary value for the Projected row shows both min and max amounts separated by an en-dash.
+      // After fix #1333, the en-dash is rendered as the actual U+2013 character via JSX expression {'\u2013'}.
       const primaryCells = Array.from(container.querySelectorAll('[class*="summaryPrimary"]'));
       const projectedPrimary = primaryCells[0];
       expect(projectedPrimary).toBeTruthy();
       expect(projectedPrimary?.textContent).toMatch(/€80,000\.00/);
       expect(projectedPrimary?.textContent).toMatch(/€120,000\.00/);
+      // Verify the actual en-dash character (U+2013) is present, not the literal escape sequence
+      expect(projectedPrimary?.textContent).toContain('\u2013');
+      expect(projectedPrimary?.textContent).not.toContain('\\u2013');
+    });
+
+    it('projected row secondary value is prefixed with "Remaining" label', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sourceWithRange] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const summaryRows = Array.from(container.querySelectorAll('[class*="summaryRow"]'));
+      const projectedRow = summaryRows[0];
+      const secondaryEl = projectedRow?.querySelector('[class*="summarySecondary"]');
+      expect(secondaryEl?.textContent).toMatch(/^Remaining\s/);
+      expect(secondaryEl?.textContent).toContain('\u2013');
+      expect(secondaryEl?.textContent).not.toContain('\\u2013');
+      // Screen-reader-readable single text node: "Remaining €X – €Y"
+      const text = secondaryEl?.textContent?.trim() ?? '';
+      expect(text).toMatch(/^Remaining €[\d,.]+ – €[\d,.]+$/);
+    });
+
+    it('paid row secondary value is prefixed with "Remaining" label', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sourceWithRange] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const summaryRows = Array.from(container.querySelectorAll('[class*="summaryRow"]'));
+      const paidRow = summaryRows[1];
+      const secondaryEl = paidRow?.querySelector('[class*="summarySecondary"]');
+      expect(secondaryEl?.textContent).toMatch(/^Remaining\s/);
+    });
+
+    it('claimed row secondary value is prefixed with "Remaining" label', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sourceWithRange] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const summaryRows = Array.from(container.querySelectorAll('[class*="summaryRow"]'));
+      const claimedRow = summaryRows[2];
+      const secondaryEl = claimedRow?.querySelector('[class*="summarySecondary"]');
+      expect(secondaryEl?.textContent).toMatch(/^Remaining\s/);
     });
 
     it('Projected row secondary value gets danger class when projectedMaxAmount > totalAmount', async () => {
@@ -1923,6 +1966,8 @@ describe('BudgetSourcesPage', () => {
       expect(secondaryEl).toBeTruthy();
       // The secondary span should include summarySecondaryNegative when projection exceeds total
       expect(secondaryEl?.className).toMatch(/summarySecondaryNegative/);
+      // Even in negative state, the "Remaining" label prefix must be present
+      expect(secondaryEl?.textContent).toMatch(/^Remaining\s/);
     });
 
     it('Projected row secondary value does NOT get danger class when projectedMaxAmount <= totalAmount', async () => {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -356,8 +356,8 @@ describe('BudgetSourcesPage', () => {
       renderPage();
 
       await waitFor(() => {
-        // €200,000.00 formatted — appears for both Total and Available
-        expect(screen.getAllByText('€200,000.00').length).toBeGreaterThanOrEqual(1);
+        // €200,000.00 formatted — appears for both Total and Remaining (prefix labels embed the amount)
+        expect(screen.getAllByText(/€200,000\.00/).length).toBeGreaterThanOrEqual(1);
       });
     });
 

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -202,13 +202,14 @@ function SourceBarChart({ source, formatCurrency, formatPercent }: SourceBarChar
           </span>
           <div className={styles.summaryValues}>
             <span className={styles.summaryPrimary}>
-              {formatCurrency(source.projectedMinAmount)} \u2013{' '}
+              {formatCurrency(source.projectedMinAmount)} {'\u2013'}{' '}
               {formatCurrency(source.projectedMaxAmount)}
             </span>
             <span
               className={`${styles.summarySecondary} ${projectedSecondaryNegative ? styles.summarySecondaryNegative : ''}`}
             >
-              {formatCurrency(source.totalAmount - source.projectedMinAmount)} \u2013{' '}
+              {t('sources.summary.remainingLabel')}{' '}
+              {formatCurrency(source.totalAmount - source.projectedMinAmount)} {'\u2013'}{' '}
               {formatCurrency(source.totalAmount - source.projectedMaxAmount)}
             </span>
           </div>
@@ -231,6 +232,7 @@ function SourceBarChart({ source, formatCurrency, formatPercent }: SourceBarChar
                 paidSecondaryNegative ? ` ${styles.summarySecondaryNegative}` : ''
               }`}
             >
+              {t('sources.summary.remainingLabel')}{' '}
               {formatCurrency(source.totalAmount - source.paidAmount)}
             </span>
           </div>
@@ -253,6 +255,7 @@ function SourceBarChart({ source, formatCurrency, formatPercent }: SourceBarChar
                 claimedSecondaryNegative ? ` ${styles.summarySecondaryNegative}` : ''
               }`}
             >
+              {t('sources.summary.remainingLabel')}{' '}
               {formatCurrency(source.totalAmount - source.claimedAmount)}
             </span>
           </div>


### PR DESCRIPTION
## Summary
- Fixed literal `\u2013` in JSX text (was rendered as an escaped string) by replacing with `{'\u2013'}` expression so the en-dash character renders correctly
- Added inline "Remaining" / "Verbleibend" labels to Projected, Paid, and Claimed secondary-value lines so remaining amounts are labelled without relying on a tooltip

Fixes #1333

## Test plan
- [ ] Unit tests updated and added to cover en-dash rendering and Remaining label display
- [ ] CI Quality Gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>