### PR TITLE
ci: fix detect-changes fallback for workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Classify changed paths
         id: filter
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then BASE_REF="main"; fi
+          CHANGED=$(git diff --name-only origin/${BASE_REF}...HEAD)
           echo "Changed files:"
           echo "$CHANGED"
 


### PR DESCRIPTION
## Summary

- Fixes `Detect Changes` step failing with exit code 128 when triggered via `workflow_dispatch`
- `github.base_ref` is only set for `pull_request` events; defaults to `main` when empty
- Allows `workflow_dispatch` runs to properly detect changed paths and run appropriate jobs

## Context

When `workflow_dispatch` is used to manually trigger CI (e.g., after a `[skip ci]` auto-fix commit), the `Detect Changes` job fails because `github.base_ref` is not set. This causes all downstream jobs to be skipped, resulting in `Quality Gates` and `E2E Gates` passing vacuously — which blocks promotion PRs from properly establishing CI status.

## Test plan
- [ ] Workflow_dispatch on beta with this fix should run `Detect Changes` successfully
- [ ] All other CI jobs should run normally after Detect Changes passes