### PR TITLE
chore(i18n): bump glossary lastUpdated

### DIFF
--- a/client/src/i18n/glossary.json
+++ b/client/src/i18n/glossary.json
@@ -2,7 +2,7 @@
   "_meta": {
     "description": "Single source of truth for domain terminology translations. The translator agent enforces these.",
     "locales": ["de"],
-    "lastUpdated": "2026-05-10"
+    "lastUpdated": "2026-05-12"
   },
   "terms": {
     "Work Item": { "de": { "singular": "Arbeitspaket", "plural": "Arbeitspakete" } },


### PR DESCRIPTION
## Summary

- Bumps `_meta.lastUpdated` in `client/src/i18n/glossary.json` so `beta` gets a fresh HEAD SHA, which unblocks promotion PR #1415 whose CI association is broken because the current `beta` HEAD is a `[skip ci]` auto-fix commit that leaves the promotion PR without any associated CI checks.

No glossary terms changed.