### PR TITLE
docs: update documentation for release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ HOST=0.0.0.0
 LOG_LEVEL=info
 NODE_ENV=production
 
-# Set to true when running behind a reverse proxy (e.g., nginx)
+# Set to true when running behind a reverse proxy (e.g., nginx, Caddy, Traefik).
+# Only the first proxy hop is trusted; rate limiting uses a spoof-resistant key.
 # TRUST_PROXY=false
 
 # Public-facing base URL — required when behind a reverse proxy

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ A self-hosted home building project management tool for homeowners. Track work i
 
 ## Features
 
-- **Work Items** -- Manage construction tasks with statuses, dates, area assignments, notes, subtasks, dependencies, and keyboard shortcuts
-- **Areas & Trades** -- Organize your project with hierarchical areas (rooms, floors, zones) and trade specialties (Electrical, Plumbing, etc.) for vendors
-- **Budget Management** -- Budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies with caps, quotation tracking, and an overview dashboard with projections
+- **Work Items** -- Manage construction tasks with statuses, dates, area assignments, notes, subtasks, dependencies, and keyboard shortcuts -- every work item shows its full area ancestor path (e.g. `House / Ground Floor / Kitchen`) as a breadcrumb across lists, detail pages, pickers, and every place it is referenced
+- **Areas & Trades** -- Organize your project with hierarchical areas (rooms, floors, zones) and trade specialties (Electrical, Plumbing, etc.) for vendors; a dedicated "No Area" filter surfaces items that have not been classified yet
+- **Budget Management** -- Budget categories, financing sources with inline expansion and mass-move of attached lines, multi-budget-line invoice linking with itemized amounts, subsidies with caps, quotation tracking, and an area-grouped overview dashboard with clickable summary tiles and print-friendly export
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, area assignment, delivery scheduling, budget integration, and work item linking

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,12 +1,55 @@
 ## What's New
 
-This release overhauls every list page in the application with a powerful DataTable system -- bringing filtering, sorting, pagination, and customizable columns to Work Items, Milestones, Vendors, Invoices, Household Items, and User Management. It also adds a full backup and restore capability with scheduled backups and retention policies, configurable from the Settings page.
+This release puts your **project's area hierarchy** at the center of every view. Work items, household items, pickers, budget summaries, and every embedded reference now surface the full area ancestor path (`House / Ground Floor / Kitchen`) as a breadcrumb, so you always know where a task, item, or cost belongs. Budget Sources gains inline expansion with multi-select mass-move, Budget Overview replaces the category breakdown with an expandable area tree and adds clickable summary tiles plus print-friendly output, and Vendors moves into the Settings section to match how the rest of the app is organized.
 
-### Highlights
+### What's new
 
