### PR TITLE
fix(docs): correct broken links in budget overview related pages

### DIFF
--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -120,7 +120,7 @@ If the exported PDF does not match what you see on screen, make sure your browse
 
 ## Related Pages
 
-- [Work Items](../work-items/overview) — track progress and link budget lines to construction tasks
-- [Household Items](../household-items/overview) — manage furniture and appliance purchases with their own budget lines
+- [Work Items](../work-items/) — track progress and link budget lines to construction tasks
+- [Household Items](../household-items/) — manage furniture and appliance purchases with their own budget lines
 - [Financing Sources](financing-sources) — detailed view of each financing source and its allocated lines
 - [Subsidies](subsidies) — manage subsidy applications and their impact on your budget


### PR DESCRIPTION
Fixes broken links introduced in #1383. The work-items and household-items links need to point to index pages (not a non-existent `/overview` sub-path), which caused the Docs Deploy job in the v2.4.3 release workflow to fail.