### PR TITLE
chore(invoice,budget): dedupe split helper, extract OverflowMenu, surface revert errors (#1413)

### DIFF
--- a/client/src/components/OverflowMenu/OverflowMenu.module.css
+++ b/client/src/components/OverflowMenu/OverflowMenu.module.css
@@ -1,0 +1,123 @@
+.wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.trigger {
+  background: none;
+  border: none;
+  padding: var(--spacing-2);
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-lg);
+  border-radius: var(--radius-md);
+  transition: var(--transition-button);
+}
+
+.trigger:hover:not(:disabled) {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+.trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trigger {
+    transition: none;
+  }
+}
+
+.menu {
+  position: absolute;
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-dropdown);
+  min-width: 160px;
+  overflow: hidden;
+}
+
+.menuBottom {
+  top: 100%;
+  right: 0;
+  margin-top: var(--spacing-1);
+}
+
+.menuTop {
+  bottom: 100%;
+  right: 0;
+  margin-bottom: var(--spacing-1);
+}
+
+.item {
+  display: flex;
+  width: 100%;
+  padding: var(--spacing-2-5) var(--spacing-3);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  transition: var(--transition-button);
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.item:hover:not(:disabled) {
+  background-color: var(--color-bg-secondary);
+}
+
+.item:focus-visible {
+  outline: none;
+  background-color: var(--color-bg-secondary);
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+
+.item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item {
+    transition: none;
+  }
+}
+
+.itemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.itemDanger {
+  color: var(--color-danger-text-on-light);
+}
+
+.itemDanger:hover:not(:disabled) {
+  background-color: var(--color-danger-bg);
+}
+
+@media (max-width: 767px) {
+  .item {
+    padding: var(--spacing-3) var(--spacing-4);
+  }
+}

--- a/client/src/components/OverflowMenu/OverflowMenu.module.css
+++ b/client/src/components/OverflowMenu/OverflowMenu.module.css
@@ -87,7 +87,7 @@
 .item:focus-visible {
   outline: none;
   background-color: var(--color-bg-secondary);
-  box-shadow: inset 0 0 0 2px var(--color-primary);
+  box-shadow: inset 0 0 0 3px var(--color-focus-ring);
 }
 
 .item:disabled {
@@ -114,6 +114,12 @@
 
 .itemDanger:hover:not(:disabled) {
   background-color: var(--color-danger-bg);
+}
+
+.itemDanger:focus-visible {
+  outline: none;
+  background-color: var(--color-bg-secondary);
+  box-shadow: inset 0 0 0 3px var(--color-focus-ring-danger);
 }
 
 @media (max-width: 767px) {

--- a/client/src/components/OverflowMenu/OverflowMenu.test.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.test.tsx
@@ -1,0 +1,470 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { OverflowMenu, type OverflowMenuItem } from './OverflowMenu.js';
+
+// ─── CSS Module note ──────────────────────────────────────────────────────────
+// identity-obj-proxy returns the class key itself as the class name.
+// So styles.itemDanger === 'itemDanger', styles.menuTop === 'menuTop', etc.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildItems(count = 2, overrides: Partial<OverflowMenuItem>[] = []): OverflowMenuItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `item-${i}`,
+    label: `Item ${i}`,
+    onClick: jest.fn<() => void>(),
+    ...overrides[i],
+  }));
+}
+
+function renderMenu(props: Partial<Parameters<typeof OverflowMenu>[0]> & { items?: OverflowMenuItem[] } = {}) {
+  const items = props.items ?? buildItems(3);
+  return render(
+    <OverflowMenu
+      items={items}
+      triggerAriaLabel="Open menu"
+      {...props}
+    />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('OverflowMenu', () => {
+  beforeEach(() => {
+    // Use real timers unless a test overrides this
+    jest.useRealTimers();
+  });
+
+  // ─── Scenario 1: Renders trigger ──────────────────────────────────────────
+
+  describe('Scenario 1: renders trigger button', () => {
+    it('renders a button with aria-haspopup="true"', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+    });
+
+    it('trigger has aria-expanded="false" initially', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('menu is not in DOM initially', () => {
+      renderMenu();
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 2: Opens on click ───────────────────────────────────────────
+
+  describe('Scenario 2: opens on click', () => {
+    it('click on trigger renders role="menu"', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('trigger aria-expanded becomes "true" when open', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('second click closes the menu again', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+      fireEvent.click(trigger);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 3: Renders all items ───────────────────────────────────────
+
+  describe('Scenario 3: renders all menu items', () => {
+    it('renders one menuitem per item provided', () => {
+      const items = buildItems(4);
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      expect(screen.getAllByRole('menuitem')).toHaveLength(4);
+    });
+
+    it('each menuitem renders with the correct label', () => {
+      const items = buildItems(2);
+      items[0]!.label = 'Edit item';
+      items[1]!.label = 'Delete item';
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      expect(screen.getByRole('menuitem', { name: /edit item/i })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /delete item/i })).toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 4: Destructive variant ─────────────────────────────────────
+
+  describe('Scenario 4: destructive variant', () => {
+    it('destructive item has CSS class containing "itemDanger"', () => {
+      const items: OverflowMenuItem[] = [
+        { id: 'del', label: 'Delete', onClick: jest.fn<() => void>(), variant: 'destructive' },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const delBtn = screen.getByRole('menuitem', { name: 'Delete' });
+      // identity-obj-proxy returns 'itemDanger' as the class name
+      expect(delBtn.className).toContain('itemDanger');
+    });
+
+    it('default variant item does NOT have "itemDanger" class', () => {
+      const items: OverflowMenuItem[] = [
+        { id: 'edit', label: 'Edit', onClick: jest.fn<() => void>(), variant: 'default' },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const editBtn = screen.getByRole('menuitem', { name: 'Edit' });
+      expect(editBtn.className).not.toContain('itemDanger');
+    });
+  });
+
+  // ─── Scenario 5: Disabled item ────────────────────────────────────────────
+
+  describe('Scenario 5: disabled item', () => {
+    it('disabled item has the disabled attribute', () => {
+      const items: OverflowMenuItem[] = [
+        { id: 'act', label: 'Action', onClick: jest.fn<() => void>(), disabled: true },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const btn = screen.getByRole('menuitem', { name: 'Action' });
+      expect(btn).toBeDisabled();
+    });
+
+    it('clicking a disabled item does not call onClick', () => {
+      const onClick = jest.fn<() => void>();
+      const items: OverflowMenuItem[] = [
+        { id: 'act', label: 'Disabled Action', onClick, disabled: true },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Disabled Action' }));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Scenario 6: Click item calls onClick and closes menu ─────────────────
+
+  describe('Scenario 6: click item calls onClick and closes menu', () => {
+    it('clicking an enabled item calls its onClick handler', () => {
+      const onClick = jest.fn<() => void>();
+      const items: OverflowMenuItem[] = [{ id: 'go', label: 'Go', onClick }];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Go' }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('clicking an item closes the menu', () => {
+      const items = buildItems(1);
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Item 0' }));
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 7: Escape closes menu ──────────────────────────────────────
+
+  describe('Scenario 7: Escape key closes menu and returns focus to trigger', () => {
+    it('Escape key closes the menu', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('after Escape, trigger has aria-expanded="false"', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  // ─── Scenario 8: ArrowDown navigation ─────────────────────────────────────
+
+  describe('Scenario 8: ArrowDown focuses next item, wraps at end', () => {
+    it('ArrowDown moves focus to next item', async () => {
+      renderMenu({ items: buildItems(3) });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      fireEvent.click(trigger);
+
+      const items = screen.getAllByRole('menuitem');
+      items[0]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(document.activeElement).toBe(items[1]);
+    });
+
+    it('ArrowDown wraps from last item to first', () => {
+      renderMenu({ items: buildItems(3) });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      const items = screen.getAllByRole('menuitem');
+      items[2]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(document.activeElement).toBe(items[0]);
+    });
+  });
+
+  // ─── Scenario 9: ArrowUp navigation ──────────────────────────────────────
+
+  describe('Scenario 9: ArrowUp focuses previous item, wraps at start', () => {
+    it('ArrowUp moves focus to previous item', () => {
+      renderMenu({ items: buildItems(3) });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      const items = screen.getAllByRole('menuitem');
+      items[2]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+      expect(document.activeElement).toBe(items[1]);
+    });
+
+    it('ArrowUp wraps from first item to last', () => {
+      renderMenu({ items: buildItems(3) });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      const items = screen.getAllByRole('menuitem');
+      items[0]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+      expect(document.activeElement).toBe(items[2]);
+    });
+  });
+
+  // ─── Scenario 10: Home / End ──────────────────────────────────────────────
+
+  describe('Scenario 10: Home/End keys', () => {
+    it('Home key focuses first item', () => {
+      renderMenu({ items: buildItems(4) });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      const items = screen.getAllByRole('menuitem');
+      items[3]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Home' });
+      expect(document.activeElement).toBe(items[0]);
+    });
+
+    it('End key focuses last item', () => {
+      renderMenu({ items: buildItems(4) });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      const items = screen.getAllByRole('menuitem');
+      items[0]!.focus();
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'End' });
+      expect(document.activeElement).toBe(items[3]);
+    });
+  });
+
+  // ─── Scenario 11: Outside click closes menu ──────────────────────────────
+
+  describe('Scenario 11: outside mousedown closes the menu', () => {
+    it('mousedown on document.body closes the menu', async () => {
+      renderMenu();
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.mouseDown(document.body);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('mousedown inside the wrapper does NOT close the menu', () => {
+      const { container } = renderMenu();
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+      // Fire mousedown on the wrapper itself (inside)
+      fireEvent.mouseDown(container.firstChild as Element);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 12: Disabled trigger ───────────────────────────────────────
+
+  describe('Scenario 12: disabled trigger does not open menu', () => {
+    it('clicking a disabled trigger does not render the menu', () => {
+      renderMenu({ disabled: true });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      expect(trigger).toBeDisabled();
+      fireEvent.click(trigger);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Scenario 13: triggerIcon prop ───────────────────────────────────────
+
+  describe('Scenario 13: triggerIcon prop', () => {
+    it('renders the default "⋮" trigger icon when no triggerIcon prop given', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      expect(trigger.textContent).toContain('⋮');
+    });
+
+    it('renders a custom trigger icon when triggerIcon prop is provided', () => {
+      renderMenu({ triggerIcon: <span data-testid="custom-icon">X</span> });
+      const icon = screen.getByTestId('custom-icon');
+      expect(icon).toBeInTheDocument();
+      expect(icon.textContent).toBe('X');
+    });
+  });
+
+  // ─── Scenario 14: placement="top-end" ────────────────────────────────────
+
+  describe('Scenario 14: placement="top-end" applies menuTop class', () => {
+    it('menu element has "menuTop" class when placement="top-end"', () => {
+      renderMenu({ placement: 'top-end' });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const menu = screen.getByRole('menu');
+      // identity-obj-proxy returns 'menuTop' as the class name
+      expect(menu.className).toContain('menuTop');
+    });
+
+    it('menu element has "menuBottom" class when placement="bottom-end" (default)', () => {
+      renderMenu({ placement: 'bottom-end' });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const menu = screen.getByRole('menu');
+      expect(menu.className).toContain('menuBottom');
+    });
+  });
+
+  // ─── Scenario 15: data-testid forwarded ──────────────────────────────────
+
+  describe('Scenario 15: data-testid forwarded to trigger', () => {
+    it('trigger button has the data-testid attribute when provided', () => {
+      renderMenu({ 'data-testid': 'my-overflow-menu' });
+      const trigger = screen.getByTestId('my-overflow-menu');
+      expect(trigger).toBeInTheDocument();
+      expect(trigger.tagName.toLowerCase()).toBe('button');
+    });
+
+    it('no data-testid on trigger when prop is not provided', () => {
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      expect(trigger.getAttribute('data-testid')).toBeNull();
+    });
+  });
+
+  // ─── ArrowDown opens menu from trigger ───────────────────────────────────
+
+  describe('ArrowDown on closed trigger opens menu and focuses first item', () => {
+    it('ArrowDown on trigger opens the menu', async () => {
+      jest.useFakeTimers();
+      renderMenu({ items: buildItems(2) });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+
+      act(() => {
+        fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      });
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      jest.useRealTimers();
+    });
+
+    it('ArrowDown on trigger focuses first menuitem after setTimeout(0)', async () => {
+      jest.useFakeTimers();
+      renderMenu({ items: buildItems(2) });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+
+      act(() => {
+        fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      });
+
+      // Advance timers to execute the setTimeout(0) callback that focuses first item
+      await act(async () => {
+        jest.runAllTimers();
+        await Promise.resolve();
+      });
+
+      const items = screen.getAllByRole('menuitem');
+      expect(document.activeElement).toBe(items[0]);
+
+      jest.useRealTimers();
+    });
+
+    it('ArrowDown on trigger when menu is already open does not close it', () => {
+      renderMenu({ items: buildItems(2) });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      // Open via click
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      // ArrowDown when already open: handleTriggerKeyDown guard `!isOpen` is false, no-op
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      // Menu should still be open
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Item without id uses fallback key ────────────────────────────────────
+
+  describe('item without id uses fallback key (item-{i})', () => {
+    it('renders items correctly when no id is provided', () => {
+      const items: OverflowMenuItem[] = [
+        { label: 'No ID Item A', onClick: jest.fn<() => void>() },
+        { label: 'No ID Item B', onClick: jest.fn<() => void>() },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      expect(screen.getByRole('menuitem', { name: 'No ID Item A' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'No ID Item B' })).toBeInTheDocument();
+    });
+  });
+
+  // ─── Item with icon ────────────────────────────────────────────────────────
+
+  describe('item with icon renders icon span', () => {
+    it('item icon is rendered inside an aria-hidden span', () => {
+      const items: OverflowMenuItem[] = [
+        {
+          id: 'icon-item',
+          label: 'With Icon',
+          onClick: jest.fn<() => void>(),
+          icon: <span data-testid="menu-item-icon">🗑</span>,
+        },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      expect(screen.getByTestId('menu-item-icon')).toBeInTheDocument();
+    });
+
+    it('item without icon does not render icon span', () => {
+      const items: OverflowMenuItem[] = [
+        { id: 'no-icon', label: 'No Icon', onClick: jest.fn<() => void>() },
+      ];
+      renderMenu({ items });
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      const menuItem = screen.getByRole('menuitem', { name: 'No Icon' });
+      // No child span with aria-hidden should exist
+      const iconSpan = menuItem.querySelector('[aria-hidden="true"]');
+      expect(iconSpan).toBeNull();
+    });
+  });
+});

--- a/client/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.tsx
@@ -54,7 +54,7 @@ export function OverflowMenu({
       // Focus first item after state updates
       setTimeout(() => {
         const firstMenuItem = menuRef.current?.querySelector(
-          '[role="menuitem"]',
+          '[role="menuitem"]:not(:disabled)',
         ) as HTMLButtonElement;
         firstMenuItem?.focus();
       }, 0);
@@ -62,7 +62,7 @@ export function OverflowMenu({
   };
 
   const handleMenuKeyDown = (e: React.KeyboardEvent) => {
-    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
+    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]:not(:disabled)');
     if (!menuItems || menuItems.length === 0) return;
 
     const currentIndex = Array.from(menuItems).findIndex(

--- a/client/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.tsx
@@ -1,0 +1,153 @@
+import { useState, useRef, useEffect, type ReactNode } from 'react';
+import styles from './OverflowMenu.module.css';
+
+export interface OverflowMenuItem {
+  id?: string;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: 'default' | 'destructive';
+  icon?: ReactNode;
+}
+
+export interface OverflowMenuProps {
+  items: OverflowMenuItem[];
+  triggerAriaLabel: string;
+  triggerIcon?: ReactNode;
+  placement?: 'bottom-end' | 'top-end';
+  disabled?: boolean;
+  'data-testid'?: string;
+}
+
+export function OverflowMenu({
+  items,
+  triggerAriaLabel,
+  triggerIcon = '⋮',
+  placement = 'bottom-end',
+  disabled = false,
+  'data-testid': dataTestId,
+}: OverflowMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen]);
+
+  // Keyboard navigation
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' && !isOpen) {
+      e.preventDefault();
+      setIsOpen(true);
+      // Focus first item after state updates
+      setTimeout(() => {
+        const firstMenuItem = menuRef.current?.querySelector(
+          '[role="menuitem"]',
+        ) as HTMLButtonElement;
+        firstMenuItem?.focus();
+      }, 0);
+    }
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
+    if (!menuItems || menuItems.length === 0) return;
+
+    const currentIndex = Array.from(menuItems).findIndex(
+      (item) => item === document.activeElement,
+    );
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault();
+        const nextIndex = currentIndex === menuItems.length - 1 ? 0 : currentIndex + 1;
+        (menuItems[nextIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        const prevIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
+        (menuItems[prevIndex] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Home': {
+        e.preventDefault();
+        (menuItems[0] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'End': {
+        e.preventDefault();
+        (menuItems[menuItems.length - 1] as HTMLButtonElement).focus();
+        break;
+      }
+      case 'Escape': {
+        e.preventDefault();
+        setIsOpen(false);
+        triggerRef.current?.focus();
+        break;
+      }
+    }
+  };
+
+  const handleItemClick = (item: OverflowMenuItem) => {
+    setIsOpen(false);
+    item.onClick();
+  };
+
+  return (
+    <div ref={wrapperRef} className={styles.wrapper}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={styles.trigger}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-label={triggerAriaLabel}
+        data-testid={dataTestId}
+        disabled={disabled}
+        onClick={() => setIsOpen((v) => !v)}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        {triggerIcon}
+      </button>
+      {isOpen && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className={`${styles.menu} ${placement === 'top-end' ? styles.menuTop : styles.menuBottom}`}
+          onKeyDown={handleMenuKeyDown}
+        >
+          {items.map((item, i) => (
+            <button
+              key={item.id || `item-${i}`}
+              type="button"
+              role="menuitem"
+              className={`${styles.item} ${item.variant === 'destructive' ? styles.itemDanger : ''}`}
+              onClick={() => handleItemClick(item)}
+              disabled={item.disabled}
+            >
+              {item.icon && (
+                <span className={styles.itemIcon} aria-hidden="true">
+                  {item.icon}
+                </span>
+              )}
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/OverflowMenu/index.ts
+++ b/client/src/components/OverflowMenu/index.ts
@@ -1,0 +1,1 @@
+export { OverflowMenu, type OverflowMenuProps, type OverflowMenuItem } from './OverflowMenu.js';

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -547,7 +547,9 @@
         "loadError": "Abschlagszahlungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
         "saveError": "Abschlagszahlung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
         "deleteError": "Abschlagszahlung konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
-        "revertError": "Status der Abschlagszahlung konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut."
+        "revertError": "Status der Abschlagszahlung konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut.",
+        "revertNetworkError": "Netzwerkfehler – Status der Abschlagszahlung konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut.",
+        "stateConfirmNetworkError": "Netzwerkfehler – Status der Abschlagszahlung konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
       },
       "stateConfirm": {
         "paidDateLabel": "Bezahlt am",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -660,7 +660,9 @@
         "loadError": "Failed to load deposits. Please try again.",
         "saveError": "Failed to save deposit. Please try again.",
         "deleteError": "Failed to delete deposit. Please try again.",
-        "revertError": "Failed to revert deposit status. Please try again."
+        "revertError": "Failed to revert deposit status. Please try again.",
+        "revertNetworkError": "Network error — could not revert deposit status. Please try again.",
+        "stateConfirmNetworkError": "Network error — could not update deposit status. Please try again."
       },
       "stateConfirm": {
         "paidDateLabel": "Paid date",

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.module.css
@@ -82,6 +82,17 @@
   background-color: var(--color-bg-secondary);
 }
 
+.tableRowMutating {
+  opacity: 0.6;
+  transition: opacity var(--transition-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tableRowMutating {
+    transition: none;
+  }
+}
+
 .table tbody td {
   padding: var(--spacing-3);
   vertical-align: middle;
@@ -109,87 +120,12 @@
   text-align: center;
 }
 
-/* ---- Action Cell Menu ---- */
+/* ---- Action Cell ---- */
 
 .actionCell {
   position: relative;
   display: flex;
   justify-content: center;
-}
-
-.menuButton {
-  background: none;
-  border: none;
-  padding: var(--spacing-2);
-  min-width: 44px;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-lg);
-  border-radius: var(--radius-md);
-  transition: var(--transition-button);
-}
-
-.menuButton:hover {
-  background-color: var(--color-bg-tertiary);
-  color: var(--color-text-primary);
-}
-
-.menuButton:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-}
-
-.menuButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: var(--color-bg-primary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
-  z-index: var(--z-dropdown);
-  min-width: 160px;
-  overflow: hidden;
-}
-
-.menuItem {
-  display: block;
-  width: 100%;
-  padding: var(--spacing-2-5) var(--spacing-3);
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  color: var(--color-text-primary);
-  font-size: var(--font-size-sm);
-  transition: var(--transition-button);
-}
-
-.menuItem:hover {
-  background-color: var(--color-bg-secondary);
-}
-
-.menuItem:focus-visible {
-  outline: none;
-  background-color: var(--color-bg-secondary);
-  box-shadow: inset 0 0 0 2px var(--color-primary);
-}
-
-.menuItemDanger {
-  color: var(--color-danger-text-on-light);
-}
-
-.menuItemDanger:hover {
-  background-color: var(--color-danger-bg);
 }
 
 /* ---- Mobile Card List ---- */

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.test.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.test.tsx
@@ -192,7 +192,6 @@ function renderSection(
   return render(
     <InvoiceDepositsSection
       invoiceId={INVOICE_ID}
-      invoiceTotal={opts.invoiceTotal ?? INVOICE_TOTAL}
       invoiceStatus={opts.invoiceStatus ?? 'pending'}
       deposits={deposits}
       finalPaymentAmount={finalPaymentAmount}
@@ -998,6 +997,181 @@ describe('InvoiceDepositsSection', () => {
       // No aria-label containing a count should exist for the heading
       const chips = document.querySelectorAll('[class*="countChip"]');
       expect(chips).toHaveLength(0);
+    });
+  });
+
+  // ─── Scenario 17–21: Revert error surfacing (#1413) ───────────────────────
+
+  describe('revert error surfacing (#1413)', () => {
+    // Helper: open the first overflow menu and return its menu items
+    function openMenuForFirstDeposit() {
+      const menuBtn = screen.getAllByRole('button').find((b) => b.textContent?.includes('⋮'))!;
+      fireEvent.click(menuBtn);
+      return screen.getAllByRole('menuitem');
+    }
+
+    // ─── Scenario 17: handleRevertToPending — API error ─────────────────────
+
+    it('Scenario 17: handleRevertToPending — ApiClientError shows section-level alert', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      mockUpdateDeposit.mockRejectedValueOnce(
+        new MockApiClientError(400, { code: 'INVALID_DEPOSIT_STATUS_TRANSITION' }),
+      );
+
+      renderSection([deposit]);
+
+      const menuItems = openMenuForFirstDeposit();
+      // For a paid deposit, "Revert to pending" is a menu item
+      const revertBtn = menuItems.find((m) =>
+        m.textContent?.toLowerCase().includes('pending'),
+      )!;
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      // The section-level FormError (role="alert") should appear
+      await waitFor(() => {
+        const alerts = screen.getAllByRole('alert');
+        expect(alerts.length).toBeGreaterThan(0);
+        // The error should contain the translated code from translateApiError mock
+        const alertText = alerts.map((a) => a.textContent ?? '').join(' ');
+        expect(alertText).toContain('translated:INVALID_DEPOSIT_STATUS_TRANSITION');
+      });
+    });
+
+    // ─── Scenario 18: handleRevertToPending — network error ──────────────────
+
+    it('Scenario 18: handleRevertToPending — plain Error shows revertNetworkError banner', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      mockUpdateDeposit.mockRejectedValueOnce(new Error('network'));
+
+      renderSection([deposit]);
+
+      const menuItems = openMenuForFirstDeposit();
+      const revertBtn = menuItems.find((m) =>
+        m.textContent?.toLowerCase().includes('pending'),
+      )!;
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      // revertNetworkError translation key is used; i18next returns the English string in tests
+      await waitFor(() => {
+        const alerts = screen.getAllByRole('alert');
+        expect(alerts.length).toBeGreaterThan(0);
+        const alertText = alerts.map((a) => a.textContent ?? '').join(' ');
+        expect(alertText).toContain('Network error');
+      });
+    });
+
+    // ─── Scenario 19: handleRevertToPaid — API error ─────────────────────────
+
+    it('Scenario 19: handleRevertToPaid — ApiClientError shows section-level alert', async () => {
+      const deposit = makeDeposit('dep-1', {
+        status: 'claimed',
+        paidDate: '2026-03-10',
+        claimedDate: '2026-03-20',
+      });
+      mockUpdateDeposit.mockRejectedValueOnce(
+        new MockApiClientError(400, { code: 'INVALID_DEPOSIT_STATUS_TRANSITION' }),
+      );
+
+      renderSection([deposit]);
+
+      const menuItems = openMenuForFirstDeposit();
+      // For a claimed deposit, "Revert to paid" is the revert action
+      const revertBtn = menuItems.find(
+        (m) =>
+          m.textContent?.toLowerCase().includes('revert') &&
+          m.textContent?.toLowerCase().includes('paid'),
+      )!;
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      await waitFor(() => {
+        const alerts = screen.getAllByRole('alert');
+        expect(alerts.length).toBeGreaterThan(0);
+        const alertText = alerts.map((a) => a.textContent ?? '').join(' ');
+        expect(alertText).toContain('translated:INVALID_DEPOSIT_STATUS_TRANSITION');
+      });
+    });
+
+    // ─── Scenario 20: Banner auto-dismiss after 6000ms ────────────────────────
+
+    it('Scenario 20: revert error banner auto-dismisses after 6000ms', async () => {
+      jest.useFakeTimers();
+
+      const deposit = makeDeposit('dep-1', { status: 'paid', paidDate: '2026-03-10' });
+      mockUpdateDeposit.mockRejectedValueOnce(new Error('network'));
+
+      renderSection([deposit]);
+
+      const menuItems = openMenuForFirstDeposit();
+      const revertBtn = menuItems.find((m) =>
+        m.textContent?.toLowerCase().includes('pending'),
+      )!;
+
+      await act(async () => {
+        fireEvent.click(revertBtn);
+      });
+
+      // Banner should be present
+      await waitFor(() => {
+        expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+      });
+
+      // Advance past the 6000ms auto-dismiss timer
+      await act(async () => {
+        jest.advanceTimersByTime(6001);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        // After dismissal, the revert error alert should be gone
+        // (The section-level FormError is only rendered when revertError !== '')
+        const remainingAlerts = screen.queryAllByRole('alert');
+        expect(remainingAlerts.length).toBe(0);
+      });
+
+      jest.useRealTimers();
+    });
+
+    // ─── Scenario 21: handleStateConfirm — modal error ───────────────────────
+
+    it('Scenario 21: handleStateConfirm — PATCH rejects with API error, FormError inside dialog', async () => {
+      const deposit = makeDeposit('dep-1', { status: 'pending' });
+      // First call is for the state-confirm (mark-paid); it should reject
+      mockUpdateDeposit.mockRejectedValueOnce(
+        new MockApiClientError(400, { code: 'INVALID_DEPOSIT_STATUS_TRANSITION' }),
+      );
+
+      renderSection([deposit]);
+
+      // Open menu and click "Mark paid"
+      const menuItems = openMenuForFirstDeposit();
+      const markPaidBtn = menuItems.find((m) =>
+        m.textContent?.toLowerCase().includes('paid'),
+      )!;
+      fireEvent.click(markPaidBtn);
+
+      // The state confirm dialog should appear
+      await waitFor(() => screen.getByRole('dialog'));
+
+      // Click the confirm button
+      const confirmBtn = screen.getByTestId('modal-footer').querySelector('button:last-child')!;
+      await act(async () => {
+        fireEvent.click(confirmBtn);
+      });
+
+      // FormError should appear INSIDE the dialog
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog');
+        // role="alert" from FormError mock
+        const alertInsideDialog = dialog.querySelector('[role="alert"]');
+        expect(alertInsideDialog).toBeInTheDocument();
+        expect(alertInsideDialog!.textContent).toContain('translated:INVALID_DEPOSIT_STATUS_TRANSITION');
+      });
     });
   });
 });

--- a/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDepositsSection.tsx
@@ -6,6 +6,7 @@ import { ApiClientError } from '../../lib/apiClient.js';
 import { useFormatters } from '../../lib/formatters.js';
 import { translateApiError } from '../../lib/errorTranslation.js';
 import { Badge, type BadgeVariantMap } from '../../components/Badge/Badge.js';
+import { OverflowMenu, type OverflowMenuItem } from '../../components/OverflowMenu/index.js';
 import { Modal } from '../../components/Modal/Modal.js';
 import { EmptyState } from '../../components/EmptyState/EmptyState.js';
 import { FormError } from '../../components/FormError/FormError.js';
@@ -14,7 +15,6 @@ import styles from './InvoiceDepositsSection.module.css';
 
 interface InvoiceDepositsSectionProps {
   invoiceId: string;
-  invoiceTotal: number;
   invoiceStatus: InvoiceStatus;
   deposits: InvoiceDeposit[];
   finalPaymentAmount: number;
@@ -38,18 +38,20 @@ interface StateConfirmState {
   action: StateConfirmAction;
 }
 
-const emptyForm = (): DepositFormState => ({
-  amount: '',
-  dueDate: '',
-  status: 'pending',
-  paidDate: new Date().toISOString().slice(0, 10),
-  claimedDate: new Date().toISOString().slice(0, 10),
-  description: '',
-});
+const getEmptyForm = (): DepositFormState => {
+  const today = new Date().toISOString().slice(0, 10);
+  return {
+    amount: '',
+    dueDate: '',
+    status: 'pending',
+    paidDate: today,
+    claimedDate: today,
+    description: '',
+  };
+};
 
 export function InvoiceDepositsSection({
   invoiceId,
-  invoiceTotal,
   invoiceStatus,
   deposits,
   finalPaymentAmount,
@@ -64,15 +66,33 @@ export function InvoiceDepositsSection({
   const [selectedDeposit, setSelectedDeposit] = useState<InvoiceDeposit | null>(null);
   const [isMutating, setIsMutating] = useState(false);
   const [mutatingDepositId, setMutatingDepositId] = useState<string | null>(null);
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [stateConfirmDeposit, setStateConfirmDeposit] = useState<StateConfirmState | null>(null);
 
   // Form state
-  const [depositForm, setDepositForm] = useState<DepositFormState>(emptyForm());
+  const [depositForm, setDepositForm] = useState<DepositFormState>(() => getEmptyForm());
   const [formError, setFormError] = useState<string>('');
+
+  // Revert error handling (transient banner)
+  const [revertError, setRevertError] = useState<string>('');
+  const revertErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // State confirm modal error
+  const [stateConfirmModalError, setStateConfirmModalError] = useState<string>('');
 
   // Focus management
   const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  const showRevertError = (msg: string) => {
+    if (revertErrorTimerRef.current) clearTimeout(revertErrorTimerRef.current);
+    setRevertError(msg);
+    revertErrorTimerRef.current = setTimeout(() => setRevertError(''), 6000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (revertErrorTimerRef.current) clearTimeout(revertErrorTimerRef.current);
+    };
+  }, []);
 
   const invoiceStatusVariants: BadgeVariantMap = {
     pending: {
@@ -92,7 +112,7 @@ export function InvoiceDepositsSection({
 
   const openAddModal = () => {
     setSelectedDeposit(null);
-    setDepositForm(emptyForm());
+    setDepositForm(getEmptyForm());
     setFormError('');
     setModalMode('add');
   };
@@ -109,28 +129,27 @@ export function InvoiceDepositsSection({
     });
     setFormError('');
     setModalMode('edit');
-    setMenuOpenId(null);
   };
 
   const openDeleteModal = (deposit: InvoiceDeposit) => {
     setSelectedDeposit(deposit);
     setFormError('');
     setModalMode('delete');
-    setMenuOpenId(null);
   };
 
   const openStateConfirm = (deposit: InvoiceDeposit, action: StateConfirmAction) => {
     setStateConfirmDeposit({ deposit, action });
-    setMenuOpenId(null);
+    setStateConfirmModalError('');
   };
 
   const closeModal = () => {
     if (!isMutating) {
       setModalMode(null);
       setSelectedDeposit(null);
-      setDepositForm(emptyForm());
+      setDepositForm(getEmptyForm());
       setFormError('');
       setStateConfirmDeposit(null);
+      setStateConfirmModalError('');
     }
   };
 
@@ -254,7 +273,11 @@ export function InvoiceDepositsSection({
       await updateDeposit(invoiceId, deposit.id, { status: 'pending' });
       onDepositMutated();
     } catch (err) {
-      // Silently fail and just clear the opacity
+      if (err instanceof ApiClientError) {
+        showRevertError(translateApiError(err.error.code, tErrors));
+      } else {
+        showRevertError(t('budget:invoiceDetail.deposits.errors.revertNetworkError'));
+      }
     } finally {
       setMutatingDepositId(null);
     }
@@ -266,7 +289,11 @@ export function InvoiceDepositsSection({
       await updateDeposit(invoiceId, deposit.id, { status: 'paid' });
       onDepositMutated();
     } catch (err) {
-      // Silently fail and just clear the opacity
+      if (err instanceof ApiClientError) {
+        showRevertError(translateApiError(err.error.code, tErrors));
+      } else {
+        showRevertError(t('budget:invoiceDetail.deposits.errors.revertNetworkError'));
+      }
     } finally {
       setMutatingDepositId(null);
     }
@@ -294,7 +321,13 @@ export function InvoiceDepositsSection({
       setStateConfirmDeposit(null);
       onDepositMutated();
     } catch (err) {
-      // Could show error, but for now just fail silently
+      let msg: string;
+      if (err instanceof ApiClientError) {
+        msg = translateApiError(err.error.code, tErrors);
+      } else {
+        msg = t('budget:invoiceDetail.deposits.errors.stateConfirmNetworkError');
+      }
+      setStateConfirmModalError(msg);
     } finally {
       setMutatingDepositId(null);
     }
@@ -342,6 +375,8 @@ export function InvoiceDepositsSection({
 
       {deposits.length > 0 && (
         <>
+          {revertError && <FormError message={revertError} />}
+
           {/* Desktop/tablet table (hidden on mobile) */}
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
@@ -367,9 +402,7 @@ export function InvoiceDepositsSection({
                   <DepositRow
                     key={deposit.id}
                     deposit={deposit}
-                    menuOpenId={menuOpenId}
                     mutatingDepositId={mutatingDepositId}
-                    onMenuToggle={setMenuOpenId}
                     onEdit={openEditModal}
                     onDelete={openDeleteModal}
                     onMarkPaid={() => openStateConfirm(deposit, 'mark-paid')}
@@ -391,9 +424,7 @@ export function InvoiceDepositsSection({
               <DepositCard
                 key={deposit.id}
                 deposit={deposit}
-                menuOpenId={menuOpenId}
                 mutatingDepositId={mutatingDepositId}
-                onMenuToggle={setMenuOpenId}
                 onEdit={openEditModal}
                 onDelete={openDeleteModal}
                 onMarkPaid={() => openStateConfirm(deposit, 'mark-paid')}
@@ -437,7 +468,6 @@ export function InvoiceDepositsSection({
           error={formError}
           isMutating={isMutating}
           t={t}
-          formatCurrency={formatCurrency}
         />
       )}
 
@@ -459,8 +489,12 @@ export function InvoiceDepositsSection({
           deposit={stateConfirmDeposit.deposit}
           action={stateConfirmDeposit.action}
           onConfirm={handleStateConfirm}
-          onClose={() => setStateConfirmDeposit(null)}
+          onClose={() => {
+            setStateConfirmDeposit(null);
+            setStateConfirmModalError('');
+          }}
           isMutating={mutatingDepositId === stateConfirmDeposit.deposit.id}
+          error={stateConfirmModalError}
           t={t}
         />
       )}
@@ -474,9 +508,7 @@ export function InvoiceDepositsSection({
 
 interface DepositRowProps {
   deposit: InvoiceDeposit;
-  menuOpenId: string | null;
   mutatingDepositId: string | null;
-  onMenuToggle: (id: string | null) => void;
   onEdit: (deposit: InvoiceDeposit) => void;
   onDelete: (deposit: InvoiceDeposit) => void;
   onMarkPaid: () => void;
@@ -490,9 +522,7 @@ interface DepositRowProps {
 
 function DepositRow({
   deposit,
-  menuOpenId,
   mutatingDepositId,
-  onMenuToggle,
   onEdit,
   onDelete,
   onMarkPaid,
@@ -503,10 +533,6 @@ function DepositRow({
   formatCurrency,
   formatDate,
 }: DepositRowProps) {
-  const isMenuOpen = menuOpenId === deposit.id;
-  const menuTriggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
   const statusVariants: BadgeVariantMap = {
     pending: {
       label: t('invoiceDetail.statusLabels.pending')!,
@@ -519,73 +545,66 @@ function DepositRow({
     },
   };
 
-  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
-    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
-    if (!menuItems || menuItems.length === 0) return;
+  // Build menu items based on deposit status
+  const menuItems: OverflowMenuItem[] = [];
 
-    const currentIndex = Array.from(menuItems).findIndex((item) => item === document.activeElement);
-
-    switch (e.key) {
-      case 'ArrowDown': {
-        e.preventDefault();
-        const nextIndex = currentIndex === menuItems.length - 1 ? 0 : currentIndex + 1;
-        (menuItems[nextIndex] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'ArrowUp': {
-        e.preventDefault();
-        const prevIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
-        (menuItems[prevIndex] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'Home': {
-        e.preventDefault();
-        (menuItems[0] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'End': {
-        e.preventDefault();
-        (menuItems[menuItems.length - 1] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'Escape': {
-        e.preventDefault();
-        onMenuToggle(null);
-        menuTriggerRef.current?.focus();
-        break;
-      }
-    }
-  };
-
-  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown' && !isMenuOpen) {
-      e.preventDefault();
-      onMenuToggle(deposit.id);
-      setTimeout(() => {
-        const firstMenuItem = menuRef.current?.querySelector(
-          '[role="menuitem"]',
-        ) as HTMLButtonElement;
-        firstMenuItem?.focus();
-      }, 0);
-    }
-  };
-
-  useEffect(() => {
-    if (isMenuOpen) {
-      const firstMenuItem = menuRef.current?.querySelector(
-        '[role="menuitem"]',
-      ) as HTMLButtonElement;
-      firstMenuItem?.focus();
-    }
-  }, [isMenuOpen]);
+  if (deposit.status === 'pending') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.markPaid'),
+        onClick: onMarkPaid,
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  } else if (deposit.status === 'paid') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.markClaimed'),
+        onClick: onMarkClaimed,
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.revertToPending'),
+        onClick: () => onRevertToPending(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  } else if (deposit.status === 'claimed') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.revertToPaid'),
+        onClick: () => onRevertToPaid(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  }
 
   return (
     <tr
-      className={styles.tableRow}
-      style={{
-        opacity: mutatingDepositId === deposit.id ? 0.6 : 1,
-        transition: `opacity var(--transition-fast)`,
-      }}
+      className={`${styles.tableRow} ${mutatingDepositId === deposit.id ? styles.tableRowMutating : ''}`}
     >
       <td>{formatDate(deposit.dueDate)}</td>
       <td>{formatCurrency(deposit.amount)}</td>
@@ -599,146 +618,13 @@ function DepositRow({
       <td className={styles.tdDescription}>{deposit.description ?? '—'}</td>
       <td className={styles.tdActions}>
         <div className={styles.actionCell}>
-          <button
-            ref={menuTriggerRef}
-            type="button"
-            className={styles.menuButton}
-            onClick={() => onMenuToggle(isMenuOpen ? null : deposit.id)}
-            onKeyDown={handleTriggerKeyDown}
-            aria-haspopup="true"
-            aria-expanded={isMenuOpen}
-            aria-label={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
+          <OverflowMenu
+            items={menuItems}
+            triggerAriaLabel={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
               description: deposit.description ?? 'deposit',
             })}
-          >
-            ⋮
-          </button>
-          {isMenuOpen && (
-            <div ref={menuRef} className={styles.menu} role="menu" onKeyDown={handleMenuKeyDown}>
-              {deposit.status === 'pending' && (
-                <>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onMarkPaid();
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.markPaid')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onEdit(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.edit')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onDelete(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.delete')}
-                  </button>
-                </>
-              )}
-              {deposit.status === 'paid' && (
-                <>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onMarkClaimed();
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.markClaimed')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onRevertToPending(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.revertToPending')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onEdit(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.edit')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onDelete(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.delete')}
-                  </button>
-                </>
-              )}
-              {deposit.status === 'claimed' && (
-                <>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onRevertToPaid(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.revertToPaid')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.menuItem}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onEdit(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.edit')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                    onClick={() => {
-                      onMenuToggle(null);
-                      onDelete(deposit);
-                    }}
-                  >
-                    {t('budget:invoiceDetail.deposits.menu.delete')}
-                  </button>
-                </>
-              )}
-            </div>
-          )}
+            placement="bottom-end"
+          />
         </div>
       </td>
     </tr>
@@ -749,20 +635,10 @@ function DepositRow({
 // Sub-component: DepositCard (mobile)
 // ============================================================================
 
-interface DepositCardProps extends Omit<
-  DepositRowProps,
-  'menuOpenId' | 'mutatingDepositId' | 'onMenuToggle'
-> {
-  menuOpenId: string | null;
-  mutatingDepositId: string | null;
-  onMenuToggle: (id: string | null) => void;
-}
+type DepositCardProps = DepositRowProps;
 
 function DepositCard({
   deposit,
-  menuOpenId,
-  mutatingDepositId,
-  onMenuToggle,
   onEdit,
   onDelete,
   onMarkPaid,
@@ -773,10 +649,6 @@ function DepositCard({
   formatCurrency,
   formatDate,
 }: DepositCardProps) {
-  const isMenuOpen = menuOpenId === deposit.id;
-  const menuTriggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
   const statusVariants: BadgeVariantMap = {
     pending: {
       label: t('invoiceDetail.statusLabels.pending')!,
@@ -789,65 +661,62 @@ function DepositCard({
     },
   };
 
-  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
-    const menuItems = menuRef.current?.querySelectorAll('[role="menuitem"]');
-    if (!menuItems || menuItems.length === 0) return;
+  // Build menu items based on deposit status
+  const menuItems: OverflowMenuItem[] = [];
 
-    const currentIndex = Array.from(menuItems).findIndex((item) => item === document.activeElement);
-
-    switch (e.key) {
-      case 'ArrowDown': {
-        e.preventDefault();
-        const nextIndex = currentIndex === menuItems.length - 1 ? 0 : currentIndex + 1;
-        (menuItems[nextIndex] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'ArrowUp': {
-        e.preventDefault();
-        const prevIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
-        (menuItems[prevIndex] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'Home': {
-        e.preventDefault();
-        (menuItems[0] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'End': {
-        e.preventDefault();
-        (menuItems[menuItems.length - 1] as HTMLButtonElement).focus();
-        break;
-      }
-      case 'Escape': {
-        e.preventDefault();
-        onMenuToggle(null);
-        menuTriggerRef.current?.focus();
-        break;
-      }
-    }
-  };
-
-  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown' && !isMenuOpen) {
-      e.preventDefault();
-      onMenuToggle(deposit.id);
-      setTimeout(() => {
-        const firstMenuItem = menuRef.current?.querySelector(
-          '[role="menuitem"]',
-        ) as HTMLButtonElement;
-        firstMenuItem?.focus();
-      }, 0);
-    }
-  };
-
-  useEffect(() => {
-    if (isMenuOpen) {
-      const firstMenuItem = menuRef.current?.querySelector(
-        '[role="menuitem"]',
-      ) as HTMLButtonElement;
-      firstMenuItem?.focus();
-    }
-  }, [isMenuOpen]);
+  if (deposit.status === 'pending') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.markPaid'),
+        onClick: onMarkPaid,
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  } else if (deposit.status === 'paid') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.markClaimed'),
+        onClick: onMarkClaimed,
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.revertToPending'),
+        onClick: () => onRevertToPending(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  } else if (deposit.status === 'claimed') {
+    menuItems.push(
+      {
+        label: t('budget:invoiceDetail.deposits.menu.revertToPaid'),
+        onClick: () => onRevertToPaid(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.edit'),
+        onClick: () => onEdit(deposit),
+      },
+      {
+        label: t('budget:invoiceDetail.deposits.menu.delete'),
+        onClick: () => onDelete(deposit),
+        variant: 'destructive',
+      },
+    );
+  }
 
   return (
     <div className={styles.mobileCard}>
@@ -882,146 +751,13 @@ function DepositCard({
       </dl>
 
       <div className={styles.cardActions}>
-        <button
-          ref={menuTriggerRef}
-          type="button"
-          className={styles.menuButton}
-          onClick={() => onMenuToggle(isMenuOpen ? null : deposit.id)}
-          onKeyDown={handleTriggerKeyDown}
-          aria-haspopup="true"
-          aria-expanded={isMenuOpen}
-          aria-label={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
+        <OverflowMenu
+          items={menuItems}
+          triggerAriaLabel={t('budget:invoiceDetail.deposits.menu.ariaLabel', {
             description: deposit.description ?? 'deposit',
           })}
-        >
-          ⋮
-        </button>
-        {isMenuOpen && (
-          <div ref={menuRef} className={styles.menu} role="menu" onKeyDown={handleMenuKeyDown}>
-            {deposit.status === 'pending' && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onMarkPaid();
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.markPaid')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onEdit(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.edit')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onDelete(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.delete')}
-                </button>
-              </>
-            )}
-            {deposit.status === 'paid' && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onMarkClaimed();
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.markClaimed')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onRevertToPending(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.revertToPending')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onEdit(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.edit')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onDelete(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.delete')}
-                </button>
-              </>
-            )}
-            {deposit.status === 'claimed' && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onRevertToPaid(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.revertToPaid')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={styles.menuItem}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onEdit(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.edit')}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                  onClick={() => {
-                    onMenuToggle(null);
-                    onDelete(deposit);
-                  }}
-                >
-                  {t('budget:invoiceDetail.deposits.menu.delete')}
-                </button>
-              </>
-            )}
-          </div>
-        )}
+          placement="top-end"
+        />
       </div>
     </div>
   );
@@ -1040,7 +776,6 @@ interface AddEditDepositModalProps {
   error: string;
   isMutating: boolean;
   t: (key: string, opts?: Record<string, unknown>) => string;
-  formatCurrency: (amount: number) => string;
 }
 
 function AddEditDepositModal({
@@ -1052,7 +787,6 @@ function AddEditDepositModal({
   error,
   isMutating,
   t,
-  formatCurrency,
 }: AddEditDepositModalProps) {
   const isEdit = mode === 'edit';
 
@@ -1313,18 +1047,19 @@ interface StateConfirmModalProps {
   onConfirm: (date: string) => void;
   onClose: () => void;
   isMutating: boolean;
+  error?: string;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }
 
 function StateConfirmModal({
-  deposit,
   action,
   onConfirm,
   onClose,
   isMutating,
+  error,
   t,
 }: StateConfirmModalProps) {
-  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
+  const [selectedDate, setSelectedDate] = useState(() => new Date().toISOString().slice(0, 10));
 
   const isMarkPaid = action === 'mark-paid';
   const title = isMarkPaid
@@ -1362,6 +1097,7 @@ function StateConfirmModal({
         </div>
       }
     >
+      {error && <FormError message={error} />}
       <div className={styles.formField}>
         <label htmlFor="state-confirm-date" className={styles.label}>
           {dateLabel}

--- a/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceDetailPage.tsx
@@ -288,7 +288,6 @@ export function InvoiceDetailPage() {
 
         <InvoiceDepositsSection
           invoiceId={id!}
-          invoiceTotal={invoice.amount}
           invoiceStatus={invoice.status}
           deposits={invoice.deposits}
           finalPaymentAmount={invoice.finalPaymentAmount}

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -829,3 +829,99 @@ test.describe('Deposits — multiple deposits and sum invariant', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 8: Revert to pending fails — section-level error banner shown
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Deposits — revert-to-pending API error (Scenario 8)', () => {
+  test(
+    'Revert to pending fails with INVALID_DEPOSIT_STATUS_TRANSITION → section-level error banner is shown',
+    async ({ page, testPrefix }) => {
+      // Desktop-only: error banner is a single behaviour, viewport-independent.
+      // Skip on narrow viewports where this test would duplicate coverage unnecessarily.
+      const viewportWidth = page.viewportSize()?.width ?? 1440;
+      if (viewportWidth < 1024) {
+        test.skip(true, 'Error banner test — desktop viewport only');
+        return;
+      }
+
+      const detailPage = new InvoiceDetailPage(page);
+      let vendorId = '';
+      let invoiceId = '';
+
+      // The page.route() interceptor handle — kept so we can unroute in teardown.
+      const routePattern = '**/api/invoices/*/deposits/*';
+
+      try {
+        // ── Setup ────────────────────────────────────────────────────────────
+        vendorId = await createVendorViaApi(page, `${testPrefix} Dep RevertErrVendor`);
+        invoiceId = await createInvoiceViaApi(page, vendorId, {
+          amount: 500,
+          date: '2026-06-01',
+        });
+
+        // Create a pending deposit, then transition it to 'paid' via the API.
+        const today = new Date().toISOString().slice(0, 10);
+        const deposit = await createDepositViaApi(page, invoiceId, {
+          amount: 200,
+          dueDate: '2026-07-01',
+        });
+
+        // pending → paid (real API call, before we install the mock)
+        const paidResp = await page.request.patch(
+          `/api/invoices/${invoiceId}/deposits/${deposit.id}`,
+          { data: { status: 'paid', paidDate: today } },
+        );
+        expect(paidResp.ok(), `PATCH pending→paid failed: ${paidResp.status()}`).toBeTruthy();
+
+        await detailPage.goto(invoiceId);
+        await expect(detailPage.heading).toBeVisible();
+
+        // Confirm the deposit is showing as Paid before installing the mock.
+        await expect(detailPage.depositsSection).toContainText('Paid');
+
+        // ── Mock ─────────────────────────────────────────────────────────────
+        // Intercept the next PATCH to /api/invoices/*/deposits/* and return a 400
+        // INVALID_DEPOSIT_STATUS_TRANSITION error.  We use page.route() (not
+        // page.routeOnce()) so we can call page.unroute() explicitly in teardown.
+        await page.route(routePattern, async (route) => {
+          if (route.request().method() === 'PATCH') {
+            await route.fulfill({
+              status: 400,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                error: {
+                  code: 'INVALID_DEPOSIT_STATUS_TRANSITION',
+                  message: 'Cannot revert',
+                },
+              }),
+            });
+          } else {
+            // Pass non-PATCH requests through unchanged (e.g. GET for page reload).
+            await route.continue();
+          }
+        });
+
+        // ── Action ───────────────────────────────────────────────────────────
+        // Open overflow menu for the paid deposit and click "Revert to pending".
+        // The menu for a 'paid' deposit contains: "Mark claimed…", "Revert to pending",
+        // "Edit", "Delete" — no confirm dialog for "Revert to pending".
+        await detailPage.openDepositMenu();
+        await detailPage.clickDepositMenuItem(/Revert to pending/);
+
+        // ── Assert ───────────────────────────────────────────────────────────
+        // The section-level error banner should appear after the mocked 400 response.
+        // The InvoiceDepositsSection renders API errors in a role="alert" element
+        // outside the add/edit modal context.
+        await expect(page.getByRole('alert')).toBeVisible();
+      } finally {
+        // ── Teardown ─────────────────────────────────────────────────────────
+        // Remove the route interceptor so subsequent tests are unaffected.
+        await page.unroute(routePattern);
+
+        if (vendorId) await deleteVendorViaApi(page, vendorId);
+      }
+    },
+  );
+});

--- a/server/src/services/budgetSourceService.ts
+++ b/server/src/services/budgetSourceService.ts
@@ -15,7 +15,11 @@ import {
   budgetCategories,
   vendors,
 } from '../db/schema.js';
-import { computeStatusContribution, type DepositAwareRow } from './shared/depositAggregateUtils.js';
+import {
+  computeStatusContribution,
+  splitByDeposits,
+  type DepositAwareRow,
+} from './shared/depositAggregateUtils.js';
 import type {
   BudgetSource,
   BudgetSourceType,
@@ -242,65 +246,38 @@ function computeDiscretionaryInvoiceAmount(db: DbType, status: string): number {
     HAVING (i.amount - COALESCE(SUM(ibl.itemized_amount), 0)) > 0`,
   );
 
-  // Process remainder rows to compute deposit-aware contributions
+  // Build remainder amounts map and split by deposits
   let remainderTotal = 0;
-  const remainderByInvoice = new Map<
-    string,
-    {
-      invoiceAmount: number;
-      remainderAmount: number;
-      invoiceStatus: string;
-      deposits: Array<{ depositId: string; depositAmount: number; depositStatus: string }>;
-    }
-  >();
-
-  for (const row of remainderRows) {
-    const key = row.invoice_id;
-    if (!remainderByInvoice.has(key)) {
-      const remainderAmount = row.invoice_amount - (row.total_itemized ?? 0);
-      remainderByInvoice.set(key, {
-        invoiceAmount: row.invoice_amount,
-        remainderAmount: remainderAmount > 0 ? remainderAmount : 0,
-        invoiceStatus: row.invoice_status,
-        deposits: [],
-      });
-    }
-    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
-      const entry = remainderByInvoice.get(key)!;
-      if (!entry.deposits.find((d) => d.depositId === row.deposit_id)) {
-        entry.deposits.push({
-          depositId: row.deposit_id,
-          depositAmount: row.deposit_amount,
-          depositStatus: row.deposit_status,
-        });
+  if (remainderRows.length > 0) {
+    // First pass: collect remainder amounts
+    const remainderAmountByInvoice = new Map<string, number>();
+    for (const row of remainderRows) {
+      if (!remainderAmountByInvoice.has(row.invoice_id)) {
+        const remainderAmount = row.invoice_amount - (row.total_itemized ?? 0);
+        remainderAmountByInvoice.set(
+          row.invoice_id,
+          remainderAmount > 0 ? remainderAmount : 0,
+        );
       }
     }
-  }
 
-  // Compute proportional split for remainder
-  for (const [_invoiceId, entry] of remainderByInvoice) {
-    if (entry.deposits.length === 0) {
-      // No deposits: entire remainder contributes under parent status
-      if (entry.invoiceStatus === status) {
-        remainderTotal += entry.remainderAmount;
-      }
-    } else {
-      const totalDepositAmount = entry.deposits.reduce((s, d) => s + d.depositAmount, 0);
-      const safeInvoiceAmount = entry.invoiceAmount > 0 ? entry.invoiceAmount : 1;
+    // Split invoices by deposits
+    const splitsByInvoiceId = splitByDeposits(remainderRows);
+
+    // Compute proportional split for remainder
+    for (const [invoiceId, split] of splitsByInvoiceId) {
+      const remainderAmount = remainderAmountByInvoice.get(invoiceId)!;
 
       // Residual contribution under parent invoice status
-      const residualFraction =
-        Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
-      const residualAmount = entry.remainderAmount * residualFraction;
-      if (entry.invoiceStatus === status) {
+      const residualAmount = remainderAmount * split.residualFraction;
+      if (split.invoiceStatus === status) {
         remainderTotal += residualAmount;
       }
 
       // Per-deposit contributions
-      for (const deposit of entry.deposits) {
-        if (deposit.depositStatus === status) {
-          const depositFraction = deposit.depositAmount / safeInvoiceAmount;
-          const depositContribution = entry.remainderAmount * depositFraction;
+      for (const df of split.depositFractions) {
+        if (df.depositStatus === status) {
+          const depositContribution = remainderAmount * df.fraction;
           remainderTotal += depositContribution;
         }
       }

--- a/server/src/services/shared/depositAggregateUtils.test.ts
+++ b/server/src/services/shared/depositAggregateUtils.test.ts
@@ -3,6 +3,7 @@ import {
   computeDepositAwareAggregates,
   computeStatusContribution,
   aggregateInvoiceStatusBreakdown,
+  splitByDeposits,
   type DepositAwareRow,
   type InvoiceDepositRow,
 } from './depositAggregateUtils.js';
@@ -555,5 +556,175 @@ describe('aggregateInvoiceStatusBreakdown', () => {
 
     expect(result['pending']!.count).toBe(0);
     expect(result['pending']!.totalAmount).toBe(100);
+  });
+});
+
+// ─── splitByDeposits ──────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal row for splitByDeposits (no ibl_id / itemized_amount needed).
+ */
+function makeSplitRow(
+  invoiceId: string,
+  invoiceAmount: number,
+  invoiceStatus: string,
+  deposit?: { id: string; amount: number; status: string },
+) {
+  return {
+    invoice_id: invoiceId,
+    invoice_amount: invoiceAmount,
+    invoice_status: invoiceStatus,
+    deposit_id: deposit?.id ?? null,
+    deposit_amount: deposit?.amount ?? null,
+    deposit_status: deposit?.status ?? null,
+  };
+}
+
+describe('splitByDeposits', () => {
+  // ─── Scenario 1: Empty input ────────────────────────────────────────────────
+
+  it('Scenario 1: empty input returns empty Map', () => {
+    const result = splitByDeposits([]);
+    expect(result.size).toBe(0);
+  });
+
+  // ─── Scenario 2: Single invoice, no deposits ────────────────────────────────
+
+  it('Scenario 2: single invoice with no deposits → residualFraction=1, depositFractions=[]', () => {
+    const rows = [makeSplitRow('inv-1', 500, 'pending')];
+    const result = splitByDeposits(rows);
+
+    expect(result.size).toBe(1);
+    const split = result.get('inv-1')!;
+    expect(split.residualFraction).toBe(1);
+    expect(split.depositFractions).toHaveLength(0);
+    expect(split.invoiceAmount).toBe(500);
+    expect(split.invoiceStatus).toBe('pending');
+  });
+
+  // ─── Scenario 3: Single invoice, one deposit covering 50% ──────────────────
+
+  it('Scenario 3: single invoice with one deposit covering 50% → residualFraction=0.5, depositFractions=[{fraction:0.5}]', () => {
+    const rows = [makeSplitRow('inv-1', 1000, 'pending', { id: 'd-1', amount: 500, status: 'paid' })];
+    const result = splitByDeposits(rows);
+
+    const split = result.get('inv-1')!;
+    expect(split.residualFraction).toBeCloseTo(0.5);
+    expect(split.depositFractions).toHaveLength(1);
+    expect(split.depositFractions[0]!.fraction).toBeCloseTo(0.5);
+    expect(split.depositFractions[0]!.depositStatus).toBe('paid');
+  });
+
+  // ─── Scenario 4: Deposits sum > invoice amount → residualFraction clamped to 0 ─
+
+  it('Scenario 4: deposits sum > invoice amount → residualFraction = 0 (clamped, not negative)', () => {
+    // invoice = 100, deposit = 150 → residual = max(0, 100 - 150) / 100 = 0
+    const rows = [
+      makeSplitRow('inv-1', 100, 'pending', { id: 'd-1', amount: 150, status: 'paid' }),
+    ];
+    const result = splitByDeposits(rows);
+
+    const split = result.get('inv-1')!;
+    expect(split.residualFraction).toBe(0);
+    // Deposit fraction can exceed 1 since it is amount / safeInvoiceAmount
+    expect(split.depositFractions[0]!.fraction).toBeCloseTo(1.5);
+  });
+
+  // ─── Scenario 5: Zero invoice amount → no division by zero ──────────────────
+
+  it('Scenario 5: zero invoice amount → no division by zero (safeInvoiceAmount = 1)', () => {
+    const rows = [
+      makeSplitRow('inv-1', 0, 'paid', { id: 'd-1', amount: 0, status: 'paid' }),
+    ];
+    expect(() => splitByDeposits(rows)).not.toThrow();
+    const result = splitByDeposits(rows);
+    const split = result.get('inv-1')!;
+    // safeInvoiceAmount = 1 (since invoiceAmount = 0)
+    // residualFraction = max(0, 1 - 0) / 1 = 1 (since deposit_amount = 0, no subtraction)
+    // depositFraction = 0 / 1 = 0
+    expect(split.residualFraction).toBe(1);
+    expect(split.depositFractions[0]!.fraction).toBe(0);
+    expect(split.invoiceAmount).toBe(0);
+  });
+
+  // ─── Scenario 6: Multiple invoices, mixed ────────────────────────────────────
+
+  it('Scenario 6: multiple invoices split independently', () => {
+    const rows = [
+      // inv-1: 1000, one deposit 300 paid
+      makeSplitRow('inv-1', 1000, 'pending', { id: 'd-A', amount: 300, status: 'paid' }),
+      // inv-2: 500, no deposits
+      makeSplitRow('inv-2', 500, 'claimed'),
+    ];
+    const result = splitByDeposits(rows);
+
+    expect(result.size).toBe(2);
+
+    const split1 = result.get('inv-1')!;
+    expect(split1.residualFraction).toBeCloseTo(0.7); // (1000 - 300) / 1000
+    expect(split1.depositFractions).toHaveLength(1);
+    expect(split1.depositFractions[0]!.fraction).toBeCloseTo(0.3);
+
+    const split2 = result.get('inv-2')!;
+    expect(split2.residualFraction).toBe(1);
+    expect(split2.depositFractions).toHaveLength(0);
+    expect(split2.invoiceStatus).toBe('claimed');
+  });
+
+  // ─── Scenario 7: Duplicate deposit rows (same deposit_id) → deduplicated ────
+
+  it('Scenario 7: duplicate deposit_id rows across multiple rows → deposit counted once', () => {
+    // Same deposit_id d-1 appears in two rows (simulating LEFT JOIN row expansion)
+    const rows = [
+      makeSplitRow('inv-1', 1000, 'pending', { id: 'd-1', amount: 200, status: 'paid' }),
+      makeSplitRow('inv-1', 1000, 'pending', { id: 'd-1', amount: 200, status: 'paid' }),
+    ];
+    const result = splitByDeposits(rows);
+
+    const split = result.get('inv-1')!;
+    // Deposit should appear exactly once, not twice
+    expect(split.depositFractions).toHaveLength(1);
+    // residualFraction = (1000 - 200) / 1000 = 0.8, NOT (1000 - 400) / 1000 = 0.6
+    expect(split.residualFraction).toBeCloseTo(0.8);
+  });
+
+  // ─── Scenario 8: Mix — some invoices with deposits, some without ─────────────
+
+  it('Scenario 8: mix of invoices with and without deposits, each splits correctly', () => {
+    const rows = [
+      // Invoice A: has a 400-claimed deposit out of 800
+      makeSplitRow('inv-A', 800, 'pending', { id: 'dA', amount: 400, status: 'claimed' }),
+      // Invoice B: no deposits
+      makeSplitRow('inv-B', 200, 'paid'),
+      // Invoice C: fully covered (one deposit = invoice amount)
+      makeSplitRow('inv-C', 300, 'pending', { id: 'dC', amount: 300, status: 'paid' }),
+    ];
+    const result = splitByDeposits(rows);
+
+    expect(result.size).toBe(3);
+
+    const splitA = result.get('inv-A')!;
+    expect(splitA.residualFraction).toBeCloseTo(0.5); // (800 - 400) / 800
+    expect(splitA.depositFractions[0]!.depositStatus).toBe('claimed');
+    expect(splitA.depositFractions[0]!.fraction).toBeCloseTo(0.5);
+
+    const splitB = result.get('inv-B')!;
+    expect(splitB.residualFraction).toBe(1);
+    expect(splitB.depositFractions).toHaveLength(0);
+
+    const splitC = result.get('inv-C')!;
+    expect(splitC.residualFraction).toBeCloseTo(0); // (300 - 300) / 300 = 0
+    expect(splitC.depositFractions[0]!.fraction).toBeCloseTo(1);
+  });
+
+  // ─── Scenario 9: invoiceAmount field populated ──────────────────────────────
+
+  it('Scenario 9: invoiceAmount field in split matches the input invoice_amount', () => {
+    const rows = [
+      makeSplitRow('inv-1', 750, 'paid', { id: 'd-1', amount: 250, status: 'claimed' }),
+    ];
+    const result = splitByDeposits(rows);
+    const split = result.get('inv-1')!;
+    expect(split.invoiceAmount).toBe(750);
   });
 });

--- a/server/src/services/shared/depositAggregateUtils.ts
+++ b/server/src/services/shared/depositAggregateUtils.ts
@@ -24,6 +24,102 @@ export interface DepositAwareRow {
 }
 
 /**
+ * Result of splitting an invoice by its deposits (proportional and residual portions).
+ * Used internally by deposit-aware aggregate functions to avoid repeated grouping/dedup logic.
+ */
+export interface InvoiceDepositSplit {
+  invoiceStatus: string;
+  invoiceAmount: number;
+  residualFraction: number;
+  depositFractions: Array<{ depositStatus: string; fraction: number }>;
+}
+
+/**
+ * Extract invoice-level splits by depositing the entire amount into fractional buckets.
+ *
+ * For each unique invoice in the input rows:
+ *   1. Deduplicate deposits by depositId
+ *   2. Compute residual fraction: max(0, invoiceAmount - Σ depositAmounts) / safeInvoiceAmount
+ *   3. Compute per-deposit fractions: depositAmount / safeInvoiceAmount
+ *   4. Return a map from invoiceId to split details
+ *
+ * safeInvoiceAmount avoids division by zero: use invoiceAmount if > 0, else 1.
+ *
+ * @param rows Rows from (invoices LEFT JOIN invoice_deposits), keyed by invoice_id
+ * @returns Map<invoiceId, split>
+ */
+export function splitByDeposits(
+  rows: Array<{
+    invoice_id: string;
+    invoice_amount: number;
+    invoice_status: string;
+    deposit_id: string | null;
+    deposit_amount: number | null;
+    deposit_status: string | null;
+  }>,
+): Map<string, InvoiceDepositSplit> {
+  const invoiceMap = new Map<string, { invoiceAmount: number; invoiceStatus: string }>();
+  const depositsByInvoice = new Map<
+    string,
+    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
+  >();
+
+  // Group rows by invoice and deduplicate deposits by depositId
+  for (const row of rows) {
+    if (!invoiceMap.has(row.invoice_id)) {
+      invoiceMap.set(row.invoice_id, {
+        invoiceAmount: row.invoice_amount,
+        invoiceStatus: row.invoice_status,
+      });
+    }
+    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
+      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
+      if (!deps.some((d) => d.depositId === row.deposit_id)) {
+        deps.push({
+          depositId: row.deposit_id,
+          depositAmount: row.deposit_amount,
+          depositStatus: row.deposit_status,
+        });
+        depositsByInvoice.set(row.invoice_id, deps);
+      }
+    }
+  }
+
+  // Compute splits for each invoice
+  const result = new Map<string, InvoiceDepositSplit>();
+  for (const [invoiceId, inv] of invoiceMap) {
+    const deposits = depositsByInvoice.get(invoiceId) ?? [];
+    const safeInvoiceAmount = inv.invoiceAmount > 0 ? inv.invoiceAmount : 1;
+
+    if (deposits.length === 0) {
+      // No deposits: entire invoice contributes under its own status
+      result.set(invoiceId, {
+        invoiceStatus: inv.invoiceStatus,
+        invoiceAmount: inv.invoiceAmount,
+        residualFraction: 1,
+        depositFractions: [],
+      });
+    } else {
+      const totalDepositAmount = deposits.reduce((s, d) => s + d.depositAmount, 0);
+      const residualFraction = Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
+      const depositFractions = deposits.map((d) => ({
+        depositStatus: d.depositStatus,
+        fraction: d.depositAmount / safeInvoiceAmount,
+      }));
+
+      result.set(invoiceId, {
+        invoiceStatus: inv.invoiceStatus,
+        invoiceAmount: inv.invoiceAmount,
+        residualFraction,
+        depositFractions,
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
  * Computes actualCost, actualCostPaid, and invoiceCount from a set of
  * (invoice_budget_lines JOIN invoices LEFT JOIN invoice_deposits) rows.
  *
@@ -48,19 +144,14 @@ export function computeDepositAwareAggregates(rows: DepositAwareRow[]): {
     return { actualCost: 0, actualCostPaid: 0, actualCostClaimed: 0, invoiceCount: 0 };
   }
 
-  // Group rows by ibl_id to deduplicate and collect deposits per invoice
+  // Group rows by ibl_id to deduplicate
   const iblMap = new Map<
     string,
     {
       itemizedAmount: number;
       invoiceId: string;
-      invoiceAmount: number;
       invoiceStatus: string;
     }
-  >();
-  const depositsByInvoice = new Map<
-    string,
-    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
   >();
 
   for (const row of rows) {
@@ -68,23 +159,13 @@ export function computeDepositAwareAggregates(rows: DepositAwareRow[]): {
       iblMap.set(row.ibl_id, {
         itemizedAmount: row.itemized_amount,
         invoiceId: row.invoice_id,
-        invoiceAmount: row.invoice_amount,
         invoiceStatus: row.invoice_status,
       });
     }
-    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
-      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
-      // Avoid duplicates (same deposit appears once per ibl row for this invoice)
-      if (!deps.find((d) => d.depositId === row.deposit_id)) {
-        deps.push({
-          depositId: row.deposit_id,
-          depositAmount: row.deposit_amount,
-          depositStatus: row.deposit_status,
-        });
-        depositsByInvoice.set(row.invoice_id, deps);
-      }
-    }
   }
+
+  // Split each invoice by its deposits
+  const splitsByInvoiceId = splitByDeposits(rows);
 
   const invoiceIds = new Set<string>();
   let actualCost = 0;
@@ -98,40 +179,25 @@ export function computeDepositAwareAggregates(rows: DepositAwareRow[]): {
 
     actualCost += ibl.itemizedAmount;
 
-    const deposits = depositsByInvoice.get(ibl.invoiceId) ?? [];
-    if (deposits.length === 0) {
-      // No deposits: entire ibl contributes under parent invoice status
-      if (ibl.invoiceStatus === 'paid' || ibl.invoiceStatus === 'claimed') {
-        actualCostPaid += ibl.itemizedAmount;
-      }
-      if (ibl.invoiceStatus === 'claimed') {
-        actualCostClaimed += ibl.itemizedAmount;
-      }
-    } else {
-      const totalDepositAmount = deposits.reduce((s, d) => s + d.depositAmount, 0);
-      const safeInvoiceAmount = ibl.invoiceAmount > 0 ? ibl.invoiceAmount : 1;
+    const split = splitsByInvoiceId.get(ibl.invoiceId)!;
 
-      // Residual contribution under parent invoice status
-      const residualFraction =
-        Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
-      const residualAmount = ibl.itemizedAmount * residualFraction;
-      if (ibl.invoiceStatus === 'paid' || ibl.invoiceStatus === 'claimed') {
-        actualCostPaid += residualAmount;
-      }
-      if (ibl.invoiceStatus === 'claimed') {
-        actualCostClaimed += residualAmount;
-      }
+    // Residual contribution under parent invoice status
+    const residualAmount = ibl.itemizedAmount * split.residualFraction;
+    if (split.invoiceStatus === 'paid' || split.invoiceStatus === 'claimed') {
+      actualCostPaid += residualAmount;
+    }
+    if (split.invoiceStatus === 'claimed') {
+      actualCostClaimed += residualAmount;
+    }
 
-      // Per-deposit contributions
-      for (const deposit of deposits) {
-        const depositFraction = deposit.depositAmount / safeInvoiceAmount;
-        const depositContribution = ibl.itemizedAmount * depositFraction;
-        if (deposit.depositStatus === 'paid' || deposit.depositStatus === 'claimed') {
-          actualCostPaid += depositContribution;
-        }
-        if (deposit.depositStatus === 'claimed') {
-          actualCostClaimed += depositContribution;
-        }
+    // Per-deposit contributions
+    for (const df of split.depositFractions) {
+      const depositContribution = ibl.itemizedAmount * df.fraction;
+      if (df.depositStatus === 'paid' || df.depositStatus === 'claimed') {
+        actualCostPaid += depositContribution;
+      }
+      if (df.depositStatus === 'claimed') {
+        actualCostClaimed += depositContribution;
       }
     }
   }
@@ -168,19 +234,13 @@ export function computeStatusContribution(
     return 0;
   }
 
-  // Group rows by ibl_id to deduplicate and collect deposits per invoice
+  // Group rows by ibl_id to deduplicate
   const iblMap = new Map<
     string,
     {
       itemizedAmount: number;
       invoiceId: string;
-      invoiceAmount: number;
-      invoiceStatus: string;
     }
-  >();
-  const depositsByInvoice = new Map<
-    string,
-    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
   >();
 
   for (const row of rows) {
@@ -188,51 +248,29 @@ export function computeStatusContribution(
       iblMap.set(row.ibl_id, {
         itemizedAmount: row.itemized_amount,
         invoiceId: row.invoice_id,
-        invoiceAmount: row.invoice_amount,
-        invoiceStatus: row.invoice_status,
       });
     }
-    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
-      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
-      if (!deps.find((d) => d.depositId === row.deposit_id)) {
-        deps.push({
-          depositId: row.deposit_id,
-          depositAmount: row.deposit_amount,
-          depositStatus: row.deposit_status,
-        });
-        depositsByInvoice.set(row.invoice_id, deps);
-      }
-    }
   }
+
+  // Split each invoice by its deposits
+  const splitsByInvoiceId = splitByDeposits(rows);
 
   let total = 0;
 
   for (const [_iblId, ibl] of iblMap) {
-    const deposits = depositsByInvoice.get(ibl.invoiceId) ?? [];
-    if (deposits.length === 0) {
-      // No deposits: entire ibl contributes under parent invoice status
-      if (ibl.invoiceStatus === targetStatus) {
-        total += ibl.itemizedAmount;
-      }
-    } else {
-      const totalDepositAmount = deposits.reduce((s, d) => s + d.depositAmount, 0);
-      const safeInvoiceAmount = ibl.invoiceAmount > 0 ? ibl.invoiceAmount : 1;
+    const split = splitsByInvoiceId.get(ibl.invoiceId)!;
 
-      // Residual contribution under parent invoice status
-      const residualFraction =
-        Math.max(0, safeInvoiceAmount - totalDepositAmount) / safeInvoiceAmount;
-      const residualAmount = ibl.itemizedAmount * residualFraction;
-      if (ibl.invoiceStatus === targetStatus) {
-        total += residualAmount;
-      }
+    // Residual contribution under parent invoice status
+    const residualAmount = ibl.itemizedAmount * split.residualFraction;
+    if (split.invoiceStatus === targetStatus) {
+      total += residualAmount;
+    }
 
-      // Per-deposit contributions
-      for (const deposit of deposits) {
-        if (deposit.depositStatus === targetStatus) {
-          const depositFraction = deposit.depositAmount / safeInvoiceAmount;
-          const depositContribution = ibl.itemizedAmount * depositFraction;
-          total += depositContribution;
-        }
+    // Per-deposit contributions
+    for (const df of split.depositFractions) {
+      if (df.depositStatus === targetStatus) {
+        const depositContribution = ibl.itemizedAmount * df.fraction;
+        total += depositContribution;
       }
     }
   }
@@ -270,53 +308,28 @@ export function aggregateInvoiceStatusBreakdown(
 ): Record<string, { count: number; totalAmount: number }> {
   if (rows.length === 0) return {};
 
-  const invoiceMap = new Map<string, { invoiceAmount: number; invoiceStatus: string }>();
-  const depositsByInvoice = new Map<
-    string,
-    Array<{ depositId: string; depositAmount: number; depositStatus: string }>
-  >();
-
-  for (const row of rows) {
-    if (!invoiceMap.has(row.invoice_id)) {
-      invoiceMap.set(row.invoice_id, {
-        invoiceAmount: row.invoice_amount,
-        invoiceStatus: row.invoice_status,
-      });
-    }
-    if (row.deposit_id !== null && row.deposit_amount !== null && row.deposit_status !== null) {
-      const deps = depositsByInvoice.get(row.invoice_id) ?? [];
-      if (!deps.some((d) => d.depositId === row.deposit_id)) {
-        deps.push({
-          depositId: row.deposit_id,
-          depositAmount: row.deposit_amount,
-          depositStatus: row.deposit_status,
-        });
-        depositsByInvoice.set(row.invoice_id, deps);
-      }
-    }
-  }
+  // Split each invoice by its deposits
+  const splitsByInvoiceId = splitByDeposits(rows);
 
   const result: Record<string, { count: number; totalAmount: number }> = {};
   const ensure = (status: string) => {
     if (!result[status]) result[status] = { count: 0, totalAmount: 0 };
   };
 
-  for (const [invoiceId, inv] of invoiceMap) {
-    const S = inv.invoiceStatus;
+  for (const [_invoiceId, split] of splitsByInvoiceId) {
+    const S = split.invoiceStatus;
     ensure(S);
     result[S]!.count += 1;
 
-    const deposits = depositsByInvoice.get(invoiceId) ?? [];
-    if (deposits.length === 0) {
-      result[S]!.totalAmount += inv.invoiceAmount;
-    } else {
-      const depositSum = deposits.reduce((s, d) => s + d.depositAmount, 0);
-      const residual = Math.max(0, inv.invoiceAmount - depositSum);
-      result[S]!.totalAmount += residual;
-      for (const deposit of deposits) {
-        ensure(deposit.depositStatus);
-        result[deposit.depositStatus]!.totalAmount += deposit.depositAmount;
-      }
+    // Residual contribution under parent invoice status
+    const residualAmount = split.invoiceAmount * split.residualFraction;
+    result[S]!.totalAmount += residualAmount;
+
+    // Per-deposit contributions
+    for (const df of split.depositFractions) {
+      ensure(df.depositStatus);
+      const depositAmount = split.invoiceAmount * df.fraction;
+      result[df.depositStatus]!.totalAmount += depositAmount;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Split helper extraction**: `splitByDeposits()` extracted into `depositAggregateUtils.ts` and reused across 4 previously-duplicated call sites in `budgetSourceService.ts` — behaviour-preserving refactor.
- **OverflowMenu shared component**: New `client/src/components/OverflowMenu/` replaces ~330 lines of duplicated menu code in `DepositRow` / `DepositCard`. Full WAI-ARIA Menu Button keyboard nav, mobile 44px touch targets, design-token-only CSS, dark mode via token cascade.
- **Inline style removal**: `<tr>` opacity transition moved from `style={{}}` to `.tableRowMutating` CSS module class (matches fd73bcad pattern).
- **Revert error surfacing**: API errors in `handleRevertToPending`, `handleRevertToPaid`, and `handleStateConfirm` now surface via `FormError` banners (section-level auto-dismiss 6s; modal-level for state-confirm). Two new i18n keys for network-error fallbacks; coded server errors use existing `translateApiError()`.

Fixes #1413

## Test plan

- [ ] Unit tests pass (95%+ coverage) — 9 `splitByDeposits` tests, 37 `OverflowMenu` tests, 5 error-surfacing tests
- [ ] Integration tests pass
- [ ] E2E Scenario 8: revert error banner visible and auto-dismisses
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>