### PR TITLE
fix(diary): replace hide-drafts checkbox with chip in DiaryFilterBar (#1446)

### DIFF
--- a/.claude/agent-memory/e2e-test-engineer/MEMORY.md
+++ b/.claude/agent-memory/e2e-test-engineer/MEMORY.md
@@ -3,18 +3,21 @@
 > Detailed notes live in topic files. This index links to them.
 > See: `e2e-pom-patterns.md`, `e2e-parallel-isolation.md`, `story-epic08-e2e.md`, `story-933-dav-vendor-contacts.md`, `milestones-e2e.md`, `story-1248-mass-move.md`
 
-## Known Beta Flakes & Regressions (triaged 2026-05-16)
+## Known Beta Flakes & Regressions (triaged 2026-05-17)
 
 - `dashboard.spec.ts:566` "Customize button appears when card dismissed" — persistent flake since 3+ beta runs. Fails 30-40% first attempts due to test isolation (prior test leaves dismissed-card prefs state). Issue #1431.
 - `invoice-budget-line-create-and-link.spec.ts:210` "Create Budget Line button below existing lines" — timing flake. `+ Add Budget Line` button disappears briefly during section re-render after first line created. Issue #1430.
 - `invoice-deposits-ux.spec.ts:259` "Portal clipping — last row kebab" — HARD FAIL since PR #1427. `createInvoiceViaApi` uses `status: 'quotation'`; backend rejects deposits on quotation invoices with 400. Test bug. Issue #1432.
 - `invoice-deposits.spec.ts:665 [mobile]` "Mark paid flow on mobile" — HARD FAIL since PR #1427. Portal-rendered menu (usePortal=true) clipped behind `cardActions_b45Ao` div on mobile viewport. Production CSS bug. Issue #1433.
-- All 4 are PRE-EXISTING on beta (not caused by PR #1428). Issues #1427 introduced the two hard failures.
+- `i18n/i18n.spec.ts` "German text does not overflow navigation sidebar on desktop" — HARD FAIL on 3 consecutive beta runs (Shard 4, main-targeted runs 25960897054/25985031080/25986721880). `waitForLoaded` times out on `getByRole('heading', { name: 'Projekt', level: 1 })` — locale init race. Pre-existing; not related to diary or invoice work.
+- `invoices/invoice-deposits-ux.spec.ts` "Clicking the kebab on the LAST deposit row shows a menu fully within the viewport" — HARD FAIL (same runs). Same root cause as Issue #1432 (quotation invoice rejects deposits).
+- All pre-existing on beta. Three most recent failed main-targeted runs are all blocked by same two tests in Shard 4.
 
 ## Diary Draft E2E (Fix #1426, UX #1435, 2026-05-17)
 
 - **#1435 BREAKING CHANGE**: DiaryEntryCreatePage no longer has a form step. Type-card click fires POST immediately and navigates to /diary/:id/edit. Removed from POM: bodyTextarea, entryDateInput, titleInput, weatherSelect, temperatureInput, workersInput, inspectorNameInput, outcomeSelect, vendorInput, deliveryConfirmedCheckbox, materialInput, addMaterialButton, severitySelect, resolutionStatusSelect, cancelButton, backToTypeButton.
 - **#1435**: Status filter chips (statusFilterAll/statusFilterDraft/statusFilterSaved) removed from DiaryPage POM. Replaced by `hideDraftsCheckbox` (data-testid="hide-drafts-checkbox"). Use `filterDraftsOnly()` helper for direct URL navigation to ?status=draft.
+- **#1446**: `hideDraftsCheckbox` replaced by `draftsChip` (data-testid="status-filter-drafts", aria-pressed button). Default aria-pressed="true" (all entries shown). Click → aria-pressed="false" (?status=saved). Use `.toHaveAttribute('aria-pressed', 'true'/'false')` and `.click()` (never `.check()/.uncheck()`). `draftsChipPressed()` helper reads aria-pressed value.
 - PhotoCard selector: `data-testid="photo-card-{id}"` (not `photo-grid-item`). PhotoGrid wraps them in `role="list" aria-label="Photos"`.
 - Draft badge on edit page: `data-testid="draft-status-badge"`. On list card: `data-testid="draft-badge-{id}"`.
 - Auto-save indicator: `data-testid="autosave-status"` — only rendered when `saveStatus !== 'idle'`.

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.module.css
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.module.css
@@ -112,13 +112,14 @@
 
 /* Drafts chip — same shape as mode chips, active state uses muted secondary tokens */
 .draftsChip.modeChipActive {
-  background-color: var(--color-bg-secondary);
-  border-color: var(--color-border-strong);
-  color: var(--color-text-secondary);
+  background-color: var(--color-bg-tertiary);
+  border-color: var(--color-border-focus);
+  color: var(--color-text-primary);
 }
 
 .draftsChip.modeChipActive:hover {
   background-color: var(--color-bg-hover);
+  border-color: var(--color-border-focus);
   color: var(--color-text-primary);
 }
 

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.module.css
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.module.css
@@ -110,6 +110,18 @@
   background-color: var(--color-primary-hover);
 }
 
+/* Drafts chip — same shape as mode chips, active state uses muted secondary tokens */
+.draftsChip.modeChipActive {
+  background-color: var(--color-bg-secondary);
+  border-color: var(--color-border-strong);
+  color: var(--color-text-secondary);
+}
+
+.draftsChip.modeChipActive:hover {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
 .typeChips {
   display: flex;
   flex-wrap: wrap;
@@ -150,24 +162,6 @@
   background-color: var(--color-primary-hover);
 }
 
-.hideDraftsRow {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  grid-column: 1 / -1;
-}
-
-.hideDraftsLabel {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
-  cursor: pointer;
-}
-
-.hideDraftsToggle:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-}
 
 .clearButton {
   padding: var(--spacing-2) var(--spacing-3);
@@ -234,6 +228,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .mobileToggle,
+  .modeChip,
   .typeChip,
   .clearButton {
     transition: none;

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.test.tsx
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.test.tsx
@@ -353,67 +353,85 @@ describe('DiaryFilterBar', () => {
     expect(inactiveChip.getAttribute('class') ?? '').not.toContain('typeChipActive');
   });
 
-  // ─── Hide drafts checkbox (Story #1435) ────────────────────────────────────
+  // ─── Drafts chip (Story #1446) ────────────────────────────────────────────
 
-  describe('hideDrafts checkbox (Story #1435)', () => {
-    it('Scenario 12: checkbox not rendered when hideDrafts/onHideDraftsChange props are absent', () => {
+  describe('drafts chip (Story #1446)', () => {
+    it('Scenario 12: chip absent when onDraftsVisibleChange prop is not provided', () => {
       renderFilterBar();
-      expect(screen.queryByTestId('hide-drafts-checkbox')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('status-filter-drafts')).not.toBeInTheDocument();
     });
 
-    it('Scenario 13: checkbox is rendered and unchecked when hideDrafts=false', () => {
+    it('Scenario 13: chip is present and aria-pressed=true when draftsVisible=true', () => {
       renderFilterBar({
-        hideDrafts: false,
-        onHideDraftsChange: jest.fn<(v: boolean) => void>(),
+        draftsVisible: true,
+        onDraftsVisibleChange: jest.fn<(v: boolean) => void>(),
       } as any);
-      const checkbox = screen.getByTestId('hide-drafts-checkbox') as HTMLInputElement;
-      expect(checkbox).toBeInTheDocument();
-      expect(checkbox.checked).toBe(false);
+      const chip = screen.getByTestId('status-filter-drafts');
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveAttribute('aria-pressed', 'true');
     });
 
-    it('Scenario 14: checkbox is checked when hideDrafts=true', () => {
+    it('Scenario 14: chip is present and aria-pressed=false when draftsVisible=false', () => {
       renderFilterBar({
-        hideDrafts: true,
-        onHideDraftsChange: jest.fn<(v: boolean) => void>(),
+        draftsVisible: false,
+        onDraftsVisibleChange: jest.fn<(v: boolean) => void>(),
       } as any);
-      const checkbox = screen.getByTestId('hide-drafts-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      const chip = screen.getByTestId('status-filter-drafts');
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('Scenario 15: checking unchecked checkbox calls onHideDraftsChange(true)', async () => {
+    it('Scenario 15: clicking pressed chip calls onDraftsVisibleChange(false)', async () => {
       const user = userEvent.setup();
-      const onHideDraftsChange = jest.fn<(v: boolean) => void>();
+      const onDraftsVisibleChange = jest.fn<(v: boolean) => void>();
       renderFilterBar({
-        hideDrafts: false,
-        onHideDraftsChange,
+        draftsVisible: true,
+        onDraftsVisibleChange,
       } as any);
 
-      await user.click(screen.getByTestId('hide-drafts-checkbox'));
+      await user.click(screen.getByTestId('status-filter-drafts'));
 
-      expect(onHideDraftsChange).toHaveBeenCalledWith(true);
+      expect(onDraftsVisibleChange).toHaveBeenCalledWith(false);
     });
 
-    it('Scenario 16: unchecking checked checkbox calls onHideDraftsChange(false)', async () => {
+    it('Scenario 16: clicking unpressed chip calls onDraftsVisibleChange(true)', async () => {
       const user = userEvent.setup();
-      const onHideDraftsChange = jest.fn<(v: boolean) => void>();
+      const onDraftsVisibleChange = jest.fn<(v: boolean) => void>();
       renderFilterBar({
-        hideDrafts: true,
-        onHideDraftsChange,
+        draftsVisible: false,
+        onDraftsVisibleChange,
       } as any);
 
-      await user.click(screen.getByTestId('hide-drafts-checkbox'));
+      await user.click(screen.getByTestId('status-filter-drafts'));
 
-      expect(onHideDraftsChange).toHaveBeenCalledWith(false);
+      expect(onDraftsVisibleChange).toHaveBeenCalledWith(true);
     });
 
-    it('Scenario 17: checkbox has an accessible label matching "Hide drafts"', () => {
+    it('Scenario 17: drafts chip is independent from mode chips and has its own group', async () => {
+      const user = userEvent.setup();
+      const onFilterModeChange = jest.fn<(mode: 'all' | 'manual' | 'automatic') => void>();
+      const onDraftsVisibleChange = jest.fn<(v: boolean) => void>();
       renderFilterBar({
-        hideDrafts: false,
-        onHideDraftsChange: jest.fn<(v: boolean) => void>(),
+        filterMode: 'all',
+        onFilterModeChange,
+        draftsVisible: false,
+        onDraftsVisibleChange,
       } as any);
-      const checkbox = screen.getByLabelText(/hide drafts/i);
-      expect(checkbox).toBeInTheDocument();
-      expect((checkbox as HTMLInputElement).type).toBe('checkbox');
+
+      // Drafts chip group exists as a distinct accessible group
+      expect(screen.getByRole('group', { name: /filter by draft status/i })).toBeInTheDocument();
+
+      // Mode chip click calls onFilterModeChange, not onDraftsVisibleChange
+      await user.click(screen.getByTestId('mode-filter-manual'));
+      expect(onFilterModeChange).toHaveBeenCalledWith('manual');
+      expect(onDraftsVisibleChange).not.toHaveBeenCalled();
+
+      jest.clearAllMocks();
+
+      // Drafts chip click calls onDraftsVisibleChange, not onFilterModeChange
+      await user.click(screen.getByTestId('status-filter-drafts'));
+      expect(onDraftsVisibleChange).toHaveBeenCalledWith(true);
+      expect(onFilterModeChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.tsx
+++ b/client/src/components/diary/DiaryFilterBar/DiaryFilterBar.tsx
@@ -19,8 +19,8 @@ interface DiaryFilterBarProps {
   filterMode?: FilterMode;
   onFilterModeChange?: (mode: FilterMode) => void;
   isCollapsed?: boolean;
-  hideDrafts?: boolean;
-  onHideDraftsChange?: (hide: boolean) => void;
+  draftsVisible?: boolean;
+  onDraftsVisibleChange?: (visible: boolean) => void;
 }
 
 const MANUAL_ENTRY_TYPES: DiaryEntryType[] = [
@@ -79,8 +79,8 @@ export function DiaryFilterBar({
   filterMode = 'all',
   onFilterModeChange,
   isCollapsed = false,
-  hideDrafts = false,
-  onHideDraftsChange,
+  draftsVisible = false,
+  onDraftsVisibleChange,
 }: DiaryFilterBarProps) {
   const { t } = useTranslation('diary');
   const [isMobileOpen, setIsMobileOpen] = useState(false);
@@ -166,6 +166,21 @@ export function DiaryFilterBar({
               {t('filterBar.filterModeAutomatic')}
             </button>
           </div>
+
+          {/* Drafts visibility chip — separate axis from mode chips */}
+          {onDraftsVisibleChange && (
+            <div role="group" aria-label={t('filterBar.draftsChipGroupLabel')}>
+              <button
+                type="button"
+                onClick={() => onDraftsVisibleChange(!draftsVisible)}
+                aria-pressed={draftsVisible}
+                className={`${styles.modeChip} ${styles.draftsChip} ${draftsVisible ? styles.modeChipActive : ''}`}
+                data-testid="status-filter-drafts"
+              >
+                {t('filterBar.filterModeDrafts')}
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Search input */}
@@ -241,23 +256,6 @@ export function DiaryFilterBar({
             ))}
           </div>
         </div>
-
-        {/* Hide drafts checkbox */}
-        {onHideDraftsChange && (
-          <div className={styles.hideDraftsRow}>
-            <label className={styles.hideDraftsLabel} htmlFor="hide-drafts-toggle">
-              {t('filterBar.hideDrafts')}
-            </label>
-            <input
-              type="checkbox"
-              id="hide-drafts-toggle"
-              className={styles.hideDraftsToggle}
-              checked={hideDrafts}
-              onChange={(e) => onHideDraftsChange(e.target.checked)}
-              data-testid="hide-drafts-checkbox"
-            />
-          </div>
-        )}
 
         {/* Clear all button */}
         {filterCount > 0 && (

--- a/client/src/i18n/de/diary.json
+++ b/client/src/i18n/de/diary.json
@@ -24,6 +24,8 @@
     "filterModeAll": "Alle",
     "filterModeManual": "Manuell",
     "filterModeAutomatic": "Automatisch",
+    "filterModeDrafts": "Entwürfe",
+    "draftsChipGroupLabel": "Nach Entwurfsstatus filtern",
     "entryTypes": "Eintragstypen",
     "clearAll": "Alles löschen",
     "noTypeOptions": "Keine Typen verfügbar",
@@ -32,8 +34,7 @@
     "fromLabel": "Von",
     "toLabel": "Bis",
     "entryTypesLabel": "Eintragstypen",
-    "clearAllButton": "Alles löschen",
-    "hideDrafts": "Entwürfe ausblenden"
+    "clearAllButton": "Alles löschen"
   },
   "entryTypes": {
     "daily_log": "Tägliches Protokoll",

--- a/client/src/i18n/en/diary.json
+++ b/client/src/i18n/en/diary.json
@@ -24,6 +24,8 @@
     "filterModeAll": "All",
     "filterModeManual": "Manual",
     "filterModeAutomatic": "Automatic",
+    "filterModeDrafts": "Drafts",
+    "draftsChipGroupLabel": "Filter by draft status",
     "entryTypes": "Entry Types",
     "clearAll": "Clear All",
     "noTypeOptions": "No types available",
@@ -32,8 +34,7 @@
     "fromLabel": "From",
     "toLabel": "To",
     "entryTypesLabel": "Entry Types",
-    "clearAllButton": "Clear all",
-    "hideDrafts": "Hide drafts"
+    "clearAllButton": "Clear all"
   },
   "entryTypes": {
     "daily_log": "Daily Log",

--- a/client/src/pages/DiaryPage/DiaryPage.test.tsx
+++ b/client/src/pages/DiaryPage/DiaryPage.test.tsx
@@ -323,8 +323,11 @@ describe('DiaryPage', () => {
     it('Scenario 8: no status chip group rendered', async () => {
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
       renderPage();
-      // The status chip group with "All / Draft / Saved" buttons no longer exists
-      expect(screen.queryByRole('group', { name: /status/i })).not.toBeInTheDocument();
+      // The OLD status chip row had three buttons: "All", "Drafts only", "Saved only".
+      // It was removed in Story #1435. Assert by button text so this doesn't collide
+      // with the new drafts chip group (aria-label "Filter by draft status", Story #1446).
+      expect(screen.queryByRole('button', { name: /^Drafts only$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^Saved only$/i })).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/DiaryPage/DiaryPage.test.tsx
+++ b/client/src/pages/DiaryPage/DiaryPage.test.tsx
@@ -328,30 +328,39 @@ describe('DiaryPage', () => {
     });
   });
 
-  // ─── hideDrafts checkbox via DiaryFilterBar (Story #1435) ────────────────────
+  // ─── Drafts chip integration via DiaryFilterBar (Story #1446) ───────────────
 
-  describe('hideDrafts checkbox integration (Story #1435)', () => {
-    it('Scenario 9: DiaryFilterBar receives hideDrafts=true when URL has ?status=saved', async () => {
+  describe('drafts chip integration (Story #1446)', () => {
+    it('Scenario 9: chip has aria-pressed=true when URL has no status param (drafts visible)', async () => {
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
-      renderPage(['/diary?status=saved']);
+      renderPage(['/diary']);
       await waitFor(() => {
-        const checkbox = screen.getByTestId('hide-drafts-checkbox') as HTMLInputElement;
-        expect(checkbox.checked).toBe(true);
+        const chip = screen.getByTestId('status-filter-drafts');
+        expect(chip).toHaveAttribute('aria-pressed', 'true');
       });
     });
 
-    it('Scenario 10: checking "Hide drafts" calls listDiaryEntries with status=saved', async () => {
+    it('Scenario 10: chip has aria-pressed=false when URL has ?status=saved (drafts hidden)', async () => {
+      mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
+      renderPage(['/diary?status=saved']);
+      await waitFor(() => {
+        const chip = screen.getByTestId('status-filter-drafts');
+        expect(chip).toHaveAttribute('aria-pressed', 'false');
+      });
+    });
+
+    it('Scenario 11: clicking pressed chip sets status=saved and calls listDiaryEntries with status="saved"', async () => {
       const user = userEvent.setup();
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
-      renderPage();
+      renderPage(['/diary']);
 
       await waitFor(() => {
         expect(mockListDiaryEntries).toHaveBeenCalledTimes(1);
       });
 
-      const checkbox = screen.getByTestId('hide-drafts-checkbox');
-      await user.click(checkbox);
+      const chip = screen.getByTestId('status-filter-drafts');
+      await user.click(chip);
 
       await waitFor(() => {
         expect(mockListDiaryEntries).toHaveBeenCalledWith(
@@ -360,7 +369,7 @@ describe('DiaryPage', () => {
       });
     });
 
-    it('Scenario 11: unchecking "Hide drafts" calls listDiaryEntries without status param', async () => {
+    it('Scenario 11b: clicking unpressed chip removes status param and calls listDiaryEntries without status', async () => {
       const user = userEvent.setup();
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
       mockListDiaryEntries.mockResolvedValueOnce(emptyResponse);
@@ -370,8 +379,8 @@ describe('DiaryPage', () => {
         expect(mockListDiaryEntries).toHaveBeenCalledTimes(1);
       });
 
-      const checkbox = screen.getByTestId('hide-drafts-checkbox');
-      await user.click(checkbox);
+      const chip = screen.getByTestId('status-filter-drafts');
+      await user.click(chip);
 
       await waitFor(() => {
         const lastCall =

--- a/client/src/pages/DiaryPage/DiaryPage.tsx
+++ b/client/src/pages/DiaryPage/DiaryPage.tsx
@@ -190,14 +190,14 @@ export default function DiaryPage() {
     setSearchParams(newParams);
   };
 
-  const hideDrafts = statusFilter === 'saved';
+  const draftsVisible = statusFilter !== 'saved';
 
-  const handleHideDraftsChange = (hide: boolean) => {
+  const handleDraftsVisibleChange = (visible: boolean) => {
     const newParams = new URLSearchParams(searchParams);
-    if (hide) {
-      newParams.set('status', 'saved');
-    } else {
+    if (visible) {
       newParams.delete('status');
+    } else {
+      newParams.set('status', 'saved');
     }
     newParams.set('page', '1');
     setSearchParams(newParams);
@@ -254,8 +254,8 @@ export default function DiaryPage() {
         onClearAll={handleClearAll}
         filterMode={filterMode}
         onFilterModeChange={handleFilterModeChange}
-        hideDrafts={hideDrafts}
-        onHideDraftsChange={handleHideDraftsChange}
+        draftsVisible={draftsVisible}
+        onDraftsVisibleChange={handleDraftsVisibleChange}
       />
 
       {isLoading && <div className={shared.loading}>{t('loading')}</div>}

--- a/e2e/pages/DiaryPage.ts
+++ b/e2e/pages/DiaryPage.ts
@@ -4,7 +4,7 @@
  * The page renders:
  * - A page header with h1 "Construction Diary" and a subtitle with the total entry count
  * - A DiaryFilterBar with search input (data-testid="diary-search-input"), date range pickers,
- *   entry type chip filters, a "Hide drafts" checkbox (data-testid="hide-drafts-checkbox"),
+ *   entry type chip filters, a "Drafts" toggle chip (data-testid="status-filter-drafts"),
  *   and a "Clear all" button
  * - A "New Entry" link button navigating to /diary/new
  * - A timeline of DiaryDateGroup sections (data-testid="date-group-{date}"), each containing
@@ -25,7 +25,8 @@
  * - Pagination buttons: data-testid="prev-page-button" / data-testid="next-page-button"
  * - Draft badge on entry card: data-testid="draft-badge-{id}"
  * - Draft entries link to /diary/:id/edit (not /diary/:id)
- * - Hide drafts checkbox: data-testid="hide-drafts-checkbox" (checked = ?status=saved in URL)
+ * - Drafts chip: data-testid="status-filter-drafts" with aria-pressed="true" (default, shows all)
+ *   or aria-pressed="false" (hides drafts, adds ?status=saved to URL)
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -63,9 +64,10 @@ export class DiaryPage {
   readonly prevPageButton: Locator;
   readonly nextPageButton: Locator;
 
-  // "Hide drafts" checkbox — data-testid="hide-drafts-checkbox" (added in #1435)
-  // Checking it adds ?status=saved to the URL; unchecking removes the param.
-  readonly hideDraftsCheckbox: Locator;
+  // "Drafts" toggle chip — data-testid="status-filter-drafts" (added in #1446)
+  // aria-pressed="true"  → all entries shown (default)
+  // aria-pressed="false" → only saved entries shown (?status=saved in URL)
+  readonly draftsChip: Locator;
 
   // Mobile filter toggle button (visible only on mobile, aria-label="Toggle filters")
   readonly mobileFilterToggle: Locator;
@@ -83,9 +85,10 @@ export class DiaryPage {
     this.dateToInput = page.getByTestId('diary-date-to');
     this.clearFiltersButton = page.getByTestId('clear-filters-button');
 
-    // Hide drafts checkbox — added in #1435; replaces the previous status filter chip row.
-    // Checking it adds ?status=saved; unchecking removes the param (shows all entries).
-    this.hideDraftsCheckbox = page.getByTestId('hide-drafts-checkbox');
+    // Drafts chip — added in #1446; replaces the previous hide-drafts-checkbox.
+    // aria-pressed="true" (default) shows all entries; click toggles to aria-pressed="false"
+    // which adds ?status=saved and hides draft entries.
+    this.draftsChip = page.getByTestId('status-filter-drafts');
 
     this.mobileFilterToggle = page.getByRole('button', { name: 'Toggle filters' });
 
@@ -198,6 +201,15 @@ export class DiaryPage {
         await this.searchInput.waitFor({ state: 'visible' });
       }
     }
+  }
+
+  /**
+   * Returns true if the Drafts chip is currently pressed (aria-pressed="true").
+   * Requires openFiltersIfCollapsed() to have been called first on mobile.
+   */
+  async draftsChipPressed(): Promise<boolean> {
+    const value = await this.draftsChip.getAttribute('aria-pressed');
+    return value === 'true';
   }
 
   /**

--- a/e2e/tests/diary/diary-drafts.spec.ts
+++ b/e2e/tests/diary/diary-drafts.spec.ts
@@ -18,7 +18,7 @@
  * 10. Promote draft — validation error (empty body, Save → error, still on edit, still draft)
  * 11. Discard draft (Discard Draft → confirm modal → /diary, entry gone)
  * 12. [smoke] Draft badge in list (create via API → /diary → Draft badge visible)
- * 13. Hide drafts checkbox (check → drafts hidden, saved visible; uncheck → drafts visible)
+ * 13. Drafts chip (default pressed; click → hides drafts, saved visible; click again → drafts restored)
  * 14. Clicking draft in list navigates to /diary/:id/edit
  * 15. Dashboard excludes drafts; shows entry after promote
  * 16. [responsive] Draft edit page on mobile (badge, auto-save indicator, discard button visible, no scroll)
@@ -749,10 +749,10 @@ test.describe('Draft badge in list view (Scenario 12)', { tag: '@responsive' }, 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 13: Hide drafts checkbox (#1435)
+// Scenario 13: Drafts chip (#1446)
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Hide drafts checkbox (Scenario 13)', () => {
-  test('Checking "Hide drafts" hides drafts; unchecking restores them; default is unchecked', async ({
+test.describe('Drafts chip (Scenario 13)', () => {
+  test('Drafts chip — default pressed; click hides drafts; click again restores them', async ({
     page,
     testPrefix,
   }) => {
@@ -766,43 +766,45 @@ test.describe('Hide drafts checkbox (Scenario 13)', () => {
       savedId = await createDiaryEntryViaApi(page, {
         entryType: 'general_note',
         entryDate: '2026-05-16',
-        body: `${testPrefix} saved entry for hide-drafts test`,
+        body: `${testPrefix} saved entry for drafts-chip test`,
       });
 
       await diaryPage.goto();
       await waitForDiaryListLoaded(diaryPage);
       // The filter panel is collapsed by default on mobile — expand it so
-      // the "Hide drafts" checkbox is interactable across all viewports.
+      // the Drafts chip is interactable across all viewports.
       await diaryPage.openFiltersIfCollapsed();
 
-      // ── Default: checkbox is unchecked, both entries visible ──
-      await expect(diaryPage.hideDraftsCheckbox).not.toBeChecked();
+      // ── Default: chip is pressed (aria-pressed="true"), both entries visible ──
+      await expect(diaryPage.draftsChip).toHaveAttribute('aria-pressed', 'true');
       await expect(diaryPage.entryCard(draftId)).toBeVisible();
       await expect(diaryPage.entryCard(savedId)).toBeVisible();
 
-      // ── Check "Hide drafts" → drafts hidden, saved visible; URL gets ?status=saved ──
+      // ── Click chip → hide drafts; URL gets ?status=saved ──
       const savedFilterResponse = waitForDiaryListResponse(page);
-      await diaryPage.hideDraftsCheckbox.scrollIntoViewIfNeeded();
-      await diaryPage.hideDraftsCheckbox.check();
+      await diaryPage.draftsChip.scrollIntoViewIfNeeded();
+      await diaryPage.draftsChip.click();
       await savedFilterResponse;
       await waitForDiaryListLoaded(diaryPage);
 
+      // Chip should now be un-pressed
+      await expect(diaryPage.draftsChip).toHaveAttribute('aria-pressed', 'false');
       // URL should contain status=saved
       expect(page.url()).toContain('status=saved');
-
       // Draft card should NOT be visible; saved card should be visible
       await expect(diaryPage.entryCard(draftId)).not.toBeVisible();
       await expect(diaryPage.entryCard(savedId)).toBeVisible();
 
-      // ── Uncheck "Hide drafts" → drafts visible again; status param removed ──
+      // ── Click chip again → restore drafts; status param removed ──
       const allFilterResponse = waitForDiaryListResponse(page);
-      await diaryPage.hideDraftsCheckbox.uncheck();
+      await diaryPage.draftsChip.click();
       await allFilterResponse;
       await waitForDiaryListLoaded(diaryPage);
 
+      // Chip should be pressed again
+      await expect(diaryPage.draftsChip).toHaveAttribute('aria-pressed', 'true');
       // URL should NOT contain status=saved
       expect(page.url()).not.toContain('status=saved');
-
       // Both cards should be visible again
       await expect(diaryPage.entryCard(draftId)).toBeVisible();
       await expect(diaryPage.entryCard(savedId)).toBeVisible();


### PR DESCRIPTION
## Summary

Replace the "Hide drafts" checkbox added in #1435 with a chip that sits inline with the existing mode filter chips. The chip:

- Sits next to **All / Manual / Automatic** as a 4th visually inline filter
- Operates **independently** from the mode filter (mode stays exclusive radio; Drafts is a toggle)
- Uses **muted secondary tokens** for its active state to signal it's on a different filter axis
- **Active by default** = drafts visible. Click to unpress → `?status=saved` → drafts hidden.

Wrapped in its own `role="group"` with `aria-label="Filter by draft status"` for clean screen-reader semantics. Mode chips keep their existing `role="group"` with `aria-label="Filter by entry mode"`.

Fixes #1446

## Test plan

- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.5) <noreply@anthropic.com>