### PR TITLE
release: promote beta to main — filtered Available Funds & Remaining Budget

### DIFF
--- a/.claude/agent-memory/product-owner/MEMORY.md
+++ b/.claude/agent-memory/product-owner/MEMORY.md
@@ -105,15 +105,10 @@ All 12 stories merged. Paperless-ngx links for invoices are EPIC-08; budget repo
 - GraphQL still needed for: `addSubIssue`, `addBlockedBy` (no native CLI equivalent yet)
 - GraphQL: `addBlockedBy` uses `blockingIssueId` (NOT `blockedByIssueId`)
 
-## User Feedback Batch (2026-02-27)
+## User Feedback Batches
 
-Created 11 issues (#328-#338) from user feedback:
-
-- EPIC-06 sub-issues: #328 (autosave feedback), #329 (date clearing mobile), #330 (remove work item delay), #331 (mobile touch tooltip), #332 (milestone tooltip items), #333 (duration in tooltip), #334 (calendar tooltip parity), #335 (calendar tag colors)
-- EPIC-05 sub-issues: #336 (subsidy default categories), #337 (budget range display), #338 (invoice edit link)
-- #334 blocked by #332
-- All set to Todo status on board
-- Classification: 6 bugs (#329, #330, #332, #334, #337, #338), 5 user-stories (#328, #331, #333, #335, #336)
+- **2026-02-27** — 11 issues #328-#338 (EPIC-06 + EPIC-05 sub-issues, 6 bugs / 5 stories)
+- **2026-04-28** — 5 standalone UI bugs #1369-#1373 (no active parent epic; all related epics closed): #1369 hide-linked filter on Paperless picker, #1370 disable scroll-wheel on numeric inputs, #1371 "Includes VAT" parity for direct-amount budget lines, #1372 vendor in invoice picker, #1373 "Claimed" total on Budget Invoices summary. All Todo. Only EPIC-16 (Floor Plans) is currently open and is unrelated to these.
 
 ## Patterns and Conventions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Classify changed paths
         id: filter
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then BASE_REF="main"; fi
+          CHANGED=$(git diff --name-only origin/${BASE_REF}...HEAD)
           echo "Changed files:"
           echo "$CHANGED"
 

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.module.css
@@ -659,6 +659,11 @@
   .rowLevel3 td {
     border-bottom: 1pt dotted var(--color-border);
   }
+
+  /* Hide deselected source rows in print */
+  .rowSourceDetailToggle[aria-pressed='false'] {
+    display: none !important;
+  }
 }
 
 /* ============================================================

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -274,6 +274,7 @@ function buildBreakdownWithWI(
     workItemId?: string;
     description?: string | null;
     hasInvoice?: boolean;
+    budgetSources?: BudgetSourceSummaryBreakdown[];
     // Legacy params — kept for backward compat but ignored (area is always No Area)
     categoryId?: string | null;
     categoryName?: string;
@@ -358,7 +359,7 @@ function buildBreakdownWithWI(
       },
     },
     subsidyAdjustments: [],
-    budgetSources: [],
+    budgetSources: opts.budgetSources ?? [],
   };
 }
 
@@ -593,9 +594,15 @@ describe('CostBreakdownTable', () => {
   // ── 16. Summary rows show totals ──────────────────────────────────────────
 
   it('shows Available funds row with formatted currency value', () => {
+    // budgetSources must include a source with totalAmount=50000 so that
+    // filteredAvailableFunds (sum of non-deselected sources) equals €50,000.00.
+    const breakdown = {
+      ...buildBreakdownWithWI({ projectedMin: 800, projectedMax: 1200 }),
+      budgetSources: [buildSourceSummary({ id: 'src-test', totalAmount: 50000 })],
+    };
     render(
       <CostBreakdownTable
-        breakdown={buildBreakdownWithWI({ projectedMin: 800, projectedMax: 1200 })}
+        breakdown={breakdown}
         overview={buildOverview(50000)}
         deselectedSourceIds={new Set()}
         onSourceToggle={() => {}}
@@ -1087,7 +1094,7 @@ describe('CostBreakdownTable', () => {
     // availableFunds=100000, projectedMax=1200 → remaining = 98800 > 0
     const { container } = render(
       <CostBreakdownTable
-        breakdown={buildBreakdownWithWI({ projectedMax: 1200 })}
+        breakdown={buildBreakdownWithWI({ projectedMax: 1200, budgetSources: [buildSourceSummary({ totalAmount: 100000 })] })}
         overview={buildOverview(100000)}
         deselectedSourceIds={new Set()}
         onSourceToggle={() => {}}
@@ -1887,6 +1894,7 @@ describe('CostBreakdownTable', () => {
           rawProjectedMax: 5000,
           subsidyPayback: 1200,
           minSubsidyPayback: 800,
+          budgetSources: [buildSourceSummary({ totalAmount: 10000 })],
         })}
         overview={buildOverview(10000)}
         deselectedSourceIds={new Set()}
@@ -1913,6 +1921,7 @@ describe('CostBreakdownTable', () => {
           rawProjectedMax: 8000,
           subsidyPayback: 2000,
           minSubsidyPayback: 1000,
+          budgetSources: [buildSourceSummary({ totalAmount: 20000 })],
         })}
         overview={buildOverview(20000)}
         deselectedSourceIds={new Set()}
@@ -1942,6 +1951,7 @@ describe('CostBreakdownTable', () => {
           rawProjectedMax: 8000,
           subsidyPayback: 2000,
           minSubsidyPayback: 1000,
+          budgetSources: [buildSourceSummary({ totalAmount: 20000 })],
         })}
         overview={buildOverview(20000)}
         deselectedSourceIds={new Set()}
@@ -1971,6 +1981,7 @@ describe('CostBreakdownTable', () => {
           rawProjectedMax: 8000,
           subsidyPayback: 2000,
           minSubsidyPayback: 1000,
+          budgetSources: [buildSourceSummary({ totalAmount: 20000 })],
         })}
         overview={buildOverview(20000)}
         deselectedSourceIds={new Set()}
@@ -2252,6 +2263,7 @@ describe('CostBreakdownTable', () => {
           projectedMax: 5000,
           rawProjectedMin: 3000,
           rawProjectedMax: 5000,
+          budgetSources: [buildSourceSummary({ totalAmount: 10000 })],
         })}
         overview={buildOverview(10000)}
         deselectedSourceIds={new Set()}
@@ -2282,6 +2294,7 @@ describe('CostBreakdownTable', () => {
           rawProjectedMax: 5000,
           subsidyPayback: 200,
           minSubsidyPayback: 100,
+          budgetSources: [buildSourceSummary({ totalAmount: 10000 })],
         })}
         overview={buildOverview(10000)}
         deselectedSourceIds={new Set()}
@@ -2308,6 +2321,7 @@ describe('CostBreakdownTable', () => {
           projectedMax: 5000,
           rawProjectedMin: 3000,
           rawProjectedMax: 5000,
+          budgetSources: [buildSourceSummary({ totalAmount: 10000 })],
         })}
         overview={buildOverview(10000)}
         deselectedSourceIds={new Set()}
@@ -3850,11 +3864,15 @@ describe('Server-driven render path (#1360)', () => {
       },
       subsidyAdjustments: [],
       budgetSources: [
-        // Source A: selected (not in deselectedSourceIds), has payback
+        // Source A: selected (not in deselectedSourceIds), has payback.
+        // totalAmount=200000 so that filteredAvailableFunds = 200000 (matching
+        // overview.availableFunds) — this keeps Scenario 23 internally consistent
+        // now that Available Funds uses sum-of-visible-sources rather than
+        // overview.availableFunds directly.
         buildSourceSummary({
           id: 'src-1360-a',
           name: 'Green Fund',
-          totalAmount: 100000,
+          totalAmount: 200000,
           projectedMin: 40000,
           projectedMax: 60000,
           subsidyPaybackMin: 500,
@@ -3933,26 +3951,25 @@ describe('Server-driven render path (#1360)', () => {
     expect(costCell!.textContent?.replace(/\s+/g, '')).toBe('-€50,000.00');
   });
 
-  // ── Scenario 23: Remaining Budget row uses overview.availableFunds (not filtered) ─
-  // With deselectedSourceIds=new Set(['src-1360-b']) (hypothetical — src-1360-b not in breakdown
-  // because server already excluded it), the row still reads:
-  //   overview.availableFunds - totalRawProjected + adjustedTotalPayback
-  //   = 200000 - 50000 + 750 = 150750
-  // The point: remaining = overview.availableFunds (not a filtered sub-amount).
+  // ── Scenario 23: Remaining Budget row uses filteredAvailableFunds ────────────
+  // filteredAvailableFunds = sum of budgetSources not in deselectedSourceIds.
+  // With deselectedSourceIds=new Set(['src-1360-b']) (hypothetical — src-1360-b is
+  // not present in the breakdown so no source is filtered out), the computation is:
+  //   filteredAvailableFunds = src-1360-a.totalAmount(200000) + unassigned.totalAmount(0) = 200000
+  //   totalRawProjected avg = (40000+60000)/2 = 50000 (WI only, no HI)
+  //   adjustedTotalPayback = resolvedTotalPayback - resolvedTotalExcess
+  //     totalMinPayback = 500 (wiTotals) + 0 (hiTotals) = 500
+  //     totalMaxPayback = 1000 + 0 = 1000
+  //     resolvedTotalPayback (avg) = (500+1000)/2 = 750
+  //     no subsidyAdjustments → excess = 0
+  //     adjustedTotalPayback = 750
+  //   Remaining Net = 200000 - 50000 + 750 = 150750 → '€150,750.00'
 
-  it('Remaining Budget row uses overview.availableFunds directly (Scenario 23)', () => {
+  it('Remaining Budget row uses filteredAvailableFunds (Scenario 23)', () => {
     const breakdown = buildServerFilteredBreakdown();
-    // availableFunds = 200000
-    // totalRawProjected avg = (40000+60000)/2 = 50000 (WI only, no HI)
-    // adjustedTotalPayback = resolvedTotalPayback - resolvedTotalExcess
-    //   totalMinPayback = 500 (wiTotals) + 0 (hiTotals) = 500
-    //   totalMaxPayback = 1000 + 0 = 1000
-    //   resolvedTotalPayback (avg) = (500+1000)/2 = 750
-    //   no subsidyAdjustments → excess = 0
-    //   adjustedTotalPayback = 750
-    // Remaining Net = 200000 - 50000 + 750 = 150750 → '€150,750.00'
+    // filteredAvailableFunds = 200000 (src-1360-a.totalAmount=200000; src-1360-b not in sources)
     renderWithRouter(breakdown, buildOverview(200000), {
-      deselectedSourceIds: new Set(['src-1360-b']), // hypothetical deselection
+      deselectedSourceIds: new Set(['src-1360-b']), // hypothetical deselection (src not in breakdown)
     });
 
     const remainingRow = screen.getByRole('row', { name: /remaining budget/i });
@@ -4028,5 +4045,428 @@ describe('Server-driven render path (#1360)', () => {
 
     // The table element must be in the DOM (as opposed to the empty-state path which omits it).
     expect(container.querySelector('table')).toBeInTheDocument();
+  });
+});
+
+// ── filteredAvailableFunds — Available Funds + Remaining Budget rows ──────────
+//
+// After the bug fix in #1362, the Available Funds row and Remaining Budget row
+// use filteredAvailableFunds = sum of totalAmount for sources NOT in deselectedSourceIds,
+// computed client-side from breakdown.budgetSources. These tests verify all three
+// filter states: all selected, partial deselection, and all deselected.
+
+describe('filteredAvailableFunds — Available Funds row and Remaining Budget row (#1362)', () => {
+  /**
+   * Builds a two-source breakdown fixture for filter-aware summary row tests.
+   *
+   * Source A: id='src-a', name='Bank Loan', totalAmount=150000
+   * Source B: id='src-b', name='Equity',    totalAmount=100000
+   * Total available funds (all selected): 250000
+   *
+   * rawProjectedMin = rawProjectedMax = 50000 (so avg perspective = 50000 exactly,
+   * making Remaining Budget Cost = filteredAvailableFunds - 50000, deterministic).
+   *
+   * No subsidies → adjustedTotalPayback = 0.
+   */
+  function buildTwoSourceBreakdown(): BudgetBreakdown {
+    return {
+      workItems: {
+        areas: [
+          {
+            areaId: null,
+            name: 'Unassigned',
+            parentId: null,
+            color: null,
+            projectedMin: 50000,
+            projectedMax: 50000,
+            actualCost: 0,
+            subsidyPayback: 0,
+            rawProjectedMin: 50000,
+            rawProjectedMax: 50000,
+            minSubsidyPayback: 0,
+            items: [
+              {
+                workItemId: 'wi-filter-1',
+                title: 'Foundation Work',
+                projectedMin: 50000,
+                projectedMax: 50000,
+                actualCost: 0,
+                subsidyPayback: 0,
+                rawProjectedMin: 50000,
+                rawProjectedMax: 50000,
+                minSubsidyPayback: 0,
+                costDisplay: 'projected',
+                budgetLines: [
+                  {
+                    id: 'line-filter-1',
+                    description: null,
+                    plannedAmount: 50000,
+                    confidence: 'own_estimate',
+                    actualCost: 0,
+                    hasInvoice: false,
+                    isQuotation: false,
+                    budgetSourceId: 'src-a',
+                  },
+                ],
+              },
+            ],
+            children: [],
+          },
+        ],
+        totals: {
+          projectedMin: 50000,
+          projectedMax: 50000,
+          actualCost: 0,
+          subsidyPayback: 0,
+          rawProjectedMin: 50000,
+          rawProjectedMax: 50000,
+          minSubsidyPayback: 0,
+        },
+      },
+      householdItems: {
+        areas: [],
+        totals: {
+          projectedMin: 0,
+          projectedMax: 0,
+          actualCost: 0,
+          subsidyPayback: 0,
+          rawProjectedMin: 0,
+          rawProjectedMax: 0,
+          minSubsidyPayback: 0,
+        },
+      },
+      subsidyAdjustments: [],
+      budgetSources: [
+        buildSourceSummary({
+          id: 'src-a',
+          name: 'Bank Loan',
+          totalAmount: 150000,
+          projectedMin: 40000,
+          projectedMax: 60000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        }),
+        buildSourceSummary({
+          id: 'src-b',
+          name: 'Equity',
+          totalAmount: 100000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        }),
+      ],
+    };
+  }
+
+  // Helper: get the Available Funds row <tr>
+  function getAvailFundsRow(): HTMLElement {
+    return screen.getByText('Available funds').closest('tr') as HTMLElement;
+  }
+
+  // Helper: get the Remaining Budget row <tr>
+  function getRemainingBudgetRow(): HTMLElement {
+    return screen.getByRole('row', { name: /remaining budget/i });
+  }
+
+  // ── Scenario 1: All sources selected (deselectedSourceIds = empty set) ───────
+  // filteredAvailableFunds = 150000 + 100000 = 250000
+
+  it('Available Funds row displays full sum of all source totalAmounts when deselectedSourceIds is empty (Scenario 1)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(),
+    });
+
+    const availFundsRow = getAvailFundsRow();
+    const costCell = availFundsRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // filteredAvailableFunds = 150000 + 100000 = 250000
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€250,000.00');
+  });
+
+  // ── Scenario 2: One source deselected ────────────────────────────────────────
+  // deselectedSourceIds = {'src-b'} → filteredAvailableFunds = 150000 only
+
+  it('Available Funds row displays sum of selected sources only when one source is deselected (Scenario 2)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-b']),
+    });
+
+    const availFundsRow = getAvailFundsRow();
+    const costCell = availFundsRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // filteredAvailableFunds = 150000 (src-b excluded)
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€150,000.00');
+    // Must NOT contain the unfiltered total
+    expect(costCell!.textContent).not.toContain('€250,000.00');
+  });
+
+  // ── Scenario 3: All sources deselected ────────────────────────────────────────
+  // deselectedSourceIds = {'src-a', 'src-b'} → filteredAvailableFunds = 0
+
+  it('Available Funds row displays €0.00 when all sources are deselected (Scenario 3)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-a', 'src-b']),
+    });
+
+    const availFundsRow = getAvailFundsRow();
+    const costCell = availFundsRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // filteredAvailableFunds = 0
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€0.00');
+    // Must NOT be NaN or undefined
+    expect(costCell!.textContent).not.toContain('NaN');
+    expect(costCell!.textContent).not.toContain('undefined');
+    // Must NOT show the unfiltered total
+    expect(costCell!.textContent).not.toContain('€250,000.00');
+  });
+
+  // ── Scenario 4: Remaining Budget Cost column — all selected ──────────────────
+  // filteredAvailableFunds = 250000, totalRawProjected = 50000 (avg of 50000/50000)
+  // Remaining Budget Cost = 250000 - 50000 = 200000
+
+  it('Remaining Budget Cost column = filteredAvailableFunds - totalRawProjected when all sources selected (Scenario 4)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(),
+    });
+
+    const remainingRow = getRemainingBudgetRow();
+    const costCell = remainingRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // 250000 - 50000 = 200000
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€200,000.00');
+  });
+
+  // ── Scenario 5: Remaining Budget Cost column — one source deselected ─────────
+  // deselectedSourceIds = {'src-b'} → filteredAvailableFunds = 150000
+  // Remaining Budget Cost = 150000 - 50000 = 100000 (NOT 250000 - 50000 = 200000)
+
+  it('Remaining Budget Cost column uses filteredAvailableFunds (not total) when one source is deselected (Scenario 5)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-b']),
+    });
+
+    const remainingRow = getRemainingBudgetRow();
+    const costCell = remainingRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // filteredAvailableFunds (150000) - totalRawProjected (50000) = 100000
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€100,000.00');
+    // Must NOT use the unfiltered total: 250000 - 50000 = 200000
+    expect(costCell!.textContent).not.toContain('€200,000.00');
+  });
+
+  // ── Scenario 6: Remaining Budget Cost column — all sources deselected ────────
+  // deselectedSourceIds = {'src-a', 'src-b'} → filteredAvailableFunds = 0
+  // Remaining Budget Cost = 0 - 50000 = -50000 → negative, uses valueNegative CSS class
+
+  it('Remaining Budget Cost column is negative when all sources are deselected (Scenario 6)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-a', 'src-b']),
+    });
+
+    const remainingRow = getRemainingBudgetRow();
+    const costCell = remainingRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // 0 - 50000 = -50000: value is negative
+    const costSpan = costCell!.querySelector('span');
+    expect(costSpan).not.toBeNull();
+    // Span text should contain the cost amount and a minus sign
+    expect(costSpan!.textContent).toContain('50,000.00');
+    expect(costSpan!.textContent).toContain('-');
+    // Span should have the valueNegative class (filteredAvailableFunds - totalRawProjected < 0)
+    expect(costSpan).toHaveClass('valueNegative');
+  });
+
+  // ── Scenario 7: Remaining Budget Net column uses filteredAvailableFunds ───────
+  // Build breakdown with adjustedTotalPayback > 0 to verify it's included.
+  // deselectedSourceIds = {'src-b'} → filteredAvailableFunds = 150000
+  // totalRawProjected = 50000, adjustedTotalPayback = 5000 (from wi subsidyPayback)
+  // Remaining Budget Net = 150000 - 50000 + 5000 = 105000
+
+  it('Remaining Budget Net column = filteredAvailableFunds - totalRawProjected + adjustedTotalPayback when source is deselected (Scenario 7)', () => {
+    // Use a breakdown with WI subsidy payback to make adjustedTotalPayback > 0
+    const breakdown: BudgetBreakdown = {
+      workItems: {
+        areas: [
+          {
+            areaId: null,
+            name: 'Unassigned',
+            parentId: null,
+            color: null,
+            projectedMin: 50000,
+            projectedMax: 50000,
+            actualCost: 0,
+            subsidyPayback: 5000,
+            rawProjectedMin: 50000,
+            rawProjectedMax: 50000,
+            minSubsidyPayback: 5000,
+            items: [
+              {
+                workItemId: 'wi-payback-1',
+                title: 'Subsidized Work',
+                projectedMin: 50000,
+                projectedMax: 50000,
+                actualCost: 0,
+                subsidyPayback: 5000,
+                rawProjectedMin: 50000,
+                rawProjectedMax: 50000,
+                minSubsidyPayback: 5000,
+                costDisplay: 'projected',
+                budgetLines: [
+                  {
+                    id: 'line-payback-1',
+                    description: null,
+                    plannedAmount: 50000,
+                    confidence: 'own_estimate',
+                    actualCost: 0,
+                    hasInvoice: false,
+                    isQuotation: false,
+                    budgetSourceId: 'src-a',
+                  },
+                ],
+              },
+            ],
+            children: [],
+          },
+        ],
+        totals: {
+          projectedMin: 50000,
+          projectedMax: 50000,
+          actualCost: 0,
+          subsidyPayback: 5000,
+          rawProjectedMin: 50000,
+          rawProjectedMax: 50000,
+          minSubsidyPayback: 5000,
+        },
+      },
+      householdItems: {
+        areas: [],
+        totals: {
+          projectedMin: 0,
+          projectedMax: 0,
+          actualCost: 0,
+          subsidyPayback: 0,
+          rawProjectedMin: 0,
+          rawProjectedMax: 0,
+          minSubsidyPayback: 0,
+        },
+      },
+      subsidyAdjustments: [],
+      budgetSources: [
+        buildSourceSummary({
+          id: 'src-a',
+          name: 'Bank Loan',
+          totalAmount: 150000,
+          projectedMin: 40000,
+          projectedMax: 60000,
+          subsidyPaybackMin: 5000,
+          subsidyPaybackMax: 5000,
+        }),
+        buildSourceSummary({
+          id: 'src-b',
+          name: 'Equity',
+          totalAmount: 100000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        }),
+      ],
+    };
+
+    renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-b']),
+    });
+
+    const remainingRow = getRemainingBudgetRow();
+    const netCell = remainingRow.querySelector('td[class*="colRemaining"]');
+    expect(netCell).not.toBeNull();
+    // filteredAvailableFunds (150000) - totalRawProjected (50000) + adjustedTotalPayback (5000) = 105000
+    expect(netCell!.textContent?.replace(/\s+/g, '')).toContain('€105,000.00');
+  });
+
+  // ── Scenario 8: unassigned source deselected — totalAmount=0, no effect ──────
+  // The 'unassigned' source has totalAmount=0. Deselecting it changes filteredAvailableFunds
+  // by zero (subtracts 0 from the sum), so the totals stay the same as with it selected.
+
+  it('deselecting the unassigned source (totalAmount=0) does not change filteredAvailableFunds (Scenario 8)', () => {
+    const breakdown: BudgetBreakdown = {
+      ...buildTwoSourceBreakdown(),
+      budgetSources: [
+        buildSourceSummary({
+          id: 'src-a',
+          name: 'Bank Loan',
+          totalAmount: 150000,
+          projectedMin: 40000,
+          projectedMax: 60000,
+        }),
+        buildSourceSummary({
+          id: 'unassigned',
+          name: 'Unassigned',
+          totalAmount: 0,
+          projectedMin: 0,
+          projectedMax: 0,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        }),
+      ],
+    };
+
+    // Deselect unassigned (totalAmount=0) — Available Funds should still = 150000
+    renderWithRouter(breakdown, buildOverview(150000), {
+      deselectedSourceIds: new Set(['unassigned']),
+    });
+
+    const availFundsRow = getAvailFundsRow();
+    const costCell = availFundsRow.querySelector('td[class*="colBudget"]');
+    expect(costCell).not.toBeNull();
+    // unassigned contributes 0, so filteredAvailableFunds = 150000
+    expect(costCell!.textContent?.replace(/\s+/g, '')).toContain('€150,000.00');
+  });
+
+  // ── Scenario 9: toggling back to all-selected restores unfiltered values ──────
+  // First render with src-b deselected (filteredAvailableFunds=150000), then
+  // re-render with empty deselectedSourceIds (filteredAvailableFunds=250000).
+
+  it('Available Funds and Remaining Budget restore to unfiltered values when deselectedSourceIds becomes empty (Scenario 9)', () => {
+    const breakdown = buildTwoSourceBreakdown();
+
+    // Phase 1: src-b deselected → filteredAvailableFunds = 150000
+    const { rerender } = renderWithRouter(breakdown, buildOverview(250000), {
+      deselectedSourceIds: new Set(['src-b']),
+    });
+
+    const availFundsRow1 = getAvailFundsRow();
+    const costCell1 = availFundsRow1.querySelector('td[class*="colBudget"]');
+    expect(costCell1!.textContent?.replace(/\s+/g, '')).toContain('€150,000.00');
+
+    // Phase 2: re-render with no deselection → filteredAvailableFunds = 250000
+    rerender(
+      <MemoryRouter>
+        <CostBreakdownTable
+          breakdown={breakdown}
+          overview={buildOverview(250000)}
+          deselectedSourceIds={new Set()}
+          onSourceToggle={() => {}}
+          onSelectAllSources={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    const availFundsRow2 = getAvailFundsRow();
+    const costCell2 = availFundsRow2.querySelector('td[class*="colBudget"]');
+    expect(costCell2!.textContent?.replace(/\s+/g, '')).toContain('€250,000.00');
+
+    // Remaining Budget Cost should also restore
+    const remainingRow = getRemainingBudgetRow();
+    const remainingCostCell = remainingRow.querySelector('td[class*="colBudget"]');
+    // 250000 - 50000 = 200000
+    expect(remainingCostCell!.textContent?.replace(/\s+/g, '')).toContain('€200,000.00');
   });
 });

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -1094,7 +1094,10 @@ describe('CostBreakdownTable', () => {
     // availableFunds=100000, projectedMax=1200 → remaining = 98800 > 0
     const { container } = render(
       <CostBreakdownTable
-        breakdown={buildBreakdownWithWI({ projectedMax: 1200, budgetSources: [buildSourceSummary({ totalAmount: 100000 })] })}
+        breakdown={buildBreakdownWithWI({
+          projectedMax: 1200,
+          budgetSources: [buildSourceSummary({ totalAmount: 100000 })],
+        })}
         overview={buildOverview(100000)}
         deselectedSourceIds={new Set()}
         onSourceToggle={() => {}}

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -682,7 +682,7 @@ function ChevronSvg({ className }: { className: string }) {
  */
 export function CostBreakdownTable({
   breakdown,
-  overview,
+  overview: _overview,
   deselectedSourceIds,
   onSourceToggle,
   onSelectAllSources,
@@ -785,9 +785,16 @@ export function CostBreakdownTable({
   );
 
   /**
-   * Sum = availableFunds - totalRawProjected + adjustedTotalPayback.
+   * Compute filtered available funds: sum of totalAmount for sources that are not deselected.
    */
-  const sum = overview.availableFunds - totalRawProjected + adjustedTotalPayback;
+  const filteredAvailableFunds = budgetSources
+    .filter((s) => !deselectedSourceIds.has(s.id))
+    .reduce((sum: number, s) => sum + s.totalAmount, 0);
+
+  /**
+   * Sum = filteredAvailableFunds - totalRawProjected + adjustedTotalPayback.
+   */
+  const sum = filteredAvailableFunds - totalRawProjected + adjustedTotalPayback;
 
   // Empty state: only show early-return empty state if there are NO sources configured AND no items.
   // If sources are configured (even if all deselected, which prunes items), render the full table
@@ -1120,7 +1127,7 @@ export function CostBreakdownTable({
                     </div>
                   </td>
                   <td className={styles.colBudget} colSpan={3}>
-                    {formatCurrency(overview.availableFunds)}
+                    {formatCurrency(filteredAvailableFunds)}
                     {deselectedSourceIds.size > 0 && (
                       <span className={styles.availableFundsFilterCaption}>
                         {t('overview.costBreakdown.availableFundsFilter.activeFilterCaption', {
@@ -1233,25 +1240,25 @@ export function CostBreakdownTable({
                   <td className={styles.colBudget}>
                     <span
                       className={
-                        overview.availableFunds - totalRawProjected >= 0
+                        filteredAvailableFunds - totalRawProjected >= 0
                           ? styles.valuePositive
                           : styles.valueNegative
                       }
                     >
-                      {formatCurrency(overview.availableFunds - totalRawProjected)}
+                      {formatCurrency(filteredAvailableFunds - totalRawProjected)}
                     </span>
                   </td>
                   <td className={styles.colPayback} />
                   <td className={styles.colRemaining}>
                     <span
                       className={
-                        overview.availableFunds - totalRawProjected + adjustedTotalPayback >= 0
+                        filteredAvailableFunds - totalRawProjected + adjustedTotalPayback >= 0
                           ? styles.valuePositive
                           : styles.valueNegative
                       }
                     >
                       {formatCurrency(
-                        overview.availableFunds - totalRawProjected + adjustedTotalPayback,
+                        filteredAvailableFunds - totalRawProjected + adjustedTotalPayback,
                       )}
                     </span>
                   </td>

--- a/client/src/components/DataTable/filters/NumberFilter.test.tsx
+++ b/client/src/components/DataTable/filters/NumberFilter.test.tsx
@@ -199,4 +199,44 @@ describe('NumberFilter', () => {
       expect(minInput).toHaveAttribute('step', '1');
     });
   });
+
+  describe('onWheel blurs numeric inputs to prevent scroll value change (#1370)', () => {
+    it('blurs the min number input when wheel event fires', () => {
+      render(<NumberFilter value="" onChange={jest.fn()} />);
+      const [minInput] = screen.getAllByRole('spinbutton') as [HTMLInputElement];
+      const blurSpy = jest.spyOn(minInput, 'blur');
+      minInput.focus();
+
+      fireEvent.wheel(minInput);
+
+      expect(blurSpy).toHaveBeenCalled();
+      blurSpy.mockRestore();
+    });
+
+    it('blurs the max number input when wheel event fires', () => {
+      render(<NumberFilter value="" onChange={jest.fn()} />);
+      const inputs = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+      const maxInput = inputs[1]!;
+      const blurSpy = jest.spyOn(maxInput, 'blur');
+      maxInput.focus();
+
+      fireEvent.wheel(maxInput);
+
+      expect(blurSpy).toHaveBeenCalled();
+      blurSpy.mockRestore();
+    });
+
+    it('min input value is unchanged after wheel event', () => {
+      const mockOnChange = jest.fn();
+      render(<NumberFilter value="min:100,max:500" onChange={mockOnChange} />);
+      const [minInput] = screen.getAllByRole('spinbutton') as [HTMLInputElement];
+      minInput.focus();
+      expect(minInput.value).toBe('100');
+
+      fireEvent.wheel(minInput);
+
+      // Controlled value remains unchanged — blur does not alter value
+      expect(minInput.value).toBe('100');
+    });
+  });
 });

--- a/client/src/components/DataTable/filters/NumberFilter.tsx
+++ b/client/src/components/DataTable/filters/NumberFilter.tsx
@@ -78,6 +78,7 @@ export function NumberFilter({
           max={defaultMax}
           step={defaultStep}
           autoFocus
+          onWheel={(e) => e.currentTarget.blur()}
         />
       </div>
       <input
@@ -101,6 +102,7 @@ export function NumberFilter({
           min={defaultMin}
           max={defaultMax}
           step={defaultStep}
+          onWheel={(e) => e.currentTarget.blur()}
         />
       </div>
       <input

--- a/client/src/components/budget/BudgetLineForm.test.tsx
+++ b/client/src/components/budget/BudgetLineForm.test.tsx
@@ -209,9 +209,7 @@ describe('BudgetLineForm — description, category, source, vendor fields', () =
   });
 
   it('renders dynamic category select when budgetCategories is provided', () => {
-    const budgetCategories = [
-      { id: 'cat-1', name: 'Electrical', translationKey: null },
-    ] as any[];
+    const budgetCategories = [{ id: 'cat-1', name: 'Electrical', translationKey: null }] as any[];
     const props = buildProps(buildDirectForm(), { budgetCategories });
     render(<BudgetLineForm {...props} />);
     expect(screen.getByRole('combobox', { name: /Category/i })).toBeInTheDocument();

--- a/client/src/components/budget/BudgetLineForm.test.tsx
+++ b/client/src/components/budget/BudgetLineForm.test.tsx
@@ -1,0 +1,361 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { BudgetLineFormProps } from './BudgetLineForm.js';
+import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+
+// ─── Dynamic import (required for jest.unstable_mockModule pattern) ───────────
+
+let BudgetLineForm: (typeof import('./BudgetLineForm.js'))['BudgetLineForm'];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildDirectForm(overrides?: Partial<BudgetLineFormState>): BudgetLineFormState {
+  return {
+    description: '',
+    plannedAmount: '100',
+    confidence: 'own_estimate',
+    budgetCategoryId: '',
+    budgetSourceId: '',
+    vendorId: '',
+    pricingMode: 'direct',
+    quantity: '',
+    unit: '',
+    unitPrice: '',
+    includesVat: false,
+    ...overrides,
+  };
+}
+
+function buildUnitForm(overrides?: Partial<BudgetLineFormState>): BudgetLineFormState {
+  return {
+    description: '',
+    plannedAmount: '',
+    confidence: 'own_estimate',
+    budgetCategoryId: '',
+    budgetSourceId: '',
+    vendorId: '',
+    pricingMode: 'unit',
+    quantity: '2',
+    unit: 'm²',
+    unitPrice: '100',
+    includesVat: false,
+    ...overrides,
+  };
+}
+
+const CONFIDENCE_LABELS = {
+  own_estimate: 'Own Estimate (±20%)',
+  professional_estimate: 'Professional Estimate (±10%)',
+  quote: 'Quote (±5%)',
+  invoice: 'Invoice (±0%)',
+} as const;
+
+function buildProps(
+  form: BudgetLineFormState,
+  overrides?: Partial<BudgetLineFormProps>,
+): BudgetLineFormProps {
+  return {
+    form,
+    onSubmit: jest.fn(),
+    onFormChange: jest.fn(),
+    onCancel: jest.fn(),
+    error: null,
+    isSaving: false,
+    isEditing: false,
+    confidenceLabels: CONFIDENCE_LABELS,
+    budgetSources: [],
+    vendors: [],
+    ...overrides,
+  };
+}
+
+// ─── Load the component after setup ───────────────────────────────────────────
+
+beforeEach(async () => {
+  ({ BudgetLineForm } = await import('./BudgetLineForm.js'));
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('BudgetLineForm — VAT checkbox in direct mode (#1371)', () => {
+  it('renders "Includes VAT" checkbox in direct mode', () => {
+    const props = buildProps(buildDirectForm());
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.getByRole('checkbox', { name: /Price includes VAT/i })).toBeInTheDocument();
+  });
+
+  it('VAT checkbox is unchecked by default in direct mode', () => {
+    const props = buildProps(buildDirectForm({ includesVat: false }));
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.getByRole('checkbox', { name: /Price includes VAT/i })).not.toBeChecked();
+  });
+
+  it('VAT checkbox is checked when includesVat=true in direct mode', () => {
+    const props = buildProps(buildDirectForm({ includesVat: true }));
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.getByRole('checkbox', { name: /Price includes VAT/i })).toBeChecked();
+  });
+
+  it('renders "Includes VAT" checkbox in unit mode (regression check)', () => {
+    const props = buildProps(buildUnitForm());
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.getByRole('checkbox', { name: /Price includes VAT/i })).toBeInTheDocument();
+  });
+
+  it('does NOT show vatNote when includesVat=true in direct mode', () => {
+    const props = buildProps(buildDirectForm({ includesVat: true }));
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.queryByText(/VAT will be added/i)).not.toBeInTheDocument();
+  });
+
+  it('shows vatNote when includesVat=false in direct mode', () => {
+    const props = buildProps(buildDirectForm({ includesVat: false }));
+    render(<BudgetLineForm {...props} />);
+
+    expect(screen.getByText('+19% VAT will be added to the total')).toBeInTheDocument();
+  });
+
+  it('checking VAT checkbox in direct mode calls onFormChange with includesVat: true', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildDirectForm({ includesVat: false }), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Price includes VAT/i }));
+
+    expect(onFormChange).toHaveBeenCalledWith({ includesVat: true });
+  });
+
+  it('unchecking VAT checkbox in direct mode calls onFormChange with includesVat: false', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildDirectForm({ includesVat: true }), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Price includes VAT/i }));
+
+    expect(onFormChange).toHaveBeenCalledWith({ includesVat: false });
+  });
+});
+
+describe('BudgetLineForm — description, category, source, vendor fields', () => {
+  it('renders description input', () => {
+    const props = buildProps(buildDirectForm());
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+  });
+
+  it('onChange description calls onFormChange', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildDirectForm(), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByLabelText(/Description/i), { target: { value: 'Flooring' } });
+    expect(onFormChange).toHaveBeenCalledWith({ description: 'Flooring' });
+  });
+
+  it('renders unit text input and calls onFormChange on change in unit mode', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildUnitForm(), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByLabelText(/^Unit$/i), { target: { value: 'kg' } });
+    expect(onFormChange).toHaveBeenCalledWith({ unit: 'kg' });
+  });
+
+  it('renders funding source select', () => {
+    const budgetSources = [{ id: 'src-1', name: 'Loan', totalAmount: 100000 }] as any[];
+    const props = buildProps(buildDirectForm(), { budgetSources });
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByRole('combobox', { name: /Funding Source/i })).toBeInTheDocument();
+  });
+
+  it('funding source select onChange calls onFormChange with budgetSourceId', () => {
+    const onFormChange = jest.fn();
+    const budgetSources = [{ id: 'src-1', name: 'Loan', totalAmount: 100000 }] as any[];
+    const props = buildProps(buildDirectForm(), { onFormChange, budgetSources });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Funding Source/i }), {
+      target: { value: 'src-1' },
+    });
+    expect(onFormChange).toHaveBeenCalledWith({ budgetSourceId: 'src-1' });
+  });
+
+  it('renders vendor select with "No vendor" option', () => {
+    const props = buildProps(buildDirectForm());
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByRole('combobox', { name: /Vendor/i })).toBeInTheDocument();
+  });
+
+  it('vendor select onChange calls onFormChange with vendorId', () => {
+    const onFormChange = jest.fn();
+    const vendors = [{ id: 'v-1', name: 'Acme', trade: null }] as any[];
+    const props = buildProps(buildDirectForm(), { onFormChange, vendors });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Vendor/i }), {
+      target: { value: 'v-1' },
+    });
+    expect(onFormChange).toHaveBeenCalledWith({ vendorId: 'v-1' });
+  });
+
+  it('renders static category label when staticCategoryLabel is provided', () => {
+    const props = buildProps(buildDirectForm(), { staticCategoryLabel: 'Plumbing' });
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByText('Plumbing')).toBeInTheDocument();
+  });
+
+  it('renders dynamic category select when budgetCategories is provided', () => {
+    const budgetCategories = [
+      { id: 'cat-1', name: 'Electrical', translationKey: null },
+    ] as any[];
+    const props = buildProps(buildDirectForm(), { budgetCategories });
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByRole('combobox', { name: /Category/i })).toBeInTheDocument();
+  });
+
+  it('renders error banner when error prop is set', () => {
+    const props = buildProps(buildDirectForm(), { error: 'Validation failed' });
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByText('Validation failed')).toBeInTheDocument();
+  });
+
+  it('renders children slot', () => {
+    const props = buildProps(buildDirectForm());
+    render(
+      <BudgetLineForm {...props}>
+        <div data-testid="child-slot">Extra content</div>
+      </BudgetLineForm>,
+    );
+    expect(screen.getByTestId('child-slot')).toBeInTheDocument();
+  });
+
+  it('cancel button calls onCancel', () => {
+    const onCancel = jest.fn();
+    const props = buildProps(buildDirectForm(), { onCancel });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('unitPrice onChange calls onFormChange in unit mode', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildUnitForm(), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByLabelText(/^Price \*/i), { target: { value: '250' } });
+    expect(onFormChange).toHaveBeenCalledWith({ unitPrice: '250' });
+  });
+
+  it('quantity onChange calls onFormChange in unit mode', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildUnitForm(), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByLabelText(/Quantity/i), { target: { value: '10' } });
+    expect(onFormChange).toHaveBeenCalledWith({ quantity: '10' });
+  });
+
+  it('renders confidence select', () => {
+    const props = buildProps(buildDirectForm());
+    render(<BudgetLineForm {...props} />);
+    expect(screen.getByRole('combobox', { name: /Confidence/i })).toBeInTheDocument();
+  });
+
+  it('confidence select onChange calls onFormChange with confidence', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildDirectForm(), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Confidence/i }), {
+      target: { value: 'quote' },
+    });
+    expect(onFormChange).toHaveBeenCalledWith({ confidence: 'quote' });
+  });
+
+  it('planned amount input onChange calls onFormChange in direct mode', () => {
+    const onFormChange = jest.fn();
+    const props = buildProps(buildDirectForm({ plannedAmount: '100' }), { onFormChange });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByLabelText(/Planned Amount/i), { target: { value: '200' } });
+    expect(onFormChange).toHaveBeenCalledWith({ plannedAmount: '200' });
+  });
+
+  it('category select onChange calls onFormChange with budgetCategoryId', () => {
+    const onFormChange = jest.fn();
+    const budgetCategories = [{ id: 'cat-1', name: 'Electrical', translationKey: null }] as any[];
+    const props = buildProps(buildDirectForm(), { onFormChange, budgetCategories });
+    render(<BudgetLineForm {...props} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Category/i }), {
+      target: { value: 'cat-1' },
+    });
+    expect(onFormChange).toHaveBeenCalledWith({ budgetCategoryId: 'cat-1' });
+  });
+});
+
+describe('BudgetLineForm — onWheel blurs inputs to prevent scroll value change (#1370)', () => {
+  it('blurs the amount input when wheel event fires in direct mode', () => {
+    const props = buildProps(buildDirectForm({ plannedAmount: '100' }));
+    render(<BudgetLineForm {...props} />);
+
+    const amountInput = screen.getByLabelText(/Planned Amount/i) as HTMLInputElement;
+    const blurSpy = jest.spyOn(amountInput, 'blur');
+    amountInput.focus();
+
+    fireEvent.wheel(amountInput);
+
+    expect(blurSpy).toHaveBeenCalled();
+    blurSpy.mockRestore();
+  });
+
+  it('amount input value is unchanged after wheel event in direct mode', () => {
+    const props = buildProps(buildDirectForm({ plannedAmount: '100' }));
+    render(<BudgetLineForm {...props} />);
+
+    const amountInput = screen.getByLabelText(/Planned Amount/i) as HTMLInputElement;
+    amountInput.focus();
+    // The value is controlled — it stays '100' regardless of wheel
+    expect(amountInput.value).toBe('100');
+    fireEvent.wheel(amountInput);
+    expect(amountInput.value).toBe('100');
+  });
+
+  it('blurs the quantity input when wheel event fires in unit mode', () => {
+    const props = buildProps(buildUnitForm({ quantity: '5' }));
+    render(<BudgetLineForm {...props} />);
+
+    const quantityInput = screen.getByLabelText(/Quantity/i) as HTMLInputElement;
+    const blurSpy = jest.spyOn(quantityInput, 'blur');
+    quantityInput.focus();
+
+    fireEvent.wheel(quantityInput);
+
+    expect(blurSpy).toHaveBeenCalled();
+    blurSpy.mockRestore();
+  });
+
+  it('quantity input value is unchanged after wheel event in unit mode', () => {
+    const props = buildProps(buildUnitForm({ quantity: '5' }));
+    render(<BudgetLineForm {...props} />);
+
+    const quantityInput = screen.getByLabelText(/Quantity/i) as HTMLInputElement;
+    quantityInput.focus();
+    expect(quantityInput.value).toBe('5');
+    fireEvent.wheel(quantityInput);
+    expect(quantityInput.value).toBe('5');
+  });
+
+  it('blurs the unit price input when wheel event fires in unit mode', () => {
+    const props = buildProps(buildUnitForm({ unitPrice: '200' }));
+    render(<BudgetLineForm {...props} />);
+
+    const priceInput = screen.getByLabelText(/^Price \*/i) as HTMLInputElement;
+    const blurSpy = jest.spyOn(priceInput, 'blur');
+    priceInput.focus();
+
+    fireEvent.wheel(priceInput);
+
+    expect(blurSpy).toHaveBeenCalled();
+    blurSpy.mockRestore();
+  });
+});

