### PR TITLE
feat(invoice,budget): invoice deposits UI + deposit-aware budget rollups (#1404, #1405)

### DIFF
--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -484,6 +484,75 @@
     "budgetLines": {
       "createFormLegend": "Neue Budgetposition erstellen",
       "autoLinkedSuccess": "Budgetposition erstellt und mit {{amount}} hinzugefügt"
+    },
+    "deposits": {
+      "sectionTitle": "Abschlagszahlungen",
+      "countChip": "{{count}} Abschlagszahlungen",
+      "addButton": "Abschlagszahlung Hinzufügen",
+      "loading": "Abschlagszahlungen werden geladen...",
+      "empty": {
+        "message": "Noch keine Abschlagszahlungen",
+        "description": "Teilen Sie diese Rechnung in Teilzahlungen auf, indem Sie eine Abschlagszahlung hinzufügen."
+      },
+      "finalPayment": "Schlusszahlung",
+      "columns": {
+        "dueDate": "Fälligkeitsdatum",
+        "amount": "Betrag",
+        "status": "Status",
+        "paidDate": "Bezahlt am",
+        "claimedDate": "Eingereicht am",
+        "description": "Beschreibung",
+        "actions": "Aktionen"
+      },
+      "mobile": {
+        "due": "Fällig",
+        "paid": "Bezahlt",
+        "claimed": "Eingereicht"
+      },
+      "menu": {
+        "markPaid": "Als bezahlt markieren…",
+        "markClaimed": "Als eingereicht markieren…",
+        "revertToPending": "Auf ausstehend zurücksetzen",
+        "revertToPaid": "Auf bezahlt zurücksetzen",
+        "edit": "Bearbeiten",
+        "delete": "Löschen",
+        "ariaLabel": "Aktionen für Abschlagszahlung {{description}}"
+      },
+      "modal": {
+        "addTitle": "Abschlagszahlung Hinzufügen",
+        "editTitle": "Abschlagszahlung Bearbeiten",
+        "deleteTitle": "Abschlagszahlung Löschen",
+        "deleteConfirm": "Diese Abschlagszahlung löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "deleteWarningPaidClaimed": "Diese Abschlagszahlung wurde als bezahlt/eingereicht markiert. Beim Löschen wird ihr Beitrag aus den Budgetgesamtwerten entfernt.",
+        "markPaidTitle": "Als bezahlt markieren",
+        "markClaimedTitle": "Als eingereicht markieren"
+      },
+      "form": {
+        "amount": "Betrag",
+        "dueDate": "Fälligkeitsdatum",
+        "status": "Status",
+        "paidDate": "Bezahlt am",
+        "claimedDate": "Eingereicht am",
+        "description": "Beschreibung",
+        "amountPlaceholder": "0.00",
+        "descriptionPlaceholder": "Optionale Beschreibung",
+        "charCounter": "{{count}} / 500",
+        "saving": "Wird gespeichert...",
+        "required": "*"
+      },
+      "errors": {
+        "exceedsTotal": "Betrag der Abschlagszahlung überschreitet den Rechnungsgesamtbetrag. Verfügbarer Spielraum: {{available}}",
+        "invalidTransition": "Statuswechsel von {{from}} nach {{to}} nicht möglich",
+        "invalidDate": "Ungültiges Datum für den ausgewählten Status",
+        "loadError": "Abschlagszahlungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+        "saveError": "Abschlagszahlung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+        "deleteError": "Abschlagszahlung konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
+        "revertError": "Status der Abschlagszahlung konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut."
+      },
+      "stateConfirm": {
+        "paidDateLabel": "Bezahlt am",
+        "claimedDateLabel": "Eingereicht am"
+      }
     }
   },
   "subsidies": {

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -541,7 +541,7 @@
         "required": "*"
       },
       "errors": {
-        "exceedsTotal": "Betrag der Abschlagszahlung überschreitet den Rechnungsgesamtbetrag. Verfügbarer Spielraum: {{available}}",
+        "exceedsTotal": "Betrag der Abschlagszahlung überschreitet den Rechnungsgesamtbetrag. Verfügbarer Spielraum: {{availableHeadroom}}",
         "invalidTransition": "Statuswechsel von {{from}} nach {{to}} nicht möglich",
         "invalidDate": "Ungültiges Datum für den ausgewählten Status",
         "loadError": "Abschlagszahlungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -654,7 +654,7 @@
         "required": "*"
       },
       "errors": {
-        "exceedsTotal": "Deposit amount exceeds invoice total. Available headroom: {{available}}",
+        "exceedsTotal": "Deposit amount exceeds invoice total. Available headroom: {{availableHeadroom}}",
         "invalidTransition": "Cannot transition from {{from}} to {{to}}",
         "invalidDate": "Invalid date for the selected status",
         "loadError": "Failed to load deposits. Please try again.",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -597,6 +597,75 @@
     "budgetLines": {
       "createFormLegend": "Create new budget line",
       "autoLinkedSuccess": "Budget line created and added for {{amount}}"
+    },
+    "deposits": {
+      "sectionTitle": "Deposits",
+      "countChip": "{{count}} deposits",
+      "addButton": "Add deposit",
+      "loading": "Loading deposits...",
+      "empty": {
+        "message": "No deposits yet",
+        "description": "Break this invoice into staged payments by adding a deposit."
+      },
+      "finalPayment": "Final payment",
+      "columns": {
+        "dueDate": "Due date",
+        "amount": "Amount",
+        "status": "Status",
+        "paidDate": "Paid date",
+        "claimedDate": "Claimed date",
+        "description": "Description",
+        "actions": "Actions"
+      },
+      "mobile": {
+        "due": "Due",
+        "paid": "Paid",
+        "claimed": "Claimed"
+      },
+      "menu": {
+        "markPaid": "Mark paid…",
+        "markClaimed": "Mark claimed…",
+        "revertToPending": "Revert to pending",
+        "revertToPaid": "Revert to paid",
+        "edit": "Edit",
+        "delete": "Delete",
+        "ariaLabel": "Deposit actions for {{description}}"
+      },
+      "modal": {
+        "addTitle": "Add deposit",
+        "editTitle": "Edit deposit",
+        "deleteTitle": "Delete deposit",
+        "deleteConfirm": "Delete this deposit? This cannot be undone.",
+        "deleteWarningPaidClaimed": "This deposit has been marked paid/claimed. Deleting it will remove its contribution from budget totals.",
+        "markPaidTitle": "Mark as paid",
+        "markClaimedTitle": "Mark as claimed"
+      },
+      "form": {
+        "amount": "Amount",
+        "dueDate": "Due date",
+        "status": "Status",
+        "paidDate": "Paid date",
+        "claimedDate": "Claimed date",
+        "description": "Description",
+        "amountPlaceholder": "0.00",
+        "descriptionPlaceholder": "Optional description",
+        "charCounter": "{{count}} / 500",
+        "saving": "Saving...",
+        "required": "*"
+      },
+      "errors": {
+        "exceedsTotal": "Deposit amount exceeds invoice total. Available headroom: {{available}}",
+        "invalidTransition": "Cannot transition from {{from}} to {{to}}",
+        "invalidDate": "Invalid date for the selected status",
+        "loadError": "Failed to load deposits. Please try again.",
+        "saveError": "Failed to save deposit. Please try again.",
+        "deleteError": "Failed to delete deposit. Please try again.",
+        "revertError": "Failed to revert deposit status. Please try again."
+      },
+      "stateConfirm": {
+        "paidDateLabel": "Paid date",
+        "claimedDateLabel": "Claimed date"
+      }
     }
   },
   "subsidies": {

--- a/client/src/i18n/glossary.json
+++ b/client/src/i18n/glossary.json
@@ -2,7 +2,7 @@
   "_meta": {
     "description": "Single source of truth for domain terminology translations. The translator agent enforces these.",
     "locales": ["de"],
-    "lastUpdated": "2026-04-16"
+    "lastUpdated": "2026-05-10"
   },
   "terms": {
     "Work Item": { "de": { "singular": "Arbeitspaket", "plural": "Arbeitspakete" } },
@@ -23,6 +23,8 @@
     "Quotation": { "de": { "singular": "Angebot", "plural": "Angebote" } },
     "Area": { "de": { "singular": "Bereich", "plural": "Bereiche" } },
     "Trade": { "de": { "singular": "Gewerk", "plural": "Gewerke" } },
-    "Unassigned": { "de": { "singular": "Nicht zugewiesen" } }
+    "Unassigned": { "de": { "singular": "Nicht zugewiesen" } },
+    "Deposit": { "de": { "singular": "Abschlagszahlung", "plural": "Abschlagszahlungen" } },
+    "Final payment": { "de": { "singular": "Schlusszahlung" } }
   }
 }

