### PR TITLE
docs: update documentation for v2.4.2 release

### DIFF
--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,47 +1,20 @@
-## What's New
+# v2.4.2 Release Summary
 
-This release sharpens the **Budget Overview** so every cost in your project is traceable to the source funding it. Every line in the Cost Breakdown now carries a colored source attribution badge, the **Available Funds** row expands into a per-source Cost / Payback / Net view, and clicking a source detail row toggles it on or off -- with the entire breakdown (totals, projections, and subsidy math) recalculated server-side and the selection persisted in the URL so you can bookmark, share, or refresh a filtered view.
+A small bug-fix release that tightens up the Budget and Document workflows introduced in v2.4. No new features, no breaking changes, no migration required -- pull and restart.
 
-### What's new
+## Bug Fixes
 
-**Source attribution everywhere**
+- **Budget source filter now drives every total on the page.** The "Available Funds" and "Remaining Budget" columns in the Cost Breakdown table -- as well as the Pending, Paid, and Quotation summary cards above the table -- now correctly reflect the active source filter. Previously they always showed unfiltered totals, which made the per-source filter misleading when you only wanted to see the picture for a single source.
+- **Document picker shows all documents by default.** The "Hide already-linked documents" checkbox in the document picker now starts unchecked, so every document is immediately visible. You no longer have to clear the filter before you can re-link a document that is already attached elsewhere.
+- **Mouse wheel no longer changes numeric fields.** Scrolling the page with your mouse wheel while the cursor sits over an Amount or budget field will not accidentally increment or decrement the value -- a common source of silent edits when scrolling long invoice forms.
+- **VAT checkbox round-trips correctly.** The VAT / tax checkbox on invoices now preserves its state when you reopen an invoice for editing. Previously the saved state was not always reflected in the form.
+- **Vendor picker no longer clears on blur.** Selecting a vendor in the Add Invoice form and then clicking elsewhere on the page (e.g. into the Amount field) no longer clears the selection.
+- **Budget Overview summary cards refresh with the source filter.** The Pending, Paid, and Quotation summary cards on the Budget Overview page now refresh correctly when you toggle the source filter, so the headline numbers always match the rows below them.
 
-- Every leaf-level budget line in the Cost Breakdown shows a deterministic, color-coded badge for its financing source -- the same source always gets the same color across the table, between sessions, and in light and dark mode.
-- On desktop the badge shows the full source name; on mobile it collapses to a colored dot to keep rows compact.
-- A 10-slot palette guarantees consistent contrast in both themes; budget lines without a source assignment use a reserved "Unassigned" color.
+## What to Update
 
-**Available Funds row redesign**
+```bash
+docker pull steilerdev/cornerstone:latest
+```
 
-- Click the **Available Funds** row to expand it and see one row per financing source.
-- Each source row shows three numbers in dedicated columns: **Cost** (allocated against budget lines, perspective-aware), **Payback** (subsidy payback against lines funded from that source), and **Net** (remaining headroom after cost and payback).
-- It's the fastest way to spot which source is most depleted, which one is being subsidized, and which one still has slack.
-
-**Per-source filter**
-
-- Click any source detail row to toggle that source on or off. The entire breakdown -- summary tiles, projected cost range, remaining budget, every nested area row -- recalculates against the visible set.
-- The selection is persisted in the URL as `?deselectedSources=<id>,<id>` so a filtered view can be bookmarked, shared, or reloaded without losing state.
-- Press **Escape** while a source row is focused to clear all deselections in one go.
-- A small "X of N selected" caption appears next to **Available Funds** while a filter is active.
-
-**Server-side filter pipeline**
-
-- The new filter is wired through to a single endpoint: `GET /api/budget/breakdown?deselectedSources=...`.
-- Subsidy payback math is computed against the filtered set on the server, so subsidies that no longer have qualifying budget lines drop out cleanly instead of double-counting.
-- Filter changes round-trip in a single request -- no client-side recomputation drift.
-
-### Fixes
-
-- Source detail rows stay visible even when every source is deselected, so the filter is never a dead-end.
-- Dark mode contrast and focus ring are corrected on the Cost Breakdown error banner.
-
-### Tooling
-
-- The `Quality Gates` workflow now supports `workflow_dispatch`, making it easy to re-run gates manually during a promotion.
-
-### Breaking changes
-
-None. Existing bookmarks, links, URLs, and data model are preserved. The `?deselectedSources=` query parameter is purely additive -- omit it (or leave it empty) to get the unchanged behavior.
-
-### Migration notes
-
-No database migration is required. The new filter parameter is server-validated and silently ignores unknown source IDs, so older clients that don't send the parameter continue to work without changes.
+Restart your container -- no database migration is required.

