### PR TITLE
docs: add release date to RELEASE_SUMMARY

### DIFF
--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -18,3 +18,7 @@ docker pull steilerdev/cornerstone:latest
 ```
 
 Restart your container -- no database migration is required.
+
+---
+
+*Released: 2026-04-28*


### PR DESCRIPTION
Adds the release date to the v2.4.2 release summary.

This is also needed to create a clean non-`[skip ci]` commit on `beta` so that PR #1381 (the beta→main promotion PR) can have its required CI status checks run through the PR mechanism (the auto-fix bot's `[skip ci]` commit prevented CI from running on that PR).