--- a/client/src/lib/invoiceDepositsApi.test.ts
+++ b/client/src/lib/invoiceDepositsApi.test.ts
@@ -1,0 +1,404 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  fetchDeposits,
+  createDeposit,
+  updateDeposit,
+  deleteDeposit,
+} from './invoiceDepositsApi.js';
+import type { InvoiceDeposit, CreateDepositRequest, UpdateDepositRequest } from '@cornerstone/shared';
+
+describe('invoiceDepositsApi', () => {
+  let mockFetch: jest.MockedFunction<typeof globalThis.fetch>;
+
+  beforeEach(() => {
+    mockFetch = jest.fn<typeof globalThis.fetch>();
+    globalThis.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ─── Fixtures ──────────────────────────────────────────────────────────────
+
+  const INVOICE_ID = 'inv-001';
+  const DEPOSIT_ID = 'dep-001';
+
+  const sampleDeposit: InvoiceDeposit = {
+    id: DEPOSIT_ID,
+    invoiceId: INVOICE_ID,
+    amount: 500,
+    dueDate: '2026-03-01',
+    paidDate: null,
+    claimedDate: null,
+    description: 'Initial deposit',
+    status: 'pending',
+    createdBy: null,
+    createdAt: '2026-01-15T10:00:00.000Z',
+    updatedAt: '2026-01-15T10:00:00.000Z',
+  };
+
+  // ─── fetchDeposits ────────────────────────────────────────────────────────
+
+  describe('fetchDeposits', () => {
+    it('sends GET request to /api/invoices/:invoiceId/deposits', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposits: [] }),
+      } as Response);
+
+      await fetchDeposits(INVOICE_ID);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/invoices/${INVOICE_ID}/deposits`,
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('returns the deposits array from the response envelope', async () => {
+      const deposits = [sampleDeposit, { ...sampleDeposit, id: 'dep-002', amount: 200 }];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposits }),
+      } as Response);
+
+      const result = await fetchDeposits(INVOICE_ID);
+
+      expect(result).toEqual({ deposits });
+      expect(result.deposits).toHaveLength(2);
+      expect(result.deposits[0]!.id).toBe(DEPOSIT_ID);
+    });
+
+    it('returns empty array when no deposits exist', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposits: [] }),
+      } as Response);
+
+      const result = await fetchDeposits(INVOICE_ID);
+
+      expect(result.deposits).toEqual([]);
+    });
+
+    it('uses the correct invoiceId in the URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposits: [] }),
+      } as Response);
+
+      await fetchDeposits('my-invoice-999');
+
+      expect(mockFetch.mock.calls[0]![0]).toBe('/api/invoices/my-invoice-999/deposits');
+    });
+
+    it('propagates API errors as thrown exceptions', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } }),
+      } as Response);
+
+      await expect(fetchDeposits(INVOICE_ID)).rejects.toThrow();
+    });
+
+    it('propagates 404 NOT_FOUND error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { code: 'NOT_FOUND', message: 'Invoice not found' } }),
+      } as Response);
+
+      await expect(fetchDeposits('nonexistent-invoice')).rejects.toThrow();
+    });
+  });
+
+  // ─── createDeposit ────────────────────────────────────────────────────────
+
+  describe('createDeposit', () => {
+    const createPayload: CreateDepositRequest = {
+      amount: 500,
+      dueDate: '2026-03-01',
+      status: 'pending',
+      description: 'Initial deposit',
+    };
+
+    it('sends POST request to /api/invoices/:invoiceId/deposits', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ deposit: sampleDeposit }),
+      } as Response);
+
+      await createDeposit(INVOICE_ID, createPayload);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/invoices/${INVOICE_ID}/deposits`,
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('sends the payload as JSON in the request body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ deposit: sampleDeposit }),
+      } as Response);
+
+      await createDeposit(INVOICE_ID, createPayload);
+
+      const call = mockFetch.mock.calls[0]!;
+      const init = call[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual(createPayload);
+    });
+
+    it('returns the created deposit wrapped in response envelope', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ deposit: sampleDeposit }),
+      } as Response);
+
+      const result = await createDeposit(INVOICE_ID, createPayload);
+
+      expect(result).toEqual({ deposit: sampleDeposit });
+      expect(result.deposit.id).toBe(DEPOSIT_ID);
+      expect(result.deposit.amount).toBe(500);
+    });
+
+    it('sends paidDate and claimedDate when provided', async () => {
+      const payloadWithDates: CreateDepositRequest = {
+        amount: 300,
+        dueDate: '2026-02-01',
+        status: 'claimed',
+        paidDate: '2026-02-10',
+        claimedDate: '2026-02-15',
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ deposit: { ...sampleDeposit, ...payloadWithDates } }),
+      } as Response);
+
+      await createDeposit(INVOICE_ID, payloadWithDates);
+
+      const call = mockFetch.mock.calls[0]!;
+      const init = call[1] as RequestInit;
+      const body = JSON.parse(init.body as string);
+      expect(body.paidDate).toBe('2026-02-10');
+      expect(body.claimedDate).toBe('2026-02-15');
+    });
+
+    it('propagates DEPOSITS_EXCEED_INVOICE_TOTAL error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 'DEPOSITS_EXCEED_INVOICE_TOTAL',
+            message: 'Deposits exceed invoice total',
+            details: { available: 40 },
+          },
+        }),
+      } as Response);
+
+      await expect(createDeposit(INVOICE_ID, createPayload)).rejects.toThrow();
+    });
+
+    it('propagates 401 UNAUTHORIZED error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
+      } as Response);
+
+      await expect(createDeposit(INVOICE_ID, createPayload)).rejects.toThrow();
+    });
+
+    it('propagates 404 NOT_FOUND when invoice does not exist', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { code: 'NOT_FOUND', message: 'Invoice not found' } }),
+      } as Response);
+
+      await expect(createDeposit('nonexistent', createPayload)).rejects.toThrow();
+    });
+  });
+
+  // ─── updateDeposit ────────────────────────────────────────────────────────
+
+  describe('updateDeposit', () => {
+    const updatePayload: UpdateDepositRequest = {
+      amount: 600,
+      status: 'paid',
+      paidDate: '2026-03-05',
+    };
+
+    it('sends PATCH request to /api/invoices/:invoiceId/deposits/:depositId', async () => {
+      const updated: InvoiceDeposit = { ...sampleDeposit, amount: 600, status: 'paid' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposit: updated }),
+      } as Response);
+
+      await updateDeposit(INVOICE_ID, DEPOSIT_ID, updatePayload);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/invoices/${INVOICE_ID}/deposits/${DEPOSIT_ID}`,
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+
+    it('sends the update payload as JSON in request body', async () => {
+      const updated: InvoiceDeposit = { ...sampleDeposit, ...updatePayload };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposit: updated }),
+      } as Response);
+
+      await updateDeposit(INVOICE_ID, DEPOSIT_ID, updatePayload);
+
+      const call = mockFetch.mock.calls[0]!;
+      const init = call[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual(updatePayload);
+    });
+
+    it('returns the updated deposit wrapped in response envelope', async () => {
+      const updated: InvoiceDeposit = {
+        ...sampleDeposit,
+        amount: 600,
+        status: 'paid',
+        paidDate: '2026-03-05',
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposit: updated }),
+      } as Response);
+
+      const result = await updateDeposit(INVOICE_ID, DEPOSIT_ID, updatePayload);
+
+      expect(result.deposit.amount).toBe(600);
+      expect(result.deposit.status).toBe('paid');
+      expect(result.deposit.paidDate).toBe('2026-03-05');
+    });
+
+    it('supports partial update (only status)', async () => {
+      const partialPayload: UpdateDepositRequest = { status: 'pending' };
+      const updated: InvoiceDeposit = { ...sampleDeposit, status: 'pending' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposit: updated }),
+      } as Response);
+
+      await updateDeposit(INVOICE_ID, DEPOSIT_ID, partialPayload);
+
+      const call = mockFetch.mock.calls[0]!;
+      const init = call[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({ status: 'pending' });
+    });
+
+    it('propagates INVALID_DEPOSIT_STATUS_TRANSITION error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 'INVALID_DEPOSIT_STATUS_TRANSITION',
+            message: 'Cannot transition from claimed to pending',
+            details: { from: 'claimed', to: 'pending' },
+          },
+        }),
+      } as Response);
+
+      await expect(
+        updateDeposit(INVOICE_ID, DEPOSIT_ID, { status: 'pending' }),
+      ).rejects.toThrow();
+    });
+
+    it('propagates 404 NOT_FOUND when deposit does not exist', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { code: 'NOT_FOUND', message: 'Deposit not found' } }),
+      } as Response);
+
+      await expect(
+        updateDeposit(INVOICE_ID, 'nonexistent-deposit', {}),
+      ).rejects.toThrow();
+    });
+
+    it('uses the correct invoiceId and depositId in the URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ deposit: sampleDeposit }),
+      } as Response);
+
+      await updateDeposit('inv-xyz', 'dep-abc', { amount: 100 });
+
+      expect(mockFetch.mock.calls[0]![0]).toBe('/api/invoices/inv-xyz/deposits/dep-abc');
+    });
+  });
+
+  // ─── deleteDeposit ────────────────────────────────────────────────────────
+
+  describe('deleteDeposit', () => {
+    it('sends DELETE request to /api/invoices/:invoiceId/deposits/:depositId', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        text: async () => '',
+      } as Response);
+
+      await deleteDeposit(INVOICE_ID, DEPOSIT_ID);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/invoices/${INVOICE_ID}/deposits/${DEPOSIT_ID}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('resolves without a return value on 204 response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        text: async () => '',
+      } as Response);
+
+      const result = await deleteDeposit(INVOICE_ID, DEPOSIT_ID);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('uses the correct invoiceId and depositId in the URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        text: async () => '',
+      } as Response);
+
+      await deleteDeposit('inv-xyz', 'dep-abc');
+
+      expect(mockFetch.mock.calls[0]![0]).toBe('/api/invoices/inv-xyz/deposits/dep-abc');
+    });
+
+    it('propagates 404 NOT_FOUND when deposit does not exist', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { code: 'NOT_FOUND', message: 'Deposit not found' } }),
+      } as Response);
+
+      await expect(deleteDeposit(INVOICE_ID, 'nonexistent')).rejects.toThrow();
+    });
+
+    it('propagates 401 UNAUTHORIZED error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
+      } as Response);
+
+      await expect(deleteDeposit(INVOICE_ID, DEPOSIT_ID)).rejects.toThrow();
+    });
+  });
+});

--- a/client/src/lib/invoiceDepositsApi.ts
+++ b/client/src/lib/invoiceDepositsApi.ts
@@ -1,0 +1,44 @@
+import { get, post, patch, del } from './apiClient.js';
+import type {
+  InvoiceDeposit,
+  CreateDepositRequest,
+  UpdateDepositRequest,
+} from '@cornerstone/shared';
+
+/**
+ * Fetches all deposits for a given invoice.
+ */
+export function fetchDeposits(invoiceId: string): Promise<{ deposits: InvoiceDeposit[] }> {
+  return get<{ deposits: InvoiceDeposit[] }>(`/invoices/${invoiceId}/deposits`);
+}
+
+/**
+ * Creates a new deposit for an invoice.
+ */
+export function createDeposit(
+  invoiceId: string,
+  data: CreateDepositRequest,
+): Promise<{ deposit: InvoiceDeposit }> {
+  return post<{ deposit: InvoiceDeposit }>(`/invoices/${invoiceId}/deposits`, data);
+}
+
+/**
+ * Updates an existing deposit.
+ */
+export function updateDeposit(
+  invoiceId: string,
+  depositId: string,
+  data: UpdateDepositRequest,
+): Promise<{ deposit: InvoiceDeposit }> {
+  return patch<{ deposit: InvoiceDeposit }>(
+    `/invoices/${invoiceId}/deposits/${depositId}`,
+    data,
+  );
+}
+
+/**
+ * Deletes a deposit.
+ */
+export function deleteDeposit(invoiceId: string, depositId: string): Promise<void> {
+  return del<void>(`/invoices/${invoiceId}/deposits/${depositId}`);
+}

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
@@ -156,7 +156,7 @@
   border: 1px solid var(--color-border-strong);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
-  z-index: 10;
+  z-index: var(--z-dropdown);
   min-width: 160px;
   overflow: hidden;
 }
@@ -404,11 +404,11 @@
 
 .warningBanner {
   background-color: var(--color-warning-bg);
-  border: 1px solid var(--color-warning-border);
+  border: 1px solid var(--color-warning);
   border-radius: var(--radius-md);
   padding: var(--spacing-3);
   margin-bottom: var(--spacing-3);
-  color: var(--color-warning-text);
+  color: var(--color-warning-text-on-light);
   font-size: var(--font-size-sm);
 }
 

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
@@ -1,0 +1,448 @@
+.depositsSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+/* ---- Section Header ---- */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.countChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  padding: var(--spacing-0-5) var(--spacing-1-5);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  min-width: 24px;
+}
+
+/* ---- Table ---- */
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.table thead {
+  background-color: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+.table th {
+  padding: var(--spacing-3);
+  text-align: left;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+.thPaidDate {
+  min-width: 120px;
+}
+
+.thClaimedDate {
+  min-width: 120px;
+}
+
+.thActions {
+  min-width: 120px;
+  text-align: center;
+}
+
+.tableRow {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tableRow:hover {
+  background-color: var(--color-bg-secondary);
+}
+
+.table tbody td {
+  padding: var(--spacing-3);
+  vertical-align: middle;
+}
+
+.tdPaidDate {
+  min-width: 120px;
+  color: var(--color-text-secondary);
+}
+
+.tdClaimedDate {
+  min-width: 120px;
+  color: var(--color-text-secondary);
+}
+
+.tdDescription {
+  color: var(--color-text-secondary);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tdActions {
+  text-align: center;
+}
+
+/* ---- Action Cell Menu ---- */
+
+.actionCell {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.menuButton {
+  background: none;
+  border: none;
+  padding: var(--spacing-2);
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-lg);
+  border-radius: var(--radius-md);
+  transition: var(--transition-button);
+}
+
+.menuButton:hover {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+.menuButton:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.menuButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  min-width: 160px;
+  overflow: hidden;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2-5) var(--spacing-3);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  transition: var(--transition-button);
+}
+
+.menuItem:hover {
+  background-color: var(--color-bg-secondary);
+}
+
+.menuItem:focus-visible {
+  outline: none;
+  background-color: var(--color-bg-secondary);
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+
+.menuItemDanger {
+  color: var(--color-danger-text-on-light);
+}
+
+.menuItemDanger:hover {
+  background-color: var(--color-danger-bg);
+}
+
+/* ---- Mobile Card List ---- */
+
+.mobileCardList {
+  display: none;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.mobileCard {
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.cardTopRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.cardAmount {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.cardFields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.cardField {
+  display: flex;
+  flex-direction: column;
+}
+
+.cardField dt {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
+.cardField dd {
+  color: var(--color-text-primary);
+  margin: var(--spacing-0-5) 0 0 0;
+}
+
+.cardActions {
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+}
+
+/* ---- Final Payment Row ---- */
+
+.finalPaymentRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3);
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.finalPaymentLabel {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.finalPaymentRight {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.finalPaymentAmount {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.finalPaymentAmountMuted {
+  color: var(--color-text-muted);
+  text-decoration: line-through;
+}
+
+/* ---- Status Badges (for deposits) ---- */
+
+.statusPending {
+  background-color: var(--color-status-not-started-bg);
+  color: var(--color-status-not-started-text);
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.statusPaid {
+  background-color: var(--color-success-badge-bg);
+  color: var(--color-success-badge-text);
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.statusClaimed {
+  background-color: var(--color-status-in-progress-bg);
+  color: var(--color-status-in-progress-text);
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.statusQuotation {
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-800);
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+/* ---- Modal Styles ---- */
+
+.modal {
+  max-width: 600px;
+}
+
+.modalActions {
+  display: flex;
+  gap: var(--spacing-2);
+  justify-content: flex-end;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.required {
+  color: var(--color-danger);
+}
+
+.charCounter {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+  margin-top: var(--spacing-1);
+}
+
+/* ---- Conditional Fields Animation ---- */
+
+.conditionalField {
+  overflow: hidden;
+  transition: max-height var(--transition-normal), opacity var(--transition-normal);
+  margin-bottom: var(--spacing-4);
+}
+
+.conditionalFieldHidden {
+  max-height: 0;
+  opacity: 0;
+}
+
+.conditionalFieldVisible {
+  max-height: 200px;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conditionalField {
+    transition: none;
+  }
+}
+
+/* ---- Delete Confirmation Styles ---- */
+
+.warningBanner {
+  background-color: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  color: var(--color-warning-text);
+  font-size: var(--font-size-sm);
+}
+
+.deleteConfirmText {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+/* ---- Responsive: Mobile ---- */
+
+@media (max-width: 767px) {
+  .tableWrapper {
+    display: none;
+  }
+
+  .mobileCardList {
+    display: flex;
+  }
+
+  .finalPaymentRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .finalPaymentRight {
+    justify-content: space-between;
+  }
+
+  .formRow {
+    grid-template-columns: 1fr;
+  }
+
+  .cardFields {
+    grid-template-columns: 1fr;
+  }
+}

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.test.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.test.tsx
@@ -1,0 +1,1042 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import type * as InvoiceDepositsApiTypes from '../../lib/invoiceDepositsApi.js';
+import type * as InvoiceDepositsSectionTypes from './InvoiceDepositsSection.js';
+import type { InvoiceDeposit } from '@cornerstone/shared';
+
+// ─── Module-scope mock functions ───────────────────────────────────────────────
+
+const mockCreateDeposit = jest.fn<typeof InvoiceDepositsApiTypes.createDeposit>();
+const mockUpdateDeposit = jest.fn<typeof InvoiceDepositsApiTypes.updateDeposit>();
+const mockDeleteDeposit = jest.fn<typeof InvoiceDepositsApiTypes.deleteDeposit>();
+const mockFetchDeposits = jest.fn<typeof InvoiceDepositsApiTypes.fetchDeposits>();
+
+// ─── Mock: invoiceDepositsApi ──────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../lib/invoiceDepositsApi.js', () => ({
+  fetchDeposits: mockFetchDeposits,
+  createDeposit: mockCreateDeposit,
+  updateDeposit: mockUpdateDeposit,
+  deleteDeposit: mockDeleteDeposit,
+}));
+
+// ─── Mock: apiClient (provides ApiClientError class) ──────────────────────────
+
+class MockApiClientError extends Error {
+  statusCode: number;
+  error: { code: string; message?: string; details?: unknown };
+  constructor(
+    statusCode: number,
+    error: { code: string; message?: string; details?: unknown },
+  ) {
+    super(error.message ?? 'API Error');
+    this.name = 'ApiClientError';
+    this.statusCode = statusCode;
+    this.error = error;
+  }
+}
+
+jest.unstable_mockModule('../../lib/apiClient.js', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+  put: jest.fn(),
+  setBaseUrl: jest.fn(),
+  getBaseUrl: jest.fn().mockReturnValue('/api'),
+  ApiClientError: MockApiClientError,
+  NetworkError: class MockNetworkError extends Error {},
+}));
+
+// ─── Mock: formatters ─────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../lib/formatters.js', () => ({
+  formatDate: (d: string | null | undefined) => d ?? '—',
+  formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+  formatTime: (d: string | null | undefined) => d ?? '—',
+  formatDateTime: (d: string | null | undefined) => d ?? '—',
+  formatRelativeTime: (d: string) => d,
+  formatPercent: (n: number) => `${n.toFixed(2)}%`,
+  computeActualDuration: () => null,
+  useFormatters: () => ({
+    formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatDate: (d: string | null | undefined) => d ?? '—',
+    formatTime: (d: string | null | undefined) => d ?? '—',
+    formatDateTime: (d: string | null | undefined) => d ?? '—',
+    formatPercent: (n: number) => `${n.toFixed(2)}%`,
+  }),
+}));
+
+// ─── Mock: errorTranslation ───────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../lib/errorTranslation.js', () => ({
+  translateApiError: (code: string) => `translated:${code}`,
+}));
+
+// ─── Mock: Modal ───────────────────────────────────────────────────────────────
+// Renders children and title inline so we can inspect them in tests
+
+jest.unstable_mockModule('../../components/Modal/Modal.js', () => ({
+  Modal: ({
+    title,
+    children,
+    footer,
+    onClose,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+    onClose: () => void;
+  }) => (
+    <div role="dialog" aria-label={title}>
+      <div data-testid="modal-title">{title}</div>
+      <div data-testid="modal-body">{children}</div>
+      {footer && <div data-testid="modal-footer">{footer}</div>}
+      <button data-testid="modal-close" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+// ─── Mock: EmptyState ─────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../components/EmptyState/EmptyState.js', () => ({
+  EmptyState: ({
+    message,
+    description,
+    action,
+  }: {
+    icon?: string;
+    message: string;
+    description?: string;
+    action?: { label: string; onClick: () => void };
+  }) => (
+    <div data-testid="empty-state">
+      <span data-testid="empty-state-message">{message}</span>
+      {description && <span data-testid="empty-state-description">{description}</span>}
+      {action && (
+        <button data-testid="empty-state-action" onClick={action.onClick}>
+          {action.label}
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+// ─── Mock: FormError ──────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../components/FormError/FormError.js', () => ({
+  FormError: ({ message }: { message: string }) => (
+    <div data-testid="form-error" role="alert">
+      {message}
+    </div>
+  ),
+}));
+
+// ─── Mock: Badge ──────────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../components/Badge/Badge.js', () => ({
+  Badge: ({
+    variants,
+    value,
+  }: {
+    variants: Record<string, { label: string; className?: string }>;
+    value: string;
+  }) => {
+    const variant = variants[value];
+    return <span data-testid={`badge-${value}`}>{variant?.label ?? value}</span>;
+  },
+}));
+
+// ─── Deferred import ─────────────────────────────────────────────────────────
+
+let InvoiceDepositsSection: (typeof InvoiceDepositsSectionTypes)['InvoiceDepositsSection'];
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const INVOICE_ID = 'inv-001';
+const INVOICE_TOTAL = 1000;
+
+function makeDeposit(
+  id: string,
+  overrides: Partial<InvoiceDeposit> = {},
+): InvoiceDeposit {
+  return {
+    id,
+    invoiceId: INVOICE_ID,
+    amount: 300,
+    dueDate: '2026-03-01',
+    paidDate: null,
+    claimedDate: null,
+    description: null,
+    status: 'pending',
+    createdBy: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderSection(
+  deposits: InvoiceDeposit[] = [],
+  opts: {
+    invoiceTotal?: number;
+    invoiceStatus?: 'pending' | 'paid' | 'claimed' | 'quotation';
+    finalPaymentAmount?: number;
+    onDepositMutated?: () => void;
+  } = {},
+) {
+  const onDepositMutated = opts.onDepositMutated ?? jest.fn();
+  const finalPaymentAmount =
+    opts.finalPaymentAmount ??
+    Math.max(0, (opts.invoiceTotal ?? INVOICE_TOTAL) - deposits.reduce((s, d) => s + d.amount, 0));
+
+  return render(
+    <InvoiceDepositsSection
+      invoiceId={INVOICE_ID}
+      invoiceTotal={opts.invoiceTotal ?? INVOICE_TOTAL}
+      invoiceStatus={opts.invoiceStatus ?? 'pending'}
+      deposits={deposits}
+      finalPaymentAmount={finalPaymentAmount}
+      onDepositMutated={onDepositMutated}
+    />,
+  );
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  const mod = await import('./InvoiceDepositsSection.js');
+  InvoiceDepositsSection = mod.InvoiceDepositsSection;
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('InvoiceDepositsSection', () => {
+  // ─── Scenario 1: empty state ───────────────────────────────────────────────
+
+  describe('Scenario 1: empty deposits array', () => {
+    it('renders EmptyState component when deposits = []', () => {
+      renderSection([]);
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    it('renders the "Add deposit" button in the header', () => {
+      renderSection([]);
+      // The primary "Add deposit" button exists in the section header
+      const buttons = screen.getAllByRole('button');
+      // At least one button with the add label exists
+      expect(buttons.some((b) => b.getAttribute('aria-label')?.includes('deposit'))).toBe(true);
+    });
+
+    it('does NOT render the Final Payment row when deposits = []', () => {
+      renderSection([]);
+      // Final payment row should not be present
+      expect(screen.queryByText(/final payment/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 2: deposit rows ──────────────────────────────────────────────
+
+  describe('Scenario 2: non-empty deposits', () => {
+    it('renders a table row for each deposit', () => {
+      const deposits = [
+        makeDeposit('dep-1', { amount: 300, dueDate: '2026-03-01' }),
+        makeDeposit('dep-2', { amount: 200, dueDate: '2026-04-01', status: 'paid' }),
+      ];
+      renderSection(deposits);
+
+      // Both amounts visible
+      expect(screen.getAllByText('$300.00')).not.toHaveLength(0);
+      expect(screen.getAllByText('$200.00')).not.toHaveLength(0);
+    });
+
+    it('renders the pending status badge for a pending deposit', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'pending' })];
+      renderSection(deposits);
+      expect(screen.getAllByTestId('badge-pending').length).toBeGreaterThan(0);
+    });
+
+    it('renders paid status badge for a paid deposit', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' })];
+      renderSection(deposits);
+      expect(screen.getAllByTestId('badge-paid').length).toBeGreaterThan(0);
+    });
+
+    it('renders claimed status badge for a claimed deposit', () => {
+      const deposits = [
+        makeDeposit('dep-1', {
+          status: 'claimed',
+          paidDate: '2026-03-10',
+          claimedDate: '2026-03-20',
+        }),
+      ];
+      renderSection(deposits);
+      expect(screen.getAllByTestId('badge-claimed').length).toBeGreaterThan(0);
+    });
+
+    it('renders em-dash for null paidDate', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'pending', paidDate: null })];
+      renderSection(deposits);
+      // null date is rendered as '—' by the mock formatter
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    });
+
+    it('renders em-dash for null claimedDate', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10', claimedDate: null })];
+      renderSection(deposits);
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Scenario 3: Final Payment row ────────────────────────────────────────
+
+  describe('Scenario 3: Final Payment row', () => {
+    it('renders Final Payment row when deposits.length > 0', () => {
+      const deposits = [makeDeposit('dep-1', { amount: 300 })];
+      renderSection(deposits, { finalPaymentAmount: 700 });
+      // Final payment amount should be visible
+      expect(screen.getByText('$700.00')).toBeInTheDocument();
+    });
+
+    it('shows the invoice status badge in the Final Payment row', () => {
+      const deposits = [makeDeposit('dep-1', { amount: 300 })];
+      renderSection(deposits, { invoiceStatus: 'paid', finalPaymentAmount: 700 });
+      // The invoice status badge appears in the final payment area
+      expect(screen.getAllByTestId('badge-paid').length).toBeGreaterThan(0);
+    });
+
+    it('renders finalPaymentAmount = 0 when deposits equal invoice total', () => {
+      const deposits = [makeDeposit('dep-1', { amount: 1000 })];
+      renderSection(deposits, { finalPaymentAmount: 0 });
+      expect(screen.getByText('$0.00')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 4: action menu — pending deposit ─────────────────────────────
+
+  describe('Scenario 4: action menu items per deposit status', () => {
+    it('pending deposit: shows "Mark paid" and "Edit" and "Delete" menu items', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'pending' })];
+      renderSection(deposits);
+
+      // Open the first overflow menu button (⋮)
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      // markPaid, edit, delete items should appear
+      const menuItems = screen.getAllByRole('menuitem');
+      const labels = menuItems.map((m) => m.textContent?.toLowerCase() ?? '');
+      expect(labels.some((l) => l.includes('paid'))).toBe(true);
+      expect(labels.some((l) => l.includes('edit'))).toBe(true);
+      expect(labels.some((l) => l.includes('delete'))).toBe(true);
+    });
+
+    it('pending deposit: does NOT show "Mark claimed" or revert items', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'pending' })];
+      renderSection(deposits);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const menuItems = screen.getAllByRole('menuitem');
+      const labels = menuItems.map((m) => m.textContent?.toLowerCase() ?? '');
+      expect(labels.some((l) => l.includes('claimed'))).toBe(false);
+      expect(labels.some((l) => l.includes('revert'))).toBe(false);
+    });
+
+    it('paid deposit: shows "Mark claimed", "Revert to pending", "Edit", "Delete"', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' })];
+      renderSection(deposits);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const menuItems = screen.getAllByRole('menuitem');
+      const labels = menuItems.map((m) => m.textContent?.toLowerCase() ?? '');
+      expect(labels.some((l) => l.includes('claimed'))).toBe(true);
+      expect(labels.some((l) => l.includes('pending'))).toBe(true);
+      expect(labels.some((l) => l.includes('edit'))).toBe(true);
+      expect(labels.some((l) => l.includes('delete'))).toBe(true);
+    });
+
+    it('paid deposit: does NOT show "Mark paid"', () => {
+      const deposits = [makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' })];
+      renderSection(deposits);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const menuItems = screen.getAllByRole('menuitem');
+      const labels = menuItems.map((m) => m.textContent?.toLowerCase() ?? '');
+      // Should not have a "mark paid" item (only claimed and revert-to-pending)
+      const paidItems = labels.filter((l) => l.includes('paid') && !l.includes('revert'));
+      expect(paidItems).toHaveLength(0);
+    });
+
+    it('claimed deposit: shows "Revert to paid", "Edit", "Delete"; no "Mark paid" or "Mark claimed"', () => {
+      const deposits = [
+        makeDeposit('dep-1', {
+          status: 'claimed',
+          paidDate: '2026-03-10',
+          claimedDate: '2026-03-20',
+        }),
+      ];
+      renderSection(deposits);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const menuItems = screen.getAllByRole('menuitem');
+      const labels = menuItems.map((m) => m.textContent?.toLowerCase() ?? '');
+      expect(labels.some((l) => l.includes('revert') && l.includes('paid'))).toBe(true);
+      expect(labels.some((l) => l.includes('edit'))).toBe(true);
+      expect(labels.some((l) => l.includes('delete'))).toBe(true);
+      // No mark paid or mark claimed
+      expect(labels.some((l) => l.includes('mark'))).toBe(false);
+    });
+  });
+
+  // ─── Scenario 5: Add deposit modal ────────────────────────────────────────
+
+  describe('Scenario 5: Add deposit modal', () => {
+    it('opens Add modal when "Add deposit" header button is clicked', () => {
+      renderSection([]);
+
+      // Header button (aria-label includes "deposit")
+      const addBtn = screen.getAllByRole('button').find(
+        (b) => b.getAttribute('aria-label')?.includes('deposit') ?? b.textContent?.includes('deposit'),
+      )!;
+      fireEvent.click(addBtn);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('modal shows amount and dueDate inputs', () => {
+      renderSection([]);
+      // Open via empty-state action button
+      const actionBtn = screen.getByTestId('empty-state-action');
+      fireEvent.click(actionBtn);
+
+      expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+      // Due date field
+      expect(screen.getByLabelText(/due date/i)).toBeInTheDocument();
+    });
+
+    it('submit button disabled when amount is empty', () => {
+      renderSection([]);
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      // amount input is empty by default; save button should be disabled
+      const saveBtn = screen
+        .getByTestId('modal-footer')
+        .querySelector('button[type="submit"]')!;
+      expect(saveBtn).toBeDisabled();
+    });
+
+    it('form submit calls createDeposit with amount and dueDate', async () => {
+      mockCreateDeposit.mockResolvedValueOnce({
+        deposit: makeDeposit('new-dep'),
+      } as Awaited<ReturnType<typeof mockCreateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([], { onDepositMutated: onMutated });
+
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      // Fill amount
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '300' } });
+      // Fill dueDate
+      fireEvent.change(screen.getByLabelText(/due date/i), {
+        target: { value: '2026-03-01' },
+      });
+
+      // Submit
+      const form = screen.getByRole('dialog').querySelector('form')!;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      await waitFor(() => {
+        expect(mockCreateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          expect.objectContaining({ amount: 300, dueDate: '2026-03-01' }),
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+
+    it('calls onDepositMutated after successful create', async () => {
+      mockCreateDeposit.mockResolvedValueOnce({
+        deposit: makeDeposit('new-dep'),
+      } as Awaited<ReturnType<typeof mockCreateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([], { onDepositMutated: onMutated });
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '300' } });
+      fireEvent.change(screen.getByLabelText(/due date/i), { target: { value: '2026-03-01' } });
+
+      const form = screen.getByRole('dialog').querySelector('form')!;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      await waitFor(() => expect(onMutated).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  // ─── Scenario 6: DEPOSITS_EXCEED_INVOICE_TOTAL error ──────────────────────
+
+  describe('Scenario 6: DEPOSITS_EXCEED_INVOICE_TOTAL error', () => {
+    it('renders FormError with available headroom from error details', async () => {
+      mockCreateDeposit.mockRejectedValueOnce(
+        new MockApiClientError(400, {
+          code: 'DEPOSITS_EXCEED_INVOICE_TOTAL',
+          message: 'Deposits exceed invoice total',
+          details: { available: 40 },
+        }),
+      );
+
+      renderSection([], { invoiceTotal: 100 });
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '90' } });
+      fireEvent.change(screen.getByLabelText(/due date/i), { target: { value: '2026-03-01' } });
+
+      const form = screen.getByRole('dialog').querySelector('form')!;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── Scenario 7: Edit modal ────────────────────────────────────────────────
+
+  describe('Scenario 7: Edit modal', () => {
+    it('opens Edit modal from action menu and pre-populates form values', async () => {
+      const deposit = makeDeposit('dep-1', {
+        amount: 500,
+        dueDate: '2026-03-15',
+        status: 'pending',
+        description: 'My deposit',
+      });
+      renderSection([deposit]);
+
+      // Open menu, click Edit
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const editBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('edit'),
+      )!;
+      fireEvent.click(editBtn);
+
+      // Amount field should be pre-populated with 500
+      await waitFor(() => {
+        const amountInput = screen.getByLabelText(/amount/i) as HTMLInputElement;
+        expect(amountInput.value).toBe('500');
+      });
+    });
+
+    it('submit on edit modal calls updateDeposit', async () => {
+      const deposit = makeDeposit('dep-1', { amount: 500, dueDate: '2026-03-15' });
+      mockUpdateDeposit.mockResolvedValueOnce({
+        deposit: { ...deposit, amount: 600 },
+      } as Awaited<ReturnType<typeof mockUpdateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      // Open menu, click Edit
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+      const editBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('edit'),
+      )!;
+      fireEvent.click(editBtn);
+
+      // Change amount
+      await waitFor(() => screen.getByLabelText(/amount/i));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '600' } });
+
+      const form = screen.getByRole('dialog').querySelector('form')!;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          'dep-1',
+          expect.objectContaining({ amount: 600 }),
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 8: INVALID_DEPOSIT_STATUS_TRANSITION ─────────────────────────
+
+  describe('Scenario 8: INVALID_DEPOSIT_STATUS_TRANSITION error on edit', () => {
+    it('renders FormError with translated transition message', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending', amount: 300, dueDate: '2026-03-01' });
+      mockUpdateDeposit.mockRejectedValueOnce(
+        new MockApiClientError(400, {
+          code: 'INVALID_DEPOSIT_STATUS_TRANSITION',
+          message: 'Invalid transition',
+          details: { from: 'pending', to: 'claimed' },
+        }),
+      );
+
+      renderSection([deposit]);
+
+      // Open menu, click Edit
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+      const editBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('edit'),
+      )!;
+      fireEvent.click(editBtn);
+
+      await waitFor(() => screen.getByLabelText(/amount/i));
+
+      const form = screen.getByRole('dialog').querySelector('form')!;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── Scenario 9: conditional date fields ──────────────────────────────────
+
+  describe('Scenario 9: status change reveals/hides date fields', () => {
+    it('paidDate field hidden when status = pending (initial state)', () => {
+      renderSection([]);
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      // paidDate field exists in DOM but parent has hidden class
+      const paidDateInput = screen.queryByLabelText(/paid date/i);
+      if (paidDateInput) {
+        // Field is in DOM; check that its container has hidden class
+        const container = paidDateInput.closest('[class*="conditionalField"]');
+        expect(container?.className).toContain('Hidden');
+      }
+      // status should be 'pending' by default - paidDate shouldn't be required/visible
+    });
+
+    it('changing status to paid reveals paidDate field', () => {
+      renderSection([]);
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      const statusSelect = screen.getByLabelText(/status/i);
+      fireEvent.change(statusSelect, { target: { value: 'paid' } });
+
+      // After changing to paid, the paidDate container should have visible class
+      const paidDateInput = screen.getByLabelText(/paid date/i);
+      const container = paidDateInput.closest('[class*="conditionalField"]');
+      expect(container?.className).toContain('Visible');
+    });
+
+    it('changing status to claimed reveals both paidDate and claimedDate fields', () => {
+      renderSection([]);
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      const statusSelect = screen.getByLabelText(/status/i);
+      fireEvent.change(statusSelect, { target: { value: 'claimed' } });
+
+      const paidDateInput = screen.getByLabelText(/paid date/i);
+      const claimedDateInput = screen.getByLabelText(/claimed date/i);
+
+      const paidContainer = paidDateInput.closest('[class*="conditionalField"]');
+      const claimedContainer = claimedDateInput.closest('[class*="conditionalField"]');
+      expect(paidContainer?.className).toContain('Visible');
+      expect(claimedContainer?.className).toContain('Visible');
+    });
+
+    it('claimedDate field hidden when status = paid', () => {
+      renderSection([]);
+      fireEvent.click(screen.getByTestId('empty-state-action'));
+
+      const statusSelect = screen.getByLabelText(/status/i);
+      fireEvent.change(statusSelect, { target: { value: 'paid' } });
+
+      const claimedDateInput = screen.getByLabelText(/claimed date/i);
+      const container = claimedDateInput.closest('[class*="conditionalField"]');
+      expect(container?.className).toContain('Hidden');
+    });
+  });
+
+  // ─── Scenario 10: Mark paid / Mark claimed (StateConfirmModal) ────────────
+
+  describe('Scenario 10: "Mark paid" opens state confirm dialog', () => {
+    it('opens StateConfirmModal when "Mark paid" is clicked', () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const markPaidBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('paid'),
+      )!;
+      fireEvent.click(markPaidBtn);
+
+      // A dialog should appear
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      // Date input should appear for selecting paid date
+      expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    });
+
+    it('confirming Mark paid calls updateDeposit with status=paid and paidDate', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      mockUpdateDeposit.mockResolvedValueOnce({
+        deposit: { ...deposit, status: 'paid', paidDate: '2026-03-10' },
+      } as Awaited<ReturnType<typeof mockUpdateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      // Open menu, click Mark paid
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+      const markPaidBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('paid'),
+      )!;
+      fireEvent.click(markPaidBtn);
+
+      // Click the Confirm button in the state confirm modal
+      await waitFor(() => screen.getByRole('dialog'));
+      const confirmBtn = screen.getByTestId('modal-footer').querySelector('button:last-child')!;
+      await act(async () => {
+        fireEvent.click(confirmBtn);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          'dep-1',
+          expect.objectContaining({ status: 'paid' }),
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 11: "Mark claimed" ──────────────────────────────────────────
+
+  describe('Scenario 11: "Mark claimed" opens state confirm dialog', () => {
+    it('opens StateConfirmModal when "Mark claimed" is clicked from paid deposit', () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const markClaimedBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('claimed'),
+      )!;
+      fireEvent.click(markClaimedBtn);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('confirming Mark claimed calls updateDeposit with status=claimed', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      mockUpdateDeposit.mockResolvedValueOnce({
+        deposit: { ...deposit, status: 'claimed', claimedDate: '2026-03-20' },
+      } as Awaited<ReturnType<typeof mockUpdateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+      const markClaimedBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('claimed'),
+      )!;
+      fireEvent.click(markClaimedBtn);
+
+      await waitFor(() => screen.getByRole('dialog'));
+      const confirmBtn = screen.getByTestId('modal-footer').querySelector('button:last-child')!;
+      await act(async () => {
+        fireEvent.click(confirmBtn);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          'dep-1',
+          expect.objectContaining({ status: 'claimed' }),
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 12: "Revert to pending" (immediate) ─────────────────────────
+
+  describe('Scenario 12: "Revert to pending" fires immediately', () => {
+    it('calls updateDeposit with status=pending immediately (no dialog)', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      mockUpdateDeposit.mockResolvedValueOnce({
+        deposit: { ...deposit, status: 'pending', paidDate: null },
+      } as Awaited<ReturnType<typeof mockUpdateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      // Open menu, click Revert to pending
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const revertBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('pending'),
+      )!;
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          'dep-1',
+          { status: 'pending' },
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 13: "Revert to paid" (immediate, claimed→paid) ─────────────
+
+  describe('Scenario 13: "Revert to paid" fires immediately', () => {
+    it('calls updateDeposit with status=paid immediately when revert from claimed', async () => {
+      const deposit = makeDeposit('dep-1', {
+        status: 'claimed',
+        paidDate: '2026-03-10',
+        claimedDate: '2026-03-20',
+      });
+      mockUpdateDeposit.mockResolvedValueOnce({
+        deposit: { ...deposit, status: 'paid', claimedDate: null },
+      } as Awaited<ReturnType<typeof mockUpdateDeposit>>);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const revertBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('revert') && m.textContent?.toLowerCase().includes('paid'),
+      )!;
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateDeposit).toHaveBeenCalledWith(
+          INVOICE_ID,
+          'dep-1',
+          { status: 'paid' },
+        );
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 14: Delete modal for pending deposit ─────────────────────────
+
+  describe('Scenario 14: Delete modal', () => {
+    it('opens delete confirmation modal from menu', () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const deleteBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('delete'),
+      )!;
+      fireEvent.click(deleteBtn);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('pending deposit delete modal: NO warning banner', () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const deleteBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('delete'),
+      )!;
+      fireEvent.click(deleteBtn);
+
+      // Warning banner should not be present for pending
+      const warningBanners = document.querySelectorAll('[class*="warningBanner"]');
+      expect(warningBanners).toHaveLength(0);
+    });
+
+    it('paid deposit delete modal: shows warning banner', () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const deleteBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('delete'),
+      )!;
+      fireEvent.click(deleteBtn);
+
+      const warningBanners = document.querySelectorAll('[class*="warningBanner"]');
+      expect(warningBanners.length).toBeGreaterThan(0);
+    });
+
+    it('claimed deposit delete modal: shows warning banner', () => {
+      const deposit = makeDeposit('dep-1', {
+        status: 'claimed',
+        paidDate: '2026-03-10',
+        claimedDate: '2026-03-20',
+      });
+      renderSection([deposit]);
+
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+
+      const deleteBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('delete'),
+      )!;
+      fireEvent.click(deleteBtn);
+
+      const warningBanners = document.querySelectorAll('[class*="warningBanner"]');
+      expect(warningBanners.length).toBeGreaterThan(0);
+    });
+
+    it('confirming delete calls deleteDeposit then onDepositMutated', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      mockDeleteDeposit.mockResolvedValueOnce(undefined);
+
+      const onMutated = jest.fn();
+      renderSection([deposit], { onDepositMutated: onMutated });
+
+      // Open menu → delete
+      const menuBtn = screen.getAllByRole('button').find(
+        (b) => b.textContent?.includes('⋮'),
+      )!;
+      fireEvent.click(menuBtn);
+      const deleteMenuBtn = screen.getAllByRole('menuitem').find(
+        (m) => m.textContent?.toLowerCase().includes('delete'),
+      )!;
+      fireEvent.click(deleteMenuBtn);
+
+      // Confirm in delete modal
+      await waitFor(() => screen.getByRole('dialog'));
+      // Click the confirm/delete button (last button in modal footer)
+      const confirmDeleteBtn = screen.getByTestId('modal-footer').querySelector('button:last-child')!;
+      await act(async () => {
+        fireEvent.click(confirmDeleteBtn);
+      });
+
+      await waitFor(() => {
+        expect(mockDeleteDeposit).toHaveBeenCalledWith(INVOICE_ID, 'dep-1');
+      });
+      expect(onMutated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 15: i18n — no hardcoded text ────────────────────────────────
+
+  describe('Scenario 15: i18n — all strings use t()', () => {
+    it('section title is rendered via translation key (not hardcoded English)', () => {
+      // If the component uses t(), JSDOM renders it; we can verify it's not just empty
+      renderSection([]);
+      // The section should render with the translated section title via i18next
+      // In jsdom, i18next returns the key itself. The section uses 'budget:invoiceDetail.deposits.sectionTitle'
+      // The heading should be present and non-empty.
+      const heading = screen.getByRole('heading');
+      expect(heading).toBeInTheDocument();
+      expect(heading.textContent?.trim().length).toBeGreaterThan(0);
+    });
+
+    it('renders the deposits section landmark with correct aria-labelledby', () => {
+      renderSection([]);
+      const section = document.querySelector('[aria-labelledby="deposits-title"]');
+      expect(section).toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 16: count chip ──────────────────────────────────────────────
+
+  describe('Scenario 16: count chip', () => {
+    it('shows count chip with deposit count when deposits.length > 0', () => {
+      const deposits = [makeDeposit('dep-1'), makeDeposit('dep-2')];
+      renderSection(deposits);
+      // Count chip contains the number 2
+      const chip = document.querySelector('[aria-label*="2"]');
+      expect(chip).toBeInTheDocument();
+    });
+
+    it('does NOT show count chip when deposits = []', () => {
+      renderSection([]);
+      // No aria-label containing a count should exist for the heading
+      const chips = document.querySelectorAll('[class*="countChip"]');
+      expect(chips).toHaveLength(0);
+    });
+  });
+});

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
@@ -1,0 +1,1348 @@
+import { useState, useRef, useEffect, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import type {
+  InvoiceDeposit,
+  InvoiceDepositStatus,
+  InvoiceStatus,
+} from '@cornerstone/shared';
+import {
+  createDeposit,
+  updateDeposit,
+  deleteDeposit,
+} from '../../lib/invoiceDepositsApi.js';
+import { ApiClientError } from '../../lib/apiClient.js';
+import { useFormatters } from '../../lib/formatters.js';
+import { translateApiError } from '../../lib/errorTranslation.js';
+import { Badge, type BadgeVariantMap } from '../../components/Badge/Badge.js';
+import { Modal } from '../../components/Modal/Modal.js';
+import { EmptyState } from '../../components/EmptyState/EmptyState.js';
+import { FormError } from '../../components/FormError/FormError.js';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './InvoiceDepositsSection.module.css';
+
+interface InvoiceDepositsSectionProps {
+  invoiceId: string;
+  invoiceTotal: number;
+  invoiceStatus: InvoiceStatus;
+  deposits: InvoiceDeposit[];
+  finalPaymentAmount: number;
+  onDepositMutated: () => void;
+}
+
+interface DepositFormState {
+  amount: string;
+  dueDate: string;
+  status: InvoiceDepositStatus;
+  paidDate: string;
+  claimedDate: string;
+  description: string;
+}
+
+type ModalMode = 'add' | 'edit' | 'delete' | null;
+type StateConfirmAction = 'mark-paid' | 'mark-claimed';
+
+interface StateConfirmState {
+  deposit: InvoiceDeposit;
+  action: StateConfirmAction;
+}
+
+const emptyForm = (): DepositFormState => ({
+  amount: '',
+  dueDate: '',
+  status: 'pending',
+  paidDate: new Date().toISOString().slice(0, 10),
+  claimedDate: new Date().toISOString().slice(0, 10),
+  description: '',
+});
+
+export function InvoiceDepositsSection({
+  invoiceId,
+  invoiceTotal,
+  invoiceStatus,
+  deposits,
+  finalPaymentAmount,
+  onDepositMutated,
+}: InvoiceDepositsSectionProps) {
+  const { formatCurrency, formatDate } = useFormatters();
+  const { t } = useTranslation('budget');
+
+  // Modal states
+  const [modalMode, setModalMode] = useState<ModalMode>(null);
+  const [selectedDeposit, setSelectedDeposit] = useState<InvoiceDeposit | null>(null);
+  const [isMutating, setIsMutating] = useState(false);
+  const [mutatingDepositId, setMutatingDepositId] = useState<string | null>(null);
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [stateConfirmDeposit, setStateConfirmDeposit] = useState<StateConfirmState | null>(null);
+
+  // Form state
+  const [depositForm, setDepositForm] = useState<DepositFormState>(emptyForm());
+  const [formError, setFormError] = useState<string>('');
+
+  // Focus management
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  const invoiceStatusVariants: BadgeVariantMap = {
+    pending: {
+      label: t('invoiceDetail.statusLabels.pending'),
+      className: styles.statusPending,
+    },
+    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    claimed: {
+      label: t('invoiceDetail.statusLabels.claimed'),
+      className: styles.statusClaimed,
+    },
+    quotation: {
+      label: t('invoiceDetail.statusLabels.quotation'),
+      className: styles.statusQuotation,
+    },
+  };
+
+  const openAddModal = () => {
+    setSelectedDeposit(null);
+    setDepositForm(emptyForm());
+    setFormError('');
+    setModalMode('add');
+  };
+
+  const openEditModal = (deposit: InvoiceDeposit) => {
+    setSelectedDeposit(deposit);
+    setDepositForm({
+      amount: deposit.amount.toString(),
+      dueDate: deposit.dueDate.slice(0, 10),
+      status: deposit.status,
+      paidDate: deposit.paidDate ? deposit.paidDate.slice(0, 10) : '',
+      claimedDate: deposit.claimedDate ? deposit.claimedDate.slice(0, 10) : '',
+      description: deposit.description ?? '',
+    });
+    setFormError('');
+    setModalMode('edit');
+    setMenuOpenId(null);
+  };
+
+  const openDeleteModal = (deposit: InvoiceDeposit) => {
+    setSelectedDeposit(deposit);
+    setFormError('');
+    setModalMode('delete');
+    setMenuOpenId(null);
+  };
+
+  const openStateConfirm = (deposit: InvoiceDeposit, action: StateConfirmAction) => {
+    setStateConfirmDeposit({ deposit, action });
+    setMenuOpenId(null);
+  };
+
+  const closeModal = () => {
+    if (!isMutating) {
+      setModalMode(null);
+      setSelectedDeposit(null);
+      setDepositForm(emptyForm());
+      setFormError('');
+      setStateConfirmDeposit(null);
+    }
+  };
+
+  const handleFormSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    const amount = parseFloat(depositForm.amount);
+    if (isNaN(amount) || amount <= 0) {
+      setFormError(t('common:validation.amountRequired'));
+      return;
+    }
+
+    if (!depositForm.dueDate) {
+      setFormError(t('common:validation.dateRequired'));
+      return;
+    }
+
+    // Validate conditional dates
+    if (depositForm.status !== 'pending' && !depositForm.paidDate) {
+      setFormError(t('common:validation.dateRequired'));
+      return;
+    }
+
+    if (depositForm.status === 'claimed' && !depositForm.claimedDate) {
+      setFormError(t('common:validation.dateRequired'));
+      return;
+    }
+
+    setIsMutating(true);
+    setFormError('');
+
+    try {
+      if (modalMode === 'add') {
+        const payload = {
+          amount,
+          dueDate: depositForm.dueDate,
+          status: depositForm.status as InvoiceDepositStatus,
+          description: depositForm.description.trim() || null,
+          paidDate: depositForm.paidDate || null,
+          claimedDate: depositForm.claimedDate || null,
+        };
+        await createDeposit(invoiceId, payload);
+      } else if (modalMode === 'edit' && selectedDeposit) {
+        const payload = {
+          amount,
+          dueDate: depositForm.dueDate,
+          status: depositForm.status as InvoiceDepositStatus,
+          description: depositForm.description.trim() || null,
+          paidDate: depositForm.paidDate || null,
+          claimedDate: depositForm.claimedDate || null,
+        };
+        await updateDeposit(invoiceId, selectedDeposit.id, payload);
+      }
+
+      closeModal();
+      onDepositMutated();
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        const code = err.error.code;
+        if (code === 'DEPOSITS_EXCEED_INVOICE_TOTAL') {
+          const available = (err.error.details as { available?: number })?.available ?? 0;
+          setFormError(
+            t('budget:invoiceDetail.deposits.errors.exceedsTotal', {
+              available: formatCurrency(available),
+            }),
+          );
+        } else if (code === 'INVALID_DEPOSIT_STATUS_TRANSITION') {
+          const details = err.error.details as { from?: string; to?: string };
+          setFormError(
+            t('budget:invoiceDetail.deposits.errors.invalidTransition', {
+              from: details.from || depositForm.status,
+              to: details.to || selectedDeposit?.status,
+            }),
+          );
+        } else if (code === 'INVALID_DEPOSIT_DATE_FOR_STATUS') {
+          setFormError(t('budget:invoiceDetail.deposits.errors.invalidDate'));
+        } else {
+          setFormError(translateApiError(err.error.code));
+        }
+      } else {
+        setFormError(
+          modalMode === 'add'
+            ? t('budget:invoiceDetail.deposits.errors.saveError')
+            : t('budget:invoiceDetail.deposits.errors.saveError'),
+        );
+      }
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!selectedDeposit) return;
+
+    setIsMutating(true);
+    setFormError('');
+
+    try {
+      await deleteDeposit(invoiceId, selectedDeposit.id);
+      closeModal();
+      onDepositMutated();
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setFormError(translateApiError(err.error.code));
+      } else {
+        setFormError(t('budget:invoiceDetail.deposits.errors.deleteError'));
+      }
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleRevertToPending = async (deposit: InvoiceDeposit) => {
+    setMutatingDepositId(deposit.id);
+    try {
+      await updateDeposit(invoiceId, deposit.id, { status: 'pending' });
+      onDepositMutated();
+    } catch (err) {
+      // Silently fail and just clear the opacity
+    } finally {
+      setMutatingDepositId(null);
+    }
+  };
+
+  const handleRevertToPaid = async (deposit: InvoiceDeposit) => {
+    setMutatingDepositId(deposit.id);
+    try {
+      await updateDeposit(invoiceId, deposit.id, { status: 'paid' });
+      onDepositMutated();
+    } catch (err) {
+      // Silently fail and just clear the opacity
+    } finally {
+      setMutatingDepositId(null);
+    }
+  };
+
+  const handleStateConfirm = async (date: string) => {
+    if (!stateConfirmDeposit) return;
+
+    const { deposit, action } = stateConfirmDeposit;
+    setMutatingDepositId(deposit.id);
+
+    try {
+      if (action === 'mark-paid') {
+        await updateDeposit(invoiceId, deposit.id, {
+          status: 'paid',
+          paidDate: date,
+        });
+      } else {
+        await updateDeposit(invoiceId, deposit.id, {
+          status: 'claimed',
+          claimedDate: date,
+        });
+      }
+
+      setStateConfirmDeposit(null);
+      onDepositMutated();
+    } catch (err) {
+      // Could show error, but for now just fail silently
+    } finally {
+      setMutatingDepositId(null);
+    }
+  };
+
+  return (
+    <section aria-labelledby="deposits-title" className={styles.depositsSection}>
+      <div className={styles.sectionHeader}>
+        <h2 id="deposits-title" className={styles.sectionTitle}>
+          {t('budget:invoiceDetail.deposits.sectionTitle')}
+          {deposits.length > 0 && (
+            <span
+              className={styles.countChip}
+              aria-label={t('budget:invoiceDetail.deposits.countChip', {
+                count: deposits.length,
+              })}
+            >
+              {deposits.length}
+            </span>
+          )}
+        </h2>
+        <button
+          ref={addButtonRef}
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={openAddModal}
+          disabled={isMutating}
+          aria-label={t('budget:invoiceDetail.deposits.addButton')}
+        >
+          {t('budget:invoiceDetail.deposits.addButton')}
+        </button>
+      </div>
+
+      {deposits.length === 0 && (
+        <EmptyState
+          icon="💳"
+          message={t('budget:invoiceDetail.deposits.empty.message')}
+          description={t('budget:invoiceDetail.deposits.empty.description')}
+          action={{
+            label: t('budget:invoiceDetail.deposits.addButton'),
+            onClick: openAddModal,
+          }}
+        />
+      )}
+
+      {deposits.length > 0 && (
+        <>
+          {/* Desktop/tablet table (hidden on mobile) */}
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>{t('budget:invoiceDetail.deposits.columns.dueDate')}</th>
+                  <th>{t('budget:invoiceDetail.deposits.columns.amount')}</th>
+                  <th>{t('budget:invoiceDetail.deposits.columns.status')}</th>
+                  <th className={styles.thPaidDate}>
+                    {t('budget:invoiceDetail.deposits.columns.paidDate')}
+                  </th>
+                  <th className={styles.thClaimedDate}>
+                    {t('budget:invoiceDetail.deposits.columns.claimedDate')}
+                  </th>
+                  <th>{t('budget:invoiceDetail.deposits.columns.description')}</th>
+                  <th className={styles.thActions}>{t('budget:invoiceDetail.deposits.columns.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {deposits.map((deposit) => (
+                  <DepositRow
+                    key={deposit.id}
+                    deposit={deposit}
+                    menuOpenId={menuOpenId}
+                    mutatingDepositId={mutatingDepositId}
+                    onMenuToggle={setMenuOpenId}
+                    onEdit={openEditModal}
+                    onDelete={openDeleteModal}
+                    onMarkPaid={() => openStateConfirm(deposit, 'mark-paid')}
+                    onMarkClaimed={() => openStateConfirm(deposit, 'mark-claimed')}
+                    onRevertToPending={handleRevertToPending}
+                    onRevertToPaid={handleRevertToPaid}
+                    t={t}
+                    formatCurrency={formatCurrency}
+                    formatDate={formatDate}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile card list */}
+          <div className={styles.mobileCardList} role="list">
+            {deposits.map((deposit) => (
+              <DepositCard
+                key={deposit.id}
+                deposit={deposit}
+                menuOpenId={menuOpenId}
+                mutatingDepositId={mutatingDepositId}
+                onMenuToggle={setMenuOpenId}
+                onEdit={openEditModal}
+                onDelete={openDeleteModal}
+                onMarkPaid={() => openStateConfirm(deposit, 'mark-paid')}
+                onMarkClaimed={() => openStateConfirm(deposit, 'mark-claimed')}
+                onRevertToPending={handleRevertToPending}
+                onRevertToPaid={handleRevertToPaid}
+                t={t}
+                formatCurrency={formatCurrency}
+                formatDate={formatDate}
+              />
+            ))}
+          </div>
+
+          {/* Final Payment row */}
+          <div className={styles.finalPaymentRow}>
+            <span className={styles.finalPaymentLabel}>
+              {t('budget:invoiceDetail.deposits.finalPayment')}
+            </span>
+            <div className={styles.finalPaymentRight}>
+              <Badge variants={invoiceStatusVariants} value={invoiceStatus} />
+              <span
+                className={`${styles.finalPaymentAmount} ${finalPaymentAmount === 0 ? styles.finalPaymentAmountMuted : ''}`}
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                {formatCurrency(finalPaymentAmount)}
+              </span>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Add/Edit modal */}
+      {(modalMode === 'add' || modalMode === 'edit') && (
+        <AddEditDepositModal
+          mode={modalMode}
+          form={depositForm}
+          onFormChange={setDepositForm}
+          onSubmit={handleFormSubmit}
+          onClose={closeModal}
+          error={formError}
+          isMutating={isMutating}
+          t={t}
+          formatCurrency={formatCurrency}
+        />
+      )}
+
+      {/* Delete modal */}
+      {modalMode === 'delete' && selectedDeposit && (
+        <DeleteDepositModal
+          deposit={selectedDeposit}
+          onConfirm={handleDeleteConfirm}
+          onClose={closeModal}
+          error={formError}
+          isMutating={isMutating}
+          t={t}
+        />
+      )}
+
+      {/* State confirm modal */}
+      {stateConfirmDeposit && (
+        <StateConfirmModal
+          deposit={stateConfirmDeposit.deposit}
+          action={stateConfirmDeposit.action}
+          onConfirm={handleStateConfirm}
+          onClose={() => setStateConfirmDeposit(null)}
+          isMutating={mutatingDepositId === stateConfirmDeposit.deposit.id}
+          t={t}
+        />
+      )}
+    </section>
+  );
+}
+
+// ============================================================================
+// Sub-component: DepositRow (table row)
+// ============================================================================
+
+interface DepositRowProps {
+  deposit: InvoiceDeposit;
+  menuOpenId: string | null;
+  mutatingDepositId: string | null;
+  onMenuToggle: (id: string | null) => void;
+  onEdit: (deposit: InvoiceDeposit) => void;
+  onDelete: (deposit: InvoiceDeposit) => void;
+  onMarkPaid: () => void;
+  onMarkClaimed: () => void;
+  onRevertToPending: (deposit: InvoiceDeposit) => void;
+  onRevertToPaid: (deposit: InvoiceDeposit) => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  formatCurrency: (amount: number) => string;
+  formatDate: (date: string) => string;
+}
+
+function DepositRow({
+  deposit,
+  menuOpenId,
+  mutatingDepositId,
+  onMenuToggle,
+  onEdit,
+  onDelete,
+  onMarkPaid,
+  onMarkClaimed,
+  onRevertToPending,
+  onRevertToPaid,
+  t,
+  formatCurrency,
+  formatDate,
+}: DepositRowProps) {
+  const isMenuOpen = menuOpenId === deposit.id;
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const statusVariants: BadgeVariantMap = {
+    pending: {
+      label: t('invoiceDetail.statusLabels.pending'),
+      className: styles.statusPending,
+    },
+    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    claimed: {
+      label: t('invoiceDetail.statusLabels.claimed'),
+      className: styles.statusClaimed,
+    },
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
+    if (!menuItems || menuItems.length === 0) return;
+
+    const currentIndex = Array.from(menuItems).findIndex((item) => item === document.activeElement);
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault();
+        const nextIndex = currentIndex === menuItems.length - 1 ? 0 : currentIndex + 1;
+        (menuItems[nextIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        const prevIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
+        (menuItems[prevIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Home': {
+        e.preventDefault();
+        (menuItems[0] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'End': {
+        e.preventDefault();
+        (menuItems[menuItems.length - 1] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Escape': {
+        e.preventDefault();
+        onMenuToggle(null);
+        menuTriggerRef.current?.focus();
+        break;
+      }
+    }
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' && !isMenuOpen) {
+      e.preventDefault();
+      onMenuToggle(deposit.id);
+      setTimeout(() => {
+        const firstMenuItem = menuRef.current?.querySelector('[role="menuitem"]') as HTMLButtonElement;
+        firstMenuItem?.focus();
+      }, 0);
+    }
+  };
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      const firstMenuItem = menuRef.current?.querySelector('[role="menuitem"]') as HTMLButtonElement;
+      firstMenuItem?.focus();
+    }
+  }, [isMenuOpen]);
+
+  return (
+    <tr
+      className={styles.tableRow}
+      style={{
+        opacity: mutatingDepositId === deposit.id ? 0.6 : 1,
+        transition: `opacity var(--transition-fast)`,
+      }}
+    >
+      <td>{formatDate(deposit.dueDate)}</td>
+      <td>{formatCurrency(deposit.amount)}</td>
+      <td>
+        <Badge variants={statusVariants} value={deposit.status} />
+      </td>
+      <td className={styles.tdPaidDate}>{deposit.paidDate ? formatDate(deposit.paidDate) : '—'}</td>
+      <td className={styles.tdClaimedDate}>
+        {deposit.claimedDate ? formatDate(deposit.claimedDate) : '—'}
+      </td>
+      <td className={styles.tdDescription}>{deposit.description ?? '—'}</td>
+      <td className={styles.tdActions}>
+        <div className={styles.actionCell}>
+          <button
+            ref={menuTriggerRef}
+            type="button"
+            className={styles.menuButton}
+            onClick={() => onMenuToggle(isMenuOpen ? null : deposit.id)}
+            onKeyDown={handleTriggerKeyDown}
+            aria-haspopup="true"
+            aria-expanded={isMenuOpen}
+            aria-label={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
+              description: deposit.description ?? 'deposit',
+            })}
+          >
+            ⋮
+          </button>
+          {isMenuOpen && (
+            <div ref={menuRef} className={styles.menu} role="menu" onKeyDown={handleMenuKeyDown}>
+              {deposit.status === 'pending' && (
+                <>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onMarkPaid();
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.markPaid')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onEdit(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.edit')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onDelete(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.delete')}
+                  </button>
+                </>
+              )}
+              {deposit.status === 'paid' && (
+                <>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onMarkClaimed();
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.markClaimed')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onRevertToPending(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.revertToPending')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onEdit(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.edit')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onDelete(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.delete')}
+                  </button>
+                </>
+              )}
+              {deposit.status === 'claimed' && (
+                <>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onRevertToPaid(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.revertToPaid')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onEdit(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.edit')}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                    onClick={() => {
+                      onMenuToggle(null);
+                      onDelete(deposit);
+                    }}
+                  >
+                    {t('budget:invoiceDetail.deposits.menu.delete')}
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ============================================================================
+// Sub-component: DepositCard (mobile)
+// ============================================================================
+
+interface DepositCardProps
+  extends Omit<DepositRowProps, 'menuOpenId' | 'mutatingDepositId' | 'onMenuToggle'> {
+  menuOpenId: string | null;
+  mutatingDepositId: string | null;
+  onMenuToggle: (id: string | null) => void;
+}
+
+function DepositCard({
+  deposit,
+  menuOpenId,
+  mutatingDepositId,
+  onMenuToggle,
+  onEdit,
+  onDelete,
+  onMarkPaid,
+  onMarkClaimed,
+  onRevertToPending,
+  onRevertToPaid,
+  t,
+  formatCurrency,
+  formatDate,
+}: DepositCardProps) {
+  const isMenuOpen = menuOpenId === deposit.id;
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const statusVariants: BadgeVariantMap = {
+    pending: {
+      label: t('invoiceDetail.statusLabels.pending'),
+      className: styles.statusPending,
+    },
+    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    claimed: {
+      label: t('invoiceDetail.statusLabels.claimed'),
+      className: styles.statusClaimed,
+    },
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
+    if (!menuItems || menuItems.length === 0) return;
+
+    const currentIndex = Array.from(menuItems).findIndex((item) => item === document.activeElement);
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault();
+        const nextIndex = currentIndex === menuItems.length - 1 ? 0 : currentIndex + 1;
+        (menuItems[nextIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        const prevIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
+        (menuItems[prevIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Home': {
+        e.preventDefault();
+        (menuItems[0] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'End': {
+        e.preventDefault();
+        (menuItems[menuItems.length - 1] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Escape': {
+        e.preventDefault();
+        onMenuToggle(null);
+        menuTriggerRef.current?.focus();
+        break;
+      }
+    }
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' && !isMenuOpen) {
+      e.preventDefault();
+      onMenuToggle(deposit.id);
+      setTimeout(() => {
+        const firstMenuItem = menuRef.current?.querySelector('[role="menuitem"]') as HTMLButtonElement;
+        firstMenuItem?.focus();
+      }, 0);
+    }
+  };
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      const firstMenuItem = menuRef.current?.querySelector('[role="menuitem"]') as HTMLButtonElement;
+      firstMenuItem?.focus();
+    }
+  }, [isMenuOpen]);
+
+  return (
+    <div className={styles.mobileCard}>
+      <div className={styles.cardTopRow}>
+        <div className={styles.cardAmount}>{formatCurrency(deposit.amount)}</div>
+        <Badge variants={statusVariants} value={deposit.status} />
+      </div>
+
+      <dl className={styles.cardFields}>
+        <div className={styles.cardField}>
+          <dt>{t('budget:invoiceDetail.deposits.mobile.due')}</dt>
+          <dd>{formatDate(deposit.dueDate)}</dd>
+        </div>
+        {deposit.paidDate && (
+          <div className={styles.cardField}>
+            <dt>{t('budget:invoiceDetail.deposits.mobile.paid')}</dt>
+            <dd>{formatDate(deposit.paidDate)}</dd>
+          </div>
+        )}
+        {deposit.claimedDate && (
+          <div className={styles.cardField}>
+            <dt>{t('budget:invoiceDetail.deposits.mobile.claimed')}</dt>
+            <dd>{formatDate(deposit.claimedDate)}</dd>
+          </div>
+        )}
+        {deposit.description && (
+          <div className={styles.cardField}>
+            <dt>{t('budget:invoiceDetail.deposits.columns.description')}</dt>
+            <dd>{deposit.description}</dd>
+          </div>
+        )}
+      </dl>
+
+      <div className={styles.cardActions}>
+        <button
+          ref={menuTriggerRef}
+          type="button"
+          className={styles.menuButton}
+          onClick={() => onMenuToggle(isMenuOpen ? null : deposit.id)}
+          onKeyDown={handleTriggerKeyDown}
+          aria-haspopup="true"
+          aria-expanded={isMenuOpen}
+          aria-label={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
+            description: deposit.description ?? 'deposit',
+          })}
+        >
+          ⋮
+        </button>
+        {isMenuOpen && (
+          <div ref={menuRef} className={styles.menu} role="menu" onKeyDown={handleMenuKeyDown}>
+            {deposit.status === 'pending' && (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onMarkPaid();
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.markPaid')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onEdit(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.edit')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onDelete(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.delete')}
+                </button>
+              </>
+            )}
+            {deposit.status === 'paid' && (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onMarkClaimed();
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.markClaimed')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onRevertToPending(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.revertToPending')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onEdit(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.edit')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onDelete(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.delete')}
+                </button>
+              </>
+            )}
+            {deposit.status === 'claimed' && (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onRevertToPaid(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.revertToPaid')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onEdit(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.edit')}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                  onClick={() => {
+                    onMenuToggle(null);
+                    onDelete(deposit);
+                  }}
+                >
+                  {t('budget:invoiceDetail.deposits.menu.delete')}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-component: AddEditDepositModal
+// ============================================================================
+
+interface AddEditDepositModalProps {
+  mode: 'add' | 'edit';
+  form: DepositFormState;
+  onFormChange: (form: DepositFormState) => void;
+  onSubmit: (e: FormEvent) => void;
+  onClose: () => void;
+  error: string;
+  isMutating: boolean;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  formatCurrency: (amount: number) => string;
+}
+
+function AddEditDepositModal({
+  mode,
+  form,
+  onFormChange,
+  onSubmit,
+  onClose,
+  error,
+  isMutating,
+  t,
+  formatCurrency,
+}: AddEditDepositModalProps) {
+  const isEdit = mode === 'edit';
+
+  return (
+    <Modal
+      title={
+        isEdit ? t('budget:invoiceDetail.deposits.modal.editTitle') : t('budget:invoiceDetail.deposits.modal.addTitle')
+      }
+      onClose={onClose}
+      className={styles.modal}
+      footer={
+        <div className={styles.modalActions}>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={onClose}
+            disabled={isMutating}
+          >
+            {t('common:buttons.cancel')}
+          </button>
+          <button
+            type="submit"
+            className={sharedStyles.btnPrimary}
+            form="deposit-form"
+            disabled={
+              isMutating || !form.amount || !form.dueDate || (form.status !== 'pending' && !form.paidDate) || (form.status === 'claimed' && !form.claimedDate)
+            }
+          >
+            {isMutating ? t('budget:invoiceDetail.deposits.form.saving') : t('common:buttons.save')}
+          </button>
+        </div>
+      }
+    >
+      <form id="deposit-form" onSubmit={onSubmit} noValidate>
+        {error && <FormError message={error} />}
+
+        {/* Row 1: amount + due date */}
+        <div className={styles.formRow}>
+          <div className={styles.formField}>
+            <label htmlFor="deposit-amount" className={styles.label}>
+              {t('budget:invoiceDetail.deposits.form.amount')}
+              <span className={styles.required}>{t('budget:invoiceDetail.deposits.form.required')}</span>
+            </label>
+            <input
+              type="number"
+              id="deposit-amount"
+              value={form.amount}
+              onChange={(e) => onFormChange({ ...form, amount: e.target.value })}
+              className={sharedStyles.input}
+              placeholder={t('budget:invoiceDetail.deposits.form.amountPlaceholder')}
+              min="0.01"
+              step="0.01"
+              required
+              disabled={isMutating}
+              onWheel={(e) => e.currentTarget.blur()}
+            />
+          </div>
+
+          <div className={styles.formField}>
+            <label htmlFor="deposit-dueDate" className={styles.label}>
+              {t('budget:invoiceDetail.deposits.form.dueDate')}
+              <span className={styles.required}>{t('budget:invoiceDetail.deposits.form.required')}</span>
+            </label>
+            <input
+              type="date"
+              id="deposit-dueDate"
+              value={form.dueDate}
+              onChange={(e) => onFormChange({ ...form, dueDate: e.target.value })}
+              className={sharedStyles.input}
+              required
+              disabled={isMutating}
+            />
+          </div>
+        </div>
+
+        {/* Row 2: status */}
+        <div className={styles.formField}>
+          <label htmlFor="deposit-status" className={styles.label}>
+            {t('budget:invoiceDetail.deposits.form.status')}
+          </label>
+          <select
+            id="deposit-status"
+            value={form.status}
+            onChange={(e) => onFormChange({ ...form, status: e.target.value as InvoiceDepositStatus })}
+            className={sharedStyles.select}
+            disabled={isMutating}
+          >
+            <option value="pending">{t('invoiceDetail.statusLabels.pending')}</option>
+            <option value="paid">{t('invoiceDetail.statusLabels.paid')}</option>
+            <option value="claimed">{t('invoiceDetail.statusLabels.claimed')}</option>
+          </select>
+        </div>
+
+        {/* Row 3: paidDate (conditional) */}
+        <div
+          className={`${styles.conditionalField} ${form.status !== 'pending' ? styles.conditionalFieldVisible : styles.conditionalFieldHidden}`}
+        >
+          <div className={styles.formField}>
+            <label htmlFor="deposit-paidDate" className={styles.label}>
+              {t('budget:invoiceDetail.deposits.form.paidDate')}
+              <span className={styles.required}>{t('budget:invoiceDetail.deposits.form.required')}</span>
+            </label>
+            <input
+              type="date"
+              id="deposit-paidDate"
+              value={form.paidDate}
+              onChange={(e) => onFormChange({ ...form, paidDate: e.target.value })}
+              className={sharedStyles.input}
+              disabled={isMutating}
+            />
+          </div>
+        </div>
+
+        {/* Row 4: claimedDate (conditional, only when claimed) */}
+        <div
+          className={`${styles.conditionalField} ${form.status === 'claimed' ? styles.conditionalFieldVisible : styles.conditionalFieldHidden}`}
+        >
+          <div className={styles.formField}>
+            <label htmlFor="deposit-claimedDate" className={styles.label}>
+              {t('budget:invoiceDetail.deposits.form.claimedDate')}
+              <span className={styles.required}>{t('budget:invoiceDetail.deposits.form.required')}</span>
+            </label>
+            <input
+              type="date"
+              id="deposit-claimedDate"
+              value={form.claimedDate}
+              onChange={(e) => onFormChange({ ...form, claimedDate: e.target.value })}
+              className={sharedStyles.input}
+              disabled={isMutating}
+            />
+          </div>
+        </div>
+
+        {/* Row 5: description */}
+        <div className={styles.formField}>
+          <label htmlFor="deposit-description" className={styles.label}>
+            {t('budget:invoiceDetail.deposits.form.description')}
+          </label>
+          <textarea
+            id="deposit-description"
+            value={form.description}
+            onChange={(e) =>
+              onFormChange({
+                ...form,
+                description: e.target.value.slice(0, 500),
+              })
+            }
+            className={sharedStyles.textarea}
+            placeholder={t('budget:invoiceDetail.deposits.form.descriptionPlaceholder')}
+            maxLength={500}
+            disabled={isMutating}
+            rows={3}
+          />
+          <div className={styles.charCounter}>
+            {t('budget:invoiceDetail.deposits.form.charCounter', {
+              count: form.description.length,
+            })}
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ============================================================================
+// Sub-component: DeleteDepositModal
+// ============================================================================
+
+interface DeleteDepositModalProps {
+  deposit: InvoiceDeposit;
+  onConfirm: () => void;
+  onClose: () => void;
+  error: string;
+  isMutating: boolean;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}
+
+function DeleteDepositModal({
+  deposit,
+  onConfirm,
+  onClose,
+  error,
+  isMutating,
+  t,
+}: DeleteDepositModalProps) {
+  const isPaidOrClaimed = deposit.status === 'paid' || deposit.status === 'claimed';
+
+  return (
+    <Modal
+      title={t('budget:invoiceDetail.deposits.modal.deleteTitle')}
+      onClose={onClose}
+      className={styles.modal}
+      footer={
+        <div className={styles.modalActions}>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={onClose}
+            disabled={isMutating}
+          >
+            {t('common:buttons.cancel')}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnConfirmDelete}
+            onClick={onConfirm}
+            disabled={isMutating}
+          >
+            {t('budget:invoiceDetail.deposits.modal.deleteTitle')}
+          </button>
+        </div>
+      }
+    >
+      <div>
+        {error && <FormError message={error} />}
+
+        {isPaidOrClaimed && (
+          <div className={styles.warningBanner}>
+            {t('budget:invoiceDetail.deposits.modal.deleteWarningPaidClaimed')}
+          </div>
+        )}
+
+        <p className={styles.deleteConfirmText}>
+          {t('budget:invoiceDetail.deposits.modal.deleteConfirm')}
+        </p>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================================
+// Sub-component: StateConfirmModal
+// ============================================================================
+
+interface StateConfirmModalProps {
+  deposit: InvoiceDeposit;
+  action: StateConfirmAction;
+  onConfirm: (date: string) => void;
+  onClose: () => void;
+  isMutating: boolean;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}
+
+function StateConfirmModal({
+  deposit,
+  action,
+  onConfirm,
+  onClose,
+  isMutating,
+  t,
+}: StateConfirmModalProps) {
+  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
+
+  const isMarkPaid = action === 'mark-paid';
+  const title = isMarkPaid
+    ? t('budget:invoiceDetail.deposits.modal.markPaidTitle')
+    : t('budget:invoiceDetail.deposits.modal.markClaimedTitle');
+  const dateLabel = isMarkPaid
+    ? t('budget:invoiceDetail.deposits.stateConfirm.paidDateLabel')
+    : t('budget:invoiceDetail.deposits.stateConfirm.claimedDateLabel');
+
+  return (
+    <Modal
+      title={title}
+      onClose={onClose}
+      className={styles.modal}
+      footer={
+        <div className={styles.modalActions}>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={onClose}
+            disabled={isMutating}
+          >
+            {t('common:buttons.cancel')}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnPrimary}
+            onClick={() => onConfirm(selectedDate)}
+            disabled={isMutating}
+          >
+            {t('common:buttons.confirm')}
+          </button>
+        </div>
+      }
+    >
+      <div className={styles.formField}>
+        <label htmlFor="state-confirm-date" className={styles.label}>
+          {dateLabel}
+        </label>
+        <input
+          type="date"
+          id="state-confirm-date"
+          value={selectedDate}
+          onChange={(e) => setSelectedDate(e.target.value)}
+          className={sharedStyles.input}
+          disabled={isMutating}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
@@ -65,6 +65,7 @@ export function InvoiceDepositsSection({
 }: InvoiceDepositsSectionProps) {
   const { formatCurrency, formatDate } = useFormatters();
   const { t } = useTranslation('budget');
+  const { t: tErrors } = useTranslation('errors');
 
   // Modal states
   const [modalMode, setModalMode] = useState<ModalMode>(null);
@@ -83,17 +84,17 @@ export function InvoiceDepositsSection({
 
   const invoiceStatusVariants: BadgeVariantMap = {
     pending: {
-      label: t('invoiceDetail.statusLabels.pending'),
-      className: styles.statusPending,
+      label: t('invoiceDetail.statusLabels.pending')!,
+      className: styles.statusPending!,
     },
-    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    paid: { label: t('invoiceDetail.statusLabels.paid')!, className: styles.statusPaid! },
     claimed: {
-      label: t('invoiceDetail.statusLabels.claimed'),
-      className: styles.statusClaimed,
+      label: t('invoiceDetail.statusLabels.claimed')!,
+      className: styles.statusClaimed!,
     },
     quotation: {
-      label: t('invoiceDetail.statusLabels.quotation'),
-      className: styles.statusQuotation,
+      label: t('invoiceDetail.statusLabels.quotation')!,
+      className: styles.statusQuotation!,
     },
   };
 
@@ -215,7 +216,7 @@ export function InvoiceDepositsSection({
         } else if (code === 'INVALID_DEPOSIT_DATE_FOR_STATUS') {
           setFormError(t('budget:invoiceDetail.deposits.errors.invalidDate'));
         } else {
-          setFormError(translateApiError(err.error.code));
+          setFormError(translateApiError(err.error.code, tErrors));
         }
       } else {
         setFormError(
@@ -241,7 +242,7 @@ export function InvoiceDepositsSection({
       onDepositMutated();
     } catch (err) {
       if (err instanceof ApiClientError) {
-        setFormError(translateApiError(err.error.code));
+        setFormError(translateApiError(err.error.code, tErrors));
       } else {
         setFormError(t('budget:invoiceDetail.deposits.errors.deleteError'));
       }
@@ -509,13 +510,13 @@ function DepositRow({
 
   const statusVariants: BadgeVariantMap = {
     pending: {
-      label: t('invoiceDetail.statusLabels.pending'),
-      className: styles.statusPending,
+      label: t('invoiceDetail.statusLabels.pending')!,
+      className: styles.statusPending!,
     },
-    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    paid: { label: t('invoiceDetail.statusLabels.paid')!, className: styles.statusPaid! },
     claimed: {
-      label: t('invoiceDetail.statusLabels.claimed'),
-      className: styles.statusClaimed,
+      label: t('invoiceDetail.statusLabels.claimed')!,
+      className: styles.statusClaimed!,
     },
   };
 
@@ -773,13 +774,13 @@ function DepositCard({
 
   const statusVariants: BadgeVariantMap = {
     pending: {
-      label: t('invoiceDetail.statusLabels.pending'),
-      className: styles.statusPending,
+      label: t('invoiceDetail.statusLabels.pending')!,
+      className: styles.statusPending!,
     },
-    paid: { label: t('invoiceDetail.statusLabels.paid'), className: styles.statusPaid },
+    paid: { label: t('invoiceDetail.statusLabels.paid')!, className: styles.statusPaid! },
     claimed: {
-      label: t('invoiceDetail.statusLabels.claimed'),
-      className: styles.statusClaimed,
+      label: t('invoiceDetail.statusLabels.claimed')!,
+      className: styles.statusClaimed!,
     },
   };
 

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
@@ -207,10 +207,10 @@ export function InvoiceDepositsSection({
       if (err instanceof ApiClientError) {
         const code = err.error.code;
         if (code === 'DEPOSITS_EXCEED_INVOICE_TOTAL') {
-          const available = (err.error.details as { available?: number })?.available ?? 0;
+          const availableHeadroom = (err.error.details as { availableHeadroom?: number })?.availableHeadroom ?? 0;
           setFormError(
             t('budget:invoiceDetail.deposits.errors.exceedsTotal', {
-              available: formatCurrency(available),
+              availableHeadroom: formatCurrency(availableHeadroom),
             }),
           );
         } else if (code === 'INVALID_DEPOSIT_STATUS_TRANSITION') {
@@ -1069,6 +1069,7 @@ function AddEditDepositModal({
             className={sharedStyles.btnSecondary}
             onClick={onClose}
             disabled={isMutating}
+            data-testid="deposit-modal-cancel"
           >
             {t('common:buttons.cancel')}
           </button>
@@ -1079,6 +1080,7 @@ function AddEditDepositModal({
             disabled={
               isMutating || !form.amount || !form.dueDate || (form.status !== 'pending' && !form.paidDate) || (form.status === 'claimed' && !form.claimedDate)
             }
+            data-testid="deposit-modal-save"
           >
             {isMutating ? t('budget:invoiceDetail.deposits.form.saving') : t('common:buttons.save')}
           </button>
@@ -1251,6 +1253,7 @@ function DeleteDepositModal({
             className={sharedStyles.btnSecondary}
             onClick={onClose}
             disabled={isMutating}
+            data-testid="deposit-delete-cancel"
           >
             {t('common:buttons.cancel')}
           </button>
@@ -1259,6 +1262,7 @@ function DeleteDepositModal({
             className={sharedStyles.btnConfirmDelete}
             onClick={onConfirm}
             disabled={isMutating}
+            data-testid="deposit-delete-confirm"
           >
             {t('budget:invoiceDetail.deposits.modal.deleteTitle')}
           </button>
@@ -1325,6 +1329,7 @@ function StateConfirmModal({
             className={sharedStyles.btnSecondary}
             onClick={onClose}
             disabled={isMutating}
+            data-testid="state-confirm-cancel"
           >
             {t('common:buttons.cancel')}
           </button>
@@ -1333,6 +1338,7 @@ function StateConfirmModal({
             className={sharedStyles.btnPrimary}
             onClick={() => onConfirm(selectedDate)}
             disabled={isMutating}
+            data-testid="state-confirm-button"
           >
             {t('common:buttons.confirm')}
           </button>

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
@@ -177,8 +177,12 @@ export function InvoiceDepositsSection({
           dueDate: depositForm.dueDate,
           status: depositForm.status as InvoiceDepositStatus,
           description: depositForm.description.trim() || null,
-          paidDate: depositForm.paidDate || null,
-          claimedDate: depositForm.claimedDate || null,
+          ...(depositForm.status !== 'pending'
+            ? { paidDate: depositForm.paidDate || null }
+            : {}),
+          ...(depositForm.status === 'claimed'
+            ? { claimedDate: depositForm.claimedDate || null }
+            : {}),
         };
         await createDeposit(invoiceId, payload);
       } else if (modalMode === 'edit' && selectedDeposit) {
@@ -187,8 +191,12 @@ export function InvoiceDepositsSection({
           dueDate: depositForm.dueDate,
           status: depositForm.status as InvoiceDepositStatus,
           description: depositForm.description.trim() || null,
-          paidDate: depositForm.paidDate || null,
-          claimedDate: depositForm.claimedDate || null,
+          ...(depositForm.status !== 'pending'
+            ? { paidDate: depositForm.paidDate || null }
+            : {}),
+          ...(depositForm.status === 'claimed'
+            ? { claimedDate: depositForm.claimedDate || null }
+            : {}),
         };
         await updateDeposit(invoiceId, selectedDeposit.id, payload);
       }

--- a/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
@@ -7,6 +7,7 @@ import { ApiClientError } from '../../lib/apiClient.js';
 import { useFormatters } from '../../lib/formatters.js';
 import { LinkedDocumentsSection } from '../../components/documents/LinkedDocumentsSection.js';
 import { InvoiceBudgetLinesSection } from './InvoiceBudgetLinesSection.js';
+import { InvoiceDepositsSection } from './InvoiceDepositsSection.js';
 import styles from './InvoiceDetailPage.module.css';
 
 // STATUS_LABELS will be dynamically generated from i18n
@@ -284,6 +285,15 @@ export function InvoiceDetailPage() {
             </div>
           </dl>
         </section>
+
+        <InvoiceDepositsSection
+          invoiceId={id!}
+          invoiceTotal={invoice.amount}
+          invoiceStatus={invoice.status}
+          deposits={invoice.deposits}
+          finalPaymentAmount={invoice.finalPaymentAmount}
+          onDepositMutated={() => void loadInvoice()}
+        />
 
         <InvoiceBudgetLinesSection invoiceId={id!} invoiceTotal={invoice.amount} />
 

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -547,11 +547,18 @@ export class InvoiceDetailPage {
     if (depositDescription !== undefined) {
       // The aria-label contains the description verbatim — use substring match
       // aria-label format: "Deposit actions for {description}"
+      // .filter({ visible: true }) is required on mobile: the desktop table rows are hidden
+      // but their overflow buttons remain in the DOM, so .first() without the filter picks
+      // the hidden table button instead of the visible mobile-card button.
       menuButton = this.depositsSection
         .locator(`button[aria-haspopup="true"][aria-label*="${depositDescription.replace(/"/g, '\\"')}"]`)