-- **DataTable across all list pages** -- Every list view now supports column-level filtering (text, enum, boolean, date range, number range, and entity filters), multi-column sorting, pagination, column reordering, and persistent column settings.
-- **Backup & Restore** -- Create manual backups or schedule automatic backups with a cron expression. Set a retention policy to automatically prune old backups. Restore from any backup directly in the Settings UI.
-- **Consistent page layout** -- All list pages share a standardized layout with unified navigation, giving the app a more cohesive feel.
-- **Translated category names** -- Predefined categories (trades, budget categories, household item categories) are now displayed in the user's language.
-- **DateRangePicker** -- Date range filters use a purpose-built calendar picker with range highlighting instead of native date inputs.
-- **UI improvements** -- Floating menu button, iPadOS Safari sidebar fix, visual cleanup across multiple pages.
+**Area hierarchy, everywhere it matters**
+
+- Work items and household items display the full area ancestor path as a breadcrumb on list pages, detail pages, and create pages.
+- Pickers (work item, household item, budget line) show the area as a secondary line under each result.
+- Every place a work item is embedded -- diary entries, invoices, household item dependencies -- now includes the area breadcrumb for instant context.
+- A shared `AreaBreadcrumb` component keeps the appearance consistent across the app.
+
+**Smarter area filters**
+
+- The Area filter on Work Items and Household Items lists correctly matches every descendant when you pick a parent area, at any depth of nesting.
+- A dedicated **No Area** option on both lists surfaces items that have not yet been assigned to any area.
+
+**Budget Overview redesign**
+
+- The cost breakdown is now grouped by **area hierarchy** instead of by category, with nested rows you can expand to drill into children and leaf-level budget lines.
+- The old "Unassigned" bucket is renamed **No Area** to match the rest of the app.
+- Every summary tile at the top of the page is clickable -- click a tile to instantly select the underlying budget lines that add up to that number.
+- Full print styling: clean page margins, nested group boxes, inner item separators, and the app's chrome suppressed in print. `Cmd+P` / `Ctrl+P` produces a clean PDF or paper copy.
+
+**Budget Sources redesign**
+
+- Click any financing source to expand it **inline** and see every budget line attached to it -- no navigation away.
+- Budget lines are grouped into a hierarchical **area tree**, with dense columnar rows and horizontal dividers between work item groups.
+- **Multi-select across groups** lets you tick budget lines spread across multiple areas and sources; the selection is preserved as you expand and collapse.
+- A new **mass-move modal** reassigns the entire selection to a different source in a single operation.
+- New API endpoints power this view: `GET /api/budget-sources/:sourceId/budget-lines` and `PATCH /api/budget-sources/:sourceId/budget-lines/move`.
+
+**Navigation**
+
+- **Vendors** has moved out of the Budget subnav into **Settings**. Vendor records are master data -- names, trades, contact info -- so they sit alongside Users, Areas, and Trades. Invoices stay in the Budget section because they are transactional.
+
+**Reliability**
+
+- Reverse-proxy handling is tightened: with `TRUST_PROXY=true`, only the first proxy hop is trusted, and rate limiting uses a resilient client identifier that no longer can be spoofed by a user-supplied `X-Forwarded-For` header. No configuration change is needed to benefit -- upgrading is enough.
+
+**Tooling**
+
+- TypeScript is upgraded to **6.0** with `noUncheckedIndexedAccess` enabled across the codebase, catching a whole class of latent array-access bugs.
+- Docker Scout comparisons against the previous stable tag are now part of the release pipeline.
+
+### Breaking changes
+
+None. Existing bookmarks, links, URLs, and data model are preserved.
+
+### Migration notes
+
+- **No database migration is required.** Area ancestor data is resolved on read -- every response that references a work item, household item, or budget line now includes the full ancestor chain automatically. Existing clients and integrations continue to work; they just see a richer payload.
+- **Reverse-proxy users**: `TRUST_PROXY=true` still means "I am running behind a reverse proxy, please read the forwarded headers," so no setting needs to change. What changes is that the server now trusts only the first proxy hop and computes rate-limit keys in a way that cannot be spoofed by an external `X-Forwarded-For`. If you were previously relying on chained / multi-hop proxy headers being trusted all the way to the origin client, review your proxy topology -- see the [reverse proxy guide](https://steilerDev.github.io/cornerstone/getting-started/docker-setup#behind-a-reverse-proxy) for the current behavior.
+- **Vendors menu move**: Vendors has moved from `Budget > Vendors` to `Settings > Vendors`. Direct URLs to individual vendor detail pages continue to resolve; only the top-level menu entry relocated.

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -32,7 +32,7 @@ All configuration is done through environment variables. The defaults are suitab
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TRUST_PROXY` | `false` | Set to `true` when running behind a reverse proxy (nginx, Caddy, Traefik, etc.) |
+| `TRUST_PROXY` | `false` | Set to `true` when running behind a reverse proxy (nginx, Caddy, Traefik, etc.). Only the first proxy hop is trusted, and rate limiting uses a resilient client identifier that resists `X-Forwarded-For` spoofing. |
 | `EXTERNAL_URL` | -- | Public-facing base URL (e.g., `https://myhouse.example.com`). Used for OIDC callback, CalDAV/CardDAV discovery, and `.mobileconfig` generation. |
 
 When deploying behind a reverse proxy, set `TRUST_PROXY=true` so the server correctly reads forwarded headers (`X-Forwarded-For`, `X-Forwarded-Proto`, etc.). Set `EXTERNAL_URL` to the public URL users access your instance at -- this ensures OIDC callbacks, CalDAV/CardDAV discovery, and Apple configuration profiles work correctly regardless of internal networking.

--- a/docs/src/getting-started/docker-setup.md
+++ b/docs/src/getting-started/docker-setup.md
@@ -49,6 +49,10 @@ SECURE_COOKIES=true
 
 `TRUST_PROXY` tells Cornerstone to read forwarded headers (`X-Forwarded-For`, `X-Forwarded-Proto`, etc.). This is required for secure cookies and OIDC redirects to work properly behind a proxy.
 
+:::note Safer proxy handling
+Cornerstone's proxy handling has been tightened: when `TRUST_PROXY=true`, only the **first** proxy hop is trusted (your own reverse proxy), and the rate-limit plugin uses a resilient client identifier that cannot be spoofed by a user-supplied `X-Forwarded-For` header. In short, you still need to set `TRUST_PROXY=true` when running behind nginx/Caddy/Traefik, but that setting no longer exposes rate limiting to header spoofing from the public internet. No configuration change is required to benefit from this -- upgrading to the current release is enough.
+:::
+
 :::tip Large file uploads
 
 Cornerstone supports photo uploads which can produce large request payloads. Most reverse proxies limit request body size by default (e.g., nginx defaults to 1 MB). Make sure your proxy is configured to allow sufficiently large uploads -- for example, in **nginx**:

--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -5,7 +5,11 @@ title: Budget Overview
 
 # Budget Overview
 
-The budget overview dashboard at **Budget > Overview** gives you a high-level view of your project's financial health. It shows totals by budget category, financing source allocations, and four different "remaining budget" perspectives.
+The budget overview dashboard at **Budget > Overview** gives you a high-level view of your project's financial health. It surfaces totals across financing sources, four different "remaining budget" perspectives, and a cost breakdown grouped by **area hierarchy**.
+
+## Summary Tiles
+
+At the top of the overview you see a set of summary tiles -- Total Budget, Total Estimated, Total Invoiced, Total Remaining, and one per financing source. Each tile is **clickable**: clicking a tile selects every matching budget line in the table below, so you can jump straight from a headline number into the underlying lines that drive it. Click the same tile again (or click in empty space) to clear the selection.
 
 ## Remaining Budget Perspectives
 
@@ -41,13 +45,16 @@ The margin applied to non-invoiced budget lines depends on the confidence level:
 | Quote | +/- 5% |
 | Invoice | 0% (actual cost used) |
 
-## Category Breakdown
+## Cost Breakdown by Area
 
-The overview groups costs by budget category, showing:
+The cost breakdown table is grouped by your **area hierarchy** rather than by category. This makes it easy to see what each room, floor, or zone of the project actually costs.
 
-- Total estimated amount for the category
-- Progress bar indicating how much has been invoiced vs estimated
-- Subsidy reductions applied to the category
+- Each **area** is a row. Its totals roll up every descendant area beneath it.
+- Clicking a row expands it to show child areas and, at the leaf level, the individual budget lines.
+- Nested rows are visually indented so the tree is easy to scan.
+- Budget lines whose work item or household item has no area assigned are collected in a dedicated **No Area** bucket at the bottom of the table (previously labeled "Unassigned").
+
+Each row displays the estimated total, invoiced total, subsidy reduction, and remaining amount for that slice of the project.
 
 ## Financing Source Summary
 
@@ -57,8 +64,24 @@ A summary of each financing source shows:
 - Current depletion (based on actual invoice costs)
 - Remaining balance
 
+For a much deeper view of each source -- including every budget line attached to it, grouped by area and work item, with multi-select and mass-move -- see [Financing Sources](financing-sources).
+
 ## Subsidy Impact
 
 Approved and disbursed [subsidies](subsidies) are factored into the overview calculations. The dashboard shows how much each subsidy reduces the total cost for its linked category. Pending and rejected subsidies are excluded from calculations.
+
+## Printing the Overview
+
+The Budget Overview has dedicated **print styling** so you can hand your bank, accountant, or partner a clean PDF or paper copy.
+
+- Use your browser's Print command (`Cmd+P` on macOS, `Ctrl+P` on Windows/Linux) directly from the overview page.
+- The app chrome -- sidebar, navigation, floating buttons -- is suppressed in print.
+- Page margins, title spacing, and nested area group boxes are tuned for A4/Letter output.
+- Inner item separators keep individual budget lines readable when an area group contains many children.
+- The browser's own print header/footer is suppressed; pick your target (printer or "Save as PDF") and go.
+
+:::tip
+If the exported PDF does not match what you see on screen, make sure your browser's "Background graphics" option is enabled in the print dialog -- the nested group boxes rely on background color to stay legible.
+:::
 
 ![Budget overview dashboard](/img/screenshots/budget-overview-light.png)

--- a/docs/src/guides/budget/financing-sources.md
+++ b/docs/src/guides/budget/financing-sources.md
@@ -5,7 +5,7 @@ title: Financing Sources
 
 # Financing Sources
 
-Financing sources represent where the money for your construction project comes from. Each source has a total amount, and Cornerstone tracks how much of each source has been depleted based on actual invoice costs.
+Financing sources represent where the money for your construction project comes from -- your construction loan, savings, a family loan, a subsidy. Each source has a total amount, and Cornerstone tracks how much of each source has been depleted based on actual invoice costs.
 
 ## Examples
 
@@ -15,30 +15,52 @@ Financing sources represent where the money for your construction project comes 
 
 ## Creating a Financing Source
 
-Navigate to **Budget > Financing Sources** in the sidebar. Click **New Source** and provide:
+Navigate to **Budget > Sources** in the sidebar. Click **New Source** and provide:
 
 - **Name** -- A descriptive label (e.g., "Construction Loan")
 - **Total Amount** -- The total amount available from this source
 
 ## Depletion Tracking
 
-Each financing source displays how much has been spent. Depletion is calculated from the actual cost of invoices linked to budget lines that use this source:
+Each financing source shows how much has been spent. Depletion is calculated from the actual cost of invoices linked to budget lines that use this source:
 
 - **Invoiced amounts** are summed to show how much of the source has been used
 - A progress bar shows the percentage depleted
 - The remaining balance updates automatically as invoices are added
 
-This gives you a clear picture of how much funding remains in each source.
+## Inline Budget Line Expansion
+
+Click any source row on the sources page to expand it inline and see **every budget line attached to that source** directly beneath it -- no navigation away, no separate tab. The expanded panel is structured as a **hierarchical area tree** so you can see exactly which rooms, floors, and zones the source is funding:
+
+- Budget lines are grouped first by their **work item or household item**, with the full area breadcrumb (e.g. `House / Ground Floor / Kitchen`) shown next to the group header.
+- Work item groups are separated by horizontal dividers for easy scanning.
+- Each budget line is a **dense columnar row** showing the category, planned amount, invoiced amount, and status.
+- Clicking a work item or household item link jumps to that item's detail page, with the correct area ancestor resolved.
+
+![Financing sources page with inline expansion](/img/screenshots/budget-sources-light.png)
+
+## Multi-Select and Mass-Move
+
+Need to reassign a batch of budget lines from one source to another -- for example, when a subsidy payout comes in and you want to move those lines off your construction loan? The sources page supports **multi-select across groups**:
+
+1. Expand one or more sources.
+2. Tick the checkboxes next to any number of budget lines -- your selection is **preserved as you expand and collapse different areas or sources**, so you can build up a batch across the tree.
+3. Click **Move selected** to open the **mass-move modal**.
+4. Pick the target financing source and confirm.
+
+Every selected line is reassigned to the new source in a single operation, and the depletion totals on both the source you moved from and the source you moved to update immediately.
+
+:::tip
+The mass-move modal is the fastest way to model a "what if" on your budget -- for example, splitting costs that were originally booked against your savings onto a newly approved loan, without editing each budget line individually.
+:::
 
 ## Managing Sources
 
-From the financing sources page you can:
+From the sources page you can:
 
 - **Edit** a source's name or total amount
 - **Delete** a source that is no longer needed
 
 :::caution
-Deleting a financing source will fail if any budget lines reference it. Reassign or remove those budget lines first.
+Deleting a financing source will fail if any budget lines reference it. Use mass-move to reassign those lines first, then delete.
 :::
-
-![Financing sources page](/img/screenshots/budget-sources-light.png)

--- a/docs/src/guides/budget/index.md
+++ b/docs/src/guides/budget/index.md
@@ -12,11 +12,11 @@ The budget system in Cornerstone helps you track construction costs across your 
 The budget system provides:
 
 - **Budget Categories** -- Organize costs into categories like "Electrical", "Plumbing", or "Windows & Doors"
-- **Financing Sources** -- Track where money comes from (construction loan, savings, family loan) with depletion tracking
+- **Financing Sources** -- Track where money comes from (construction loan, savings, family loan) with depletion tracking, inline expansion of all attached budget lines, and a mass-move tool to reassign lines to a different source
 - **Work Item Budget Lines** -- Link estimated costs to work items with confidence levels that reflect estimate accuracy
-- **Vendors & Invoices** -- Track vendors, their invoices, and line items linked to budget lines
+- **Invoices** -- Track vendor invoices and their line-item links to budget lines (vendor records now live under the Settings section -- see [Invoices & Vendors](vendors-and-invoices))
 - **Subsidy Programs** -- Manage percentage-based or fixed-amount subsidies that reduce your effective costs
-- **Budget Overview Dashboard** -- See your project's financial health at a glance with four "remaining budget" perspectives
+- **Budget Overview Dashboard** -- See your project's financial health grouped by **area hierarchy**, with clickable summary tiles, expandable nested rows, and print-friendly styling
 
 ## How It Fits Together
 
@@ -31,8 +31,8 @@ When a vendor submits an **invoice**, you link the relevant budget lines to the 
 ## Next Steps
 
 - [Budget Categories](categories) -- Create and manage budget categories
-- [Financing Sources](financing-sources) -- Track your funding sources and depletion
+- [Financing Sources](financing-sources) -- Track funding sources, inline expansion of attached lines, and mass-move
 - [Work Item Budgets](work-item-budgets) -- Add cost estimates to work items
-- [Vendors & Invoices](vendors-and-invoices) -- Track vendors and their invoices
+- [Invoices](vendors-and-invoices) -- Track invoices and link them to budget lines (vendors are managed from Settings)
 - [Subsidies](subsidies) -- Manage subsidy programs
-- [Budget Overview](budget-overview) -- Understand the overview dashboard and projections
+- [Budget Overview](budget-overview) -- Area-grouped cost breakdown, clickable tiles, and print output

--- a/docs/src/guides/budget/vendors-and-invoices.md
+++ b/docs/src/guides/budget/vendors-and-invoices.md
@@ -1,17 +1,21 @@
 ---
 sidebar_position: 4
-title: Vendors & Invoices
+title: Invoices & Vendors
 ---
 
-# Vendors & Invoices
+# Invoices & Vendors
 
-Vendors are the companies and contractors that provide services or materials for your project. Each vendor can have multiple invoices, and each invoice can be linked to multiple budget lines across your work items and household items.
+Invoices track the real cost of your project -- the receipts from everyone you pay. Each invoice can be linked to multiple budget lines across your work items and household items, and each vendor can have any number of invoices attached.
 
-## Vendors
+:::info Vendors now live under Settings
+Vendor records have moved out of the Budget subnav and into **Settings > Vendors**. That makes sense because a vendor's name, trade, and contact details are master data you set up once -- similar to areas, trades, and user accounts -- whereas invoices are financial transactions that belong with the rest of the budget. All existing links between invoices, budget lines, and vendors are preserved; only the menu location has changed.
+:::
+
+## Vendors (under Settings)
 
 ### Vendor List
 
-Navigate to **Budget > Vendors** in the sidebar to see all vendors. The list supports:
+Navigate to **Settings > Vendors** in the sidebar to see all vendors. The list supports:
 
 - **Search** -- Find vendors by name
 - **Sorting** -- Sort by name or creation date
@@ -31,7 +35,7 @@ Click a vendor to see their detail page, which shows the vendor's information, a
 
 ### Invoice List
 
-Navigate to **Budget > Invoices** in the sidebar to see all invoices across all vendors. The list supports:
+Navigate to **Budget > Invoices** in the sidebar to see all invoices across all vendors. (Invoices remain in the Budget section; only the vendor records themselves moved to Settings.) The list supports:
 
 - **Search** -- Find invoices by number or vendor name
 - **Status Filter** -- Filter by Quotation, Pending, Paid, or Claimed

--- a/docs/src/guides/budget/work-item-budgets.md
+++ b/docs/src/guides/budget/work-item-budgets.md
@@ -38,7 +38,7 @@ When a vendor invoice arrives for work covered by a budget line, you can link th
 
 When multiple budget lines on the same work item share an invoice, they collapse into an **Invoice Group** showing the invoice total alongside each line's planned and itemized amounts.
 
-See [Vendors & Invoices](vendors-and-invoices) for details on managing invoices and the linking workflow.
+See [Invoices & Vendors](vendors-and-invoices) for details on managing invoices and the linking workflow.
 
 ## Multiple Budget Lines per Work Item
 

--- a/docs/src/guides/household-items/budget-and-invoices.md
+++ b/docs/src/guides/household-items/budget-and-invoices.md
@@ -39,7 +39,7 @@ When a vendor invoice arrives for a household item purchase, you can link the it
 
 A single invoice can cover multiple budget lines across different items. When multiple budget lines on the same household item share an invoice, they collapse into an **Invoice Group** showing the invoice total alongside each line's planned and itemized amounts.
 
-See [Vendors & Invoices](/guides/budget/vendors-and-invoices) for details on managing invoices and the full linking workflow.
+See [Invoices & Vendors](/guides/budget/vendors-and-invoices) for details on managing invoices and the full linking workflow.
 
 ## Subsidies
 

--- a/docs/src/guides/household-items/index.md
+++ b/docs/src/guides/household-items/index.md
@@ -47,6 +47,10 @@ Household items move through a purchase lifecycle:
 | **Scheduled** | Delivery date confirmed |
 | **Arrived** | Item delivered |
 
+## Area Breadcrumbs
+
+Household items display the full **area ancestor path** (e.g. `House / Ground Floor / Kitchen`) wherever they appear -- list pages, detail pages, pickers, and any work item or diary entry that references them. See [Areas & Trades](/guides/work-items/areas-and-trades) for how the area hierarchy works.
+
 ## List View
 
 The household items list page provides:
@@ -58,6 +62,10 @@ The household items list page provides:
 - **Responsive layout** -- Table view on desktop, card view on mobile and tablet
 
 All filter and sort settings are synced to the URL, so your view is bookmarkable and shareable.
+
+### Filtering by Area
+
+The **Area** filter supports the full area hierarchy: picking a parent area also matches every descendant area. A dedicated **No Area** option surfaces items that have not yet been assigned to any area.
 
 ![Household items list page](/img/screenshots/household-items-list-light.png)
 

--- a/docs/src/guides/work-items/areas-and-trades.md
+++ b/docs/src/guides/work-items/areas-and-trades.md
@@ -28,11 +28,26 @@ Navigate to **Manage** in the sidebar to access the areas and trades management 
 
 ### Hierarchy
 
-Areas can be nested to any depth. A parent area implicitly includes all its children -- for example, filtering work items by "Ground Floor" will also show items assigned to "Kitchen", "Living Room", and any other child areas.
+Areas can be nested to any depth. A parent area implicitly includes all its children -- for example, filtering work items by "Ground Floor" will also show items assigned to "Kitchen", "Living Room", and any other child areas. Filters support arbitrary hierarchy depth, so deeply nested trees resolve correctly across every list page.
 
 ### Assigning Areas
 
 When creating or editing a work item or household item, select an area from the area picker. The picker displays the full hierarchy so you can quickly find the right location.
+
+### Area Breadcrumbs Everywhere
+
+Once you assign an area, Cornerstone displays the **full ancestor path** as a breadcrumb (e.g. `House / Ground Floor / Kitchen`) wherever the item surfaces:
+
+- Work item and household item lists, detail pages, and create pages
+- Pickers that let you select a work item, household item, or budget line (the area appears as a secondary line under the title)
+- Embedded references -- diary entries, invoices, and household item dependencies that point back to a work item
+- The Budget Overview cost breakdown and the Budget Sources line panel (grouped by the full area hierarchy)
+
+The breadcrumb keeps each item grounded in its location at a glance, without having to click through to the detail page.
+
+### The "No Area" Option
+
+Not every item has an area assigned -- maybe it is a project-wide task, an administrative item, or something you have not classified yet. The Work Items and Household Items lists include a dedicated **No Area** filter option that surfaces exactly those items, separate from any real area. The Budget Overview uses the same label ("No Area") for the bucket of budget lines whose work item or household item has no area assigned.
 
 ## Trades
 

--- a/docs/src/guides/work-items/index.md
+++ b/docs/src/guides/work-items/index.md
@@ -14,11 +14,22 @@ Work items support:
 - **Statuses** -- Not Started, In Progress, Completed, or Blocked
 - **Dates and scheduling** -- Start dates, end dates, durations, and scheduling constraints
 - **User assignment** -- Assign tasks to any user on your instance
-- **Areas** -- Hierarchical location assignment (e.g., "Ground Floor > Kitchen")
+- **Areas** -- Hierarchical location assignment (e.g., "House / Ground Floor / Kitchen") with the full ancestor path shown as a breadcrumb wherever the work item appears
 - **Notes** -- Timestamped comments with author attribution
 - **Subtasks** -- Checklist items within a work item
 - **Dependencies** -- Relationships between work items (what must happen before or after)
 - **Document links** -- Attach documents from [Paperless-ngx](/guides/documents) (contracts, receipts, plans)
+
+## Area Breadcrumbs
+
+Every work item now displays the full **area ancestor path** as a breadcrumb -- for example, `House / Ground Floor / Kitchen` -- so you always know where a task belongs without having to open its detail page. Breadcrumbs appear on:
+
+- The work item list (next to each row)
+- The work item detail page
+- Work item pickers (as a secondary line under the title)
+- Embedded references from diary entries, invoices, and household items that link to a work item
+
+See [Areas & Trades](areas-and-trades) for how areas are organized and nested.
 
 ## List View
 
@@ -31,6 +42,13 @@ The work items list page provides:
 - **Responsive layout** -- Table view on desktop, card view on mobile and tablet
 
 All filter and sort settings are synced to the URL, so your view is bookmarkable and shareable.
+
+### Filtering by Area
+
+The **Area** filter on the work items list supports the full area hierarchy:
+
+- Picking a parent area also matches every work item in its descendant areas (no more empty results when you filter by a top-level location).
+- A dedicated **No Area** option lets you find work items that have not yet been assigned to any area -- useful for cleaning up legacy or imported items.
 
 ![Work items list page](/img/screenshots/work-items-list-light.png)
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -31,8 +31,9 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 
 ## Key Features
 
-- **Work Items** -- Create and manage construction tasks with statuses, dates, assignments, areas, notes, subtasks, and dependencies
-- **Budget Management** -- Track costs with budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies, and a dashboard with multiple projection perspectives
+- **Work Items** -- Create and manage construction tasks with statuses, dates, assignments, areas, notes, subtasks, and dependencies -- each work item surfaces its full area ancestor path (e.g. `House / Ground Floor / Kitchen`) as a breadcrumb wherever it appears
+- **Budget Management** -- Track costs with budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies, and an area-grouped overview dashboard with multiple projection perspectives, clickable summary tiles, and print-friendly export
+- **Hierarchical Financing Sources** -- Click any source to expand it inline, see every attached budget line grouped by area and work item, and mass-move selected lines between sources
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path highlighting, zoom controls, milestones, and automatic scheduling via the Critical Path Method
 - **Calendar View** -- Monthly and weekly calendar grids showing work items and milestones
 - **Milestones** -- Track major project checkpoints with target dates, projected completion, and late detection


### PR DESCRIPTION
## Summary

Refresh user-facing documentation to reflect the changes bundled in the beta->main promotion PR #1332:

- **Area hierarchy everywhere** -- work items, household items, pickers, and embedded references now document the full ancestor breadcrumb (`House / Ground Floor / Kitchen`) and the "No Area" filter on list pages.
- **Budget Overview** -- rewritten to describe the new area-grouped cost breakdown, clickable summary tiles, and print-friendly output (page margins, nested group boxes, AppShell chrome suppressed).
- **Budget Sources** -- rewritten to cover inline expansion, hierarchical area tree, dense columnar rows, multi-select across groups with preserved selection, and the new mass-move modal.
- **Vendors moved to Settings** -- budget docs now explain that vendor records live under Settings while invoices remain in the Budget section.
- **Reverse-proxy reliability** -- getting-started docs explain the narrower `TRUST_PROXY` behavior and spoof-resistant rate-limit key.
- **README** -- Features list refreshed (area breadcrumbs, No Area filter, Budget Sources mass-move, area-grouped Budget Overview). The protected NOTE block is untouched.
- **RELEASE_SUMMARY.md** -- rewritten end-to-end with user-facing prose, grouped "what's new" bullets, an explicit "no breaking changes" statement, and migration notes covering the `TRUST_PROXY` behavior change and the Vendors menu relocation.
- **.env.example** -- short inline comment on `TRUST_PROXY` noting only the first hop is trusted.

No production code, schema, or test changes are in scope for this PR.

## Test plan

- [ ] Docusaurus build succeeds (runs via CI)
- [ ] Spot-check the rendered Budget Overview, Budget Sources, Work Items, and Household Items pages on the docs preview
- [ ] Confirm the README NOTE block is byte-identical to before
- [ ] Confirm `RELEASE_SUMMARY.md` renders cleanly on GitHub (preview the raw markdown)

Targets `beta` per the branching strategy in CLAUDE.md. Will be included in the next promotion along with #1332.

Co-Authored-By: Claude docs-writer (Opus 4.6) <noreply@anthropic.com>