### PR TITLE
chore: trivial docs bump to refire promotion CI

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -64,3 +64,4 @@ See the [Roadmap](roadmap) for upcoming features.
 - [GitHub Repository](https://github.com/steilerDev/cornerstone) -- Source code and issue tracker
 - [GitHub Wiki](https://github.com/steilerDev/cornerstone/wiki) -- Technical architecture documentation
 
+


### PR DESCRIPTION
The auto-fix bot's `[skip ci]` commit on top of `beta` is suppressing all `pull_request` workflows for promotion PR #1474. This bumps `beta`'s head SHA so Quality Gates and E2E Gates can run on the promotion PR.

Appends a single trailing newline to `docs/src/intro.md`. The `docs/` directory is ignored by Prettier and ESLint, so the auto-fix bot will not produce a follow-up `[skip ci]` commit on top.

Related: #1474, same workaround used for #1392's promotion (see #1393, #1394, #1395).