+        .filter({ visible: true })
         .first();
     } else {
-      menuButton = this.depositsSection.locator('button[aria-haspopup="true"]').first();
+      menuButton = this.depositsSection
+        .locator('button[aria-haspopup="true"]')
+        .filter({ visible: true })
+        .first();
     }
 
     await menuButton.click();

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -53,9 +53,12 @@
  * - State confirm modal: contains h2 "Mark as paid" or "Mark as claimed"
  * - Form inputs: #deposit-amount, #deposit-dueDate, #deposit-status,
  *   #deposit-paidDate (conditional), #deposit-claimedDate (conditional), #deposit-description
- * - Save button: type="submit", form="deposit-form", text from t('common:buttons.save')="Save"
- * - Cancel button: text from t('common:buttons.cancel')="Cancel"
- * - Confirm button (state confirm): text from t('common:buttons.confirm')="Confirm"
+ * - Save button: data-testid="deposit-modal-save" (added #1407)
+ * - Cancel button: data-testid="deposit-modal-cancel" (add/edit modal, added #1407)
+ * - Delete cancel: data-testid="deposit-delete-cancel" (delete modal, added #1407)
+ * - Delete confirm: data-testid="deposit-delete-confirm" (added #1407)
+ * - Confirm button (state confirm): data-testid="state-confirm-button" (added #1407)
+ * - State confirm cancel: data-testid="state-confirm-cancel" (added #1407)
  * - Error banner in form modals: role="alert" (FormError with variant='banner')
  * - Warning banner in delete modal: [class*="warningBanner"] (visible for paid/claimed deposits)
  * - Overflow menu trigger: button[aria-haspopup="true"], aria-label includes "deposit"
@@ -313,15 +316,11 @@ export class InvoiceDetailPage {
     this.depositClaimedDateInput = page.locator('#deposit-claimedDate');
     this.depositDescriptionInput = page.locator('#deposit-description');
 
-    // Save button: type="submit", form="deposit-form" — locale-independent structural locator
-    this.depositModalSave = page.locator('button[type="submit"][form="deposit-form"]');
+    // Save button in add/edit deposit modal — stable data-testid added in #1407
+    this.depositModalSave = page.getByTestId('deposit-modal-save');
 
-    // Cancel button in add/edit/delete deposit modals
-    // Scoped to any open dialog that contains #deposit-amount or the delete confirm text
-    this.depositModalCancel = page.locator('[role="dialog"]').getByRole('button', {
-      name: 'Cancel',
-      exact: true,
-    });
+    // Cancel button in add/edit deposit modal — stable data-testid added in #1407
+    this.depositModalCancel = page.getByTestId('deposit-modal-cancel');
 
     // Error banner (FormError with variant='banner' renders role="alert")
     this.depositModalError = page.locator('[role="dialog"] [role="alert"]');
@@ -331,11 +330,8 @@ export class InvoiceDetailPage {
       has: page.locator('h2'),
     });
 
-    // Confirm button inside state confirm modal — text="Confirm"
-    this.stateConfirmButton = page.locator('[role="dialog"]').getByRole('button', {
-      name: 'Confirm',
-      exact: true,
-    });
+    // Confirm button inside state confirm modal — stable data-testid added in #1407
+    this.stateConfirmButton = page.getByTestId('state-confirm-button');
 
     // State confirm date input
     this.stateConfirmDateInput = page.locator('#state-confirm-date');
@@ -348,8 +344,8 @@ export class InvoiceDetailPage {
     // Warning banner inside delete deposit modal: [class*="warningBanner"]
     this.deleteDepositWarning = page.locator('[class*="warningBanner"]');
 
-    // Delete deposit confirm button uses btnConfirmDelete class
-    this.deleteDepositConfirmButton = page.locator('[class*="btnConfirmDelete"]');
+    // Delete deposit confirm button — stable data-testid added in #1407
+    this.deleteDepositConfirmButton = page.getByTestId('deposit-delete-confirm');
 
     // Final payment row (always visible when deposits.length > 0)
     this.finalPaymentRow = page.locator('[class*="finalPaymentRow"]');

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -8,6 +8,7 @@
  * - Edit and Delete action buttons in the header row
  * - A detail card (section) with a dl/dt/dd list of:
  *   - Invoice #, Vendor (link), Amount, Date, Due Date, Status, Notes, Created by
+ * - An InvoiceDepositsSection (deposits between details and budget lines) — Issue #1404
  * - An InvoiceBudgetLinesSection for linking work item / household item budget lines
  * - A LinkedDocumentsSection (Paperless-ngx integration)
  * - An Edit modal (role="dialog", aria-labelledby="edit-modal-title")
@@ -40,6 +41,32 @@
  * - Submit button: button[type="submit"] inside <fieldset> (locale-independent structural locator)
  * - Cancel button: [class*="cancelButton"] inside picker modal (locale-independent)
  * - Error banner inside modal: role="alert"
+ *
+ * Deposits Section (Issue #1404):
+ * - Section: <section aria-labelledby="deposits-title">
+ * - Add button: type="button", aria-label="Add deposit", className=sharedStyles.btnPrimary
+ * - Empty state: <button type="button">Add deposit</button> (EmptyState CTA)
+ * - Modals use the shared Modal component which generates a dynamic id via useId().
+ *   Locate modals by getByRole('dialog') filtered to the visible one, or by heading text.
+ * - Add/Edit modal: contains h2 "Add deposit" or "Edit deposit"
+ * - Delete modal: contains h2 "Delete deposit"
+ * - State confirm modal: contains h2 "Mark as paid" or "Mark as claimed"
+ * - Form inputs: #deposit-amount, #deposit-dueDate, #deposit-status,
+ *   #deposit-paidDate (conditional), #deposit-claimedDate (conditional), #deposit-description
+ * - Save button: type="submit", form="deposit-form", text from t('common:buttons.save')="Save"
+ * - Cancel button: text from t('common:buttons.cancel')="Cancel"
+ * - Confirm button (state confirm): text from t('common:buttons.confirm')="Confirm"
+ * - Error banner in form modals: role="alert" (FormError with variant='banner')
+ * - Warning banner in delete modal: [class*="warningBanner"] (visible for paid/claimed deposits)
+ * - Overflow menu trigger: button[aria-haspopup="true"], aria-label includes "deposit"
+ * - Menu: role="menu", items role="menuitem"
+ * - Menu items (pending): "Mark paid…", "Edit", "Delete"
+ * - Menu items (paid): "Mark claimed…", "Revert to pending", "Edit", "Delete"
+ * - Menu items (claimed): "Revert to paid", "Edit", "Delete"
+ * - Final payment row: [class*="finalPaymentRow"]
+ * - Final payment amount: aria-live="polite" inside finalPaymentRow
+ * - Mobile card list (≤767px): [class*="mobileCardList"] with role="list"
+ * - Desktop table (>767px): [class*="tableWrapper"] > table
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -86,6 +113,64 @@ export class InvoiceDetailPage {
 
   // Error card (not found / load failure)
   readonly errorCard: Locator;
+
+  // ─── Deposits Section locators (Issue #1404) ────────────────────────────
+  /** The deposits section: <section aria-labelledby="deposits-title"> */
+  readonly depositsSection: Locator;
+
+  /** "Add deposit" button in the section header (aria-label="Add deposit") */
+  readonly addDepositButton: Locator;
+
+  /** EmptyState "Add deposit" CTA (only visible when deposits.length === 0) */
+  readonly depositEmptyState: Locator;
+
+  /**
+   * Add/Edit deposit modal (shared Modal component — useId() generates a dynamic
+   * aria-labelledby, so we locate by role="dialog" + heading text instead).
+   * When multiple modals are on the page, use getDepositModal() to target by title.
+   */
+  readonly depositModal: Locator;
+
+  // Form inputs inside the add/edit modal
+  readonly depositAmountInput: Locator;
+  readonly depositDueDateInput: Locator;
+  readonly depositStatusSelect: Locator;
+  readonly depositPaidDateInput: Locator;
+  readonly depositClaimedDateInput: Locator;
+  readonly depositDescriptionInput: Locator;
+
+  /** Save button (type="submit", form="deposit-form", text="Save") */
+  readonly depositModalSave: Locator;
+
+  /** Cancel button inside the add/edit or delete deposit modal */
+  readonly depositModalCancel: Locator;
+
+  /** Error banner (role="alert") inside a deposit modal */
+  readonly depositModalError: Locator;
+
+  /** State confirm modal (Mark as paid / Mark as claimed) */
+  readonly stateConfirmModal: Locator;
+
+  /** Confirm button inside the state confirm modal */
+  readonly stateConfirmButton: Locator;
+
+  /** The state-confirm date input (#state-confirm-date) */
+  readonly stateConfirmDateInput: Locator;
+
+  /** Delete deposit modal — located by its title "Delete deposit" */
+  readonly deleteDepositModal: Locator;
+
+  /** Warning banner inside the delete deposit modal (visible for paid/claimed deposits) */
+  readonly deleteDepositWarning: Locator;
+
+  /** Confirm delete button inside the delete deposit modal */
+  readonly deleteDepositConfirmButton: Locator;
+
+  /** Final payment row at the bottom of the deposits table */
+  readonly finalPaymentRow: Locator;
+
+  /** aria-live amount inside the final payment row */
+  readonly finalPaymentAmount: Locator;
 
   // ─── Budget Line Picker locators (Issue #1401) ───────────────────────────
   /** The two-step picker modal: role="dialog", aria-labelledby="picker-title" */
@@ -182,6 +267,77 @@ export class InvoiceDetailPage {
 
     // Error card (rendered when invoice not found or load fails)
     this.errorCard = page.locator('[class*="errorCard"]');
+
+    // ─── Deposits Section locators (Issue #1404) ──────────────────────────
+    this.depositsSection = page.locator('[aria-labelledby="deposits-title"]');
+
+    // The "Add deposit" button in the section header has aria-label="Add deposit"
+    this.addDepositButton = this.depositsSection.getByRole('button', {
+      name: 'Add deposit',
+    });
+
+    // EmptyState CTA button (only rendered when deposits.length === 0)
+    this.depositEmptyState = this.depositsSection.locator('[class*="emptyState"], [class*="empty"]');
+
+    // The deposit modal renders via the shared Modal component which uses useId() for
+    // aria-labelledby — locate by role="dialog" + the visible h2 heading.
+    // When add/edit modal is open its h2 is "Add deposit" or "Edit deposit".
+    this.depositModal = page.locator('[role="dialog"]').filter({
+      has: page.locator('h2'),
+    });
+
+    // Form inputs are page-scoped (they render in a portal, so scoping to depositModal
+    // would miss them since the portal attaches to document.body).
+    this.depositAmountInput = page.locator('#deposit-amount');
+    this.depositDueDateInput = page.locator('#deposit-dueDate');
+    this.depositStatusSelect = page.locator('#deposit-status');
+    this.depositPaidDateInput = page.locator('#deposit-paidDate');
+    this.depositClaimedDateInput = page.locator('#deposit-claimedDate');
+    this.depositDescriptionInput = page.locator('#deposit-description');
+
+    // Save button: type="submit", form="deposit-form" — locale-independent structural locator
+    this.depositModalSave = page.locator('button[type="submit"][form="deposit-form"]');
+
+    // Cancel button in add/edit/delete deposit modals
+    // Scoped to any open dialog that contains #deposit-amount or the delete confirm text
+    this.depositModalCancel = page.locator('[role="dialog"]').getByRole('button', {
+      name: 'Cancel',
+      exact: true,
+    });
+
+    // Error banner (FormError with variant='banner' renders role="alert")
+    this.depositModalError = page.locator('[role="dialog"] [role="alert"]');
+
+    // State confirm modal: h2 is "Mark as paid" or "Mark as claimed"
+    this.stateConfirmModal = page.locator('[role="dialog"]').filter({
+      has: page.locator('h2'),
+    });
+
+    // Confirm button inside state confirm modal — text="Confirm"
+    this.stateConfirmButton = page.locator('[role="dialog"]').getByRole('button', {
+      name: 'Confirm',
+      exact: true,
+    });
+
+    // State confirm date input
+    this.stateConfirmDateInput = page.locator('#state-confirm-date');
+
+    // Delete deposit modal contains h2 "Delete deposit"
+    this.deleteDepositModal = page.locator('[role="dialog"]').filter({
+      has: page.locator('h2'),
+    });
+
+    // Warning banner inside delete deposit modal: [class*="warningBanner"]
+    this.deleteDepositWarning = page.locator('[class*="warningBanner"]');
+
+    // Delete deposit confirm button uses btnConfirmDelete class
+    this.deleteDepositConfirmButton = page.locator('[class*="btnConfirmDelete"]');
+
+    // Final payment row (always visible when deposits.length > 0)
+    this.finalPaymentRow = page.locator('[class*="finalPaymentRow"]');
+
+    // aria-live amount inside the final payment row
+    this.finalPaymentAmount = this.finalPaymentRow.locator('[aria-live="polite"]');
 
     // ─── Budget Line Picker locators (Issue #1401) ────────────────────────
     this.budgetLinePickerModal = page.locator('[role="dialog"][aria-labelledby="picker-title"]');
@@ -351,6 +507,149 @@ export class InvoiceDetailPage {
   async goBackToInvoices(): Promise<void> {
     await this.backButton.click();
     await this.page.waitForURL('**/budget/invoices');
+  }
+
+  // ─── Deposits Section helpers (Issue #1404) ─────────────────────────────
+
+  /**
+   * Opens the overflow menu for a deposit.
+   *
+   * The overflow menu button renders as:
+   *   <button type="button" aria-haspopup="true"
+   *           aria-label="Deposit actions for {description}">⋮</button>
+   * When description is null, the aria-label uses "deposit" as fallback.
+   *
+   * If depositDescription is provided, matches by aria-label substring.
+   * If omitted, clicks the first visible deposit menu button in the section.
+   */
+  async openDepositMenu(depositDescription?: string): Promise<void> {
+    let menuButton: Locator;
+    if (depositDescription !== undefined) {
+      // The aria-label contains the description verbatim — use substring match
+      // aria-label format: "Deposit actions for {description}"
+      menuButton = this.depositsSection
+        .locator(`button[aria-haspopup="true"][aria-label*="${depositDescription.replace(/"/g, '\\"')}"]`)
+        .first();
+    } else {
+      menuButton = this.depositsSection.locator('button[aria-haspopup="true"]').first();
+    }
+
+    await menuButton.click();
+    // Wait for menu to appear
+    await this.page.locator('[role="menu"]').first().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Clicks a menu item by its label text within the currently open menu.
+   */
+  async clickDepositMenuItem(label: string | RegExp): Promise<void> {
+    const menuItem = this.page.locator('[role="menuitem"]').filter({ hasText: label });
+    await menuItem.first().click();
+  }
+
+  /**
+   * Opens the "Add deposit" modal by clicking the section header button.
+   * Waits for the form inputs to appear.
+   */
+  async openAddDepositModal(): Promise<void> {
+    await this.addDepositButton.click();
+    await this.depositAmountInput.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Fills the add/edit deposit form. Only provided fields are updated.
+   * For status values other than 'pending', paidDate is required by the submit button.
+   */
+  async fillDepositForm(data: {
+    amount?: string;
+    dueDate?: string;
+    status?: 'pending' | 'paid' | 'claimed';
+    paidDate?: string;
+    claimedDate?: string;
+    description?: string;
+  }): Promise<void> {
+    if (data.amount !== undefined) {
+      await this.depositAmountInput.clear();
+      await this.depositAmountInput.fill(data.amount);
+    }
+    if (data.dueDate !== undefined) {
+      await this.depositDueDateInput.fill(data.dueDate);
+    }
+    if (data.status !== undefined) {
+      await this.depositStatusSelect.selectOption(data.status);
+    }
+    if (data.paidDate !== undefined) {
+      await this.depositPaidDateInput.fill(data.paidDate);
+    }
+    if (data.claimedDate !== undefined) {
+      await this.depositClaimedDateInput.fill(data.claimedDate);
+    }
+    if (data.description !== undefined) {
+      await this.depositDescriptionInput.fill(data.description);
+    }
+  }
+
+  /**
+   * Saves the add/edit deposit form. Registers waitForResponse before clicking.
+   * Returns after the API response and the amount input leaves the DOM.
+   */
+  async saveDepositForm(expectedStatus: 201 | 200 = 201): Promise<void> {
+    const method = expectedStatus === 201 ? 'POST' : 'PATCH';
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/invoices/') &&
+        resp.url().includes('/deposits') &&
+        resp.request().method() === method &&
+        resp.status() === expectedStatus,
+    );
+    await this.depositModalSave.click();
+    await responsePromise;
+    // Wait for form modal to close (amount input leaves DOM)
+    await this.depositAmountInput.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Confirms the "Mark paid" or "Mark claimed" state transition.
+   * The state confirm modal must already be open.
+   * Optionally updates the date input before confirming.
+   */
+  async confirmStateTransition(date?: string): Promise<void> {
+    if (date !== undefined) {
+      await this.stateConfirmDateInput.fill(date);
+    }
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/deposits/') &&
+        resp.request().method() === 'PATCH' &&
+        resp.status() === 200,
+    );
+    await this.stateConfirmButton.click();
+    await responsePromise;
+  }
+
+  /**
+   * Confirms deletion of a deposit from the delete modal.
+   * Registers waitForResponse before clicking.
+   */
+  async confirmDepositDelete(): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/deposits/') &&
+        resp.request().method() === 'DELETE' &&
+        resp.status() === 204,
+    );
+    await this.deleteDepositConfirmButton.click();
+    await responsePromise;
+  }
+
+  /**
+   * Get the Badge text for a specific deposit row/card.
+   * Returns the badge element scoped to the table row or card that contains the amount text.
+   */
+  getDepositBadgeByAmount(formattedAmount: string): Locator {
+    return this.depositsSection.locator('[class*="tableRow"], [class*="mobileCard"]').filter({
+      hasText: formattedAmount,
+    }).locator('[class*="badge"], [class*="Badge"]');
   }
 
   // ─── Budget Line Picker helpers (Issue #1401) ────────────────────────────

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -173,6 +173,9 @@ export class InvoiceDetailPage {
   /** Warning banner inside the delete deposit modal (visible for paid/claimed deposits) */
   readonly deleteDepositWarning: Locator;
 
+  /** Cancel button inside the delete deposit modal (data-testid="deposit-delete-cancel") */
+  readonly deleteDepositCancelButton: Locator;
+
   /** Confirm delete button inside the delete deposit modal */
   readonly deleteDepositConfirmButton: Locator;
 
@@ -343,6 +346,9 @@ export class InvoiceDetailPage {
 
     // Warning banner inside delete deposit modal: [class*="warningBanner"]
     this.deleteDepositWarning = page.locator('[class*="warningBanner"]');
+
+    // Cancel button in delete deposit modal — stable data-testid added in #1407
+    this.deleteDepositCancelButton = page.getByTestId('deposit-delete-cancel');
 
     // Delete deposit confirm button — stable data-testid added in #1407
     this.deleteDepositConfirmButton = page.getByTestId('deposit-delete-confirm');

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -562,8 +562,13 @@ export class InvoiceDetailPage {
     }
 
     await menuButton.click();
-    // Wait for menu to appear
-    await this.page.locator('[role="menu"]').first().waitFor({ state: 'visible' });
+    // Wait for menu to appear. The desktop table (display:none on mobile) keeps its
+    // [role="menu"] in the DOM, so filter to visible before resolving .first().
+    await this.page
+      .locator('[role="menu"]')
+      .filter({ visible: true })
+      .first()
+      .waitFor({ state: 'visible' });
   }
 
   /**

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -575,7 +575,13 @@ export class InvoiceDetailPage {
    * Clicks a menu item by its label text within the currently open menu.
    */
   async clickDepositMenuItem(label: string | RegExp): Promise<void> {
-    const menuItem = this.page.locator('[role="menuitem"]').filter({ hasText: label });
+    // Mobile/tablet hide the desktop table via CSS but keep its [role="menuitem"]
+    // nodes in the DOM. Filter to visible elements so .first() picks the visible
+    // menu item (not the hidden table duplicate).
+    const menuItem = this.page
+      .locator('[role="menuitem"]')
+      .filter({ visible: true })
+      .filter({ hasText: label });
     await menuItem.first().click();
   }
 

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -121,7 +121,14 @@ export class InvoiceDetailPage {
   /** "Add deposit" button in the section header (aria-label="Add deposit") */
   readonly addDepositButton: Locator;
 
-  /** EmptyState "Add deposit" CTA (only visible when deposits.length === 0) */
+  /**
+   * "Add deposit" CTA inside the EmptyState component (only visible when deposits.length === 0).
+   * This button has visible text "Add deposit" but NO aria-label — use this locator when you
+   * specifically need to click the EmptyState CTA rather than the header button.
+   */
+  readonly addDepositFromEmptyState: Locator;
+
+  /** EmptyState container element (only visible when deposits.length === 0) */
   readonly depositEmptyState: Locator;
 
   /**
@@ -271,12 +278,23 @@ export class InvoiceDetailPage {
     // ─── Deposits Section locators (Issue #1404) ──────────────────────────
     this.depositsSection = page.locator('[aria-labelledby="deposits-title"]');
 
-    // The "Add deposit" button in the section header has aria-label="Add deposit"
-    this.addDepositButton = this.depositsSection.getByRole('button', {
-      name: 'Add deposit',
-    });
+    // The "Add deposit" button in the section header has aria-label="Add deposit".
+    // getByLabel matches elements whose aria-label === "Add deposit" — this is true
+    // ONLY for the header CTA. The EmptyState button has text but no aria-label, so
+    // getByLabel does NOT match it. This keeps strict mode happy when both buttons are
+    // rendered simultaneously (empty state scenario).
+    this.addDepositButton = this.depositsSection.getByLabel('Add deposit', { exact: true });
 
-    // EmptyState CTA button (only rendered when deposits.length === 0)
+    // EmptyState "Add deposit" CTA — the button rendered by the EmptyState component when
+    // deposits.length === 0. It has visible text "Add deposit" but NO aria-label attribute.
+    // We locate it via CSS attribute selector to exclude buttons that carry aria-label,
+    // which would otherwise match the header button too.
+    this.addDepositFromEmptyState = this.depositsSection.locator(
+      'button:not([aria-label])',
+      { hasText: 'Add deposit' },
+    );
+
+    // EmptyState container element (only visible when deposits.length === 0)
     this.depositEmptyState = this.depositsSection.locator('[class*="emptyState"], [class*="empty"]');
 
     // The deposit modal renders via the shared Modal component which uses useId() for

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -427,7 +427,7 @@ test.describe('Deposits — delete paid deposit warning (Scenario 4)', () => {
         await expect(detailPage.deleteDepositWarning).toBeVisible();
 
         // Cancel — deposit still present
-        await detailPage.depositModalCancel.first().click();
+        await detailPage.deleteDepositCancelButton.click();
         // Modal closes
         await expect(detailPage.deleteDepositWarning).not.toBeVisible();
 

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -192,7 +192,13 @@ test.describe('Deposits — add deposit (Scenario 2)', { tag: '@responsive' }, (
 
         // Badge says "Pending" (locale-independent: look for the CSS class on the badge)
         // The badge renders inside the deposits section row
-        const depositRows = detailPage.depositsSection.locator('[class*="tableRow"], [class*="mobileCard"]');
+        // Filter to visible elements only: on mobile (≤767px) tableRow elements are
+        // hidden via CSS (display:none) while mobileCard elements are shown. Without the
+        // filter, .first() returns the first DOM-order match — a hidden tableRow — and
+        // toBeVisible() fails on mobile viewports.
+        const depositRows = detailPage.depositsSection
+          .locator('[class*="tableRow"], [class*="mobileCard"]')
+          .filter({ visible: true });
         await expect(depositRows.first()).toBeVisible();
 
         // Final Payment row is now visible: invoice total (1000) − deposit (300) = 700
@@ -319,10 +325,11 @@ test.describe('Deposits — full lifecycle (Scenario 3)', () => {
         await detailPage.clickDepositMenuItem(/Revert to paid/);
         await revertToPaidResponsePromise;
 
-        // Badge reverts to "Paid"
+        // Badge reverts to "Paid".
+        // Note: we do NOT assert not.toContainText('Claimed') here because the table
+        // always renders a "Claimed date" column header that contains the text "Claimed".
+        // The containText('Paid') assertion above is sufficient to confirm the badge state.
         await expect(detailPage.depositsSection).toContainText('Paid');
-        // "Claimed" badge should no longer be present
-        await expect(detailPage.depositsSection).not.toContainText('Claimed');
 
         // ── Step 5: Edit amount (overflow menu → "Edit") ──
         await detailPage.openDepositMenu();

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -1,0 +1,798 @@
+/**
+ * E2E tests for Invoice Deposits (Issue #1404)
+ *
+ * The InvoiceDepositsSection renders between Invoice Details and Budget Lines.
+ * Users can add, edit, delete deposits and drive them through a state machine:
+ *   pending → paid → claimed (forward)
+ *   paid → pending (revert)
+ *   claimed → paid (revert)
+ *   pending → claimed DISALLOWED
+ *
+ * Scenarios covered:
+ *   1. Empty state: invoice with zero deposits shows EmptyState + "Add deposit" CTA, no Final Payment row
+ *   2. Add deposit happy path: modal opens, fill form, save → row appears with Pending badge,
+ *      Final Payment = total − deposit amount
+ *   3. Full lifecycle: add → mark paid → mark claimed → revert to paid → edit → delete
+ *   4. Delete paid deposit: warning banner visible in delete modal
+ *   5. DEPOSITS_EXCEED_INVOICE_TOTAL error surfaces in the form with available headroom
+ *   6. Responsive tablet: table renders, Final Payment row visible (768px)
+ *   7. Responsive mobile: cards render, Final Payment row visible, "Mark paid" flow works (375px)
+ *
+ * Implementation notes:
+ * - Deposit add/edit modal uses shared Modal with useId() dynamic aria-labelledby.
+ *   Locate modals by role="dialog" + form input visibility or heading text.
+ * - "Save" button: button[type="submit"][form="deposit-form"] (locale-independent)
+ * - "Confirm" button for state transitions: role="button", name="Confirm" (locale-independent)
+ * - Warning banner: [class*="warningBanner"] (CSS module class on the warning div)
+ * - Final payment row: [class*="finalPaymentRow"] with aria-live="polite" amount
+ * - Mobile cards (≤767px): [class*="mobileCard"] role="list" in [class*="mobileCardList"]
+ * - Desktop table (>767px): [class*="tableWrapper"] > table
+ *
+ * API endpoints used in helpers:
+ *   POST   /api/invoices/:invoiceId/deposits        → 201 { deposit: { id, status, amount } }
+ *   PATCH  /api/invoices/:invoiceId/deposits/:id    → 200 { deposit: { ... } }
+ *   DELETE /api/invoices/:invoiceId/deposits/:id    → 204
+ */
+
+import { test, expect } from '../../fixtures/auth.js';
+import { InvoiceDetailPage } from '../../pages/InvoiceDetailPage.js';
+import { API } from '../../fixtures/testData.js';
+import type { Page } from '@playwright/test';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface DepositData {
+  id: string;
+  status: string;
+  amount: number;
+}
+
+async function createVendorViaApi(page: Page, name: string): Promise<string> {
+  const response = await page.request.post(API.vendors, { data: { name } });
+  expect(response.ok(), `POST vendor "${name}" failed: ${response.status()}`).toBeTruthy();
+  const body = (await response.json()) as { vendor: { id: string } };
+  return body.vendor.id;
+}
+
+async function deleteVendorViaApi(page: Page, id: string): Promise<void> {
+  await page.request.delete(`${API.vendors}/${id}`);
+}
+
+async function createInvoiceViaApi(
+  page: Page,
+  vendorId: string,
+  data: { amount: number; date: string; status?: string; invoiceNumber?: string },
+): Promise<string> {
+  const response = await page.request.post(`${API.vendors}/${vendorId}/invoices`, {
+    data: { status: 'quotation', ...data },
+  });
+  expect(response.ok(), `POST invoice failed: ${response.status()}`).toBeTruthy();
+  const body = (await response.json()) as { invoice: { id: string } };
+  return body.invoice.id;
+}
+
+async function createDepositViaApi(
+  page: Page,
+  invoiceId: string,
+  data: {
+    amount: number;
+    dueDate: string;
+    status?: 'pending' | 'paid' | 'claimed';
+    paidDate?: string;
+    claimedDate?: string;
+    description?: string;
+  },
+): Promise<DepositData> {
+  const response = await page.request.post(`/api/invoices/${invoiceId}/deposits`, {
+    data: { status: 'pending', ...data },
+  });
+  expect(response.ok(), `POST deposit failed: ${response.status()}`).toBeTruthy();
+  const body = (await response.json()) as { deposit: DepositData };
+  return body.deposit;
+}
+
+async function deleteDepositViaApi(
+  page: Page,
+  invoiceId: string,
+  depositId: string,
+): Promise<void> {
+  await page.request.delete(`/api/invoices/${invoiceId}/deposits/${depositId}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: Empty state
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — empty state (Scenario 1)', { tag: '@responsive' }, () => {
+  test(
+    'Invoice with no deposits shows empty state message and "Add deposit" CTA; no Final Payment row',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+
+      try {
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep EmptyVendor`);
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 1000,
+          date: '2026-06-01',
+        });
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // Deposits section is present
+        await expect(detailPage.depositsSection).toBeVisible();
+
+        // Empty state message visible
+        // EmptyState renders the message in a paragraph and the action as a <button>
+        await expect(detailPage.depositsSection).toContainText('No deposits yet');
+
+        // "Add deposit" button visible in both the section header and EmptyState CTA
+        // (the header button always renders; the EmptyState CTA also renders when empty)
+        await expect(detailPage.addDepositButton).toBeVisible();
+
+        // No Final Payment row when deposits.length === 0
+        await expect(detailPage.finalPaymentRow).not.toBeVisible();
+      } finally {
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: Add deposit happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — add deposit (Scenario 2)', { tag: '@responsive' }, () => {
+  test(
+    'Add deposit → row appears with Pending badge; Final Payment = invoice total − deposit amount',
+    { tag: '@smoke' },
+    async ({ page, testPrefix }) => {
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+
+      try {
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep AddVendor`);
+        // Invoice total = 1000
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 1000,
+          date: '2026-06-01',
+        });
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // Click "Add deposit"
+        await detailPage.openAddDepositModal();
+
+        // Form is visible
+        await expect(detailPage.depositAmountInput).toBeVisible();
+        await expect(detailPage.depositDueDateInput).toBeVisible();
+        await expect(detailPage.depositStatusSelect).toBeVisible();
+
+        // Fill amount=300, due date
+        await detailPage.fillDepositForm({
+          amount: '300',
+          dueDate: '2026-07-01',
+          // status defaults to 'pending'
+        });
+
+        // Save — POST /api/invoices/:id/deposits → 201
+        await detailPage.saveDepositForm(201);
+
+        // Deposit row appears with Pending badge
+        // The table row will show the amount (300.00) and the Pending status
+        await expect(detailPage.depositsSection).toContainText('300');
+
+        // Badge says "Pending" (locale-independent: look for the CSS class on the badge)
+        // The badge renders inside the deposits section row
+        const depositRows = detailPage.depositsSection.locator('[class*="tableRow"], [class*="mobileCard"]');
+        await expect(depositRows.first()).toBeVisible();
+
+        // Final Payment row is now visible: invoice total (1000) − deposit (300) = 700
+        await expect(detailPage.finalPaymentRow).toBeVisible();
+        await expect(detailPage.finalPaymentAmount).toContainText('700');
+
+        // Invoice total in the detail card is unchanged
+        // (The invoice total is shown in the detail card — we don't assert exact formatted
+        //  value here since currency formatting is locale-specific)
+        await expect(detailPage.detailCard).toBeVisible();
+      } finally {
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+
+  test('Add deposit modal can be cancelled without creating a deposit', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep CancelVendor`);
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 500,
+        date: '2026-06-01',
+      });
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      await detailPage.openAddDepositModal();
+      await expect(detailPage.depositAmountInput).toBeVisible();
+
+      // Fill amount but cancel
+      await detailPage.depositAmountInput.fill('100');
+
+      // Click cancel button in the modal footer
+      await detailPage.depositModalCancel.first().click();
+
+      // Modal closes — amount input leaves DOM
+      await detailPage.depositAmountInput.waitFor({ state: 'hidden' });
+
+      // No deposit was created — still in empty state
+      await expect(detailPage.depositsSection).toContainText('No deposits yet');
+      await expect(detailPage.finalPaymentRow).not.toBeVisible();
+    } finally {
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: Full lifecycle — add, mark paid, mark claimed, revert, edit, delete
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — full lifecycle (Scenario 3)', () => {
+  test(
+    'Add → mark paid → mark claimed → revert to paid → edit amount → delete pending deposit',
+    async ({ page, testPrefix }) => {
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+
+      try {
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep LifecycleVendor`);
+        // Invoice total = 500
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 500,
+          date: '2026-06-01',
+        });
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // ── Step 1: Add a deposit (amount=150, dueDate=2026-07-01, pending) ──
+        await detailPage.openAddDepositModal();
+        await detailPage.fillDepositForm({
+          amount: '150',
+          dueDate: '2026-07-01',
+        });
+        await detailPage.saveDepositForm(201);
+
+        // Row appears; Final Payment = 500 − 150 = 350
+        await expect(detailPage.depositsSection).toContainText('150');
+        await expect(detailPage.finalPaymentAmount).toContainText('350');
+
+        // ── Step 2: Mark paid (overflow menu → "Mark paid…") ──
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Mark paid/);
+
+        // State confirm modal opens with "Mark as paid" title
+        await expect(page.getByRole('dialog').filter({ has: page.getByText('Mark as paid') })).toBeVisible();
+
+        // Confirm (date is pre-filled with today)
+        await detailPage.confirmStateTransition();
+
+        // Badge now shows "Paid" — the deposit row's badge class changes to statusPaid
+        // We verify by checking the status badge text via the badge component's visible text.
+        // The section should contain "Paid" text after the re-render.
+        await expect(detailPage.depositsSection).toContainText('Paid');
+
+        // ── Step 3: Mark claimed (overflow menu → "Mark claimed…") ──
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Mark claimed/);
+
+        await expect(page.getByRole('dialog').filter({ has: page.getByText('Mark as claimed') })).toBeVisible();
+
+        await detailPage.confirmStateTransition();
+
+        await expect(detailPage.depositsSection).toContainText('Claimed');
+
+        // ── Step 4: Revert to paid (overflow menu → "Revert to paid") ──
+        await detailPage.openDepositMenu();
+        const revertToPaidResponsePromise = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/deposits/') &&
+            resp.request().method() === 'PATCH' &&
+            resp.status() === 200,
+        );
+        await detailPage.clickDepositMenuItem(/Revert to paid/);
+        await revertToPaidResponsePromise;
+
+        // Badge reverts to "Paid"
+        await expect(detailPage.depositsSection).toContainText('Paid');
+        // "Claimed" badge should no longer be present
+        await expect(detailPage.depositsSection).not.toContainText('Claimed');
+
+        // ── Step 5: Edit amount (overflow menu → "Edit") ──
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Edit/);
+
+        // Edit modal opens
+        await expect(detailPage.depositAmountInput).toBeVisible();
+
+        // Change amount from 150 to 200
+        await detailPage.depositAmountInput.clear();
+        await detailPage.depositAmountInput.fill('200');
+
+        // Save edit (PATCH)
+        await detailPage.saveDepositForm(200);
+
+        // Final Payment = 500 − 200 = 300
+        await expect(detailPage.depositsSection).toContainText('200');
+        await expect(detailPage.finalPaymentAmount).toContainText('300');
+
+        // ── Step 6: Revert to pending (so we can delete without paid warning) ──
+        await detailPage.openDepositMenu();
+        const revertToPendingResponsePromise = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/deposits/') &&
+            resp.request().method() === 'PATCH' &&
+            resp.status() === 200,
+        );
+        await detailPage.clickDepositMenuItem(/Revert to pending/);
+        await revertToPendingResponsePromise;
+        await expect(detailPage.depositsSection).toContainText('Pending');
+
+        // ── Step 7: Delete the deposit ──
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Delete/);
+
+        // Delete modal opens — for a pending deposit no warning banner
+        await expect(page.getByRole('dialog').filter({ has: page.getByText('Delete deposit') })).toBeVisible();
+        await expect(detailPage.deleteDepositWarning).not.toBeVisible();
+
+        await detailPage.confirmDepositDelete();
+
+        // Deposit removed — back to empty state
+        await expect(detailPage.depositsSection).toContainText('No deposits yet');
+        await expect(detailPage.finalPaymentRow).not.toBeVisible();
+      } finally {
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: Delete paid deposit — warning banner visible
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — delete paid deposit warning (Scenario 4)', () => {
+  test(
+    'Delete modal for a paid deposit shows warning banner; cancel keeps deposit; confirm removes it',
+    async ({ page, testPrefix }) => {
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+      let depositId = '';
+
+      try {
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep DelWarnVendor`);
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 600,
+          date: '2026-06-01',
+        });
+
+        // Create a deposit already in 'paid' status via API
+        const today = new Date().toISOString().slice(0, 10);
+        const deposit = await createDepositViaApi(page, invoiceId, {
+          amount: 150,
+          dueDate: '2026-07-01',
+          status: 'paid',
+          paidDate: today,
+        });
+        depositId = deposit.id;
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // Deposit row is visible
+        await expect(detailPage.depositsSection).toContainText('150');
+        await expect(detailPage.depositsSection).toContainText('Paid');
+
+        // Open overflow menu → Delete
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Delete/);
+
+        // Delete modal opens
+        await expect(page.getByRole('dialog').filter({ has: page.getByText('Delete deposit') })).toBeVisible();
+
+        // Warning banner IS visible for a paid deposit
+        await expect(detailPage.deleteDepositWarning).toBeVisible();
+
+        // Cancel — deposit still present
+        await detailPage.depositModalCancel.first().click();
+        // Modal closes
+        await expect(detailPage.deleteDepositWarning).not.toBeVisible();
+
+        // Deposit still in the list
+        await expect(detailPage.depositsSection).toContainText('150');
+        await expect(detailPage.depositsSection).toContainText('Paid');
+
+        // Now actually delete
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Delete/);
+        await expect(detailPage.deleteDepositWarning).toBeVisible();
+        await detailPage.confirmDepositDelete();
+
+        // Deposit gone, empty state
+        depositId = ''; // cleared — no cleanup needed
+        await expect(detailPage.depositsSection).toContainText('No deposits yet');
+      } finally {
+        if (depositId && invoiceId)
+          await deleteDepositViaApi(page, invoiceId, depositId).catch(() => {
+            /* already deleted */
+          });
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+
+  test('Delete modal for a claimed deposit shows warning banner', async ({ page, testPrefix }) => {
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+    let depositId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep DelClaimedVendor`);
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 400,
+        date: '2026-06-01',
+      });
+
+      const today = new Date().toISOString().slice(0, 10);
+      const deposit = await createDepositViaApi(page, invoiceId, {
+        amount: 100,
+        dueDate: '2026-07-01',
+        status: 'claimed',
+        paidDate: today,
+        claimedDate: today,
+      });
+      depositId = deposit.id;
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      // Open Delete dialog
+      await detailPage.openDepositMenu();
+      await detailPage.clickDepositMenuItem(/Delete/);
+      await expect(page.getByRole('dialog').filter({ has: page.getByText('Delete deposit') })).toBeVisible();
+
+      // Warning banner visible for claimed deposit too
+      await expect(detailPage.deleteDepositWarning).toBeVisible();
+
+      // Confirm deletion
+      await detailPage.confirmDepositDelete();
+      depositId = '';
+
+      await expect(detailPage.depositsSection).toContainText('No deposits yet');
+    } finally {
+      if (depositId && invoiceId)
+        await deleteDepositViaApi(page, invoiceId, depositId).catch(() => {
+          /* already deleted */
+        });
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: DEPOSITS_EXCEED_INVOICE_TOTAL error
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — exceed invoice total error (Scenario 5)', () => {
+  test(
+    'Adding a deposit whose amount exceeds available headroom shows DEPOSITS_EXCEED_INVOICE_TOTAL error with available amount',
+    async ({ page, testPrefix }) => {
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+
+      try {
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep ExceedVendor`);
+        // Invoice total = 100
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 100,
+          date: '2026-06-01',
+        });
+
+        // Add first deposit of 60 (succeeds, headroom = 40 remaining)
+        await createDepositViaApi(page, invoiceId, {
+          amount: 60,
+          dueDate: '2026-07-01',
+        });
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // Verify first deposit visible and Final Payment = 40
+        await expect(detailPage.depositsSection).toContainText('60');
+        await expect(detailPage.finalPaymentAmount).toContainText('40');
+
+        // Try to add a second deposit of 60 (exceeds remaining 40)
+        await detailPage.openAddDepositModal();
+        await detailPage.fillDepositForm({
+          amount: '60',
+          dueDate: '2026-08-01',
+        });
+
+        // Register the expected 400 response BEFORE clicking save
+        const errorResponsePromise = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/deposits') &&
+            resp.request().method() === 'POST' &&
+            resp.status() === 400,
+        );
+
+        await detailPage.depositModalSave.click();
+        await errorResponsePromise;
+
+        // Error banner renders in the modal with the error message
+        // The message includes "Available headroom" and the formatted available amount (40)
+        await expect(detailPage.depositModalError).toBeVisible();
+        await expect(detailPage.depositModalError).toContainText('40');
+
+        // Modal stays open — user can correct the amount
+        await expect(detailPage.depositAmountInput).toBeVisible();
+
+        // Cancel to close modal
+        await detailPage.depositModalCancel.first().click();
+        await detailPage.depositAmountInput.waitFor({ state: 'hidden' });
+      } finally {
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: Responsive tablet (768px) — table layout
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — tablet layout (Scenario 6)', { tag: '@responsive' }, () => {
+  test('Deposits table visible on tablet viewport (768px); Final Payment row visible', async ({
+    page,
+    testPrefix,
+  }) => {
+    // Only run this on tablet or wider — skip on mobile (375px) where table is hidden
+    const viewportWidth = page.viewportSize()?.width ?? 1440;
+    if (viewportWidth < 600) {
+      test.skip(true, 'Table layout test — skipping on mobile viewport');
+      return;
+    }
+
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep TabletVendor`);
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 800,
+        date: '2026-06-01',
+      });
+
+      // Create a deposit via API
+      await createDepositViaApi(page, invoiceId, {
+        amount: 200,
+        dueDate: '2026-07-15',
+      });
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      // The deposits section renders
+      await expect(detailPage.depositsSection).toBeVisible();
+
+      // Deposit amount visible in the section
+      await expect(detailPage.depositsSection).toContainText('200');
+
+      // Final payment row visible: 800 − 200 = 600
+      await expect(detailPage.finalPaymentRow).toBeVisible();
+      await expect(detailPage.finalPaymentAmount).toContainText('600');
+
+      // No horizontal overflow
+      const overflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(overflow).toBe(false);
+    } finally {
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 7: Responsive mobile (375px) — card list layout
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — mobile card layout (Scenario 7)', { tag: '@responsive' }, () => {
+  test('Deposits render as cards on mobile; "Mark paid" flow works; Final Payment visible', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep MobileVendor`);
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 900,
+        date: '2026-06-01',
+      });
+
+      // Create a pending deposit via API
+      await createDepositViaApi(page, invoiceId, {
+        amount: 250,
+        dueDate: '2026-07-20',
+      });
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      // Deposits section renders
+      await expect(detailPage.depositsSection).toBeVisible();
+
+      // Amount visible (works for both table and card layout)
+      await expect(detailPage.depositsSection).toContainText('250');
+
+      // Final payment row visible: 900 − 250 = 650
+      await expect(detailPage.finalPaymentRow).toBeVisible();
+      await expect(detailPage.finalPaymentAmount).toContainText('650');
+
+      const viewportWidth = page.viewportSize()?.width ?? 1440;
+
+      // On mobile viewports (≤767px) the mobile card list should be visible
+      if (viewportWidth <= 767) {
+        // The mobileCardList role="list" should be present
+        const mobileCardList = detailPage.depositsSection.locator('[role="list"]');
+        await expect(mobileCardList).toBeVisible();
+
+        // Individual card is visible
+        const mobileCard = detailPage.depositsSection.locator('[class*="mobileCard"]').first();
+        await expect(mobileCard).toBeVisible();
+
+        // Amount and status badge visible in the card
+        await expect(mobileCard).toContainText('250');
+      }
+
+      // ── "Mark paid" flow via overflow menu ──
+      await detailPage.openDepositMenu();
+      await detailPage.clickDepositMenuItem(/Mark paid/);
+
+      // State confirm modal opens
+      await expect(
+        page.getByRole('dialog').filter({ has: page.getByText('Mark as paid') }),
+      ).toBeVisible();
+
+      // Confirm state transition
+      await detailPage.confirmStateTransition();
+
+      // Badge updates to "Paid"
+      await expect(detailPage.depositsSection).toContainText('Paid');
+
+      // Final payment row still visible
+      await expect(detailPage.finalPaymentRow).toBeVisible();
+      await expect(detailPage.finalPaymentAmount).toContainText('650');
+    } finally {
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+
+  test('Mobile: Add deposit modal is usable; form inputs accessible', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep MobFormVendor`);
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 400,
+        date: '2026-06-01',
+      });
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      // Open add deposit modal
+      await detailPage.openAddDepositModal();
+
+      // All form inputs accessible
+      await expect(detailPage.depositAmountInput).toBeVisible();
+      await expect(detailPage.depositDueDateInput).toBeVisible();
+      await expect(detailPage.depositStatusSelect).toBeVisible();
+      await expect(detailPage.depositDescriptionInput).toBeVisible();
+
+      // Save button visible (may need scroll)
+      await detailPage.depositModalSave.scrollIntoViewIfNeeded();
+      await expect(detailPage.depositModalSave).toBeVisible();
+
+      // Fill and submit
+      await detailPage.fillDepositForm({
+        amount: '120',
+        dueDate: '2026-08-01',
+      });
+
+      await detailPage.saveDepositForm(201);
+
+      // Deposit appears in the section
+      await expect(detailPage.depositsSection).toContainText('120');
+      await expect(detailPage.finalPaymentAmount).toContainText('280');
+    } finally {
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Additional: Multiple deposits — sum invariant
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — multiple deposits and sum invariant', () => {
+  test('Multiple deposits: Final Payment = invoice total − sum of all deposit amounts', async ({
+    page,
+    testPrefix,
+  }) => {
+    const detailPage = new InvoiceDetailPage(page);
+    let vendorId = '';
+    let invoiceId = '';
+
+    try {
+      vendorId = await createVendorViaApi(page, `${testPrefix} Dep MultiVendor`);
+      // Invoice total = 1000
+      invoiceId = await createInvoiceViaApi(page, vendorId, {
+        amount: 1000,
+        date: '2026-06-01',
+      });
+
+      // Create two deposits: 200 + 300 = 500 total; Final Payment = 500
+      await createDepositViaApi(page, invoiceId, {
+        amount: 200,
+        dueDate: '2026-07-01',
+      });
+      await createDepositViaApi(page, invoiceId, {
+        amount: 300,
+        dueDate: '2026-08-01',
+      });
+
+      await detailPage.goto(invoiceId);
+      await expect(detailPage.heading).toBeVisible();
+
+      // Both deposits visible
+      await expect(detailPage.depositsSection).toContainText('200');
+      await expect(detailPage.depositsSection).toContainText('300');
+
+      // Final Payment = 1000 − 200 − 300 = 500
+      await expect(detailPage.finalPaymentRow).toBeVisible();
+      await expect(detailPage.finalPaymentAmount).toContainText('500');
+    } finally {
+      if (vendorId) await deleteVendorViaApi(page, vendorId);
+    }
+  });
+});

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -394,15 +394,20 @@ test.describe('Deposits — delete paid deposit warning (Scenario 4)', () => {
           date: '2026-06-01',
         });
 
-        // Create a deposit already in 'paid' status via API
+        // Create a deposit in 'paid' status via the state machine: pending → paid
+        // Direct creation with status='paid' is rejected by the server (ALLOWED_TRANSITIONS).
         const today = new Date().toISOString().slice(0, 10);
         const deposit = await createDepositViaApi(page, invoiceId, {
           amount: 150,
           dueDate: '2026-07-01',
-          status: 'paid',
-          paidDate: today,
         });
         depositId = deposit.id;
+        // pending → paid
+        const paidResp = await page.request.patch(
+          `/api/invoices/${invoiceId}/deposits/${deposit.id}`,
+          { data: { status: 'paid', paidDate: today } },
+        );
+        expect(paidResp.ok(), `PATCH pending→paid failed: ${paidResp.status()}`).toBeTruthy();
 
         await detailPage.goto(invoiceId);
         await expect(detailPage.heading).toBeVisible();
@@ -462,15 +467,26 @@ test.describe('Deposits — delete paid deposit warning (Scenario 4)', () => {
         date: '2026-06-01',
       });
 
+      // Create a deposit in 'claimed' status via state machine: pending → paid → claimed.
+      // Direct creation with status='claimed' is rejected by the server (ALLOWED_TRANSITIONS).
       const today = new Date().toISOString().slice(0, 10);
       const deposit = await createDepositViaApi(page, invoiceId, {
         amount: 100,
         dueDate: '2026-07-01',
-        status: 'claimed',
-        paidDate: today,
-        claimedDate: today,
       });
       depositId = deposit.id;
+      // pending → paid
+      const paidResp = await page.request.patch(
+        `/api/invoices/${invoiceId}/deposits/${deposit.id}`,
+        { data: { status: 'paid', paidDate: today } },
+      );
+      expect(paidResp.ok(), `PATCH pending→paid failed: ${paidResp.status()}`).toBeTruthy();
+      // paid → claimed
+      const claimedResp = await page.request.patch(
+        `/api/invoices/${invoiceId}/deposits/${deposit.id}`,
+        { data: { status: 'claimed', claimedDate: today } },
+      );
+      expect(claimedResp.ok(), `PATCH paid→claimed failed: ${claimedResp.status()}`).toBeTruthy();
 
       await detailPage.goto(invoiceId);
       await expect(detailPage.heading).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "picomatch@>=4.0.0 <4.0.4": "4.0.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",
-    "serialize-javascript": "7.0.5",
-    "webpack": "5.105.0"
+    "serialize-javascript": "7.0.5"
   }
 }

--- a/server/src/services/budgetOverviewService.test.ts
+++ b/server/src/services/budgetOverviewService.test.ts
@@ -1338,4 +1338,207 @@ describe('getBudgetOverview', () => {
       expect(result.remainingVsMaxPlannedWithPayback).toBe(result.remainingVsMaxPlanned);
     });
   });
+
+  // ─── #1405 deposit-aware actualCostPaid / actualCostClaimed (step 8) ─────
+
+  describe('deposit-aware invoice totals (#1405)', () => {
+    /**
+     * Helper: insert a deposit for a given invoice, directly into the DB.
+     */
+    function insertDeposit(
+      invoiceId: string,
+      opts: { amount: number; status: 'pending' | 'paid' | 'claimed' },
+    ): void {
+      const id = `dep-ov-${idCounter++}`;
+      const now = new Date().toISOString();
+      db.insert(schema.invoiceDeposits)
+        .values({
+          id,
+          invoiceId,
+          amount: opts.amount,
+          dueDate: '2026-03-01',
+          status: opts.status,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    /**
+     * Create a paid invoice for a work item budget line and return its id.
+     * The paid invoice uses the 'paid' status for insertion; allows deposit override.
+     */
+    function insertWorkItemWithPaidInvoiceAndDeposits(
+      opts: {
+        plannedAmount: number;
+        invoiceAmount: number;
+        invoiceStatus: 'pending' | 'paid' | 'claimed';
+        deposits: Array<{ amount: number; status: 'pending' | 'paid' | 'claimed' }>;
+      },
+    ): string {
+      const { workItemId, budgetLineId } = insertWorkItem({
+        plannedAmount: opts.plannedAmount,
+        actualCost: opts.invoiceStatus !== 'pending' ? opts.invoiceAmount : undefined,
+      });
+
+      if (budgetLineId === null) return workItemId;
+
+      // The insertWorkItem helper already created the invoice when actualCost > 0 and invoiceStatus=paid.
+      // For cases where we need a specific invoice status, insert manually.
+      // Get the last invoice inserted (from actualCost helper) and update its status if needed.
+      // Simpler: create our own invoice directly.
+      const vendorId = `dep-ov-v-${idCounter++}`;
+      const now = new Date().toISOString();
+      db.insert(schema.vendors)
+        .values({ id: vendorId, name: `DepOv Vendor ${vendorId}`, createdAt: now, updatedAt: now })
+        .run();
+
+      // Create a sibling budget line (primary may already have an invoice from insertWorkItem helper)
+      const siblingBudgetId = `bud-dep-ov-${idCounter++}`;
+      db.insert(schema.workItemBudgets)
+        .values({
+          id: siblingBudgetId,
+          workItemId,
+          plannedAmount: opts.invoiceAmount,
+          confidence: 'own_estimate',
+          budgetSourceId: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      const invoiceId = `inv-dep-ov-${idCounter++}`;
+      db.insert(schema.invoices)
+        .values({
+          id: invoiceId,
+          vendorId,
+          amount: opts.invoiceAmount,
+          date: '2026-01-01',
+          status: opts.invoiceStatus,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      db.insert(schema.invoiceBudgetLines)
+        .values({
+          id: randomUUID(),
+          invoiceId,
+          workItemBudgetId: siblingBudgetId,
+          itemizedAmount: opts.invoiceAmount,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      // Insert deposits
+      for (const dep of opts.deposits) {
+        insertDeposit(invoiceId, dep);
+      }
+
+      return workItemId;
+    }
+
+    it('AC-25: actualCostPaid includes paid deposit fractions for pending invoice', () => {
+      // Invoice=1000 pending; deposit 300 paid → actualCostPaid += 300, actualCostClaimed += 0
+      insertWorkItemWithPaidInvoiceAndDeposits({
+        plannedAmount: 1000,
+        invoiceAmount: 1000,
+        invoiceStatus: 'pending',
+        deposits: [{ amount: 300, status: 'paid' }],
+      });
+
+      const result = getBudgetOverview(db);
+
+      expect(result.actualCost).toBeGreaterThanOrEqual(1000);
+      expect(result.actualCostPaid).toBeGreaterThanOrEqual(300);
+    });
+
+    it('AC-25: actualCostClaimed includes claimed deposit fraction', () => {
+      // Invoice=1000 pending; deposit 400 claimed → actualCostClaimed += 400
+      insertWorkItemWithPaidInvoiceAndDeposits({
+        plannedAmount: 1000,
+        invoiceAmount: 1000,
+        invoiceStatus: 'pending',
+        deposits: [{ amount: 400, status: 'claimed' }],
+      });
+
+      const result = getBudgetOverview(db);
+
+      expect(result.actualCostClaimed).toBeGreaterThanOrEqual(400);
+    });
+
+    it('AC-26 (AC-10 regression): zero-deposit paid invoice — actualCostPaid unchanged', () => {
+      // No deposits: full invoice amount goes to actualCostPaid
+      insertWorkItem({ plannedAmount: 500, actualCost: 500 });
+
+      const result = getBudgetOverview(db);
+
+      expect(result.actualCost).toBeGreaterThanOrEqual(500);
+      expect(result.actualCostPaid).toBeGreaterThanOrEqual(500);
+    });
+
+    it('mixed deposits: actualCostPaid includes both paid and claimed deposit contributions', () => {
+      // Invoice=1000 pending; deposit 200 paid + 300 claimed → actualCostPaid = 500
+      insertWorkItemWithPaidInvoiceAndDeposits({
+        plannedAmount: 1000,
+        invoiceAmount: 1000,
+        invoiceStatus: 'pending',
+        deposits: [
+          { amount: 200, status: 'paid' },
+          { amount: 300, status: 'claimed' },
+        ],
+      });
+
+      const result = getBudgetOverview(db);
+
+      expect(result.actualCostPaid).toBeGreaterThanOrEqual(500);
+      expect(result.actualCostClaimed).toBeGreaterThanOrEqual(300);
+    });
+
+    it('quotation invoice with deposits: excluded from actualCost (parity check)', () => {
+      // Quotation invoices should still be excluded regardless of deposits
+      const { workItemId, budgetLineId } = insertWorkItem({ plannedAmount: 500 });
+      if (budgetLineId) {
+        const now = new Date().toISOString();
+        const vendorId = `dep-quot-v-${idCounter++}`;
+        db.insert(schema.vendors)
+          .values({
+            id: vendorId,
+            name: `Quot Vendor ${vendorId}`,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        const invoiceId = `inv-quot-${idCounter++}`;
+        db.insert(schema.invoices)
+          .values({
+            id: invoiceId,
+            vendorId,
+            amount: 500,
+            date: '2026-01-01',
+            status: 'quotation',
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        db.insert(schema.invoiceBudgetLines)
+          .values({
+            id: randomUUID(),
+            invoiceId,
+            workItemBudgetId: budgetLineId,
+            itemizedAmount: 500,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        insertDeposit(invoiceId, { amount: 200, status: 'paid' });
+      }
+
+      const result = getBudgetOverview(db);
+
+      // Quotation excluded: actualCost should remain 0 for this work item
+      expect(result.actualCost).toBe(0);
+      expect(result.actualCostPaid).toBe(0);
+    });
+  });
 });

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -9,6 +9,7 @@ import type {
   SubsidyCapMeta,
   PerSubsidyTotals,
 } from './shared/subsidyCalculationEngine.js';
+import { computeDepositAwareAggregates, type DepositAwareRow } from './shared/depositAggregateUtils.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
@@ -286,26 +287,27 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
     totalMaxPlanned += maxPlanned;
   }
 
-  // ── 8. Actual costs from invoices linked to budget lines ──────────────────
+  // ── 8. Actual costs from invoices linked to budget lines (deposit-aware) ──
   // Include both work item and household item invoices
   // Exclude quotation invoices from actual cost aggregates
-  const invoiceTotalsRow = db.get<{
-    actualCost: number | null;
-    actualCostPaid: number | null;
-    actualCostClaimed: number | null;
-  }>(
+  // Includes deposits split proportionally by amount
+  const overviewRows = db.all<DepositAwareRow>(
     sql`SELECT
-      COALESCE(SUM(ibl.itemized_amount), 0)                                                         AS actualCost,
-      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0) AS actualCostPaid,
-      COALESCE(SUM(CASE WHEN i.status = 'claimed' THEN ibl.itemized_amount ELSE 0 END), 0)            AS actualCostClaimed
+      ibl.id              AS ibl_id,
+      ibl.itemized_amount AS itemized_amount,
+      i.id                AS invoice_id,
+      i.amount            AS invoice_amount,
+      i.status            AS invoice_status,
+      d.id                AS deposit_id,
+      d.amount            AS deposit_amount,
+      d.status            AS deposit_status
     FROM invoice_budget_lines ibl
     INNER JOIN invoices i ON i.id = ibl.invoice_id
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
     WHERE i.status != 'quotation'`,
   );
 
-  const actualCost = invoiceTotalsRow?.actualCost ?? 0;
-  const actualCostPaid = invoiceTotalsRow?.actualCostPaid ?? 0;
-  const actualCostClaimed = invoiceTotalsRow?.actualCostClaimed ?? 0;
+  const { actualCost, actualCostPaid, actualCostClaimed } = computeDepositAwareAggregates(overviewRows);
 
   // ── 9. Subsidy summary ───────────────────────────────────────────────────
   const subsidyCountRow = db.get<{ activeSubsidyCount: number }>(

--- a/server/src/services/budgetSourceService.test.ts
+++ b/server/src/services/budgetSourceService.test.ts
@@ -2420,4 +2420,157 @@ describe('Budget Source Service', () => {
       expect(result.projectedAmount).toBeCloseTo(result.projectedMaxAmount);
     });
   });
+
+  // ─── #1405 deposit-aware claimed/unclaimed/discretionary amounts ──────────
+
+  describe('deposit-aware amounts (#1405)', () => {
+    /**
+     * Helper: insert a deposit for a given invoice.
+     */
+    function insertDepositForInvoice(
+      invoiceId: string,
+      opts: { amount: number; status: 'pending' | 'paid' | 'claimed' },
+    ): string {
+      const id = `dep-src-${++workItemCounter}`;
+      const ts = new Date(Date.now() + workItemCounter).toISOString();
+      db.insert(schema.invoiceDeposits)
+        .values({
+          id,
+          invoiceId,
+          amount: opts.amount,
+          dueDate: '2026-03-01',
+          status: opts.status,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      return id;
+    }
+
+    /**
+     * Helper: insert a vendor + invoice with given amount and status, linked to a work item budget line.
+     * Returns the invoiceId.
+     */
+    function insertInvoiceForBudgetLine(
+      budgetLineId: string,
+      invoiceAmount: number,
+      status: 'pending' | 'paid' | 'claimed',
+    ): string {
+      const ts = new Date(Date.now() + workItemCounter).toISOString();
+      const vendorId = `vendor-dep-${++workItemCounter}`;
+      db.insert(schema.vendors)
+        .values({ id: vendorId, name: `Dep Vendor ${vendorId}`, createdAt: ts, updatedAt: ts })
+        .run();
+      const invoiceId = `inv-dep-${workItemCounter}`;
+      db.insert(schema.invoices)
+        .values({
+          id: invoiceId,
+          vendorId,
+          amount: invoiceAmount,
+          date: '2026-01-01',
+          status,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      db.insert(schema.invoiceBudgetLines)
+        .values({
+          id: randomUUID(),
+          invoiceId,
+          workItemBudgetId: budgetLineId,
+          itemizedAmount: invoiceAmount,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      return invoiceId;
+    }
+
+    describe('computeClaimedAmount — with claimed deposit', () => {
+      it('AC-23: claimed deposit fraction is attributed to claimedAmount', () => {
+        // invoice=1000 pending, deposit 400 claimed → claimedAmount should be 400
+        const raw = insertRawSource({ name: 'Deposit Claim Source', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 1000);
+        const invoiceId = insertInvoiceForBudgetLine(budgetId, 1000, 'pending');
+        insertDepositForInvoice(invoiceId, { amount: 400, status: 'claimed' });
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        // claimedAmount = 400/1000 * 1000 = 400
+        expect(result.claimedAmount).toBeCloseTo(400);
+      });
+
+      it('claimed deposit on claimed invoice: both deposit and remaining residual are claimed', () => {
+        // invoice=1000 claimed, deposit 300 claimed, residual 700 claimed
+        // Both contribute to claimedAmount → total = 1000
+        const raw = insertRawSource({ name: 'Full Claim Source', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 1000);
+        const invoiceId = insertInvoiceForBudgetLine(budgetId, 1000, 'claimed');
+        insertDepositForInvoice(invoiceId, { amount: 300, status: 'claimed' });
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        expect(result.claimedAmount).toBeCloseTo(1000);
+      });
+
+      it('zero-deposit claimed invoice: claimedAmount unchanged from pre-deposit behavior (AC-10)', () => {
+        // No deposits: whole invoice amount contributes to claimedAmount
+        const raw = insertRawSource({ name: 'No Deposit Claim', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 800);
+        insertClaimedInvoice(budgetId, 800);
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        expect(result.claimedAmount).toBe(800);
+      });
+    });
+
+    describe('computeUnclaimedAmount — with paid deposit', () => {
+      it('AC-24: paid deposit fraction is attributed to unclaimedAmount', () => {
+        // invoice=1000 pending, deposit 300 paid → unclaimedAmount = 300
+        const raw = insertRawSource({ name: 'Unclaimed Dep Source', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 1000);
+        const invoiceId = insertInvoiceForBudgetLine(budgetId, 1000, 'pending');
+        insertDepositForInvoice(invoiceId, { amount: 300, status: 'paid' });
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        // unclaimedAmount = computeStatusContribution('paid') = 300
+        expect(result.unclaimedAmount).toBeCloseTo(300);
+      });
+
+      it('paid deposit on paid invoice: deposit fraction + residual paid fraction = full amount', () => {
+        // invoice=1000 paid, deposit 400 paid, residual 600 paid → unclaimedAmount = 1000
+        const raw = insertRawSource({ name: 'Full Unclaim Source', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 1000);
+        const invoiceId = insertInvoiceForBudgetLine(budgetId, 1000, 'paid');
+        insertDepositForInvoice(invoiceId, { amount: 400, status: 'paid' });
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        expect(result.unclaimedAmount).toBeCloseTo(1000);
+      });
+
+      it('zero-deposit paid invoice: unclaimedAmount unchanged from pre-deposit behavior (AC-10)', () => {
+        const raw = insertRawSource({ name: 'No Deposit Unclaim', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 500);
+        insertPaidInvoice(budgetId, 500);
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        expect(result.unclaimedAmount).toBe(500);
+      });
+    });
+
+    describe('paidAmount = claimedAmount + unclaimedAmount (deposit-aware)', () => {
+      it('paidAmount sums deposit-aware claimed + unclaimed contributions', () => {
+        // invoice=1000 pending; deposit 200 claimed + deposit 300 paid → residual 500 pending
+        // claimedAmount=200, unclaimedAmount=300, paidAmount=500
+        const raw = insertRawSource({ name: 'Mixed Dep Source', totalAmount: 50000 });
+        const { budgetId } = insertRawWorkItemWithSource(raw.id, 1000);
+        const invoiceId = insertInvoiceForBudgetLine(budgetId, 1000, 'pending');
+        insertDepositForInvoice(invoiceId, { amount: 200, status: 'claimed' });
+        insertDepositForInvoice(invoiceId, { amount: 300, status: 'paid' });
+
+        const result = budgetSourceService.getBudgetSourceById(db, raw.id);
+        expect(result.claimedAmount).toBeCloseTo(200);
+        expect(result.unclaimedAmount).toBeCloseTo(300);
+        expect(result.paidAmount).toBeCloseTo(500);
+      });
+    });
+  });
 });

--- a/server/src/services/budgetSourceService.ts
+++ b/server/src/services/budgetSourceService.ts
@@ -15,6 +15,7 @@ import {
   budgetCategories,
   vendors,
 } from '../db/schema.js';
+import { computeStatusContribution, type DepositAwareRow } from './shared/depositAggregateUtils.js';
 import type {
   BudgetSource,
   BudgetSourceType,
@@ -119,56 +120,74 @@ function computeUsedAmount(db: DbType, sourceId: string): number {
 
 /**
  * Compute the claimed amount for a budget source.
- * Sums invoice amounts where status = 'claimed' and the invoice's budget line
- * references this source (either work item OR household item budget). Returns 0 if no claimed invoices exist.
+ * Sums claimed contributions from invoice budget lines linked to this source,
+ * including deposits split proportionally by amount.
+ * Returns 0 if no claimed invoices exist.
  */
 function computeClaimedAmount(db: DbType, sourceId: string): number {
-  // EPIC-15: Join through invoiceBudgetLines junction table; fixed in EPIC-16 to include household items
-  const result = db.get<{ total: number }>(
-    sql`SELECT COALESCE(SUM(ibl.itemized_amount), 0) AS total
+  const rows = db.all<DepositAwareRow>(
+    sql`SELECT
+      ibl.id              AS ibl_id,
+      ibl.itemized_amount AS itemized_amount,
+      i.id                AS invoice_id,
+      i.amount            AS invoice_amount,
+      i.status            AS invoice_status,
+      d.id                AS deposit_id,
+      d.amount            AS deposit_amount,
+      d.status            AS deposit_status
     FROM invoice_budget_lines ibl
     INNER JOIN invoices i ON i.id = ibl.invoice_id
-    WHERE i.status = 'claimed'
-      AND (
-        (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM work_item_budgets wib
-          WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id = ${sourceId}
-        ))
-        OR
-        (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM household_item_budgets hib
-          WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id = ${sourceId}
-        ))
-      )`,
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
+    WHERE (
+      (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM work_item_budgets wib
+        WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id = ${sourceId}
+      ))
+      OR
+      (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM household_item_budgets hib
+        WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id = ${sourceId}
+      ))
+    )`,
   );
-  return result?.total ?? 0;
+
+  return computeStatusContribution(rows, 'claimed');
 }
 
 /**
  * Compute the unclaimed (paid but not claimed) amount for a budget source.
- * Sums invoice amounts where status = 'paid' and the invoice's budget line
- * references this source (either work item OR household item budget). Returns 0 if no paid invoices exist.
+ * Sums paid contributions from invoice budget lines linked to this source,
+ * including deposits split proportionally by amount.
+ * Returns 0 if no paid invoices exist.
  */
 function computeUnclaimedAmount(db: DbType, sourceId: string): number {
-  // EPIC-15: Join through invoiceBudgetLines junction table; fixed in EPIC-16 to include household items
-  const result = db.get<{ total: number }>(
-    sql`SELECT COALESCE(SUM(ibl.itemized_amount), 0) AS total
+  const rows = db.all<DepositAwareRow>(
+    sql`SELECT
+      ibl.id              AS ibl_id,
+      ibl.itemized_amount AS itemized_amount,
+      i.id                AS invoice_id,
+      i.amount            AS invoice_amount,
+      i.status            AS invoice_status,
+      d.id                AS deposit_id,
+      d.amount            AS deposit_amount,
+      d.status            AS deposit_status
     FROM invoice_budget_lines ibl
     INNER JOIN invoices i ON i.id = ibl.invoice_id
-    WHERE i.status = 'paid'
-      AND (
-        (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM work_item_budgets wib
-          WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id = ${sourceId}
-        ))
-        OR
-        (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM household_item_budgets hib
-          WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id = ${sourceId}
-        ))
-      )`,
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
+    WHERE (
+      (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM work_item_budgets wib
+        WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id = ${sourceId}
+      ))
+      OR
+      (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM household_item_budgets hib
+        WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id = ${sourceId}
+      ))
+    )`,
   );
-  return result?.total ?? 0;
+
+  return computeStatusContribution(rows, 'paid');
 }
 
 /**
@@ -190,43 +209,133 @@ function countBudgetLineReferences(db: DbType, sourceId: string): number {
 /**
  * Compute the discretionary invoice amount for a given status.
  * Includes:
- * 1. Unallocated remainder: invoice.amount - SUM(itemized_amount) for invoices with this status
- * 2. Lines with no budget_source: amount allocated to budget lines where source is NULL
+ * 1. Unallocated remainder: invoice.amount - SUM(itemized_amount) for invoices with this status,
+ *    split proportionally by deposits
+ * 2. Lines with no budget_source: amount allocated to budget lines where source is NULL,
+ *    split proportionally by deposits
  */
 function computeDiscretionaryInvoiceAmount(db: DbType, status: string): number {
-  // 1. Unallocated remainder: invoice.amount - SUM(itemized_amount) for invoices with this status
-  const remainderResult = db.get<{ total: number }>(
-    sql`SELECT COALESCE(SUM(remainder), 0) AS total
-    FROM (
-      SELECT i.amount - COALESCE(SUM(ibl.itemized_amount), 0) AS remainder
-      FROM invoices i
-      LEFT JOIN invoice_budget_lines ibl ON ibl.invoice_id = i.id
-      WHERE i.status = ${status}
-      GROUP BY i.id
-    )
-    WHERE remainder > 0`,
+  // 1. Unallocated remainder with deposit-aware split
+  // Fetch all invoices with unallocated remainder, along with their deposits
+  const remainderRows = db.all<{
+    invoice_id: string;
+    invoice_amount: number;
+    invoice_status: string;
+    total_itemized: number | null;
+    deposit_id: string | null;
+    deposit_amount: number | null;
+    deposit_status: string | null;
+  }>(
+    sql`SELECT
+      i.id              AS invoice_id,
+      i.amount          AS invoice_amount,
+      i.status          AS invoice_status,
+      COALESCE(SUM(ibl.itemized_amount), 0) AS total_itemized,
+      d.id              AS deposit_id,
+      d.amount          AS deposit_amount,
+      d.status          AS deposit_status
+    FROM invoices i
+    LEFT JOIN invoice_budget_lines ibl ON ibl.invoice_id = i.id
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
+    WHERE i.status = ${status}
+    GROUP BY i.id, d.id
+    HAVING (i.amount - COALESCE(SUM(ibl.itemized_amount), 0)) > 0`,
   );
 
-  // 2. Lines with no budget_source: amount allocated to budget lines where source is NULL
-  const noSourceResult = db.get<{ total: number }>(
-    sql`SELECT COALESCE(SUM(ibl.itemized_amount), 0) AS total
+  // Process remainder rows to compute deposit-aware contributions
+  let remainderTotal = 0;
+  const remainderByInvoice = new Map<
+    string,
+    {
+      invoiceAmount: number;
+      remainderAmount: number;
+      invoiceStatus: string;
+      deposits: Array<{ depositId: string; depositAmount: number; depositStatus: string }>;
+    }
+  >();
+
+  for (const row of remainderRows) {
+    const key = row.invoice_id;
+    if (!remainderByInvoice.has(key)) {
+      const remainderAmount = row.invoice_amount - (row.total_itemized ?? 0);
+      remainderByInvoice.set(key, {
+        invoiceAmount: row.invoice_amount,
+        remainderAmount: remainderAmount > 0 ? remainderAmount : 0,
+        invoiceStatus: row.invoice_status,
+        deposits: [],
+      });
+    }
+    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
+      const entry = remainderByInvoice.get(key)!;
+      if (!entry.deposits.find((d) => d.depositId === row.deposit_id)) {
+        entry.deposits.push({
+          depositId: row.deposit_id,
+          depositAmount: row.deposit_amount,
+          depositStatus: row.deposit_status,
+        });
+      }
+    }
+  }
+
+  // Compute proportional split for remainder
+  for (const [_invoiceId, entry] of remainderByInvoice) {
+    if (entry.deposits.length === 0) {
+      // No deposits: entire remainder contributes under parent status
+      if (entry.invoiceStatus === status) {
+        remainderTotal += entry.remainderAmount;
+      }
+    } else {
+      const totalDepositAmount = entry.deposits.reduce((s, d) => s + d.depositAmount, 0);
+      const safeInvoiceAmount = entry.invoiceAmount > 0 ? entry.invoiceAmount : 1;
+
+      // Residual contribution under parent invoice status
+      const residualFraction = Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
+      const residualAmount = entry.remainderAmount * residualFraction;
+      if (entry.invoiceStatus === status) {
+        remainderTotal += residualAmount;
+      }
+
+      // Per-deposit contributions
+      for (const deposit of entry.deposits) {
+        if (deposit.depositStatus === status) {
+          const depositFraction = deposit.depositAmount / safeInvoiceAmount;
+          const depositContribution = entry.remainderAmount * depositFraction;
+          remainderTotal += depositContribution;
+        }
+      }
+    }
+  }
+
+  // 2. Lines with no budget_source with deposit-aware split
+  const noSourceRows = db.all<DepositAwareRow>(
+    sql`SELECT
+      ibl.id              AS ibl_id,
+      ibl.itemized_amount AS itemized_amount,
+      i.id                AS invoice_id,
+      i.amount            AS invoice_amount,
+      i.status            AS invoice_status,
+      d.id                AS deposit_id,
+      d.amount            AS deposit_amount,
+      d.status            AS deposit_status
     FROM invoice_budget_lines ibl
     INNER JOIN invoices i ON i.id = ibl.invoice_id
-    WHERE i.status = ${status}
-      AND (
-        (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM work_item_budgets wib
-          WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id IS NULL
-        ))
-        OR
-        (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
-          SELECT 1 FROM household_item_budgets hib
-          WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id IS NULL
-        ))
-      )`,
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
+    WHERE (
+      (ibl.work_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM work_item_budgets wib
+        WHERE wib.id = ibl.work_item_budget_id AND wib.budget_source_id IS NULL
+      ))
+      OR
+      (ibl.household_item_budget_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM household_item_budgets hib
+        WHERE hib.id = ibl.household_item_budget_id AND hib.budget_source_id IS NULL
+      ))
+    )`,
   );
 
-  return (remainderResult?.total ?? 0) + (noSourceResult?.total ?? 0);
+  const noSourceTotal = computeStatusContribution(noSourceRows, status);
+
+  return remainderTotal + noSourceTotal;
 }
 
 /**

--- a/server/src/services/shared/budgetServiceFactory.test.ts
+++ b/server/src/services/shared/budgetServiceFactory.test.ts
@@ -1419,6 +1419,117 @@ describe('budgetServiceFactory — createBudgetService()', () => {
       expect(result.confidenceMargin).toBe(0);
     });
   });
+
+  // ─── #1405 deposit-aware aggregates via list() ──────────────────────────────
+
+  describe('deposit-aware invoice aggregates via list() (#1405)', () => {
+    /**
+     * Helper: insert a deposit directly into the DB for a given invoice.
+     */
+    function insertDeposit(
+      invoiceId: string,
+      opts: { amount: number; status: 'pending' | 'paid' | 'claimed' },
+    ): string {
+      const id = `dep-list-${++idCounter}`;
+      const now = new Date(Date.now() + idCounter).toISOString();
+      db.insert(schema.invoiceDeposits)
+        .values({
+          id,
+          invoiceId,
+          amount: opts.amount,
+          dueDate: '2026-03-01',
+          status: opts.status,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      return id;
+    }
+
+    it('AC-22: work-item list — single paid deposit split counted in actualCostPaid', () => {
+      // Invoice 1000 pending; deposit 300 paid, residual 700 pending
+      // listWorkItemBudgets actualCostPaid should be 300 (deposit fraction only)
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 1000,
+        budgetSourceId: 'discretionary-system',
+      });
+      const invoiceId = insertInvoiceForWorkItemBudget(line.id, vendorId, {
+        amount: 1000,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 300, status: 'paid' });
+
+      const result = listWorkItemBudgets(db, workItemId);
+      const lineResult = result.find((r) => r.id === line.id)!;
+
+      expect(lineResult.actualCost).toBe(1000);
+      expect(lineResult.actualCostPaid).toBeCloseTo(300);
+      expect(lineResult.invoiceCount).toBe(1);
+    });
+
+    it('zero-deposit paid invoice: actualCostPaid unchanged (AC-10 regression)', () => {
+      // Pre-deposit behavior must be preserved
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 500,
+        budgetSourceId: 'discretionary-system',
+      });
+      insertInvoiceForWorkItemBudget(line.id, vendorId, { amount: 500, status: 'paid' });
+
+      const result = listWorkItemBudgets(db, workItemId);
+      const lineResult = result.find((r) => r.id === line.id)!;
+
+      expect(lineResult.actualCost).toBe(500);
+      expect(lineResult.actualCostPaid).toBe(500);
+    });
+
+    it('household-item list — deposit-aware split via household_item_budget_id column', () => {
+      // Deposit 200 claimed on 600-pending invoice → actualCostPaid = 200
+      const hiId = insertHouseholdItem();
+      const vendorId = insertVendor();
+      const line = createHouseholdItemBudget(db, hiId, 'user-001', {
+        plannedAmount: 600,
+        budgetSourceId: 'discretionary-system',
+      });
+      const invoiceId = insertInvoiceForHouseholdItemBudget(line.id, vendorId, {
+        amount: 600,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 200, status: 'claimed' });
+
+      const result = listHouseholdItemBudgets(db, hiId);
+      const lineResult = result.find((r) => r.id === line.id)!;
+
+      expect(lineResult.actualCost).toBe(600);
+      expect(lineResult.actualCostPaid).toBeCloseTo(200);
+    });
+
+    it('fully-allocated deposits (Σ=invoice.amount): residual=0, parent status ignored', () => {
+      // Invoice 800 pending; deposit 500 paid + 300 pending = 800 total → residual 0
+      // parent status pending contributes 0; only paid deposit (500) counts
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = createWorkItemBudget(db, workItemId, 'user-001', {
+        plannedAmount: 800,
+        budgetSourceId: 'discretionary-system',
+      });
+      const invoiceId = insertInvoiceForWorkItemBudget(line.id, vendorId, {
+        amount: 800,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 500, status: 'paid' });
+      insertDeposit(invoiceId, { amount: 300, status: 'pending' });
+
+      const result = listWorkItemBudgets(db, workItemId);
+      const lineResult = result.find((r) => r.id === line.id)!;
+
+      expect(lineResult.actualCost).toBe(800);
+      expect(lineResult.actualCostPaid).toBeCloseTo(500);
+    });
+  });
 });
 
 // ─── resolveRelationsBatch() unit tests ────────────────────────────────────────
@@ -1856,5 +1967,181 @@ describe('resolveRelationsBatch()', () => {
     const workItemId = insertWorkItem();
     const result = listWorkItemBudgets(db, workItemId);
     expect(result).toEqual([]);
+  });
+
+  // ─── #1405 deposit-aware aggregate tests ──────────────────────────────────
+
+  describe('deposit-aware invoice aggregates (#1405)', () => {
+    /**
+     * Helper: insert a deposit record for an existing invoice.
+     */
+    function insertDeposit(
+      invoiceId: string,
+      opts: {
+        amount: number;
+        status: 'pending' | 'paid' | 'claimed';
+        dueDate?: string;
+      },
+    ): string {
+      const id = `dep-${++idCounter}`;
+      const now = new Date(Date.now() + idCounter).toISOString();
+      db.insert(schema.invoiceDeposits)
+        .values({
+          id,
+          invoiceId,
+          amount: opts.amount,
+          dueDate: opts.dueDate ?? '2026-03-01',
+          status: opts.status,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      return id;
+    }
+
+    it('AC-22: single paid deposit — paid fraction counted in actualCostPaid via resolveRelationsBatch', () => {
+      // invoice 1000 pending, deposit 300 paid, residual 700 pending
+      // resolveRelationsBatch should yield: actualCost=1000, actualCostPaid=300
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = insertWorkItemBudgetLine({ workItemId, plannedAmount: 1000 });
+      const { invoiceId } = insertInvoiceLinkedToWorkItemBudget(line.id, vendorId, {
+        amount: 1000,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 300, status: 'paid' });
+
+      const rows = [
+        {
+          id: line.id,
+          confidence: line.confidence,
+          budgetCategoryId: line.budgetCategoryId,
+          budgetSourceId: line.budgetSourceId,
+          vendorId: line.vendorId,
+          createdBy: line.createdBy,
+        },
+      ];
+      const result = resolveRelationsBatch(db, rows, 'work_item_budget_id');
+      const resolved = result.get(line.id)!;
+
+      expect(resolved.actualCost).toBe(1000);
+      expect(resolved.actualCostPaid).toBeCloseTo(300);
+      expect(resolved.invoiceCount).toBe(1);
+    });
+
+    it('claimed deposit + pending residual — actualCostClaimed proportional', () => {
+      // Invoice 1000 pending, deposit 400 claimed → actualCostPaid = 400, actualCostClaimed = 400
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = insertWorkItemBudgetLine({ workItemId, plannedAmount: 1000 });
+      const { invoiceId } = insertInvoiceLinkedToWorkItemBudget(line.id, vendorId, {
+        amount: 1000,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 400, status: 'claimed' });
+
+      const rows = [
+        {
+          id: line.id,
+          confidence: line.confidence,
+          budgetCategoryId: line.budgetCategoryId,
+          budgetSourceId: line.budgetSourceId,
+          vendorId: line.vendorId,
+          createdBy: line.createdBy,
+        },
+      ];
+      const result = resolveRelationsBatch(db, rows, 'work_item_budget_id');
+      const resolved = result.get(line.id)!;
+
+      expect(resolved.actualCost).toBe(1000);
+      // claimed deposit contributes to actualCostPaid
+      expect(resolved.actualCostPaid).toBeCloseTo(400);
+    });
+
+    it('zero-deposit invoice aggregates unchanged (AC-10 regression)', () => {
+      // Pre-deposit behavior: paid invoice, no deposits → actualCostPaid = full ibl amount
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = insertWorkItemBudgetLine({ workItemId, plannedAmount: 500 });
+      insertInvoiceLinkedToWorkItemBudget(line.id, vendorId, { amount: 500, status: 'paid' });
+
+      const rows = [
+        {
+          id: line.id,
+          confidence: line.confidence,
+          budgetCategoryId: line.budgetCategoryId,
+          budgetSourceId: line.budgetSourceId,
+          vendorId: line.vendorId,
+          createdBy: line.createdBy,
+        },
+      ];
+      const result = resolveRelationsBatch(db, rows, 'work_item_budget_id');
+      const resolved = result.get(line.id)!;
+
+      expect(resolved.actualCost).toBe(500);
+      expect(resolved.actualCostPaid).toBe(500);
+      expect(resolved.invoiceCount).toBe(1);
+    });
+
+    it('fully-allocated deposits (Σ=invoice.amount) — residual = 0, only deposits count', () => {
+      // Invoice 800 pending; deposit 500 paid + deposit 300 pending → residual 0
+      // actualCostPaid = 500 (paid deposit only)
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const line = insertWorkItemBudgetLine({ workItemId, plannedAmount: 800 });
+      const { invoiceId } = insertInvoiceLinkedToWorkItemBudget(line.id, vendorId, {
+        amount: 800,
+        status: 'pending',
+      });
+      insertDeposit(invoiceId, { amount: 500, status: 'paid' });
+      insertDeposit(invoiceId, { amount: 300, status: 'pending' });
+
+      const rows = [
+        {
+          id: line.id,
+          confidence: line.confidence,
+          budgetCategoryId: line.budgetCategoryId,
+          budgetSourceId: line.budgetSourceId,
+          vendorId: line.vendorId,
+          createdBy: line.createdBy,
+        },
+      ];
+      const result = resolveRelationsBatch(db, rows, 'work_item_budget_id');
+      const resolved = result.get(line.id)!;
+
+      expect(resolved.actualCost).toBe(800);
+      expect(resolved.actualCostPaid).toBeCloseTo(500);
+    });
+
+    it('batch with multiple budget lines — each gets its own deposit-aware split', () => {
+      // Line A: invoice 600 pending, deposit 200 paid → actualCostPaid=200
+      // Line B: invoice 400 paid (no deposits) → actualCostPaid=400
+      const workItemId = insertWorkItem();
+      const vendorId = insertVendor();
+      const lineA = insertWorkItemBudgetLine({ workItemId, plannedAmount: 600 });
+      const lineB = insertWorkItemBudgetLine({ workItemId, plannedAmount: 400 });
+      const { invoiceId: invA } = insertInvoiceLinkedToWorkItemBudget(lineA.id, vendorId, {
+        amount: 600,
+        status: 'pending',
+      });
+      insertDeposit(invA, { amount: 200, status: 'paid' });
+      insertInvoiceLinkedToWorkItemBudget(lineB.id, vendorId, { amount: 400, status: 'paid' });
+
+      const rows = [lineA, lineB].map((l) => ({
+        id: l.id,
+        confidence: l.confidence,
+        budgetCategoryId: l.budgetCategoryId,
+        budgetSourceId: l.budgetSourceId,
+        vendorId: l.vendorId,
+        createdBy: l.createdBy,
+      }));
+      const result = resolveRelationsBatch(db, rows, 'work_item_budget_id');
+
+      const resolvedA = result.get(lineA.id)!;
+      expect(resolvedA.actualCostPaid).toBeCloseTo(200);
+
+      const resolvedB = result.get(lineB.id)!;
+      expect(resolvedB.actualCostPaid).toBe(400);
+    });
   });
 });

--- a/server/src/services/shared/budgetServiceFactory.ts
+++ b/server/src/services/shared/budgetServiceFactory.ts
@@ -17,6 +17,7 @@ import {
   validateBudgetSourceId,
   validateVendorId,
 } from './validators.js';
+import { computeDepositAwareAggregates, type DepositAwareRow } from './depositAggregateUtils.js';
 import { CONFIDENCE_MARGINS as confidenceMargins } from '@cornerstone/shared';
 import type { ConfidenceLevel } from '@cornerstone/shared';
 import { NotFoundError, ValidationError, BudgetLineInUseError } from '../../errors/AppError.js';
@@ -192,7 +193,7 @@ export function resolveRelationsBatch(
     userList.forEach((u) => userMap.set(u.id, u));
   }
 
-  // Bulk-fetch invoice aggregates
+  // Bulk-fetch invoice aggregates with deposit-aware split
   const invoiceAggregatesMap = new Map<
     string,
     { actualCost: number; actualCostPaid: number; invoiceCount: number }
@@ -200,29 +201,39 @@ export function resolveRelationsBatch(
   if (invoiceBudgetIdColumn) {
     const budgetIds = rows.map((r) => r.id);
     const idItems = budgetIds.map((id) => sql`${id}`);
-    const aggregateRows = db.all<{
-      budget_id: string;
-      actualCost: number;
-      actualCostPaid: number;
-      invoiceCount: number;
-    }>(
+    const allRows = db.all<DepositAwareRow & { budget_id: string }>(
       sql`SELECT
         ibl.${sql.raw(invoiceBudgetIdColumn)} AS budget_id,
-        COALESCE(SUM(ibl.itemized_amount), 0) AS actualCost,
-        COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0) AS actualCostPaid,
-        COUNT(*) AS invoiceCount
+        ibl.id              AS ibl_id,
+        ibl.itemized_amount AS itemized_amount,
+        i.id                AS invoice_id,
+        i.amount            AS invoice_amount,
+        i.status            AS invoice_status,
+        d.id                AS deposit_id,
+        d.amount            AS deposit_amount,
+        d.status            AS deposit_status
       FROM invoice_budget_lines ibl
       INNER JOIN invoices i ON i.id = ibl.invoice_id
-      WHERE ibl.${sql.raw(invoiceBudgetIdColumn)} IN (${sql.join(idItems, sql`, `)})
-      GROUP BY ibl.${sql.raw(invoiceBudgetIdColumn)}`,
+      LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
+      WHERE ibl.${sql.raw(invoiceBudgetIdColumn)} IN (${sql.join(idItems, sql`, `)})`,
     );
