### PR TITLE
chore(deps): drop dead transitive lockfile entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4369,16 +4369,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@docusaurus/bundler/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/@docusaurus/bundler/node_modules/slash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -28846,16 +28836,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {


### PR DESCRIPTION
## Summary

- `npm audit fix` removes two stale transitive lockfile entries (`serialize-javascript` and `randombytes`) nested under `@docusaurus/bundler` that are already shadowed by the root `serialize-javascript` override — 20 lockfile lines deleted, no functional impact.
- Pre-applying this as a regular CI-eligible commit so the auto-fix bot does **not** push a `[skip ci]` commit after the next beta merge; the `[skip ci]` pattern has been blocking CI association on promotion PR #1415, preventing the `pull_request synchronize` event from firing on that PR.

No dependency versions changed. No production code affected.