### PR TITLE
fix(budget-sources): make card layout a single full-width column (#1346)

### DIFF
--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -390,18 +390,9 @@
 .sourceRowHeader {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--spacing-4);
-}
-
-/* ---- Source info (left side) ---- */
-
-.sourceInfo {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
+  flex-wrap: wrap;
 }
 
 .sourceMain {
@@ -430,12 +421,12 @@
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-1-5) var(--spacing-3);
-  background-color: transparent;
-  border: 1px solid var(--color-border);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-strong);
   border-radius: var(--radius-md);
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--color-text-muted);
+  color: var(--color-text-secondary);
   cursor: pointer;
   transition:
     background-color var(--transition-normal),
@@ -445,9 +436,7 @@
 }
 
 .expandToggle:hover:not(:disabled) {
-  background-color: var(--color-bg-secondary);
-  border-color: var(--color-border);
-  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
 }
 
 .expandToggle:focus-visible {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -2164,5 +2164,45 @@ describe('BudgetSourcesPage', () => {
       const toggleInsideMain = sourceMainDiv!.querySelector('[class*="expandToggle"]');
       expect(toggleInsideMain).toBeNull();
     });
+
+    it('sourceInfo wrapper div is NOT rendered in view mode', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const sourceInfoDiv = container.querySelector('[class*="sourceInfo"]');
+      expect(sourceInfoDiv).toBeNull();
+    });
+
+    it('SourceBarChart renders as a sibling of sourceRowHeader, not inside it', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const header = container.querySelector('[class*="sourceRowHeader"]');
+      expect(header).not.toBeNull();
+      const barInsideHeader = header!.querySelector('[class*="sourceBarSection"]');
+      expect(barInsideHeader).toBeNull();
+
+      // Bar chart still exists in the row
+      const sourceRow = container.querySelector('[class*="sourceRow"]');
+      expect(sourceRow!.querySelector('[class*="sourceBarSection"]')).not.toBeNull();
+    });
+
+    it('sourceMain is a direct child of sourceRowHeader after restructure', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+      const { container } = renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+      const header = container.querySelector('[class*="sourceRowHeader"]');
+      expect(header).not.toBeNull();
+      const sourceMainAsDirectChild = Array.from(header!.children).find((el) =>
+        el.className.includes('sourceMain'),
+      );
+      expect(sourceMainAsDirectChild).toBeDefined();
+    });
   });
 });

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -916,236 +916,216 @@ export function BudgetSourcesPage() {
           <div className={styles.sourcesList}>
             {sources.map((source) => (
               <div key={source.id} className={styles.sourceRow}>
-                <div className={styles.sourceRowHeader}>
-                  {editingSource?.id === source.id ? (
-                    <form
-                      onSubmit={handleUpdateSource}
-                      className={styles.editForm}
-                      aria-label={`Edit ${source.name}`}
-                    >
-                      {updateError && (
-                        <div className={styles.errorBanner} role="alert">
-                          {updateError}
-                        </div>
-                      )}
-
-                      <div className={styles.editFormRow}>
-                        <div className={styles.fieldGrow}>
-                          <label htmlFor={`edit-name-${source.id}`} className={styles.label}>
-                            {t('sources.form.name')}{' '}
-                            <span className={styles.required}>{t('sources.form.required')}</span>
-                          </label>
-                          <input
-                            type="text"
-                            id={`edit-name-${source.id}`}
-                            value={editingSource.name}
-                            onChange={(e) =>
-                              setEditingSource({ ...editingSource, name: e.target.value })
-                            }
-                            className={styles.input}
-                            maxLength={200}
-                            disabled={isUpdating}
-                            autoFocus
-                          />
-                        </div>
-
-                        <div className={styles.fieldSelect}>
-                          <label htmlFor={`edit-type-${source.id}`} className={styles.label}>
-                            {t('sources.form.type')}
-                          </label>
-                          <select
-                            id={`edit-type-${source.id}`}
-                            value={editingSource.sourceType}
-                            onChange={(e) =>
-                              setEditingSource({
-                                ...editingSource,
-                                sourceType: e.target.value as BudgetSourceType,
-                              })
-                            }
-                            className={styles.select}
-                            disabled={isUpdating || source.isDiscretionary}
-                          >
-                            {Object.entries(SOURCE_TYPE_LABELS).map(([value, label]) => (
-                              <option key={value} value={value}>
-                                {label}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-
-                        <div className={styles.fieldSelect}>
-                          <label htmlFor={`edit-status-${source.id}`} className={styles.label}>
-                            {t('sources.form.status')}
-                          </label>
-                          <select
-                            id={`edit-status-${source.id}`}
-                            value={editingSource.status}
-                            onChange={(e) =>
-                              setEditingSource({
-                                ...editingSource,
-                                status: e.target.value as BudgetSourceStatus,
-                              })
-                            }
-                            className={styles.select}
-                            disabled={isUpdating}
-                          >
-                            {Object.entries(STATUS_LABELS).map(([value, label]) => (
-                              <option key={value} value={value}>
-                                {label}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
+                {editingSource?.id === source.id ? (
+                  <form
+                    onSubmit={handleUpdateSource}
+                    className={styles.editForm}
+                    aria-label={`Edit ${source.name}`}
+                  >
+                    {updateError && (
+                      <div className={styles.errorBanner} role="alert">
+                        {updateError}
                       </div>
+                    )}
 
-                      <div className={styles.editFormRow}>
-                        <div className={styles.fieldGrow}>
-                          <label htmlFor={`edit-amount-${source.id}`} className={styles.label}>
-                            {t('sources.form.totalAmount')}{' '}
-                            <span className={styles.required}>{t('sources.form.required')}</span>
-                          </label>
-                          <input
-                            type="number"
-                            id={`edit-amount-${source.id}`}
-                            value={editingSource.totalAmount}
-                            onChange={(e) =>
-                              setEditingSource({ ...editingSource, totalAmount: e.target.value })
-                            }
-                            className={styles.input}
-                            min={0}
-                            step="0.01"
-                            disabled={isUpdating}
-                          />
-                        </div>
-
-                        <div className={styles.fieldNarrow}>
-                          <label htmlFor={`edit-rate-${source.id}`} className={styles.label}>
-                            {t('sources.form.interestRate')}
-                          </label>
-                          <input
-                            type="number"
-                            id={`edit-rate-${source.id}`}
-                            value={editingSource.interestRate}
-                            onChange={(e) =>
-                              setEditingSource({ ...editingSource, interestRate: e.target.value })
-                            }
-                            className={styles.input}
-                            min={0}
-                            step="0.01"
-                            disabled={isUpdating}
-                          />
-                        </div>
-                      </div>
-
-                      <div className={styles.field}>
-                        <label htmlFor={`edit-terms-${source.id}`} className={styles.label}>
-                          {t('sources.form.terms')}
+                    <div className={styles.editFormRow}>
+                      <div className={styles.fieldGrow}>
+                        <label htmlFor={`edit-name-${source.id}`} className={styles.label}>
+                          {t('sources.form.name')}{' '}
+                          <span className={styles.required}>{t('sources.form.required')}</span>
                         </label>
                         <input
                           type="text"
-                          id={`edit-terms-${source.id}`}
-                          value={editingSource.terms}
+                          id={`edit-name-${source.id}`}
+                          value={editingSource.name}
                           onChange={(e) =>
-                            setEditingSource({ ...editingSource, terms: e.target.value })
+                            setEditingSource({ ...editingSource, name: e.target.value })
                           }
                           className={styles.input}
-                          placeholder="e.g., 30-year fixed, monthly payments"
-                          maxLength={500}
+                          maxLength={200}
                           disabled={isUpdating}
+                          autoFocus
                         />
                       </div>
 
-                      <div className={styles.field}>
-                        <label htmlFor={`edit-notes-${source.id}`} className={styles.label}>
-                          {t('sources.form.notes')}
+                      <div className={styles.fieldSelect}>
+                        <label htmlFor={`edit-type-${source.id}`} className={styles.label}>
+                          {t('sources.form.type')}
                         </label>
-                        <textarea
-                          id={`edit-notes-${source.id}`}
-                          value={editingSource.notes}
+                        <select
+                          id={`edit-type-${source.id}`}
+                          value={editingSource.sourceType}
                           onChange={(e) =>
-                            setEditingSource({ ...editingSource, notes: e.target.value })
+                            setEditingSource({
+                              ...editingSource,
+                              sourceType: e.target.value as BudgetSourceType,
+                            })
                           }
-                          className={styles.textarea}
-                          placeholder="Optional notes"
-                          maxLength={2000}
+                          className={styles.select}
+                          disabled={isUpdating || source.isDiscretionary}
+                        >
+                          {Object.entries(SOURCE_TYPE_LABELS).map(([value, label]) => (
+                            <option key={value} value={value}>
+                              {label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className={styles.fieldSelect}>
+                        <label htmlFor={`edit-status-${source.id}`} className={styles.label}>
+                          {t('sources.form.status')}
+                        </label>
+                        <select
+                          id={`edit-status-${source.id}`}
+                          value={editingSource.status}
+                          onChange={(e) =>
+                            setEditingSource({
+                              ...editingSource,
+                              status: e.target.value as BudgetSourceStatus,
+                            })
+                          }
+                          className={styles.select}
                           disabled={isUpdating}
-                          rows={3}
+                        >
+                          {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                            <option key={value} value={value}>
+                              {label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+
+                    <div className={styles.editFormRow}>
+                      <div className={styles.fieldGrow}>
+                        <label htmlFor={`edit-amount-${source.id}`} className={styles.label}>
+                          {t('sources.form.totalAmount')}{' '}
+                          <span className={styles.required}>{t('sources.form.required')}</span>
+                        </label>
+                        <input
+                          type="number"
+                          id={`edit-amount-${source.id}`}
+                          value={editingSource.totalAmount}
+                          onChange={(e) =>
+                            setEditingSource({ ...editingSource, totalAmount: e.target.value })
+                          }
+                          className={styles.input}
+                          min={0}
+                          step="0.01"
+                          disabled={isUpdating}
                         />
                       </div>
 
-                      <div className={styles.editActions}>
-                        <button
-                          type="submit"
-                          className={styles.saveButton}
-                          disabled={
-                            isUpdating ||
-                            !editingSource.name.trim() ||
-                            !editingSource.totalAmount.trim()
+                      <div className={styles.fieldNarrow}>
+                        <label htmlFor={`edit-rate-${source.id}`} className={styles.label}>
+                          {t('sources.form.interestRate')}
+                        </label>
+                        <input
+                          type="number"
+                          id={`edit-rate-${source.id}`}
+                          value={editingSource.interestRate}
+                          onChange={(e) =>
+                            setEditingSource({ ...editingSource, interestRate: e.target.value })
                           }
-                        >
-                          {isUpdating ? t('sources.buttons.saving') : t('sources.buttons.save')}
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.cancelButton}
-                          onClick={cancelEdit}
+                          className={styles.input}
+                          min={0}
+                          step="0.01"
                           disabled={isUpdating}
-                        >
-                          {t('sources.buttons.cancel')}
-                        </button>
+                        />
                       </div>
-                    </form>
-                  ) : (
-                    <>
-                      <div className={styles.sourceInfo}>
-                        <div className={styles.sourceMain}>
-                          <span className={styles.sourceName}>{source.name}</span>
-                          <div className={styles.sourceBadges}>
-                            <span
-                              className={`${styles.typeBadge} ${getSourceTypeClass(styles, source.sourceType)}`}
-                            >
-                              {SOURCE_TYPE_LABELS[source.sourceType]}
+                    </div>
+
+                    <div className={styles.field}>
+                      <label htmlFor={`edit-terms-${source.id}`} className={styles.label}>
+                        {t('sources.form.terms')}
+                      </label>
+                      <input
+                        type="text"
+                        id={`edit-terms-${source.id}`}
+                        value={editingSource.terms}
+                        onChange={(e) =>
+                          setEditingSource({ ...editingSource, terms: e.target.value })
+                        }
+                        className={styles.input}
+                        placeholder="e.g., 30-year fixed, monthly payments"
+                        maxLength={500}
+                        disabled={isUpdating}
+                      />
+                    </div>
+
+                    <div className={styles.field}>
+                      <label htmlFor={`edit-notes-${source.id}`} className={styles.label}>
+                        {t('sources.form.notes')}
+                      </label>
+                      <textarea
+                        id={`edit-notes-${source.id}`}
+                        value={editingSource.notes}
+                        onChange={(e) =>
+                          setEditingSource({ ...editingSource, notes: e.target.value })
+                        }
+                        className={styles.textarea}
+                        placeholder="Optional notes"
+                        maxLength={2000}
+                        disabled={isUpdating}
+                        rows={3}
+                      />
+                    </div>
+
+                    <div className={styles.editActions}>
+                      <button
+                        type="submit"
+                        className={styles.saveButton}
+                        disabled={
+                          isUpdating ||
+                          !editingSource.name.trim() ||
+                          !editingSource.totalAmount.trim()
+                        }
+                      >
+                        {isUpdating ? t('sources.buttons.saving') : t('sources.buttons.save')}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.cancelButton}
+                        onClick={cancelEdit}
+                        disabled={isUpdating}
+                      >
+                        {t('sources.buttons.cancel')}
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <>
+                    <div className={styles.sourceRowHeader}>
+                      <div className={styles.sourceMain}>
+                        <span className={styles.sourceName}>{source.name}</span>
+                        <div className={styles.sourceBadges}>
+                          <span
+                            className={`${styles.typeBadge} ${getSourceTypeClass(styles, source.sourceType)}`}
+                          >
+                            {SOURCE_TYPE_LABELS[source.sourceType]}
+                          </span>
+                          <span
+                            className={`${styles.statusBadge} ${getStatusClass(styles, source.status)}`}
+                          >
+                            {STATUS_LABELS[source.status]}
+                          </span>
+                          {source.isDiscretionary && (
+                            <span className={styles.systemBadge}>
+                              {t('sources.sourcesList.system')}
                             </span>
-                            <span
-                              className={`${styles.statusBadge} ${getStatusClass(styles, source.status)}`}
-                            >
-                              {STATUS_LABELS[source.status]}
-                            </span>
-                            {source.isDiscretionary && (
-                              <span className={styles.systemBadge}>
-                                {t('sources.sourcesList.system')}
-                              </span>
-                            )}
-                            <span
-                              className={styles.totalBadge}
-                              aria-label={t('sources.barChart.totalBadgeAriaLabel', {
-                                amount: formatCurrency(source.totalAmount),
-                              })}
-                            >
-                              {t('sources.barChart.totalBadge', {
-                                amount: formatCurrency(source.totalAmount),
-                              })}
-                            </span>
-                          </div>
+                          )}
+                          <span
+                            className={styles.totalBadge}
+                            aria-label={t('sources.barChart.totalBadgeAriaLabel', {
+                              amount: formatCurrency(source.totalAmount),
+                            })}
+                          >
+                            {t('sources.barChart.totalBadge', {
+                              amount: formatCurrency(source.totalAmount),
+                            })}
+                          </span>
                         </div>
-
-                        {source.interestRate != null && (
-                          <p className={styles.sourceInterestRate}>
-                            {t('sources.barChart.rate')} {formatPercent(source.interestRate)}
-                          </p>
-                        )}
-
-                        <SourceBarChart
-                          source={source}
-                          formatCurrency={formatCurrency}
-                          formatPercent={formatPercent}
-                        />
-
-                        {source.terms && (
-                          <p className={styles.sourceTerms} title="Terms">
-                            {source.terms}
-                          </p>
-                        )}
                       </div>
 
                       <div className={styles.sourceActions}>
@@ -1202,9 +1182,27 @@ export function BudgetSourcesPage() {
                           </button>
                         )}
                       </div>
-                    </>
-                  )}
-                </div>
+                    </div>
+
+                    {source.interestRate != null && (
+                      <p className={styles.sourceInterestRate}>
+                        {t('sources.barChart.rate')} {formatPercent(source.interestRate)}
+                      </p>
+                    )}
+
+                    <SourceBarChart
+                      source={source}
+                      formatCurrency={formatCurrency}
+                      formatPercent={formatPercent}
+                    />
+
+                    {source.terms && (
+                      <p className={styles.sourceTerms} title="Terms">
+                        {source.terms}
+                      </p>
+                    )}
+                  </>
+                )}
                 {editingSource?.id !== source.id && expandedSources.has(source.id) && (
                   <SourceBudgetLinePanel
                     sourceId={source.id}


### PR DESCRIPTION
## Summary

- Restructure the Budget Sources source card: `.sourceRowHeader` now holds only `[name + badges]` and the action group; the bar chart, interest rate, and terms are direct children of `.sourceRow`, giving the bar chart and summary rows the full card width
- `.expandToggle` (Show lines) at-rest style now matches `.editButton` so the three header buttons read as one cohesive group; the primary-based expanded/active state is unchanged

Fixes #1346

## Test plan
- [ ] Unit tests pass (3 new DOM-structure regression tests; all 101 tests green locally)
- [ ] Pre-commit hook quality gates pass