### PR TITLE
chore: trivial docs bump

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -63,3 +63,4 @@ See the [Roadmap](roadmap) for upcoming features.
 - [Development](development) -- How Cornerstone is built by an AI agent team
 - [GitHub Repository](https://github.com/steilerDev/cornerstone) -- Source code and issue tracker
 - [GitHub Wiki](https://github.com/steilerDev/cornerstone/wiki) -- Technical architecture documentation
+


### PR DESCRIPTION
Append a trailing newline to docs/src/intro.md to advance the beta SHA via a clean synchronize event for the promotion PR.

Followup to #1393 and #1394 — the auto-fix bot keeps pushing a directive-suppressing commit on top of beta after each merge, which moves PR #1392's head past the SHA where its CI completed. Touching only docs/ avoids triggering an auto-fix follow-up commit (docs/ is ignored by Prettier and ESLint).

No production code change.