--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -79,13 +79,14 @@ This makes it easy to spot which source is most depleted, which one is being sub
 
 Click any source detail row inside the **Available Funds** expansion to toggle that source on or off. Deselected sources are dropped from the entire breakdown:
 
-- The summary tiles, projected cost range, remaining budget, and every nested area row recalculate against the visible set.
+- The summary tiles, projected cost range, every nested area row, and the **Available Funds** and **Remaining Budget** (Cost + Net) totals all recalculate against the visible set in real time as you toggle.
 - A small "X of N selected" caption appears next to **Available Funds** while a filter is active.
 - The selection is **persisted in the URL** as `?deselectedSources=<id>,<id>` so you can bookmark a filtered view, share it with your bank or partner, or refresh without losing state.
 - Press **Escape** while focused on a source row to clear all deselections in one go.
 - Source detail rows stay visible even when every source is deselected -- the filter is never a dead-end; you can always click your way back in.
+- When you print a filtered view, deselected source rows are hidden from the printed output so the report only shows the sources you actually have selected.
 
-Filtering happens **server-side** (`GET /api/budget/breakdown?deselectedSources=...`), which means subsidy payback math stays consistent with the visible set: subsidies that no longer have any qualifying budget lines drop out cleanly instead of double-counting.
+Filtering happens **server-side** (`GET /api/budget/breakdown?deselectedSources=...`), which means subsidy payback math stays consistent with the visible set: subsidies that no longer have any qualifying budget lines drop out cleanly instead of double-counting. The Pending, Paid, and Quotation summary cards at the top of the page also refresh in step with the filter -- pick the sources you care about and the headline numbers update without leaving the page.
 
 ## Financing Source Summary
 

--- a/docs/src/guides/documents/linking-documents.md
+++ b/docs/src/guides/documents/linking-documents.md
@@ -31,6 +31,8 @@ Screenshots for the documents feature require a connected Paperless-ngx instance
 
 The document is immediately linked and appears in the Documents section. A screen reader announcement confirms the link was created.
 
+The picker shows **all documents** by default. If your document store is large and you only want to see documents that are not yet linked anywhere in Cornerstone, tick the **Hide already-linked documents** checkbox at the top of the picker -- it stays unchecked unless you turn it on, so you never have to clear it just to find a document you intend to re-link.
+
 :::note
 Each document can only be linked once to the same entity. If you try to link a document that is already attached, Cornerstone will show a message that the document is already linked.
 :::


### PR DESCRIPTION
## Summary

Updates user-facing documentation to reflect the six bug fixes shipped in v2.4.2. No new features, no schema changes.

### Changes

- **`docs/src/guides/budget/budget-overview.md`** -- The "Filter by Source" section now explicitly states that the **Available Funds** and **Remaining Budget** (Cost + Net) totals and the Pending/Paid/Quotation summary cards recalculate in step with the filter, and that deselected source rows are hidden from printed output. (Covers #1366 and #1373.)
- **`docs/src/guides/documents/linking-documents.md`** -- New paragraph documents the "Hide already-linked documents" checkbox and clarifies it defaults to **unchecked**, so re-linking a document does not require clearing the filter first. (Covers #1369.)
- **`RELEASE_SUMMARY.md`** -- Rewritten as a v2.4.2 changelog covering all six fixes: source filter totals (#1366), picker default (#1369), scroll wheel on numeric inputs (#1370), VAT checkbox round-trip (#1371), vendor picker blur (#1372), and Budget Overview summary cards refresh (#1373).

### Other validation

- `.env.example` was diffed against `server/src/plugins/config.ts` and every `process.env.*` reference under `server/src/` -- no drift, no missing or stale variables.

### Out of scope

- The other v2.4.2 fixes (#1370 scroll wheel, #1371 VAT round-trip, #1372 vendor blur) restore expected default behavior for invisible UI interactions; they have no doc-level surface to update beyond the release summary.
- README.md was not modified -- it has no version-specific or fix-specific text and the protected `> [!NOTE]` block is untouched.

## Test plan

- [x] Ran `git diff` on `.env.example` vs `server/src/plugins/config.ts` (no drift)
- [x] Verified `> [!NOTE]` block in README.md is untouched
- [x] `RELEASE_SUMMARY.md` follows the requested `# vX.Y.Z` + `## Bug Fixes` + `## What to Update` format
- [ ] Quality Gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)