### PR TITLE
test(e2e): zero-pad month in invoice-deposits-ux dueDate generator

### DIFF
--- a/e2e/tests/invoices/invoice-deposits-ux.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits-ux.spec.ts
@@ -283,7 +283,7 @@ test.describe('Deposit OverflowMenu portal — not clipped (#1423)', () => {
       for (let i = 0; i < descriptions.length; i++) {
         await createDepositViaApi(page, invoiceId, {
           amount: 100,
-          dueDate: `2026-0${i + 7}-01`,
+          dueDate: `2026-${String(i + 7).padStart(2, '0')}-01`,
           description: `${testPrefix} ${descriptions[i]} deposit`,
         });
       }


### PR DESCRIPTION
## Summary

`invoice-deposits-ux.spec.ts` Scenario 4 built `dueDate` via `` `2026-0${i + 7}-01` ``. For `i=3` this evaluated to `2026-010-01` — a 3-digit month — which the server's `isValidIsoDate` correctly rejects with HTTP 400. The test failed at the `createDepositViaApi` helper.

## Fix

Zero-pad the month with `String(i + 7).padStart(2, '0')`. All four iterations now produce valid YYYY-MM-DD strings (07, 08, 09, 10).

## Test plan

- [x] Verified the only occurrence in `e2e/` — no other instances of the same shape.
- [ ] E2E shard 4 desktop passes in CI.

## Notes

This unblocks promotion PR #1474 (beta → main). It is a test-only bug exposed once the OverflowMenu mobile fixes (#1481, #1485) let prior shards reach this test in fail-fast mode.

Fixes #1487