### PR TITLE
fix(overflow-menu): drop conflicting menuTop/menuBottom CSS classes in portal mode

### DIFF
--- a/client/src/components/OverflowMenu/OverflowMenu.test.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.test.tsx
@@ -611,5 +611,35 @@ describe('OverflowMenu', () => {
       const menu = screen.getByRole('menu');
       expect(menu.className).not.toContain('menuFixed');
     });
+
+    it('menu does NOT carry .menuTop class when usePortal=true with placement="top-end"', () => {
+      renderMenu({ usePortal: true, placement: 'top-end' });
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      mockRect(trigger);
+
+      fireEvent.click(trigger);
+      const menu = screen.getByRole('menu');
+
+      // .menuTop applies bottom: 100% which conflicts with inline top: <Npx> in fixed
+      // positioning. In portal mode the inline style fully controls positioning, so
+      // .menuTop/.menuBottom must NOT be present.
+      expect(menu.className).not.toMatch(/menuTop/);
+      expect(menu.className).not.toMatch(/menuBottom/);
+
+      // .menuFixed must still be present so position: fixed and z-index apply.
+      expect(menu.className).toMatch(/menuFixed/);
+    });
+
+    it('menu carries .menuTop class when usePortal=false with placement="top-end"', () => {
+      renderMenu({ placement: 'top-end' }); // usePortal omitted = false
+      const trigger = screen.getByRole('button', { name: 'Open menu' });
+      mockRect(trigger);
+
+      fireEvent.click(trigger);
+      const menu = screen.getByRole('menu');
+
+      expect(menu.className).toMatch(/menuTop/);
+      expect(menu.className).not.toMatch(/menuFixed/);
+    });
   });
 });

--- a/client/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/client/src/components/OverflowMenu/OverflowMenu.tsx
@@ -153,7 +153,7 @@ export function OverflowMenu({
     <div
       ref={menuRef}
       role="menu"
-      className={`${styles.menu} ${usePortal ? styles.menuFixed : ''} ${placement === 'top-end' ? styles.menuTop : styles.menuBottom}`}
+      className={`${styles.menu} ${usePortal ? styles.menuFixed : ''} ${!usePortal ? (placement === 'top-end' ? styles.menuTop : styles.menuBottom) : ''}`}
       onKeyDown={handleMenuKeyDown}
       style={
         usePortal && menuPos


### PR DESCRIPTION
## Summary

After #1481 fixed `OverflowMenu`'s close-on-scroll behavior, a second portal-mode bug surfaced: the menu DOM element stretches to fill the entire viewport because the `.menuTop` / `.menuBottom` CSS classes (which set `bottom: 100%` or `top: 100%`) collide with the inline `top: <Npx>` set on the fixed-positioned element. The over-sized menu intercepts its own item clicks.

## Fix

`.menuTop` / `.menuBottom` are only applied when `usePortal === false`. In portal mode positioning is fully controlled by inline styles (`position: fixed`, `top`, `right`, `transform: translateY(-100%)`).

## Test plan

- [x] Unit: portal mode — menu className contains `menuFixed`, NOT `menuTop` / `menuBottom`
- [x] Unit: non-portal mode — menu className contains `menuTop`, NOT `menuFixed` (regression guard)
- [ ] E2E: `e2e/tests/invoices/invoice-deposits.spec.ts:665` (mobile Mark Paid flow) passes in CI

## Notes

This is round 2 of the `OverflowMenu` portal-mode mobile fixes that unblock promotion PR #1474 (beta → main). Round 1 was #1481 (close-on-scroll threshold).

Fixes #1484