### PR TITLE
chore: retrigger promotion CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ Cornerstone is a personal project built primarily through an agentic development
 ## License
 
 This project is not currently published under an open-source license.
+


### PR DESCRIPTION
## Why

The most recent commit on \`beta\` is \`044d8fd8 style: auto-fix lint and format [skip ci]\` from the auto-fix bot. GitHub's \`[skip ci]\` directive blocks **all** workflow runs for that SHA, including \`pull_request\`-triggered ones. As a result, promotion PR #1392 (beta -> main) showed zero CI checks and could not advance through the required \`Quality Gates\` and \`E2E Gates\`.

Closing/reopening #1392 did not help (head SHA unchanged).

## What

Empty no-op commit. Squash-merging this PR advances the \`beta\` head to a SHA without \`[skip ci]\`, which retriggers the promotion PR's CI.

No production code change.

## Follow-up

Consider removing \`[skip ci]\` from the auto-fix workflow's commit message — the existing \`if: github.actor != 'cornerstone-bot[bot]'\` actor guard already prevents the auto-fix recursion, so \`[skip ci]\` is redundant and creates this gap. Tracking separately if needed.