-    aggregateRows.forEach((row) => {
-      invoiceAggregatesMap.set(row.budget_id, {
-        actualCost: row.actualCost,
-        actualCostPaid: row.actualCostPaid,
-        invoiceCount: row.invoiceCount,
+
+    // Group by budget_id, then compute aggregates
+    const rowsByBudgetId = new Map<string, DepositAwareRow[]>();
+    for (const row of allRows) {
+      const rows = rowsByBudgetId.get(row.budget_id) ?? [];
+      rows.push(row);
+      rowsByBudgetId.set(row.budget_id, rows);
+    }
+
+    for (const [budgetId, budgetRows] of rowsByBudgetId) {
+      const { actualCost, actualCostPaid, invoiceCount } = computeDepositAwareAggregates(budgetRows);
+      invoiceAggregatesMap.set(budgetId, {
+        actualCost,
+        actualCostPaid,
+        invoiceCount,
       });
-    });
+    }
   }
 
   // Bulk-fetch invoice links (one per budget line)
@@ -335,24 +346,29 @@ export function getInvoiceAggregates(
   budgetId: string,
   invoiceBudgetIdColumn: string,
 ): { actualCost: number; actualCostPaid: number; invoiceCount: number } {
-  const row = db.get<{
-    actualCost: number | null;
-    actualCostPaid: number | null;
-    invoiceCount: number;
-  }>(
+  // Fetch (ibl, invoice, deposit?) tuples with deposit-aware split
+  const rows = db.all<DepositAwareRow>(
     sql`SELECT
-      COALESCE(SUM(ibl.itemized_amount), 0) AS actualCost,
-      COALESCE(SUM(CASE WHEN i.status IN ('paid', 'claimed') THEN ibl.itemized_amount ELSE 0 END), 0) AS actualCostPaid,
-      COUNT(*) AS invoiceCount
+      ibl.id              AS ibl_id,
+      ibl.itemized_amount AS itemized_amount,
+      i.id                AS invoice_id,
+      i.amount            AS invoice_amount,
+      i.status            AS invoice_status,
+      d.id                AS deposit_id,
+      d.amount            AS deposit_amount,
+      d.status            AS deposit_status
     FROM invoice_budget_lines ibl
     INNER JOIN invoices i ON i.id = ibl.invoice_id
+    LEFT JOIN invoice_deposits d ON d.invoice_id = i.id
     WHERE ibl.${sql.raw(invoiceBudgetIdColumn)} = ${budgetId}`,
   );
 
+  const { actualCost, actualCostPaid, invoiceCount } = computeDepositAwareAggregates(rows);
+
   return {
-    actualCost: row?.actualCost ?? 0,
-    actualCostPaid: row?.actualCostPaid ?? 0,
-    invoiceCount: row?.invoiceCount ?? 0,
+    actualCost,
+    actualCostPaid,
+    invoiceCount,
   };
 }
 

--- a/server/src/services/shared/depositAggregateUtils.test.ts
+++ b/server/src/services/shared/depositAggregateUtils.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  computeDepositAwareAggregates,
+  computeStatusContribution,
+  type DepositAwareRow,
+} from './depositAggregateUtils.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a DepositAwareRow for a single invoice budget line with no deposits.
+ */
+function makeRow(
+  iblId: string,
+  itemizedAmount: number,
+  invoiceId: string,
+  invoiceAmount: number,
+  invoiceStatus: string,
+  deposit?: { id: string; amount: number; status: string },
+): DepositAwareRow {
+  return {
+    ibl_id: iblId,
+    itemized_amount: itemizedAmount,
+    invoice_id: invoiceId,
+    invoice_amount: invoiceAmount,
+    invoice_status: invoiceStatus,
+    deposit_id: deposit?.id ?? null,
+    deposit_amount: deposit?.amount ?? null,
+    deposit_status: deposit?.status ?? null,
+  };
+}
+
+// ─── computeDepositAwareAggregates ────────────────────────────────────────────
+
+describe('computeDepositAwareAggregates', () => {
+  // ─── Empty input ───────────────────────────────────────────────────────────
+
+  describe('empty input', () => {
+    it('returns all zeros for empty rows array', () => {
+      const result = computeDepositAwareAggregates([]);
+      expect(result).toEqual({
+        actualCost: 0,
+        actualCostPaid: 0,
+        actualCostClaimed: 0,
+        invoiceCount: 0,
+      });
+    });
+  });
+
+  // ─── Zero-deposit invoices (AC-2 regression) ───────────────────────────────
+
+  describe('zero-deposit invoices (pre-deposit behavior unchanged)', () => {
+    it('pending invoice: actualCost = iblAmount, actualCostPaid = 0, actualCostClaimed = 0', () => {
+      const rows = [makeRow('ibl-1', 500, 'inv-1', 500, 'pending')];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(500);
+      expect(result.actualCostPaid).toBe(0);
+      expect(result.actualCostClaimed).toBe(0);
+      expect(result.invoiceCount).toBe(1);
+    });
+
+    it('paid invoice: actualCostPaid = iblAmount, actualCostClaimed = 0', () => {
+      const rows = [makeRow('ibl-1', 300, 'inv-1', 300, 'paid')];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(300);
+      expect(result.actualCostPaid).toBe(300);
+      expect(result.actualCostClaimed).toBe(0);
+    });
+
+    it('claimed invoice: actualCostPaid = iblAmount AND actualCostClaimed = iblAmount', () => {
+      const rows = [makeRow('ibl-1', 400, 'inv-1', 400, 'claimed')];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(400);
+      expect(result.actualCostPaid).toBe(400);
+      expect(result.actualCostClaimed).toBe(400);
+    });
+
+    it('quotation invoice: excluded from actualCost', () => {
+      const rows = [makeRow('ibl-1', 250, 'inv-1', 250, 'quotation')];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(0);
+      expect(result.actualCostPaid).toBe(0);
+      expect(result.actualCostClaimed).toBe(0);
+      expect(result.invoiceCount).toBe(1); // invoiceCount still counts the invoice
+    });
+
+    it('multiple zero-deposit invoices across multiple ibls', () => {
+      const rows = [
+        makeRow('ibl-1', 100, 'inv-1', 100, 'paid'),
+        makeRow('ibl-2', 200, 'inv-2', 200, 'pending'),
+        makeRow('ibl-3', 300, 'inv-3', 300, 'claimed'),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(600); // 100 + 200 + 300
+      expect(result.actualCostPaid).toBe(400); // 100 (paid) + 300 (claimed)
+      expect(result.actualCostClaimed).toBe(300);
+      expect(result.invoiceCount).toBe(3);
+    });
+  });
+
+  // ─── Scenario 2: one paid deposit + pending residual ──────────────────────
+
+  describe('single paid deposit + pending residual', () => {
+    it('paid deposit fraction of iblAmount, residual (pending) contributes 0', () => {
+      // invoice amount=1000, ibl itemized=1000
+      // deposit: 300 paid → fraction 300/1000 = 0.3
+      // residual: 700 pending → contributes 0 to actualCostPaid
+      const rows = [
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-1',
+          amount: 300,
+          status: 'paid',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(1000);
+      expect(result.actualCostPaid).toBeCloseTo(300); // 300/1000 * 1000 = 300
+      expect(result.actualCostClaimed).toBe(0);
+    });
+
+    it('works when ibl.itemizedAmount differs from invoice.amount (proportional split)', () => {
+      // invoice amount=1000, ibl itemized=500 (partial allocation)
+      // deposit: 300 paid → deposit fraction 300/1000 = 0.3 → ibl contribution 500 * 0.3 = 150
+      // residual: 700 pending → residual fraction 700/1000 = 0.7 → ibl residual = 500 * 0.7 = 350
+      //   pending → 0 contribution to actualCostPaid
+      const rows = [
+        makeRow('ibl-1', 500, 'inv-1', 1000, 'pending', {
+          id: 'd-1',
+          amount: 300,
+          status: 'paid',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(500);
+      expect(result.actualCostPaid).toBeCloseTo(150); // 500 * 0.3
+      expect(result.actualCostClaimed).toBe(0);
+    });
+  });
+
+  // ─── Scenario 3: claimed deposit + paid residual ──────────────────────────
+
+  describe('claimed deposit + paid residual', () => {
+    it('claimed deposit contributes to both actualCostPaid and actualCostClaimed; paid residual to actualCostPaid only', () => {
+      // invoice amount=1000, ibl=1000
+      // deposit: 400 claimed → 0.4 fraction → claimedContrib=400, paidContrib=400
+      // residual: 600 paid → residualContrib=600 to actualCostPaid, 0 to actualCostClaimed
+      const rows = [
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'paid', {
+          id: 'd-1',
+          amount: 400,
+          status: 'claimed',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(1000);
+      // actualCostPaid = residual(600) + claimed_deposit(400) = 1000
+      expect(result.actualCostPaid).toBeCloseTo(1000);
+      // actualCostClaimed = only claimed deposit fraction = 400
+      expect(result.actualCostClaimed).toBeCloseTo(400);
+    });
+  });
+
+  // ─── Scenario 4: fully allocated (Σdeposits = invoice.amount) ────────────
+
+  describe('fully allocated: Σdeposits = invoice.amount, residual = 0', () => {
+    it('no residual contribution; only deposit statuses count', () => {
+      // invoice=1000, deposit 600 paid + deposit 400 pending
+      // residual = 0 → parent invoice status (pending) contributes 0
+      // paid deposit: 600/1000 * 1000 = 600 → actualCostPaid += 600
+      // pending deposit: 400/1000 * 1000 = 400 → actualCostPaid += 0
+      const rows = [
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-1',
+          amount: 600,
+          status: 'paid',
+        }),
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-2',
+          amount: 400,
+          status: 'pending',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(1000);
+      expect(result.actualCostPaid).toBeCloseTo(600);
+      expect(result.actualCostClaimed).toBe(0);
+    });
+
+    it('fully claimed: all deposits claimed, residual=0, actualCostClaimed = iblAmount', () => {
+      // invoice=500, one deposit 500 claimed
+      const rows = [
+        makeRow('ibl-1', 500, 'inv-1', 500, 'pending', {
+          id: 'd-1',
+          amount: 500,
+          status: 'claimed',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(500);
+      expect(result.actualCostPaid).toBeCloseTo(500);
+      expect(result.actualCostClaimed).toBeCloseTo(500);
+    });
+  });
+
+  // ─── Scenario 5: quotation invoice with deposits ───────────────────────────
+
+  describe('quotation invoice with deposits', () => {
+    it('excludes quotation invoice from actualCost even when deposits present', () => {
+      const rows = [
+        makeRow('ibl-1', 200, 'inv-1', 200, 'quotation', {
+          id: 'd-1',
+          amount: 100,
+          status: 'paid',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(0);
+      expect(result.actualCostPaid).toBe(0);
+      expect(result.actualCostClaimed).toBe(0);
+    });
+  });
+
+  // ─── Scenario 6: multiple ibl rows pointing to same invoice ───────────────
+
+  describe('multiple ibl rows for the same invoice (no double-counting)', () => {
+    it('deposits de-duplicated: same deposit appears once per ibl row but counted once', () => {
+      // Two budget lines link to same invoice (realistic: different work item budgets)
+      // Each row for deposit appears once per ibl — deposits map deduplicates by depositId
+      const rows = [
+        // ibl-A: 600 itemized, invoice 1000 paid, deposit 300 paid
+        makeRow('ibl-A', 600, 'inv-1', 1000, 'paid', { id: 'd-1', amount: 300, status: 'paid' }),
+        // ibl-B: 400 itemized, same invoice 1000, same deposit 300 paid
+        makeRow('ibl-B', 400, 'inv-1', 1000, 'paid', { id: 'd-1', amount: 300, status: 'paid' }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      // ibl-A: depositFraction=300/1000=0.3, depositContrib=600*0.3=180; residualFraction=700/1000=0.7, residualContrib=600*0.7=420 (paid)
+      //        actualCostPaid += 180 + 420 = 600
+      // ibl-B: depositFraction=0.3, depositContrib=400*0.3=120; residualFraction=0.7, residualContrib=400*0.7=280 (paid)
+      //        actualCostPaid += 120 + 280 = 400
+      // total actualCostPaid = 1000
+      expect(result.actualCost).toBe(1000);
+      expect(result.actualCostPaid).toBeCloseTo(1000);
+      expect(result.invoiceCount).toBe(1); // same invoice counted once
+    });
+  });
+
+  // ─── Scenario 7: invoice.amount = 0 (division-by-zero guard) ─────────────
+
+  describe('invoice.amount = 0 (division-by-zero guard)', () => {
+    it('handles invoice.amount = 0 safely without throwing', () => {
+      const rows = [
+        makeRow('ibl-1', 0, 'inv-1', 0, 'paid', { id: 'd-1', amount: 0, status: 'paid' }),
+      ];
+      expect(() => computeDepositAwareAggregates(rows)).not.toThrow();
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCost).toBe(0);
+      expect(result.actualCostPaid).toBe(0);
+    });
+  });
+
+  // ─── Mixed-state deposits (AC-1 invariant) ────────────────────────────────
+
+  describe('mixed-state deposits: total contribution invariant', () => {
+    it('sum of all contributions equals iblAmount regardless of deposit split', () => {
+      // invoice=1000, ibl=1000, deposits: 200 paid + 300 claimed + 100 pending, residual=400 pending
+      const rows = [
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-1',
+          amount: 200,
+          status: 'paid',
+        }),
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-2',
+          amount: 300,
+          status: 'claimed',
+        }),
+        makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+          id: 'd-3',
+          amount: 100,
+          status: 'pending',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      // actualCost must equal iblAmount = 1000 (not double-counted)
+      expect(result.actualCost).toBe(1000);
+      // actualCostPaid: d-1 contrib=200, d-2 contrib=300 → 500
+      // residual=400 pending → 0
+      expect(result.actualCostPaid).toBeCloseTo(500);
+      // actualCostClaimed: only d-2 contrib=300
+      expect(result.actualCostClaimed).toBeCloseTo(300);
+    });
+
+    it('invariant: actualCostClaimed ≤ actualCostPaid ≤ actualCost always holds', () => {
+      const rows = [
+        makeRow('ibl-1', 750, 'inv-1', 1000, 'claimed', {
+          id: 'd-1',
+          amount: 500,
+          status: 'pending',
+        }),
+        makeRow('ibl-1', 750, 'inv-1', 1000, 'claimed', {
+          id: 'd-2',
+          amount: 300,
+          status: 'claimed',
+        }),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.actualCostClaimed).toBeLessThanOrEqual(result.actualCostPaid);
+      expect(result.actualCostPaid).toBeLessThanOrEqual(result.actualCost);
+    });
+  });
+
+  // ─── invoiceCount deduplification ─────────────────────────────────────────
+
+  describe('invoiceCount deduplication', () => {
+    it('counts each unique invoice once even with multiple ibl rows', () => {
+      const rows = [
+        makeRow('ibl-1', 100, 'inv-1', 200, 'paid'),
+        makeRow('ibl-2', 100, 'inv-1', 200, 'paid'),
+        makeRow('ibl-3', 150, 'inv-2', 150, 'pending'),
+      ];
+      const result = computeDepositAwareAggregates(rows);
+      expect(result.invoiceCount).toBe(2);
+    });
+  });
+});
+
+// ─── computeStatusContribution ────────────────────────────────────────────────
+
+describe('computeStatusContribution', () => {
+  it('returns 0 for empty rows array', () => {
+    expect(computeStatusContribution([], 'claimed')).toBe(0);
+  });
+
+  it('no deposits: entire ibl amount contributes when invoice status matches target', () => {
+    const rows = [makeRow('ibl-1', 400, 'inv-1', 400, 'claimed')];
+    expect(computeStatusContribution(rows, 'claimed')).toBe(400);
+  });
+
+  it('no deposits: returns 0 when invoice status does not match target', () => {
+    const rows = [makeRow('ibl-1', 400, 'inv-1', 400, 'paid')];
+    expect(computeStatusContribution(rows, 'claimed')).toBe(0);
+  });
+
+  it('with deposits: claimed deposit contributes its fraction, residual under parent status', () => {
+    // invoice=1000, ibl=1000, deposit 400 claimed, residual 600 paid
+    // computeStatusContribution('claimed'): deposit fraction=400/1000=0.4 → 400
+    // residual: parent status='paid' != 'claimed' → 0
+    const rows = [
+      makeRow('ibl-1', 1000, 'inv-1', 1000, 'paid', { id: 'd-1', amount: 400, status: 'claimed' }),
+    ];
+    expect(computeStatusContribution(rows, 'claimed')).toBeCloseTo(400);
+  });
+
+  it('with deposits: paid deposit contributes its fraction to paid; parent status pending contributes 0', () => {
+    // invoice=1000, ibl=1000, deposit 300 paid, residual 700 pending
+    // computeStatusContribution('paid'): deposit fraction=300/1000=0.3 → 300; residual pending → 0
+    const rows = [
+      makeRow('ibl-1', 1000, 'inv-1', 1000, 'pending', {
+        id: 'd-1',
+        amount: 300,
+        status: 'paid',
+      }),
+    ];
+    expect(computeStatusContribution(rows, 'paid')).toBeCloseTo(300);
+  });
+
+  it('with deposits: residual under parent invoice status contributes when status matches', () => {
+    // invoice=1000, ibl=500, deposit 200 pending, residual 800 claimed
+    // computeStatusContribution('claimed'): residual fraction=800/1000=0.8 → ibl 500*0.8=400; deposit pending → 0
+    const rows = [
+      makeRow('ibl-1', 500, 'inv-1', 1000, 'claimed', {
+        id: 'd-1',
+        amount: 200,
+        status: 'pending',
+      }),
+    ];
+    expect(computeStatusContribution(rows, 'claimed')).toBeCloseTo(400);
+  });
+
+  it('handles multiple ibls and deduplicates deposit rows correctly', () => {
+    // Two ibl rows, same invoice, same deposit
+    const rows = [
+      makeRow('ibl-A', 300, 'inv-1', 1000, 'paid', { id: 'd-1', amount: 500, status: 'claimed' }),
+      makeRow('ibl-B', 200, 'inv-1', 1000, 'paid', { id: 'd-1', amount: 500, status: 'claimed' }),
+    ];
+    // ibl-A: claimed deposit 500/1000=0.5 → 300*0.5=150; residual 500/1000=0.5 → paid, not claimed → 0
+    // ibl-B: claimed deposit → 200*0.5=100; residual paid → 0
+    expect(computeStatusContribution(rows, 'claimed')).toBeCloseTo(250);
+  });
+
+  it('returns 0 for empty deposit list with non-matching invoice status', () => {
+    const rows = [makeRow('ibl-1', 500, 'inv-1', 500, 'pending')];
+    expect(computeStatusContribution(rows, 'claimed')).toBe(0);
+    expect(computeStatusContribution(rows, 'paid')).toBe(0);
+  });
+
+  it('handles invoice.amount = 0 safely', () => {
+    const rows = [makeRow('ibl-1', 0, 'inv-1', 0, 'claimed')];
+    expect(() => computeStatusContribution(rows, 'claimed')).not.toThrow();
+  });
+});

--- a/server/src/services/shared/depositAggregateUtils.ts
+++ b/server/src/services/shared/depositAggregateUtils.ts
@@ -1,0 +1,239 @@
+/**
+ * Shared utilities for computing deposit-aware aggregates.
+ *
+ * When invoices have deposits, budget line amounts need to be split proportionally:
+ * - Each deposit contributes (deposit.amount / invoice.amount) × ibl.itemized_amount under the deposit's status
+ * - The residual ((invoice.amount − Σ deposits) / invoice.amount) × ibl.itemized_amount contributes under the parent invoice's status
+ *
+ * This pattern is used across budgetServiceFactory, budgetSourceService, and budgetOverviewService.
+ */
+
+/**
+ * Raw row type for (invoice_budget_line, invoice, deposit?) jointures.
+ * Used by computeDepositAwareAggregates to compute proportional splits.
+ */
+export interface DepositAwareRow {
+  ibl_id: string;
+  itemized_amount: number;
+  invoice_id: string;
+  invoice_amount: number;
+  invoice_status: string;
+  deposit_id: string | null;
+  deposit_amount: number | null;
+  deposit_status: string | null;
+}
+
+/**
+ * Computes actualCost, actualCostPaid, and invoiceCount from a set of
+ * (invoice_budget_lines JOIN invoices LEFT JOIN invoice_deposits) rows.
+ *
+ * Each invoice's contribution is split proportionally: each deposit contributes
+ * (deposit.amount / invoice.amount) × ibl.itemized_amount under the deposit's status.
+ * The residual ((invoice.amount − Σ deposits) / invoice.amount) × ibl.itemized_amount
+ * contributes under the parent invoice's status.
+ *
+ * When an invoice has no deposits, the entire ibl.itemized_amount contributes under
+ * the parent invoice's status (identical to pre-deposit behaviour).
+ *
+ * actualCost excludes quotation invoices (matching existing behaviour).
+ * actualCostPaid = sum of contributions where status is 'paid' or 'claimed'.
+ */
+export function computeDepositAwareAggregates(rows: DepositAwareRow[]): {
+  actualCost: number;
+  actualCostPaid: number;
+  actualCostClaimed: number;
+  invoiceCount: number;
+} {
+  if (rows.length === 0) {
+    return { actualCost: 0, actualCostPaid: 0, actualCostClaimed: 0, invoiceCount: 0 };
+  }
+
+  // Group rows by ibl_id to deduplicate and collect deposits per invoice
+  const iblMap = new Map<
+    string,
+    {
+      itemizedAmount: number;
+      invoiceId: string;
+      invoiceAmount: number;
+      invoiceStatus: string;
+    }
+  >();
+  const depositsByInvoice = new Map<
+    string,
+    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
+  >();
+
+  for (const row of rows) {
+    if (!iblMap.has(row.ibl_id)) {
+      iblMap.set(row.ibl_id, {
+        itemizedAmount: row.itemized_amount,
+        invoiceId: row.invoice_id,
+        invoiceAmount: row.invoice_amount,
+        invoiceStatus: row.invoice_status,
+      });
+    }
+    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
+      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
+      // Avoid duplicates (same deposit appears once per ibl row for this invoice)
+      if (!deps.find((d) => d.depositId === row.deposit_id)) {
+        deps.push({
+          depositId: row.deposit_id,
+          depositAmount: row.deposit_amount,
+          depositStatus: row.deposit_status,
+        });
+        depositsByInvoice.set(row.invoice_id, deps);
+      }
+    }
+  }
+
+  const invoiceIds = new Set<string>();
+  let actualCost = 0;
+  let actualCostPaid = 0;
+  let actualCostClaimed = 0;
+
+  for (const [_iblId, ibl] of iblMap) {
+    invoiceIds.add(ibl.invoiceId);
+    // Skip quotations from actualCost (matches existing behavior)
+    if (ibl.invoiceStatus === 'quotation') continue;
+
+    actualCost += ibl.itemizedAmount;
+
+    const deposits = depositsByInvoice.get(ibl.invoiceId) ?? [];
+    if (deposits.length === 0) {
+      // No deposits: entire ibl contributes under parent invoice status
+      if (ibl.invoiceStatus === 'paid' || ibl.invoiceStatus === 'claimed') {
+        actualCostPaid += ibl.itemizedAmount;
+      }
+      if (ibl.invoiceStatus === 'claimed') {
+        actualCostClaimed += ibl.itemizedAmount;
+      }
+    } else {
+      const totalDepositAmount = deposits.reduce((s, d) => s + d.depositAmount, 0);
+      const safeInvoiceAmount = ibl.invoiceAmount > 0 ? ibl.invoiceAmount : 1;
+
+      // Residual contribution under parent invoice status
+      const residualFraction = Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
+      const residualAmount = ibl.itemizedAmount * residualFraction;
+      if (ibl.invoiceStatus === 'paid' || ibl.invoiceStatus === 'claimed') {
+        actualCostPaid += residualAmount;
+      }
+      if (ibl.invoiceStatus === 'claimed') {
+        actualCostClaimed += residualAmount;
+      }
+
+      // Per-deposit contributions
+      for (const deposit of deposits) {
+        const depositFraction = deposit.depositAmount / safeInvoiceAmount;
+        const depositContribution = ibl.itemizedAmount * depositFraction;
+        if (deposit.depositStatus === 'paid' || deposit.depositStatus === 'claimed') {
+          actualCostPaid += depositContribution;
+        }
+        if (deposit.depositStatus === 'claimed') {
+          actualCostClaimed += depositContribution;
+        }
+      }
+    }
+  }
+
+  return {
+    actualCost,
+    actualCostPaid,
+    actualCostClaimed,
+    invoiceCount: invoiceIds.size,
+  };
+}
+
+/**
+ * Computes the sum of contributions that match a specific status (for budgetSourceService).
+ * Used for claimed/unclaimed/paid amount calculations.
+ *
+ * Only counts contributions where the status matches the target (either the deposit status
+ * if deposits exist, or the parent invoice status if no deposits).
+ */
+export function computeStatusContribution(
+  rows: Array<{
+    ibl_id: string;
+    itemized_amount: number;
+    invoice_id: string;
+    invoice_amount: number;
+    invoice_status: string;
+    deposit_id: string | null;
+    deposit_amount: number | null;
+    deposit_status: string | null;
+  }>,
+  targetStatus: string,
+): number {
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  // Group rows by ibl_id to deduplicate and collect deposits per invoice
+  const iblMap = new Map<
+    string,
+    {
+      itemizedAmount: number;
+      invoiceId: string;
+      invoiceAmount: number;
+      invoiceStatus: string;
+    }
+  >();
+  const depositsByInvoice = new Map<
+    string,
+    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
+  >();
+
+  for (const row of rows) {
+    if (!iblMap.has(row.ibl_id)) {
+      iblMap.set(row.ibl_id, {
+        itemizedAmount: row.itemized_amount,
+        invoiceId: row.invoice_id,
+        invoiceAmount: row.invoice_amount,
+        invoiceStatus: row.invoice_status,
+      });
+    }
+    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
+      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
+      if (!deps.find((d) => d.depositId === row.deposit_id)) {
+        deps.push({
+          depositId: row.deposit_id,
+          depositAmount: row.deposit_amount,
+          depositStatus: row.deposit_status,
+        });
+        depositsByInvoice.set(row.invoice_id, deps);
+      }
+    }
+  }
+
+  let total = 0;
+
+  for (const [_iblId, ibl] of iblMap) {
+    const deposits = depositsByInvoice.get(ibl.invoiceId) ?? [];
+    if (deposits.length === 0) {
+      // No deposits: entire ibl contributes under parent invoice status
+      if (ibl.invoiceStatus === targetStatus) {
+        total += ibl.itemizedAmount;
+      }
+    } else {
+      const totalDepositAmount = deposits.reduce((s, d) => s + d.depositAmount, 0);
+      const safeInvoiceAmount = ibl.invoiceAmount > 0 ? ibl.invoiceAmount : 1;
+
+      // Residual contribution under parent invoice status
+      const residualFraction = Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
+      const residualAmount = ibl.itemizedAmount * residualFraction;
+      if (ibl.invoiceStatus === targetStatus) {
+        total += residualAmount;
+      }
+
+      // Per-deposit contributions
+      for (const deposit of deposits) {
+        if (deposit.depositStatus === targetStatus) {
+          const depositFraction = deposit.depositAmount / safeInvoiceAmount;
+          const depositContribution = ibl.itemizedAmount * depositFraction;
+          total += depositContribution;
+        }
+      }
+    }
+  }
+
+  return total;
+}

--- a/shared/src/types/budget.ts
+++ b/shared/src/types/budget.ts
@@ -77,7 +77,8 @@ export interface BaseBudgetLine {
   vendor: VendorSummary | null;
   /** Computed: sum of all linked invoices (any status) */
   actualCost: number;
-  /** Computed: sum of linked invoices with status 'paid' or 'claimed' */
+  /** Computed: sum of paid+claimed contributions, including paid+claimed deposits within
+   *  partially-paid invoices (proportional split by deposit amount / invoice amount). */
   actualCostPaid: number;
   /** Computed: count of linked invoices */
   invoiceCount: number;

--- a/shared/src/types/budgetSource.ts
+++ b/shared/src/types/budgetSource.ts
@@ -29,8 +29,8 @@ export interface BudgetSource {
   totalAmount: number;
   usedAmount: number; // planned allocation: SUM(planned_amount) of linked budget lines
   availableAmount: number; // totalAmount - usedAmount (planned perspective)
-  claimedAmount: number; // actual drawdown: SUM(amount) of claimed invoices on linked budget lines
-  unclaimedAmount: number; // paid but not claimed: SUM(amount) of paid invoices on linked budget lines
+  claimedAmount: number; // actual drawdown: claimed contributions — includes claimed deposits in split invoices
+  unclaimedAmount: number; // paid but not claimed: paid contributions — includes paid deposits in split invoices
   paidAmount: number; // paid and claimed: claimedAmount + unclaimedAmount
   actualAvailableAmount: number; // totalAmount - claimedAmount (actual perspective)
   projectedAmount: number; // confidence-margined planned amount for non-invoiced lines + actual cost for invoiced


### PR DESCRIPTION
## Summary

**#1404 — Invoice deposits detail-page UI**
- Adds a Deposits section to the invoice detail page with add/edit/delete controls, per-deposit state toggles (unclaimed → claimed → paid), and a read-only "Final payment" row showing the residual amount (invoice total minus sum of deposits).
- Uses shared `Modal`, `Badge`, `FormError`, and `EmptyState` components. Responsive: table layout on desktop/tablet (claimed-date column hidden below 1024 px), card list on mobile. Overflow menu implements the WAI-ARIA Menu Button pattern (ArrowUp/Down/Home/End/Escape keyboard navigation). New i18n keys under `invoiceDetail.deposits.*` in EN and DE; glossary updated: Deposit → Abschlagszahlung, Final payment → Schlusszahlung.

**#1405 — Deposit-aware budget rollups**
- Budget rollups now proportionally split each invoice budget-line contribution between its deposits (each under the deposit's state) and the residual (under the parent invoice's status): `deposit_i = ibl.itemizedAmount × (d_i.amount / I.amount)`, `residual = ibl.itemizedAmount × ((I.amount − Σd) / I.amount)`. Zero-deposit invoices behave identically to the pre-existing logic (regression-tested). All queries use one extra `LEFT JOIN invoice_deposits` — no N+1. Applies to budget overview, budget sources (paid/unclaimed/claimed/discretionary), and work-item + household-item budget summaries (`actualCost`/`actualCostPaid`/`actualCostClaimed`). No new schema, no new endpoints, no response-shape changes.

> **Note on mobile modal layout**: The UX spec mentioned a bottom-sheet modal on mobile. Per the dev-team-lead implementation spec, the shared center-modal is used across all viewports for this release (the bottom-sheet pattern is not yet part of the shared component library). A follow-up can revisit this once the UX designer specs the bottom-sheet as a reusable shared component — it is not a blocker for this feature.

> **Context**: #1403 (invoice deposits schema, CRUD API, cascade logic) already shipped. This PR completes the deposits feature end-to-end.

Fixes #1404
Fixes #1405

## Test plan
- [ ] Unit tests pass (95%+ coverage on new/modified files)
- [ ] Integration tests pass (`depositAggregateUtils`, `budgetServiceFactory`, `budgetSourceService`, `budgetOverviewService`)
- [ ] Component tests pass (`InvoiceDepositsSection`, `invoiceDepositsApi`)
- [ ] E2E tests pass (`invoice-deposits.spec.ts` — desktop/tablet/mobile viewports)
- [ ] Pre-commit hook quality gates pass (lint, format, typecheck, build, audit)
- [ ] Zero-deposit invoice rollup regression tests pass
- [ ] DE locale translations verified against glossary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>