### PR TITLE
fix(overflow-menu): tolerate tiny scroll-into-view nudges before closing menu

### DIFF
--- a/client/src/components/OverflowMenu/OverflowMenu.test.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { OverflowMenu, type OverflowMenuItem } from './OverflowMenu.js';
+import { OverflowMenu, SCROLL_CLOSE_THRESHOLD_PX, type OverflowMenuItem } from './OverflowMenu.js';
 
 // ─── CSS Module note ──────────────────────────────────────────────────────────
 // identity-obj-proxy returns the class key itself as the class name.
@@ -481,6 +481,19 @@ describe('OverflowMenu', () => {
       }));
     }
 
+    afterEach(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'scrollX', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
+    });
+
     it('menu appears as a child of document.body when usePortal=true', () => {
       renderMenu({ usePortal: true });
       const trigger = screen.getByRole('button', { name: 'Open menu' });
@@ -509,7 +522,7 @@ describe('OverflowMenu', () => {
       expect(wrapper?.contains(menu)).toBe(true);
     });
 
-    it('scroll event on document closes the menu when usePortal=true', () => {
+    it('large scroll (> threshold) closes the menu when usePortal=true', () => {
       renderMenu({ usePortal: true });
       const trigger = screen.getByRole('button', { name: 'Open menu' });
       mockRect(trigger);
@@ -517,11 +530,36 @@ describe('OverflowMenu', () => {
       fireEvent.click(trigger);
       expect(screen.getByRole('menu')).toBeInTheDocument();
 
+      Object.defineProperty(window, 'scrollY', {
+        value: SCROLL_CLOSE_THRESHOLD_PX * 6,
+        writable: true,
+        configurable: true,
+      });
       act(() => {
         document.dispatchEvent(new Event('scroll', { bubbles: true }));
       });
 
       expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('tiny incidental scroll (≤ threshold) does NOT close the menu when usePortal=true', () => {
+      renderMenu({ usePortal: true });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      mockRect(trigger);
+
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      Object.defineProperty(window, 'scrollY', {
+        value: SCROLL_CLOSE_THRESHOLD_PX - 4,
+        writable: true,
+        configurable: true,
+      });
+      act(() => {
+        document.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
     });
 
     it('resize event on window closes the menu when usePortal=true', () => {

--- a/client/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './OverflowMenu.module.css';
 
+export const SCROLL_CLOSE_THRESHOLD_PX = 8;
+
 export interface OverflowMenuItem {
   id?: string;
   label: string;
@@ -57,7 +59,16 @@ export function OverflowMenu({
   useEffect(() => {
     if (!isOpen || !usePortal) return;
 
-    const handleScroll = () => setIsOpen(false);
+    const initialScrollX = window.scrollX;
+    const initialScrollY = window.scrollY;
+
+    const handleScroll = () => {
+      const deltaX = Math.abs(window.scrollX - initialScrollX);
+      const deltaY = Math.abs(window.scrollY - initialScrollY);
+      if (deltaX > SCROLL_CLOSE_THRESHOLD_PX || deltaY > SCROLL_CLOSE_THRESHOLD_PX) {
+        setIsOpen(false);
+      }
+    };
     const handleResize = () => setIsOpen(false);
 
     document.addEventListener('scroll', handleScroll, { capture: true });


### PR DESCRIPTION
## Summary

In portal mode the `OverflowMenu` closed on the very first scroll event it observed. Playwright's `scrollIntoViewIfNeeded` fires a synthetic scroll *before* the click is delivered — so the menu closed mid-click and the tap landed on the underlying `cardActions` div instead of the intended menu item. This broke the new mobile deposit-card "Mark paid" flow (`e2e/tests/invoices/invoice-deposits.spec.ts:665`) and is plausibly fragile for real touch users on the same surface.

## Fix

`OverflowMenu` now snapshots `window.scrollX` / `window.scrollY` when the menu opens, and closes on scroll **only** when the absolute delta in either axis exceeds `SCROLL_CLOSE_THRESHOLD_PX` (8 px). Resize-closes and outside-mousedown-closes are unchanged.

Constants are exported for use in tests so the threshold can change without rewriting assertions.

## Test plan

- [x] Unit: large scroll (> threshold) still closes the menu
- [x] Unit: tiny scroll (≤ threshold) leaves the menu open
- [x] Unit: resize still closes the menu (regression guard)
- [x] Unit: outside-mousedown still closes the menu (unchanged)
- [ ] E2E: `e2e/tests/invoices/invoice-deposits.spec.ts:665` (mobile, Mark paid flow) passes in CI

## Notes

This unblocks promotion PR #1474 (beta → main).

Fixes #1480