### PR TITLE
chore: refire promotion CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Cornerstone is a personal project built primarily through an agentic development
 
 This project is not currently published under an open-source license.
 
+


### PR DESCRIPTION
Add a trailing newline to README to advance the beta SHA via a clean synchronize event. Followup to #1393 — the previous trigger commit body inadvertently contained the directive that suppresses CI, which suppressed all workflow runs for its squash-merged commit on beta.

No production code change.