### PR TITLE
fix(tests): stabilize three intermittent test flakes (#1430, #1431, #1438)

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -216,6 +216,13 @@ describe('App', () => {
     if (!App) {
       const appModule = await import('./App.js');
       App = appModule.App;
+
+      // Pre-resolve lazy-loaded route components so the redirect test does not race
+      // their dynamic import under CPU pressure (#1438).
+      // The root path / redirects to /project which redirects to /project/overview,
+      // which renders DashboardPage (lazy). Pre-importing here warms the module cache
+      // before any test rendering starts, making the 5s waitFor timeout safe to keep.
+      await import('./pages/DashboardPage/DashboardPage.js');
     }
 
     // Reset mocks

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -782,6 +782,10 @@ export class InvoiceDetailPage {
    * Waits for the modal to become visible.
    */
   async openBudgetLinePicker(): Promise<void> {
+    // The button may briefly detach during section re-renders (e.g. after the first budget line
+    // is created, the section transitions from empty-state to non-empty-state and the DOM
+    // is rebuilt). Wait for stable visibility before clicking to avoid a stale-element race.
+    await this.pickerAddBudgetLineButton.waitFor({ state: 'visible' });
     await this.pickerAddBudgetLineButton.click();
     await this.budgetLinePickerModal.waitFor({ state: 'visible' });
   }

--- a/e2e/tests/navigation/dashboard.spec.ts
+++ b/e2e/tests/navigation/dashboard.spec.ts
@@ -577,9 +577,18 @@ test.describe('Card re-enable (Scenario 7)', () => {
       await dashboardPage.goto();
       await dashboardPage.waitForCardsLoaded();
 
-      // Verify Customize button is NOT visible before dismissing
-      // The button is only rendered when cards are hidden, so it may be absent from the DOM entirely.
-      await expect(dashboardPage.customizeButton).not.toBeVisible();
+      // Verify Customize button is NOT visible before dismissing.
+      // The button visibility depends on the preferences GET that the dashboard issues on mount.
+      // This GET is independent of the card-loading skeleton, so waitForCardsLoaded() does not
+      // guarantee it has completed. Use expect.poll to wait until the preference state settles
+      // (waitForResponse is not usable here because the request fires during goto() before we
+      // can attach a listener).
+      await expect
+        .poll(() => dashboardPage.customizeButton.isVisible(), {
+          timeout: 7000,
+          intervals: [100, 200, 500],
+        })
+        .toBe(false);
 
       // Dismiss a card
       await dashboardPage.dismissCard('Quick Actions');


### PR DESCRIPTION
## Summary

Three independent intermittent test failures, stabilized in a single batch.

**#1430 — `invoice-budget-line-create-and-link.spec.ts:210`** (e2e-test-engineer)
`openBudgetLinePicker()` in `InvoiceDetailPage` POM was racing the empty→non-empty section re-render when called a second time after the first budget line was created. Added an explicit `waitFor({ state: 'visible' })` on the `+ Add Budget Line` button before clicking.

**#1431 — `dashboard.spec.ts:566`** (e2e-test-engineer)
Customize button visibility assertion ran before the preferences GET that drives it had settled. `waitForCardsLoaded()` synchronizes on cards but not on preference state. Replaced `expect().not.toBeVisible()` with `expect.poll().toBe(false)` (7s timeout, 100/200/500ms intervals) so the assertion spins until the UI reflects the settled `hiddenCards: []` state.

**#1438 — `App.test.tsx:383`** (qa-integration-tester)
Test was racing the `React.lazy` dynamic import of `DashboardPage` (the `/` → `/project/overview` redirect target). The 5000ms `findByRole` boundary intermittently fired before the module finished loading on CPU-pressured CI runners. Pre-resolve the import in `beforeAll` so the module cache is warm before any test renders. The 5s timeout becomes a real performance budget.

## Test plan
- [x] No `waitForTimeout` / arbitrary sleeps added (per project standards)
- [x] No production code changes — test/PageObject scaffolding only
- [x] Static review confirms fixes target the documented race conditions

Fixes #1430
Fixes #1431
Fixes #1438

Co-Authored-By: Claude e2e-test-engineer (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude qa-integration-tester (Sonnet 4.6) <noreply@anthropic.com>