### PR TITLE
feat(budget-sources): consolidate header actions and mute negative-remaining color (#1335, #1336)

### DIFF
--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -429,7 +429,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-3);
+  padding: var(--spacing-1-5) var(--spacing-3);
   background-color: transparent;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -686,7 +686,7 @@
 }
 
 .summarySecondaryNegative {
-  color: var(--color-danger);
+  color: var(--color-danger-text-on-light);
 }
 
 /* ---- Interest rate subtitle ---- */
@@ -893,7 +893,8 @@
   }
 
   .editButton,
-  .deleteButton {
+  .deleteButton,
+  .expandToggle {
     flex: 1;
   }
 
@@ -928,6 +929,7 @@
   .cancelButton,
   .editButton,
   .deleteButton,
+  .expandToggle,
   .confirmDeleteButton {
     min-height: 44px;
   }

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -2104,4 +2104,57 @@ describe('BudgetSourcesPage', () => {
       expect(secondaryEl?.className).toMatch(/summarySecondaryNegative/);
     });
   });
+
+  // ─── source actions layout (Issues #1335 + #1336) ────────────────────────────
+
+  describe('source actions layout', () => {
+    it('Show lines, Edit, and Delete buttons are all direct children of sourceActions in that order', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const actionsDiv = container.querySelector('[class*="sourceActions"]');
+      expect(actionsDiv).not.toBeNull();
+      const buttons = Array.from(actionsDiv!.querySelectorAll('button'));
+      expect(buttons.length).toBe(3);
+      // Order: Show lines → Edit → Delete
+      expect(buttons[0]).toHaveAttribute('aria-label', expect.stringMatching(/expand budget lines for home loan/i));
+      expect(buttons[1]).toHaveAccessibleName(/edit home loan/i);
+      expect(buttons[2]).toHaveAccessibleName(/delete home loan/i);
+    });
+
+    it('discretionary source shows Show lines and Edit in sourceActions but not Delete', async () => {
+      const discretionarySource: BudgetSource = {
+        ...sampleSource1,
+        id: 'src-disc',
+        name: 'Contingency Reserve',
+        isDiscretionary: true,
+      };
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [discretionarySource] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Contingency Reserve')).toBeInTheDocument();
+      });
+      const actionsDiv = container.querySelector('[class*="sourceActions"]');
+      expect(actionsDiv).not.toBeNull();
+      const buttons = Array.from(actionsDiv!.querySelectorAll('button'));
+      expect(buttons.length).toBe(2);
+      expect(buttons[0]).toHaveAttribute('aria-label', expect.stringMatching(/expand budget lines for contingency reserve/i));
+      expect(buttons[1]).toHaveAccessibleName(/edit contingency reserve/i);
+      expect(screen.queryByRole('button', { name: /delete contingency reserve/i })).not.toBeInTheDocument();
+    });
+
+    it('expandToggle button is NOT inside sourceMain', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const sourceMainDiv = container.querySelector('[class*="sourceMain"]');
+      expect(sourceMainDiv).not.toBeNull();
+      const toggleInsideMain = sourceMainDiv!.querySelector('[class*="expandToggle"]');
+      expect(toggleInsideMain).toBeNull();
+    });
+  });
 });

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -1127,38 +1127,6 @@ export function BudgetSourcesPage() {
                               })}
                             </span>
                           </div>
-                          <button
-                            type="button"
-                            className={`${styles.expandToggle} ${expandedSources.has(source.id) ? styles.expandToggleActive : ''}`}
-                            onClick={() => handleToggleLinesWithClearing(source.id)}
-                            disabled={!!editingSource}
-                            aria-expanded={expandedSources.has(source.id)}
-                            aria-controls={`source-lines-${source.id}`}
-                            aria-label={
-                              expandedSources.has(source.id)
-                                ? t('sources.lines.collapseAriaLabel', { name: source.name })
-                                : t('sources.lines.expandAriaLabel', { name: source.name })
-                            }
-                          >
-                            <svg
-                              className={`${styles.chevronIcon} ${expandedSources.has(source.id) ? styles.chevronExpanded : ''}`}
-                              viewBox="0 0 16 16"
-                              fill="currentColor"
-                              aria-hidden="true"
-                            >
-                              <path
-                                d="M6 5l4 4-4 4"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                fill="none"
-                              />
-                            </svg>
-                            <span>
-                              {expandedSources.has(source.id)
-                                ? t('sources.lines.collapse')
-                                : t('sources.lines.expand')}
-                            </span>
-                          </button>
                         </div>
 
                         {source.interestRate != null && (
@@ -1181,6 +1149,38 @@ export function BudgetSourcesPage() {
                       </div>
 
                       <div className={styles.sourceActions}>
+                        <button
+                          type="button"
+                          className={`${styles.expandToggle} ${expandedSources.has(source.id) ? styles.expandToggleActive : ''}`}
+                          onClick={() => handleToggleLinesWithClearing(source.id)}
+                          disabled={!!editingSource}
+                          aria-expanded={expandedSources.has(source.id)}
+                          aria-controls={`source-lines-${source.id}`}
+                          aria-label={
+                            expandedSources.has(source.id)
+                              ? t('sources.lines.collapseAriaLabel', { name: source.name })
+                              : t('sources.lines.expandAriaLabel', { name: source.name })
+                          }
+                        >
+                          <svg
+                            className={`${styles.chevronIcon} ${expandedSources.has(source.id) ? styles.chevronExpanded : ''}`}
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M6 5l4 4-4 4"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              fill="none"
+                            />
+                          </svg>
+                          <span>
+                            {expandedSources.has(source.id)
+                              ? t('sources.lines.collapse')
+                              : t('sources.lines.expand')}
+                          </span>
+                        </button>
                         <button
                           type="button"
                           className={styles.editButton}


### PR DESCRIPTION
## Summary

- **#1335** — Moved Show lines / Edit / Delete into a single right-aligned action group in the source-card header next to the label + badges; unified button heights
- **#1336** — Swapped saturated `--color-danger` for the muted `--color-danger-text-on-light` token in the negative-remaining state

Fixes #1335
Fixes #1336

## Test plan
- [ ] Unit tests pass (3 new tests covering action order, discretionary-source guard, and DOM-move regression; all 98 tests green locally)
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>