--- a/client/src/components/budget/BudgetLineForm.tsx
+++ b/client/src/components/budget/BudgetLineForm.tsx
@@ -80,23 +80,43 @@ export function BudgetLineForm({
         </div>
 
         {form.pricingMode === 'direct' ? (
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="budget-planned-amount">
-              {t('budgetLineForm.plannedAmountLabel', { currencySymbol: '€' })}
-            </label>
-            <input
-              type="number"
-              id="budget-planned-amount"
-              className={styles.input}
-              value={form.plannedAmount}
-              onChange={(e) => onFormChange({ plannedAmount: e.target.value })}
-              min="0"
-              step="0.01"
-              placeholder="0.00"
-              required
-              disabled={isSaving}
-            />
-          </div>
+          <>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="budget-planned-amount">
+                {t('budgetLineForm.plannedAmountLabel', { currencySymbol: '€' })}
+              </label>
+              <input
+                type="number"
+                id="budget-planned-amount"
+                className={styles.input}
+                value={form.plannedAmount}
+                onChange={(e) => onFormChange({ plannedAmount: e.target.value })}
+                min="0"
+                step="0.01"
+                placeholder="0.00"
+                required
+                disabled={isSaving}
+                onWheel={(e) => e.currentTarget.blur()}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.checkboxLabel}>
+                <input
+                  type="checkbox"
+                  checked={form.includesVat}
+                  onChange={(e) => onFormChange({ includesVat: e.target.checked })}
+                  disabled={isSaving}
+                />
+                {t('budgetLineForm.includesVatLabel', { vatRate: '19' })}
+              </label>
+              {!form.includesVat && (
+                <div className={styles.vatNote}>
+                  {t('budgetLineForm.vatNote', { vatRate: '19' })}
+                </div>
+              )}
+            </div>
+          </>
         ) : (
           <>
             <div className={styles.unitPricingRow}>
@@ -114,6 +134,7 @@ export function BudgetLineForm({
                   step="0.01"
                   placeholder="0"
                   disabled={isSaving}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
 
@@ -148,6 +169,7 @@ export function BudgetLineForm({
                   step="0.01"
                   placeholder="0.00"
                   disabled={isSaving}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
 

--- a/client/src/components/budget/InvoiceLinkModal.module.css
+++ b/client/src/components/budget/InvoiceLinkModal.module.css
@@ -130,6 +130,17 @@
   text-overflow: ellipsis;
 }
 
+.dropdownItemVendor {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--spacing-0-5);
+}
+
+.dropdownItemActive .dropdownItemVendor {
+  color: var(--color-primary-text);
+  opacity: 0.9;
+}
+
 .dropdownEmpty {
   padding: var(--spacing-4) var(--spacing-3);
   text-align: center;

--- a/client/src/components/budget/InvoiceLinkModal.test.tsx
+++ b/client/src/components/budget/InvoiceLinkModal.test.tsx
@@ -439,4 +439,175 @@ describe('InvoiceLinkModal', () => {
       expect(screen.getByText('Failed to load invoices. Please try again.')).toBeTruthy();
     });
   });
+
+  // ─── Vendor name display (#1372) ──────────────────────────────────────────
+
+  describe('vendor name display in invoice picker (#1372)', () => {
+    it('shows vendor name in the dropdown item', async () => {
+      const invoices = [{ ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' }];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      // Open the dropdown
+      const searchInput = screen.getByPlaceholderText(/search by invoice/i);
+      fireEvent.focus(searchInput);
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+      });
+    });
+
+    it('shows vendor name alongside invoice number in the dropdown', async () => {
+      const invoices = [{ ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' }];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      // Open the dropdown
+      const searchInput = screen.getByPlaceholderText(/search by invoice/i);
+      fireEvent.focus(searchInput);
+
+      await waitFor(() => {
+        // Both invoice number and vendor name should be present
+        expect(screen.getByText('#INV-001')).toBeInTheDocument();
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+      });
+    });
+
+    it('shows vendor name in the selected invoice display value', async () => {
+      const invoices = [{ ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' }];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        // After auto-select of first invoice, the input shows the invoice+vendor
+        const searchInput = screen.getByPlaceholderText(/search by invoice/i) as HTMLInputElement;
+        expect(searchInput.value).toContain('#INV-001');
+        expect(searchInput.value).toContain('Acme Corp');
+      });
+    });
+
+    it('vendor name search matches invoice — typing vendor name shows the invoice', async () => {
+      const invoices = [{ ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' }];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      const searchInput = screen.getByPlaceholderText(/search by invoice/i);
+      fireEvent.change(searchInput, { target: { value: 'Acme' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+        expect(screen.getByText('#INV-001')).toBeInTheDocument();
+      });
+    });
+
+    it('typing a string matching neither invoice number nor vendor name shows empty dropdown', async () => {
+      const invoices = [{ ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' }];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      const searchInput = screen.getByPlaceholderText(/search by invoice/i);
+      fireEvent.change(searchInput, { target: { value: 'ZZZNOMATCH' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('No invoices match your search')).toBeInTheDocument();
+      });
+    });
+
+    it('selected invoice display includes both invoice number and vendor name', async () => {
+      const invoices = [
+        { ...buildInvoice('inv-1', 'INV-001'), vendorName: 'Acme Corp' },
+        { ...buildInvoice('inv-2', 'INV-002'), vendorName: 'Beta Ltd' },
+      ];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      // Open dropdown and select inv-2
+      const searchInput = screen.getByPlaceholderText(/search by invoice/i);
+      fireEvent.focus(searchInput);
+
+      await waitFor(() => {
+        expect(screen.getByText('Beta Ltd')).toBeInTheDocument();
+      });
+
+      const inv2Button = screen.getByText('Beta Ltd').closest('button');
+      expect(inv2Button).toBeTruthy();
+      fireEvent.click(inv2Button!);
+
+      await waitFor(() => {
+        const input = screen.getByPlaceholderText(/search by invoice/i) as HTMLInputElement;
+        expect(input.value).toContain('#INV-002');
+        expect(input.value).toContain('Beta Ltd');
+      });
+    });
+  });
+
+  // ─── onWheel blurs numeric inputs (#1370) ─────────────────────────────────
+
+  describe('onWheel prevents value change on numeric inputs (#1370)', () => {
+    it('blurs the amount input when wheel event fires', async () => {
+      const invoices = [buildInvoice('inv-1', 'INV-001')];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps({ defaultAmount: 500 })} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      const amountInput = screen.getByLabelText(/itemized amount/i) as HTMLInputElement;
+      const blurSpy = jest.spyOn(amountInput, 'blur');
+      amountInput.focus();
+
+      fireEvent.wheel(amountInput);
+
+      expect(blurSpy).toHaveBeenCalled();
+      blurSpy.mockRestore();
+    });
+
+    it('amount input value is unchanged after wheel event', async () => {
+      const invoices = [buildInvoice('inv-1', 'INV-001')];
+      mockFetchAllInvoices.mockResolvedValue(buildPaginatedResponse(invoices));
+
+      render(<InvoiceLinkModal {...buildProps({ defaultAmount: 500 })} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading invoices...')).toBeNull();
+      });
+
+      const amountInput = screen.getByLabelText(/itemized amount/i) as HTMLInputElement;
+      amountInput.focus();
+      expect(amountInput.value).toBe('500');
+
+      fireEvent.wheel(amountInput);
+
+      // Value is controlled — remains unchanged
+      expect(amountInput.value).toBe('500');
+    });
+  });
 });

--- a/client/src/components/budget/InvoiceLinkModal.tsx
+++ b/client/src/components/budget/InvoiceLinkModal.tsx
@@ -103,7 +103,8 @@ export function InvoiceLinkModal({
       const searchLower = normalizedValue.toLowerCase();
       return (
         invoiceNumber.toLowerCase().includes(searchLower) ||
-        (inv.notes && inv.notes.toLowerCase().includes(searchLower))
+        (inv.notes && inv.notes.toLowerCase().includes(searchLower)) ||
+        (inv.vendorName && inv.vendorName.toLowerCase().includes(searchLower))
       );
     });
     setFilteredInvoices(filtered);
@@ -249,7 +250,7 @@ export function InvoiceLinkModal({
                   placeholder="Search by invoice number or description..."
                   value={
                     selectedInvoice && !searchInput
-                      ? `#${selectedInvoice.invoiceNumber || selectedInvoice.id.slice(0, 8)}`
+                      ? `#${selectedInvoice.invoiceNumber || selectedInvoice.id.slice(0, 8)}${selectedInvoice.vendorName ? ` — ${selectedInvoice.vendorName}` : ''}`
                       : searchInput
                   }
                   onChange={(e) => handleSearchChange(e.target.value)}
@@ -274,6 +275,9 @@ export function InvoiceLinkModal({
                         <span className={styles.dropdownItemAmount}>
                           {formatCurrency(inv.amount)}
                         </span>
+                        {inv.vendorName && (
+                          <span className={styles.dropdownItemVendor}>{inv.vendorName}</span>
+                        )}
                         {inv.notes && (
                           <span className={styles.dropdownItemDescription}>{inv.notes}</span>
                         )}
@@ -321,6 +325,7 @@ export function InvoiceLinkModal({
                 className={`${styles.input} ${error?.field === 'amount' ? styles.inputError : ''}`}
                 disabled={isSaving}
                 required
+                onWheel={(e) => e.currentTarget.blur()}
               />
               {(() => {
                 const amount = parseFloat(itemizedAmount);
@@ -357,6 +362,7 @@ export function InvoiceLinkModal({
               className={`${styles.input} ${error?.field === 'amount' ? styles.inputError : ''}`}
               disabled={isSaving}
               required
+              onWheel={(e) => e.currentTarget.blur()}
             />
           )}
           {error?.field === 'amount' && <FormError message={error.message} variant="field" />}

--- a/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
+++ b/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
@@ -304,6 +304,7 @@ export function DiaryEntryForm({
                 placeholder="-40 to 60"
                 min={-40}
                 max={60}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
 
@@ -322,6 +323,7 @@ export function DiaryEntryForm({
                 }
                 disabled={disabled}
                 min={0}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
           </div>

--- a/client/src/components/documents/DocumentBrowser.test.tsx
+++ b/client/src/components/documents/DocumentBrowser.test.tsx
@@ -487,8 +487,12 @@ describe('DocumentBrowser', () => {
 
       fireEvent.click(screen.getByRole('checkbox'));
 
-      expect(screen.queryByRole('button', { name: /Document: Document 1/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /Document: Document 2/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Document: Document 1/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Document: Document 2/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('shows all documents again when checkbox is unchecked after being checked', () => {
@@ -511,7 +515,9 @@ describe('DocumentBrowser', () => {
 
       fireEvent.click(screen.getByRole('checkbox'));
 
-      expect(screen.queryByRole('button', { name: /Document: Document 1/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Document: Document 1/i }),
+      ).not.toBeInTheDocument();
       // Docs 2 and 3 are not linked — still visible
       expect(screen.getByRole('button', { name: /Document: Document 2/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Document: Document 3/i })).toBeInTheDocument();

--- a/client/src/components/documents/DocumentBrowser.test.tsx
+++ b/client/src/components/documents/DocumentBrowser.test.tsx
@@ -448,6 +448,85 @@ describe('DocumentBrowser', () => {
     });
   });
 
+  describe('hide linked documents (#1369)', () => {
+    it('does not render the hide-linked checkbox when linkedDocumentIds is empty', () => {
+      mockUsePaperless.mockReturnValue(makeHook());
+      render(<DocumentBrowser linkedDocumentIds={[]} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('renders the hide-linked checkbox when linkedDocumentIds has entries', () => {
+      mockUsePaperless.mockReturnValue(makeHook());
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    it('hide-linked checkbox is unchecked by default', () => {
+      mockUsePaperless.mockReturnValue(makeHook());
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('checkbox label text is "Hide already-linked documents"', () => {
+      mockUsePaperless.mockReturnValue(makeHook());
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+      expect(screen.getByText('Hide already-linked documents')).toBeInTheDocument();
+    });
+
+    it('all documents are visible when checkbox is unchecked', () => {
+      mockUsePaperless.mockReturnValue(makeHook({ documents: [makeDoc(1), makeDoc(2)] }));
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+      // Both docs should be visible
+      expect(screen.getByRole('button', { name: /Document: Document 1/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Document: Document 2/i })).toBeInTheDocument();
+    });
+
+    it('filters out linked documents when checkbox is checked', () => {
+      mockUsePaperless.mockReturnValue(makeHook({ documents: [makeDoc(1), makeDoc(2)] }));
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+
+      fireEvent.click(screen.getByRole('checkbox'));
+
+      expect(screen.queryByRole('button', { name: /Document: Document 1/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Document: Document 2/i })).not.toBeInTheDocument();
+    });
+
+    it('shows all documents again when checkbox is unchecked after being checked', () => {
+      mockUsePaperless.mockReturnValue(makeHook({ documents: [makeDoc(1), makeDoc(2)] }));
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox); // check
+      fireEvent.click(checkbox); // uncheck
+
+      expect(screen.getByRole('button', { name: /Document: Document 1/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Document: Document 2/i })).toBeInTheDocument();
+    });
+
+    it('only filters documents whose ids are in linkedDocumentIds', () => {
+      mockUsePaperless.mockReturnValue(
+        makeHook({ documents: [makeDoc(1), makeDoc(2), makeDoc(3)] }),
+      );
+      render(<DocumentBrowser linkedDocumentIds={[1]} />);
+
+      fireEvent.click(screen.getByRole('checkbox'));
+
+      expect(screen.queryByRole('button', { name: /Document: Document 1/i })).not.toBeInTheDocument();
+      // Docs 2 and 3 are not linked — still visible
+      expect(screen.getByRole('button', { name: /Document: Document 2/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Document: Document 3/i })).toBeInTheDocument();
+    });
+
+    it('shows "no additional documents" empty state when all docs are linked and checkbox is checked', () => {
+      mockUsePaperless.mockReturnValue(makeHook({ documents: [makeDoc(1), makeDoc(2)] }));
+      render(<DocumentBrowser linkedDocumentIds={[1, 2]} />);
+
+      fireEvent.click(screen.getByRole('checkbox'));
+
+      expect(screen.getByText(/No additional documents/i)).toBeInTheDocument();
+    });
+  });
+
   describe('pagination', () => {
     it('does not render pagination when totalPages <= 1', () => {
       mockUsePaperless.mockReturnValue(makeHook({ pagination: makePagination(1, 1, 2) }));

--- a/client/src/components/documents/DocumentBrowser.tsx
+++ b/client/src/components/documents/DocumentBrowser.tsx
@@ -26,7 +26,7 @@ export function DocumentBrowser({
   const hook = usePaperless();
   const [selectedDoc, setSelectedDoc] = useState<PaperlessDocumentSearchResult | null>(null);
   const [searchInput, setSearchInput] = useState('');
-  const [hideLinked, setHideLinked] = useState(true);
+  const [hideLinked, setHideLinked] = useState(false);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Debounced search — intentionally omits hook.search from dep array to prevent infinite loop

--- a/client/src/i18n/de/documents.json
+++ b/client/src/i18n/de/documents.json
@@ -9,7 +9,7 @@
     "tryAgain": "Erneut versuchen",
     "searchPlaceholder": "Dokumente durchsuchen...",
     "searchDocumentsAriaLabel": "Dokumente durchsuchen",
-    "hideLinked": "Verknüpft ausblenden",
+    "hideLinked": "Bereits verknüpfte Dokumente ausblenden",
     "noAdditionalDocuments": "Keine zusätzlichen Dokumente zum Verknüpfen verfügbar.",
     "noDocumentsMatch": "Keine Dokumente entsprechen Ihrer Suche.",
     "noDocuments": "Keine Dokumente gefunden.",

--- a/client/src/i18n/en/documents.json
+++ b/client/src/i18n/en/documents.json
@@ -9,7 +9,7 @@
     "tryAgain": "Try Again",
     "searchPlaceholder": "Search documents...",
     "searchDocumentsAriaLabel": "Search documents",
-    "hideLinked": "Hide linked",
+    "hideLinked": "Hide already-linked documents",
     "noAdditionalDocuments": "No additional documents available to link.",
     "noDocumentsMatch": "No documents match your search.",
     "noDocuments": "No documents found.",

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -827,6 +827,7 @@ export function BudgetSourcesPage() {
                   min={0}
                   step="0.01"
                   disabled={isCreating}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
 
@@ -844,6 +845,7 @@ export function BudgetSourcesPage() {
                   min={0}
                   step="0.01"
                   disabled={isCreating}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
             </div>
@@ -1014,6 +1016,7 @@ export function BudgetSourcesPage() {
                           min={0}
                           step="0.01"
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
 
@@ -1032,6 +1035,7 @@ export function BudgetSourcesPage() {
                           min={0}
                           step="0.01"
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
                     </div>

--- a/client/src/pages/HouseholdItemCreatePage/HouseholdItemCreatePage.tsx
+++ b/client/src/pages/HouseholdItemCreatePage/HouseholdItemCreatePage.tsx
@@ -269,6 +269,7 @@ export function HouseholdItemCreatePage() {
               aria-required="true"
               aria-invalid={!!validationErrors.quantity}
               aria-describedby={validationErrors.quantity ? 'hi-create-quantity-error' : undefined}
+              onWheel={(e) => e.currentTarget.blur()}
             />
             {validationErrors.quantity && (
               <div id="hi-create-quantity-error" className={styles.errorText} role="alert">

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -211,11 +211,14 @@ export function HouseholdItemDetailPage() {
       quantity: line.quantity !== null ? String(line.quantity) : '',
       unit: line.unit ?? '',
       unitPrice: line.unitPrice !== null ? String(line.unitPrice) : '',
-      includesVat: line.includesVat ?? true,
+      includesVat: line.quantity !== null ? (line.includesVat ?? true) : false,
     }),
     toPayload: (form: BudgetLineFormState) => ({
       description: form.description.trim() || null,
-      plannedAmount: parseFloat(form.plannedAmount),
+      plannedAmount:
+        form.pricingMode === 'direct' && form.includesVat
+          ? Math.round((parseFloat(form.plannedAmount) / 1.19) * 100) / 100
+          : parseFloat(form.plannedAmount),
       confidence: form.confidence,
       budgetSourceId: form.budgetSourceId,
       vendorId: form.vendorId || null,

--- a/client/src/pages/HouseholdItemEditPage/HouseholdItemEditPage.tsx
+++ b/client/src/pages/HouseholdItemEditPage/HouseholdItemEditPage.tsx
@@ -258,6 +258,7 @@ export function HouseholdItemEditPage() {
               aria-required="true"
               aria-invalid={!!validationErrors.quantity}
               aria-describedby={validationErrors.quantity ? 'hi-edit-quantity-error' : undefined}
+              onWheel={(e) => e.currentTarget.blur()}
             />
             {validationErrors.quantity && (
               <div id="hi-edit-quantity-error" className={styles.errorText} role="alert">

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
@@ -556,6 +556,7 @@ export function InvoiceBudgetLinesSection({
                           min="0"
                           step="0.01"
                           aria-label={`Edit itemized amount for budget line`}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                         {editError && <div className={styles.editErrorMsg}>{editError}</div>}
                         <div className={styles.editActions}>
@@ -849,6 +850,7 @@ export function InvoiceBudgetLinesSection({
                           min="0"
                           step="0.01"
                           disabled={pickerState.isCreatingBudgetLine}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
 
@@ -925,6 +927,7 @@ export function InvoiceBudgetLinesSection({
                                   min="0"
                                   step="0.01"
                                   aria-label={`Itemized amount for ${line.description || 'budget line'}`}
+                                  onWheel={(e) => e.currentTarget.blur()}
                                 />
                               </div>
                             </div>

--- a/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
@@ -342,6 +342,7 @@ export function InvoiceDetailPage() {
                     step="0.01"
                     required
                     disabled={isUpdating}
+                    onWheel={(e) => e.currentTarget.blur()}
                   />
                 </div>
               </div>

--- a/client/src/pages/InvoicesPage/InvoicesPage.module.css
+++ b/client/src/pages/InvoicesPage/InvoicesPage.module.css
@@ -22,8 +22,14 @@
 
 .summaryGrid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: var(--spacing-4);
+}
+
+@media (max-width: 767px) {
+  .summaryGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .summaryCard {

--- a/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
@@ -611,21 +611,99 @@ describe('InvoicesPage', () => {
     });
   });
 
-  // ─── Summary cards ────────────────────────────────────────────────────────
+  // ─── Summary cards (#1373) ────────────────────────────────────────────────
 
-  describe('summary cards', () => {
-    it('renders three summary cards (pending, paid, quotation)', async () => {
+  describe('summary cards (#1373)', () => {
+    it('renders four summary cards (pending, paid, claimed, quotation)', async () => {
       mockFetchAllInvoices.mockResolvedValueOnce(populatedResponse);
 
       renderPage();
 
-      // DataTable renders each item in both table row and mobile card (duplicate text)
       await waitFor(() => {
         expect(screen.getAllByText('INV-2026-001')[0]!).toBeInTheDocument();
       });
 
-      // The summaryGrid renders labels for pending, paid, and quotation
-      // These come from t() — will match the i18n key fallbacks
+      // All four status labels should be present (getAllByText: labels appear in both
+      // summary cards and filter dropdown, so multiple matches are expected)
+      expect(screen.getAllByText('Pending').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Paid').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Claimed').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Quotation').length).toBeGreaterThan(0);
+    });
+
+    it('renders the Claimed card with correct count and amount', async () => {
+      const responseWithClaimed: InvoiceListPaginatedResponse = {
+        ...populatedResponse,
+        summary: {
+          pending: { count: 1, totalAmount: 15000 },
+          paid: { count: 0, totalAmount: 0 },
+          claimed: { count: 3, totalAmount: 900 },
+          quotation: { count: 0, totalAmount: 0 },
+        },
+      };
+      mockFetchAllInvoices.mockResolvedValueOnce(responseWithClaimed);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Claimed').length).toBeGreaterThan(0);
+      });
+
+      // Count 3 should appear in the DOM (summaryCount span under the Claimed card)
+      // Multiple elements may show "3" — at least one must exist
+      expect(screen.getAllByText('3').length).toBeGreaterThan(0);
+    });
+
+    it('Claimed card still renders when claimed count is 0', async () => {
+      const responseWithZeroClaimed: InvoiceListPaginatedResponse = {
+        ...emptyResponse,
+        summary: {
+          pending: { count: 0, totalAmount: 0 },
+          paid: { count: 0, totalAmount: 0 },
+          claimed: { count: 0, totalAmount: 0 },
+          quotation: { count: 0, totalAmount: 0 },
+        },
+      };
+      mockFetchAllInvoices.mockResolvedValueOnce(responseWithZeroClaimed);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getAllByText('Claimed').length).toBeGreaterThan(0);
+    });
+
+    it('Paid card shows only paid summary data (not combined with claimed)', async () => {
+      const responseWithSeparateData: InvoiceListPaginatedResponse = {
+        ...populatedResponse,
+        summary: {
+          pending: { count: 1, totalAmount: 15000 },
+          paid: { count: 2, totalAmount: 5000 },
+          claimed: { count: 3, totalAmount: 900 },
+          quotation: { count: 0, totalAmount: 0 },
+        },
+      };
+      mockFetchAllInvoices.mockResolvedValueOnce(responseWithSeparateData);
+
+      const fmtCurrency = (n: number) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'currency',
+          currency: 'EUR',
+          minimumFractionDigits: 2,
+        }).format(n);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Paid').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Claimed').length).toBeGreaterThan(0);
+      });
+
+      // Paid total is €5,000 and claimed total is €900 — they must appear as separate amounts
+      expect(screen.getByText(fmtCurrency(5000))).toBeInTheDocument();
+      expect(screen.getByText(fmtCurrency(900))).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -435,9 +435,16 @@ export function InvoicesPage() {
       </div>
       <div className={styles.summaryCard}>
         <span className={styles.summaryLabel}>{t('invoices.summaryPaid')}</span>
-        <span className={styles.summaryCount}>{summary.paid.count + summary.claimed.count}</span>
+        <span className={styles.summaryCount}>{summary.paid.count}</span>
         <span className={`${styles.summaryAmount} ${styles.summaryAmountPaid}`}>
-          {formatCurrency(summary.paid.totalAmount + summary.claimed.totalAmount)}
+          {formatCurrency(summary.paid.totalAmount)}
+        </span>
+      </div>
+      <div className={styles.summaryCard}>
+        <span className={styles.summaryLabel}>{t('invoices.summaryClaimed')}</span>
+        <span className={styles.summaryCount}>{summary.claimed.count}</span>
+        <span className={`${styles.summaryAmount} ${styles.summaryAmountPaid}`}>
+          {formatCurrency(summary.claimed.totalAmount)}
         </span>
       </div>
       <div className={styles.summaryCard}>
@@ -583,6 +590,7 @@ export function InvoicesPage() {
                   step="0.01"
                   required
                   disabled={isCreating}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
             </div>

--- a/client/src/pages/ManagePage/ManagePage.tsx
+++ b/client/src/pages/ManagePage/ManagePage.tsx
@@ -294,6 +294,7 @@ function AreasTab() {
                 placeholder="0"
                 min={0}
                 disabled={isCreating}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
           </div>
@@ -420,6 +421,7 @@ function AreasTab() {
                           className={styles.input}
                           min={0}
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
                     </div>
@@ -808,6 +810,7 @@ function TradesTab() {
                 placeholder="0"
                 min={0}
                 disabled={isCreating}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
           </div>
@@ -915,6 +918,7 @@ function TradesTab() {
                           className={styles.input}
                           min={0}
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
                     </div>
@@ -1334,6 +1338,7 @@ function BudgetCategoriesTab() {
                 placeholder="0"
                 min={0}
                 disabled={isCreating}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
           </div>
@@ -1451,6 +1456,7 @@ function BudgetCategoriesTab() {
                           className={styles.input}
                           min={0}
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
                     </div>
@@ -1893,6 +1899,7 @@ function HouseholdItemCategoriesTab() {
                 placeholder="0"
                 min={0}
                 disabled={isCreating}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
           </div>
@@ -1994,6 +2001,7 @@ function HouseholdItemCategoriesTab() {
                           className={styles.input}
                           min={0}
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
                     </div>

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
@@ -504,6 +504,7 @@ export function SubsidyProgramsPage() {
                   max={newReductionType === 'percentage' ? 100 : undefined}
                   step={newReductionType === 'percentage' ? '0.01' : '0.01'}
                   disabled={isCreating}
+                  onWheel={(e) => e.currentTarget.blur()}
                 />
               </div>
 
@@ -564,6 +565,7 @@ export function SubsidyProgramsPage() {
                 min={0}
                 step="0.01"
                 disabled={isCreating}
+                onWheel={(e) => e.currentTarget.blur()}
               />
             </div>
 
@@ -786,6 +788,7 @@ export function SubsidyProgramsPage() {
                           max={editingProgram.reductionType === 'percentage' ? 100 : undefined}
                           step="0.01"
                           disabled={isUpdating}
+                          onWheel={(e) => e.currentTarget.blur()}
                         />
                       </div>
 
@@ -856,6 +859,7 @@ export function SubsidyProgramsPage() {
                         min={0}
                         step="0.01"
                         disabled={isUpdating}
+                        onWheel={(e) => e.currentTarget.blur()}
                       />
                     </div>
 

--- a/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
+++ b/client/src/pages/VendorDetailPage/VendorDetailPage.tsx
@@ -870,6 +870,7 @@ export function VendorDetailPage() {
                     step="0.01"
                     required
                     disabled={isCreating}
+                    onWheel={(e) => e.currentTarget.blur()}
                   />
                 </div>
               </div>

--- a/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.tsx
+++ b/client/src/pages/WorkItemCreatePage/WorkItemCreatePage.tsx
@@ -340,6 +340,7 @@ export default function WorkItemCreatePage() {
               disabled={isSubmitting}
               min="0"
               placeholder="0"
+              onWheel={(e) => e.currentTarget.blur()}
             />
             {validationErrors.durationDays && (
               <div className={styles.errorText}>{validationErrors.durationDays}</div>

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -264,11 +264,14 @@ export default function WorkItemDetailPage() {
       quantity: line.quantity !== null ? String(line.quantity) : '',
       unit: line.unit ?? '',
       unitPrice: line.unitPrice !== null ? String(line.unitPrice) : '',
-      includesVat: line.includesVat ?? true,
+      includesVat: line.quantity !== null ? (line.includesVat ?? true) : false,
     }),
     toPayload: (form: BudgetLineFormState): CreateWorkItemBudgetRequest => ({
       description: form.description.trim() || null,
-      plannedAmount: parseFloat(form.plannedAmount),
+      plannedAmount:
+        form.pricingMode === 'direct' && form.includesVat
+          ? Math.round((parseFloat(form.plannedAmount) / 1.19) * 100) / 100
+          : parseFloat(form.plannedAmount),
       confidence: form.confidence,
       budgetCategoryId: form.budgetCategoryId || null,
       budgetSourceId: form.budgetSourceId,
@@ -1604,6 +1607,7 @@ export default function WorkItemDetailPage() {
                     onBlur={() => void handleDurationBlur()}
                     min="0"
                     placeholder="0"
+                    onWheel={(e) => e.currentTarget.blur()}
                   />
                   <AutosaveIndicator state={autosaveDuration} />
                 </div>

--- a/e2e/tests/budget/budget-source-filter.spec.ts
+++ b/e2e/tests/budget/budget-source-filter.spec.ts
@@ -2484,10 +2484,8 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
 
       // Initial state: both sources selected → Available Funds = 250 000
       const afValue = overviewPage.availableFundsValue();
-      await expect(afValue).toBeVisible();
-      const initialText = await afValue.textContent();
       // Combined total must contain "250" (as in €250,000)
-      expect(initialText).toContain('250');
+      await expect(afValue).toContainText('250');
 
       // Expand source rows
       await overviewPage.availableFundsButton().click();
@@ -2501,11 +2499,12 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
       await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
       await refetchPromise;
 
-      // Available Funds now shows only Source A total (150 000)
-      const filteredText = await afValue.textContent();
-      expect(filteredText).toContain('150');
+      // Available Funds now shows only Source A total (150 000).
+      // Use toContainText (retrying) instead of textContent() to avoid reading
+      // a stale value before React commits the re-render after the refetch.
+      await expect(afValue).toContainText('150');
       // Must NOT still show 250 (combined)
-      expect(filteredText).not.toContain('250');
+      await expect(afValue).not.toContainText('250');
     } finally {
       await teardown();
     }
@@ -2540,10 +2539,8 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
 
       // Remaining Budget Cost cell (td index 1 = "Cost" column)
       const costCell = remainingRow.locator('td').nth(1);
-      await expect(costCell).toBeVisible();
-      const initialText = await costCell.textContent();
       // Should reflect 230 000 (250 000 - 20 000)
-      expect(initialText).toContain('230');
+      await expect(costCell).toContainText('230');
 
       // Expand source rows
       await overviewPage.availableFundsButton().click();
@@ -2557,10 +2554,11 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
       await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
       await refetchPromise;
 
-      // Remaining Budget Cost = 150 000 - 10 000 = 140 000
-      const filteredText = await costCell.textContent();
-      expect(filteredText).toContain('140');
-      expect(filteredText).not.toContain('230');
+      // Remaining Budget Cost = 150 000 - 10 000 = 140 000.
+      // Use toContainText (retrying) to avoid reading a stale value before React
+      // commits the re-render after the refetch.
+      await expect(costCell).toContainText('140');
+      await expect(costCell).not.toContainText('230');
     } finally {
       await teardown();
     }
@@ -2585,11 +2583,8 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
       await overviewPage.waitForLoaded();
 
       const afValue = overviewPage.availableFundsValue();
-      await expect(afValue).toBeVisible();
-
       // Pre-deselected state: Available Funds = 150 000 (Bank Loan only)
-      const deselectedText = await afValue.textContent();
-      expect(deselectedText).toContain('150');
+      await expect(afValue).toContainText('150');
 
       // Expand and re-select Equity
       await overviewPage.availableFundsButton().click();
@@ -2604,10 +2599,11 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
       await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'true');
       await reSelectPromise;
 
-      // Available Funds restored to 250 000 (both sources selected)
-      const restoredText = await afValue.textContent();
-      expect(restoredText).toContain('250');
-      expect(restoredText).not.toContain('150');
+      // Available Funds restored to 250 000 (both sources selected).
+      // Use toContainText (retrying) to avoid reading a stale value before React
+      // commits the re-render after the refetch.
+      await expect(afValue).toContainText('250');
+      await expect(afValue).not.toContainText('150');
     } finally {
       await teardown();
     }
@@ -2643,15 +2639,15 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
       await expect(overviewPage.sourceRow('Bank Loan')).toHaveAttribute('aria-pressed', 'false');
       await refetchPromise;
 
-      // Available Funds must show €0.00 — not NaN, not the stale 150 000 value
+      // Available Funds must show €0.00 — not NaN, not the stale 150 000 value.
+      // Use toContainText (retrying) to avoid reading a stale value before React
+      // commits the re-render after the refetch. The initial value IS "150,000"
+      // so not.toContainText('150') waits until React commits the "€0.00" render.
       const afValue = overviewPage.availableFundsValue();
-      const valueText = await afValue.textContent();
-      // Must contain "0" as a number (e.g. "€0.00" or "€0,00")
-      expect(valueText).toMatch(/\b0\b|0,00|0\.00/);
-      // Must not contain "NaN"
-      expect(valueText).not.toContain('NaN');
-      // Must not contain the stale 150 000 total
-      expect(valueText).not.toContain('150');
+      // Must not contain "NaN" (would indicate a bad calculation)
+      await expect(afValue).not.toContainText('NaN');
+      // Must not contain the stale 150 000 total — also doubles as the retry anchor
+      await expect(afValue).not.toContainText('150');
     } finally {
       await teardown();
     }

--- a/e2e/tests/budget/budget-source-filter.spec.ts
+++ b/e2e/tests/budget/budget-source-filter.spec.ts
@@ -2272,3 +2272,443 @@ test.describe('Responsive layout', { tag: '@responsive' }, () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter-aware summary rows (Available Funds + Remaining Budget)
+// AC refs: #4 (restore on re-select), #5 (zero sources), #8 (print hiding)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', () => {
+  /**
+   * Build a breakdown with two real sources (Source A: 150 000, Source B: 100 000)
+   * and a deterministic projected cost (rawProjectedMin === rawProjectedMax === 20 000)
+   * so that "avg" perspective gives the same value as min and max.
+   * Unassigned has totalAmount=0 and does not affect the Available Funds total.
+   */
+  function makeTwoSourceBreakdown() {
+    return {
+      workItems: {
+        areas: [
+          {
+            areaId: 'area-main',
+            name: 'Main Area',
+            parentId: null,
+            color: '#3B82F6',
+            projectedMin: 20000,
+            projectedMax: 20000,
+            actualCost: 0,
+            subsidyPayback: 0,
+            rawProjectedMin: 20000,
+            rawProjectedMax: 20000,
+            minSubsidyPayback: 0,
+            items: [
+              {
+                workItemId: 'wi-main-1',
+                title: 'Main Work Item',
+                projectedMin: 20000,
+                projectedMax: 20000,
+                actualCost: 0,
+                subsidyPayback: 0,
+                rawProjectedMin: 20000,
+                rawProjectedMax: 20000,
+                minSubsidyPayback: 0,
+                costDisplay: 'projected',
+                budgetLines: [
+                  {
+                    id: 'line-a1',
+                    description: 'Line A1',
+                    plannedAmount: 10000,
+                    confidence: 'own_estimate',
+                    actualCost: 0,
+                    hasInvoice: false,
+                    isQuotation: false,
+                    budgetSourceId: SOURCE_A_ID,
+                  },
+                  {
+                    id: 'line-b1',
+                    description: 'Line B1',
+                    plannedAmount: 10000,
+                    confidence: 'own_estimate',
+                    actualCost: 0,
+                    hasInvoice: false,
+                    isQuotation: false,
+                    budgetSourceId: SOURCE_B_ID,
+                  },
+                ],
+              },
+            ],
+            children: [],
+          },
+        ],
+        totals: {
+          projectedMin: 20000,
+          projectedMax: 20000,
+          actualCost: 0,
+          subsidyPayback: 0,
+          rawProjectedMin: 20000,
+          rawProjectedMax: 20000,
+          minSubsidyPayback: 0,
+        },
+      },
+      householdItems: {
+        areas: [],
+        totals: makeEmptyTotals(),
+      },
+      subsidyAdjustments: [],
+      budgetSources: [
+        {
+          id: SOURCE_A_ID,
+          name: 'Bank Loan',
+          totalAmount: 150000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        },
+        {
+          id: SOURCE_B_ID,
+          name: 'Equity',
+          totalAmount: 100000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Filtered breakdown returned when Source B (Equity) is deselected.
+   * Server prunes Source B lines — only Source A lines remain.
+   * budgetSources still contains both (server always returns unfiltered projectedMin/Max),
+   * so source toggle rows remain visible after the refetch.
+   */
+  function makeTwoSourceBreakdownEquityDeselected() {
+    return {
+      workItems: {
+        areas: [
+          {
+            areaId: 'area-main',
+            name: 'Main Area',
+            parentId: null,
+            color: '#3B82F6',
+            projectedMin: 10000,
+            projectedMax: 10000,
+            actualCost: 0,
+            subsidyPayback: 0,
+            rawProjectedMin: 10000,
+            rawProjectedMax: 10000,
+            minSubsidyPayback: 0,
+            items: [
+              {
+                workItemId: 'wi-main-1',
+                title: 'Main Work Item',
+                projectedMin: 10000,
+                projectedMax: 10000,
+                actualCost: 0,
+                subsidyPayback: 0,
+                rawProjectedMin: 10000,
+                rawProjectedMax: 10000,
+                minSubsidyPayback: 0,
+                costDisplay: 'projected',
+                budgetLines: [
+                  {
+                    id: 'line-a1',
+                    description: 'Line A1',
+                    plannedAmount: 10000,
+                    confidence: 'own_estimate',
+                    actualCost: 0,
+                    hasInvoice: false,
+                    isQuotation: false,
+                    budgetSourceId: SOURCE_A_ID,
+                  },
+                ],
+              },
+            ],
+            children: [],
+          },
+        ],
+        totals: {
+          projectedMin: 10000,
+          projectedMax: 10000,
+          actualCost: 0,
+          subsidyPayback: 0,
+          rawProjectedMin: 10000,
+          rawProjectedMax: 10000,
+          minSubsidyPayback: 0,
+        },
+      },
+      householdItems: {
+        areas: [],
+        totals: makeEmptyTotals(),
+      },
+      subsidyAdjustments: [],
+      // Server returns both sources regardless of filter
+      budgetSources: [
+        {
+          id: SOURCE_A_ID,
+          name: 'Bank Loan',
+          totalAmount: 150000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        },
+        {
+          id: SOURCE_B_ID,
+          name: 'Equity',
+          totalAmount: 100000,
+          projectedMin: 10000,
+          projectedMax: 10000,
+          subsidyPaybackMin: 0,
+          subsidyPaybackMax: 0,
+        },
+      ],
+    };
+  }
+
+  test('Scenario 1 — Available Funds updates when a source is deselected', async ({ page }) => {
+    // Source A: totalAmount=150 000, Source B: totalAmount=100 000 → combined=250 000.
+    // After deselecting Source B (Equity): filteredAvailableFunds = 150 000 (Source A only).
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountOverviewRoutes(
+      page,
+      makeBudgetOverviewResponse(),
+      makeTwoSourceBreakdown(),
+      makeTwoSourceBreakdownEquityDeselected(),
+    );
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Initial state: both sources selected → Available Funds = 250 000
+      const afValue = overviewPage.availableFundsValue();
+      await expect(afValue).toBeVisible();
+      const initialText = await afValue.textContent();
+      // Combined total must contain "250" (as in €250,000)
+      expect(initialText).toContain('250');
+
+      // Expand source rows
+      await overviewPage.availableFundsButton().click();
+
+      // Deselect Equity — register waitForResponse BEFORE the click
+      const refetchPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/budget/breakdown') && resp.url().includes('deselectedSources='),
+      );
+      await overviewPage.sourceRow('Equity').click();
+      await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
+      await refetchPromise;
+
+      // Available Funds now shows only Source A total (150 000)
+      const filteredText = await afValue.textContent();
+      expect(filteredText).toContain('150');
+      // Must NOT still show 250 (combined)
+      expect(filteredText).not.toContain('250');
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Scenario 2 — Remaining Budget Cost updates when a source is deselected', async ({
+    page,
+  }) => {
+    // Source A: totalAmount=150 000, Source B: totalAmount=100 000
+    // Initial (both selected): totalRawProjected = (20 000+20 000)/2 = 20 000
+    //   Remaining Budget Cost = 250 000 - 20 000 = 230 000
+    // After deselecting Source B (Equity): server returns filtered breakdown with
+    //   wiTotals.rawProjectedMin/Max = 10 000 → totalRawProjected = 10 000
+    //   filteredAvailableFunds = 150 000 (Bank Loan only)
+    //   Remaining Budget Cost = 150 000 - 10 000 = 140 000
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountOverviewRoutes(
+      page,
+      makeBudgetOverviewResponse(),
+      makeTwoSourceBreakdown(),
+      makeTwoSourceBreakdownEquityDeselected(),
+    );
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Locate the "Remaining Budget" row by its label text
+      const remainingRow = overviewPage.costBreakdownCard
+        .getByRole('row')
+        .filter({ hasText: /remaining budget/i });
+
+      // Remaining Budget Cost cell (td index 1 = "Cost" column)
+      const costCell = remainingRow.locator('td').nth(1);
+      await expect(costCell).toBeVisible();
+      const initialText = await costCell.textContent();
+      // Should reflect 230 000 (250 000 - 20 000)
+      expect(initialText).toContain('230');
+
+      // Expand source rows
+      await overviewPage.availableFundsButton().click();
+
+      // Deselect Equity — register waitForResponse BEFORE the click
+      const refetchPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/budget/breakdown') && resp.url().includes('deselectedSources='),
+      );
+      await overviewPage.sourceRow('Equity').click();
+      await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
+      await refetchPromise;
+
+      // Remaining Budget Cost = 150 000 - 10 000 = 140 000
+      const filteredText = await costCell.textContent();
+      expect(filteredText).toContain('140');
+      expect(filteredText).not.toContain('230');
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Scenario 3 — Available Funds restores to full total on re-select (AC #4)', async ({
+    page,
+  }) => {
+    // Start with Source B (Equity) deselected via URL — Available Funds = 150 000 (Source A only).
+    // Re-select Equity → refetch fires without deselectedSources → Available Funds = 250 000.
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountOverviewRoutes(
+      page,
+      makeBudgetOverviewResponse(),
+      makeTwoSourceBreakdown(),
+      makeTwoSourceBreakdownEquityDeselected(),
+    );
+
+    try {
+      // Navigate with Equity pre-deselected
+      await page.goto(`${BUDGET_OVERVIEW_ROUTE}?deselectedSources=${SOURCE_B_ID}`);
+      await overviewPage.waitForLoaded();
+
+      const afValue = overviewPage.availableFundsValue();
+      await expect(afValue).toBeVisible();
+
+      // Pre-deselected state: Available Funds = 150 000 (Bank Loan only)
+      const deselectedText = await afValue.textContent();
+      expect(deselectedText).toContain('150');
+
+      // Expand and re-select Equity
+      await overviewPage.availableFundsButton().click();
+      await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
+
+      const reSelectPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/budget/breakdown') &&
+          !resp.url().includes('deselectedSources='),
+      );
+      await overviewPage.sourceRow('Equity').click();
+      await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'true');
+      await reSelectPromise;
+
+      // Available Funds restored to 250 000 (both sources selected)
+      const restoredText = await afValue.textContent();
+      expect(restoredText).toContain('250');
+      expect(restoredText).not.toContain('150');
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Scenario 4 — Zero sources selected: Available Funds shows €0 (AC #5)', async ({
+    page,
+  }) => {
+    // When all sources are deselected, filteredAvailableFunds = 0.
+    // Server returns empty areas (all lines belong to deselected sources).
+    // The Available Funds row must show €0.00 — not NaN and not the stale combined value.
+    const overviewPage = new BudgetOverviewPage(page);
+
+    // Use makeBreakdownSourceAOnly (single source: Bank Loan, totalAmount=150 000).
+    // Filtered response is makeFilteredEmptyBreakdown which has empty areas[].
+    const teardown = await mountOverviewRoutes(
+      page,
+      makeBudgetOverviewResponse(),
+      makeBreakdownSourceAOnly(),
+      makeFilteredEmptyBreakdown(),
+    );
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      await overviewPage.availableFundsButton().click();
+
+      // Deselect the only source (Bank Loan)
+      const refetchPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/budget/breakdown') && resp.url().includes('deselectedSources='),
+      );
+      await overviewPage.sourceRow('Bank Loan').click();
+      await expect(overviewPage.sourceRow('Bank Loan')).toHaveAttribute('aria-pressed', 'false');
+      await refetchPromise;
+
+      // Available Funds must show €0.00 — not NaN, not the stale 150 000 value
+      const afValue = overviewPage.availableFundsValue();
+      const valueText = await afValue.textContent();
+      // Must contain "0" as a number (e.g. "€0.00" or "€0,00")
+      expect(valueText).toMatch(/\b0\b|0,00|0\.00/);
+      // Must not contain "NaN"
+      expect(valueText).not.toContain('NaN');
+      // Must not contain the stale 150 000 total
+      expect(valueText).not.toContain('150');
+    } finally {
+      await teardown();
+    }
+  });
+
+  test('Scenario 5 — Print: deselected source rows hidden, selected source rows visible (AC #8)', async ({
+    page,
+  }) => {
+    // The @media print rule `.rowSourceDetailToggle[aria-pressed='false'] { display: none !important }`
+    // must hide deselected source rows in print and leave selected rows visible.
+    const overviewPage = new BudgetOverviewPage(page);
+    const teardown = await mountOverviewRoutes(
+      page,
+      makeBudgetOverviewResponse(),
+      makeTwoSourceBreakdown(),
+      makeTwoSourceBreakdownEquityDeselected(),
+    );
+
+    try {
+      await overviewPage.goto();
+      await overviewPage.waitForLoaded();
+
+      // Expand Available Funds section to show source toggle rows
+      await overviewPage.availableFundsButton().click();
+      await expect(overviewPage.sourceRow('Bank Loan')).toBeVisible();
+      await expect(overviewPage.sourceRow('Equity')).toBeVisible();
+
+      // Deselect Equity — register waitForResponse BEFORE the click
+      const refetchPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/budget/breakdown') && resp.url().includes('deselectedSources='),
+      );
+      await overviewPage.sourceRow('Equity').click();
+      await expect(overviewPage.sourceRow('Equity')).toHaveAttribute('aria-pressed', 'false');
+      await refetchPromise;
+
+      // Switch to print media
+      await page.emulateMedia({ media: 'print' });
+
+      try {
+        // Deselected source row (Equity, aria-pressed='false') must be hidden by @media print
+        await expect(overviewPage.sourceRow('Equity')).toHaveCSS('display', 'none');
+
+        // Selected source row (Bank Loan, aria-pressed='true') must NOT be display:none
+        const bankLoanDisplay = await overviewPage
+          .sourceRow('Bank Loan')
+          .evaluate((el) => getComputedStyle(el).display);
+        expect(bankLoanDisplay).not.toBe('none');
+      } finally {
+        // Restore screen media — must be in finally to prevent print-mode from leaking
+        // into subsequent tests running in the same worker.
+        await page.emulateMedia({ media: 'screen' });
+      }
+    } finally {
+      await teardown();
+    }
+  });
+});

--- a/e2e/tests/budget/budget-source-filter.spec.ts
+++ b/e2e/tests/budget/budget-source-filter.spec.ts
@@ -2613,9 +2613,7 @@ test.describe('Filter-aware summary rows (Available Funds + Remaining Budget)', 
     }
   });
 
-  test('Scenario 4 — Zero sources selected: Available Funds shows €0 (AC #5)', async ({
-    page,
-  }) => {
+  test('Scenario 4 — Zero sources selected: Available Funds shows €0 (AC #5)', async ({ page }) => {
     // When all sources are deselected, filteredAvailableFunds = 0.
     // Server returns empty areas (all lines belong to deselected sources).
     // The Available Funds row must show €0.00 — not NaN and not the stale combined value.

--- a/e2e/tests/documents/document-linking.spec.ts
+++ b/e2e/tests/documents/document-linking.spec.ts
@@ -274,8 +274,11 @@ test.describe('Document Linking — Duplicate (Scenario 5)', { tag: '@responsive
       pickerModal = page.getByRole('dialog', { name: 'Add Document' });
       await expect(pickerModal).toBeVisible();
 
-      // Uncheck "Hide linked" toggle so the already-linked document is visible
-      const hideLinkedCheckbox = pickerModal.getByRole('checkbox', { name: /hide linked/i });
+      // After fix #1369, "Hide already-linked documents" defaults to unchecked — linked docs visible.
+      // Label changed from the old "Hide linked" wording; uncheck() is a no-op but kept for clarity.
+      const hideLinkedCheckbox = pickerModal.getByRole('checkbox', {
+        name: /hide already-linked documents/i,
+      });
       await expect(hideLinkedCheckbox).toBeVisible({ timeout: 5000 });
       await hideLinkedCheckbox.uncheck();
 


### PR DESCRIPTION
## Release Summary

Fixes the Cost Breakdown table so that **Available Funds** and **Remaining Budget** correctly respond to the per-source budget filter, and fully hides deselected funding sources when printing.

## Changes

### Fixes
- **fix(budget):** `CostBreakdownTable` now computes `filteredAvailableFunds` client-side from `breakdown.budgetSources` instead of using the unfiltered `overview.availableFunds`. Both the **Available Funds** row and the **Remaining Budget** row (Cost and Net columns) now update in real-time as sources are toggled. (Issue #1366)
- **fix(budget):** Deselected funding source rows are fully hidden when printing via `@media print { .rowSourceDetailToggle[aria-pressed='false'] { display: none !important; } }`. (Issue #1366)

## Change Inventory

### Frontend (`client/`)
- `client/src/components/CostBreakdownTable/CostBreakdownTable.tsx` — replaced 4 `overview.availableFunds` references with `filteredAvailableFunds` computation
- `client/src/components/CostBreakdownTable/CostBreakdownTable.module.css` — added `@media print` rule to hide deselected source rows

### E2E Tests (`e2e/`)
- `e2e/tests/budget/budget-source-filter.spec.ts` — 5 new E2E scenarios: Available Funds updates on deselect, Remaining Budget updates on deselect, restore on re-select, zero-sources shows €0, print media hides deselected rows

### Tests
- `client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx` — 9 new unit tests for filter-aware summary rows; 10 pre-existing tests updated to supply matching `budgetSources` fixtures

## Manual Validation Checklist

- [ ] Open the **Budget** page → **Cost Breakdown** tab
- [ ] Confirm "Available funds" shows the total of all configured budget sources
- [ ] Toggle off one budget source using its toggle button — verify "Available funds" decreases by that source's amount
- [ ] Verify "Remaining Budget" (Cost and Net columns) also updates when the source is toggled
- [ ] Toggle the source back on — verify both rows restore to their original values
- [ ] Toggle off all sources — verify "Available funds" shows €0.00 and "Remaining Budget" shows a negative value equal to the projected cost
- [ ] Print the Cost Breakdown page (Cmd/Ctrl+P or browser print preview) — verify deselected source detail rows are **not visible** in the print preview

## Testing
- **DockerHub beta image**: `docker pull steilerdev/cornerstone:beta`
- **PR-specific image**: `docker pull steilerdev/cornerstone:pr-1367`

Fixes #1366