### PR TITLE
feat(photo-annotator): add measurement and freehand tools (#1477)

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -97,10 +97,10 @@ jest.unstable_mockModule('./geometry.js', () => ({
   resizeEllipse: (shape: unknown) => shape,
   translateText: (shape: unknown) => shape,
   translateCallout: (shape: unknown) => shape,
-  translateTailAnchor: (newTailX: number, newTailY: number) => ({
-    tailX: newTailX,
-    tailY: newTailY,
-  }),
+  translateTailAnchor: (newTailX: number, newTailY: number) => ({ tailX: newTailX, tailY: newTailY }),
+  hitTestPolyline: () => null,
+  translateMeasurement: (x1: number, y1: number, x2: number, y2: number) => ({ x1, y1, x2, y2 }),
+  translateFreehand: (points: [number, number][]) => points,
 }));
 
 // ─── Dynamic imports ──────────────────────────────────────────────────────────

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { nanoid } from 'nanoid';
 import type { Photo } from '@cornerstone/shared';
 import { useAnnotator, type ToolName } from './useAnnotator.js';
-import type { TextShape, CalloutShape } from './useUndoStack.js';
+import type { TextShape, CalloutShape, MeasurementShape } from './useUndoStack.js';
 import { ToolPalette } from './ToolPalette.js';
 import { RectangleTool } from './tools/RectangleTool.js';
 import { HighlightTool } from './tools/HighlightTool.js';
@@ -12,6 +12,8 @@ import { LineTool } from './tools/LineTool.js';
 import { EllipseTool } from './tools/EllipseTool.js';
 import { TextTool } from './tools/TextTool.js';
 import { CalloutTool, resetCalloutTool, getCalloutPhase } from './tools/CalloutTool.js';
+import { MeasurementTool, resetMeasurementTool } from './tools/MeasurementTool.js';
+import { FreehandTool } from './tools/FreehandTool.js';
 import { SelectTool } from './tools/SelectTool.js';
 import type { PointerContext } from './tools/SelectTool.js';
 import { screenToImage, imageToScreen, clamp } from './geometry.js';
@@ -75,10 +77,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       const existingShape = editingShapeId
         ? state.shapes.find((s) => s.id === editingShapeId)
         : null;
-      const originalText =
-        existingShape && (existingShape.type === 'text' || existingShape.type === 'callout')
-          ? existingShape.text
-          : '';
+      const originalText = (() => {
+        if (!existingShape) return '';
+        if (existingShape.type === 'text' || existingShape.type === 'callout') return existingShape.text;
+        if (existingShape.type === 'measurement') return existingShape.label;
+        return '';
+      })();
       setInlineInput({
         isOpen: true,
         anchorImageX,
@@ -107,10 +111,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     if (text === '') {
       // Empty — if editing existing, no-op (preserve original). If new, discard.
       if (inlineInput.editingShapeId === null) {
-        // Discard draft if it was a callout phase 2
-        dispatch({ type: 'SET_DRAFT', shape: null });
+        // Discard draft if it was a callout phase 2 (but NOT measurement — measurement commits with empty label)
+        if (state.selectedTool !== 'measurement') {
+          dispatch({ type: 'SET_DRAFT', shape: null });
+        }
       }
-      return;
+      // For measurement with empty text, fall through to commit with empty label
     }
 
     const fontSize = getActiveFontSize();
@@ -120,6 +126,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       const shape = state.shapes.find((s) => s.id === inlineInput.editingShapeId);
       if (shape && (shape.type === 'text' || shape.type === 'callout')) {
         const updated = { ...shape, text };
+        dispatch({ type: 'UPDATE_SHAPE', shape: updated });
+        undoStack.commit(state.shapes.map((s) => (s.id === updated.id ? updated : s)));
+      } else if (shape && shape.type === 'measurement') {
+        const updated: MeasurementShape = { ...shape, label: text };
         dispatch({ type: 'UPDATE_SHAPE', shape: updated });
         undoStack.commit(state.shapes.map((s) => (s.id === updated.id ? updated : s)));
       }
@@ -143,28 +153,42 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       dispatch({ type: 'SET_DRAFT', shape: null });
       undoStack.commit(newShapes);
       dispatch({ type: 'SELECT_SHAPE', id: committed.id });
+    } else if (state.selectedTool === 'measurement' && state.draftShape?.type === 'measurement') {
+      // Commit the measurement draft with the user's label (may be empty)
+      const committed: MeasurementShape = {
+        ...(state.draftShape as MeasurementShape),
+        label: text,  // text may be '' — that is valid; line is drawn, no label
+      };
+      const newShapes = [...undoStack.shapes, committed];
+      dispatch({ type: 'SET_DRAFT', shape: null });
+      undoStack.commit(newShapes);
+      dispatch({ type: 'SELECT_SHAPE', id: committed.id });
+      if (liveRegionRef.current) {
+        liveRegionRef.current.textContent = t('shapeAddedMeasurement');
+      }
     }
-  }, [
-    inlineInput,
-    state.shapes,
-    state.draftShape,
-    state.selectedTool,
-    state.activeColor,
-    undoStack,
-    dispatch,
-  ]);
+  }, [inlineInput, state.shapes, state.draftShape, state.selectedTool, state.activeColor, undoStack, dispatch, t]);
 
   // Callback to cancel the inline input
   const cancelInlineInput = useCallback(() => {
     if (!inlineInput.isOpen) return;
+
+    // For measurement: Escape commits with whatever is in the input (may be empty)
+    // This preserves the drawn line even if no label is typed.
+    if (state.selectedTool === 'measurement') {
+      commitInlineInput();
+      return;
+    }
+
     setInlineInput((prev) => ({ ...prev, isOpen: false }));
     if (inlineInput.editingShapeId === null) {
       // Abort new shape — discard draft if any
       dispatch({ type: 'SET_DRAFT', shape: null });
       resetCalloutTool();
+      resetMeasurementTool();
     }
     // For existing shapes: no change, original text preserved
-  }, [inlineInput, dispatch]);
+  }, [inlineInput, state.selectedTool, dispatch, commitInlineInput]);
 
   // Measure text bbox for DOM-accurate selection overlay
   useEffect(() => {
@@ -305,6 +329,28 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                 y: clamp(selectedShape.y + dy, 0, photo.height! - selectedShape.h),
               },
             });
+          } else if (selectedShape.type === 'measurement') {
+            dispatch({
+              type: 'UPDATE_SHAPE',
+              shape: {
+                ...selectedShape,
+                x1: clamp(selectedShape.x1 + dx, 0, photo.width!),
+                y1: clamp(selectedShape.y1 + dy, 0, photo.height!),
+                x2: clamp(selectedShape.x2 + dx, 0, photo.width!),
+                y2: clamp(selectedShape.y2 + dy, 0, photo.height!),
+              },
+            });
+          } else if (selectedShape.type === 'freehand') {
+            dispatch({
+              type: 'UPDATE_SHAPE',
+              shape: {
+                ...selectedShape,
+                points: selectedShape.points.map(([x, y]) => [
+                  clamp(x + dx, 0, photo.width!),
+                  clamp(y + dy, 0, photo.height!),
+                ]) as [number, number][],
+              },
+            });
           }
         }
       }
@@ -354,6 +400,8 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         ellipse: EllipseTool,
         text: TextTool,
         callout: CalloutTool,
+        measurement: MeasurementTool,
+        freehand: FreehandTool,
       };
 
       const handler = toolHandlers[state.selectedTool];
@@ -397,6 +445,8 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         ellipse: EllipseTool,
         text: TextTool,
         callout: CalloutTool,
+        measurement: MeasurementTool,
+        freehand: FreehandTool,
       };
 
       const handler = toolHandlers[state.selectedTool];
@@ -440,6 +490,8 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         ellipse: EllipseTool,
         text: TextTool,
         callout: CalloutTool,
+        measurement: MeasurementTool,
+        freehand: FreehandTool,
       };
 
       // Capture callout phase BEFORE tool handler executes.
@@ -482,8 +534,16 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         resetCalloutTool();
         dispatch({ type: 'SET_DRAFT', shape: null });
       }
+
+      // Announce freehand shape added
+      if (state.selectedTool === 'freehand') {
+        const hasFreehandCommit = actions.some((a) => a.type === 'COMMIT_DRAFT');
+        if (hasFreehandCommit && liveRegionRef.current) {
+          liveRegionRef.current.textContent = t('shapeAddedFreehand');
+        }
+      }
     },
-    [state, photo.width, photo.height, dispatch, undoStack, openInlineInput, inlineInput.isOpen],
+    [state, photo.width, photo.height, dispatch, undoStack, openInlineInput, inlineInput.isOpen, t],
   );
 
   // Floating input positioning
@@ -628,11 +688,26 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
             const result = renderShapeSvgProps(shape, false);
             if (result.tagName === 'callout') {
               return (
-                <g key={shape.id}>
+                <g key={shape.id} data-shapeid={shape.id}>
                   <rect {...(result.boxAttrs as Record<string, unknown>)} />
                   <line {...(result.tailAttrs as Record<string, unknown>)} />
                   <text {...(result.textAttrs as Record<string, unknown>)}>{result.children}</text>
                 </g>
+              );
+            } else if (result.tagName === 'measurement') {
+              return (
+                <g key={shape.id} data-shapeid={shape.id}>
+                  <line {...(result.lineAttrs as Record<string, unknown>)} />
+                  <line {...(result.tick1Attrs as Record<string, unknown>)} />
+                  <line {...(result.tick2Attrs as Record<string, unknown>)} />
+                  {result.children && (
+                    <text {...(result.labelAttrs as Record<string, unknown>)}>{result.children}</text>
+                  )}
+                </g>
+              );
+            } else if (result.tagName === 'polyline') {
+              return (
+                <polyline key={shape.id} data-shapeid={shape.id} {...(result.attributes as Record<string, unknown>)} />
               );
             } else if (result.tagName === 'text') {
               return (
@@ -646,7 +721,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
               );
             } else {
               const Tag = result.tagName as any;
-              return <Tag key={shape.id} {...(result.attributes as Record<string, unknown>)} />;
+              return <Tag key={shape.id} data-shapeid={shape.id} {...(result.attributes as Record<string, unknown>)} />;
             }
           })}
 
@@ -663,6 +738,21 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                       {result.children}
                     </text>
                   </g>
+                );
+              } else if (result.tagName === 'measurement') {
+                return (
+                  <g>
+                    <line {...(result.lineAttrs as Record<string, unknown>)} />
+                    <line {...(result.tick1Attrs as Record<string, unknown>)} />
+                    <line {...(result.tick2Attrs as Record<string, unknown>)} />
+                    {result.children && (
+                      <text {...(result.labelAttrs as Record<string, unknown>)}>{result.children}</text>
+                    )}
+                  </g>
+                );
+              } else if (result.tagName === 'polyline') {
+                return (
+                  <polyline {...(result.attributes as Record<string, unknown>)} />
                 );
               } else if (result.tagName === 'text') {
                 return (
@@ -930,6 +1020,62 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   />
                 </>
               )}
+
+              {selectedShape.type === 'measurement' && (
+                <>
+                  <line
+                    x1={selectedShape.x1}
+                    y1={selectedShape.y1}
+                    x2={selectedShape.x2}
+                    y2={selectedShape.y2}
+                    stroke="var(--color-primary)"
+                    strokeWidth="1"
+                    strokeDasharray="4 2"
+                    pointerEvents="none"
+                  />
+                  {/* Endpoint handles (start and end) — same as arrow/line */}
+                  {[
+                    { pos: 'start', x: selectedShape.x1, y: selectedShape.y1 },
+                    { pos: 'end', x: selectedShape.x2, y: selectedShape.y2 },
+                  ].map(({ pos, x, y }) => (
+                    <rect
+                      key={pos}
+                      x={x - 4}
+                      y={y - 4}
+                      width={8}
+                      height={8}
+                      fill="var(--color-bg-primary)"
+                      stroke="var(--color-primary)"
+                      strokeWidth="1.5"
+                      style={{ cursor: 'move' }}
+                    />
+                  ))}
+                </>
+              )}
+
+              {selectedShape.type === 'freehand' && (() => {
+                // Freehand has no handles — show dashed bounding box as selection indicator
+                if (selectedShape.points.length < 2) return null;
+                const xs = selectedShape.points.map(([x]) => x);
+                const ys = selectedShape.points.map(([, y]) => y);
+                const minX = Math.min(...xs);
+                const minY = Math.min(...ys);
+                const maxX = Math.max(...xs);
+                const maxY = Math.max(...ys);
+                return (
+                  <rect
+                    x={minX - 4}
+                    y={minY - 4}
+                    width={maxX - minX + 8}
+                    height={maxY - minY + 8}
+                    stroke="var(--color-primary)"
+                    strokeWidth="1"
+                    strokeDasharray="4 2"
+                    fill="none"
+                    pointerEvents="none"
+                  />
+                );
+              })()}
             </>
           )}
         </svg>
@@ -940,7 +1086,16 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
             type="text"
             className={styles.inlineTextInput}
             style={inlineInputStyle}
-            aria-label={t(state.selectedTool === 'callout' ? 'editCallout' : 'editText')}
+            aria-label={
+              state.selectedTool === 'callout'
+                ? t('editCallout')
+                : state.selectedTool === 'measurement'
+                  ? t('editMeasurement')
+                  : t('editText')
+            }
+            placeholder={
+              state.selectedTool === 'measurement' ? t('measurementPlaceholder') : undefined
+            }
             data-testid="annotator-inline-input"
             onKeyDown={(e) => {
               if (e.key === 'Enter') {

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.test.tsx
@@ -337,4 +337,105 @@ describe('ToolPalette', () => {
       expect(screen.getByTestId('tool-ellipse')).toBeInTheDocument();
     });
   });
+
+  // ─── Measurement tool button ──────────────────────────────────────────────
+
+  describe('Measurement tool button', () => {
+    it('renders measurement tool button with data-testid="tool-measurement"', () => {
+      renderPalette();
+      expect(screen.getByTestId('tool-measurement')).toBeInTheDocument();
+    });
+
+    it('measurement tool button is not active by default (selectedTool=select)', () => {
+      renderPalette({ selectedTool: 'select' });
+      expect(screen.getByTestId('tool-measurement')).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('measurement tool button is active when selectedTool="measurement"', () => {
+      renderPalette({ selectedTool: 'measurement' });
+      expect(screen.getByTestId('tool-measurement')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('clicking measurement tool button calls onSelectTool with "measurement"', () => {
+      const onSelectTool = jest.fn() as AnyMock;
+      renderPalette({ onSelectTool });
+      fireEvent.click(screen.getByTestId('tool-measurement'));
+      expect(onSelectTool).toHaveBeenCalledWith('measurement');
+    });
+  });
+
+  // ─── Freehand tool button ─────────────────────────────────────────────────
+
+  describe('Freehand tool button', () => {
+    it('renders freehand tool button with data-testid="tool-freehand"', () => {
+      renderPalette();
+      expect(screen.getByTestId('tool-freehand')).toBeInTheDocument();
+    });
+
+    it('freehand tool button is not active by default (selectedTool=select)', () => {
+      renderPalette({ selectedTool: 'select' });
+      expect(screen.getByTestId('tool-freehand')).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('freehand tool button is active when selectedTool="freehand"', () => {
+      renderPalette({ selectedTool: 'freehand' });
+      expect(screen.getByTestId('tool-freehand')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('clicking freehand tool button calls onSelectTool with "freehand"', () => {
+      const onSelectTool = jest.fn() as AnyMock;
+      renderPalette({ onSelectTool });
+      fireEvent.click(screen.getByTestId('tool-freehand'));
+      expect(onSelectTool).toHaveBeenCalledWith('freehand');
+    });
+  });
+
+  // ─── Font-size selector visibility: measurement extends existing tools ────
+
+  describe('Font-size selector visibility — measurement tool', () => {
+    it('font-size selector IS visible when selectedTool is "measurement"', () => {
+      const { unmount } = renderPalette({ selectedTool: 'select' });
+      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
+      unmount();
+
+      renderPalette({ selectedTool: 'measurement' });
+      const groupsWithMeasurement = screen.queryAllByRole('radiogroup').length;
+
+      // measurement was added to the font-size selector gate — should show it
+      expect(groupsWithMeasurement).toBeGreaterThan(groupsWithSelect);
+    });
+
+    it('font-size selector is NOT visible when selectedTool is "freehand"', () => {
+      renderPalette({ selectedTool: 'freehand' });
+      const radiogroups = screen.queryAllByRole('radiogroup');
+      const hasFontSize = radiogroups.some(
+        (el) =>
+          el.getAttribute('aria-label') === 'fontSize' ||
+          el.getAttribute('aria-label') === 'Font size',
+      );
+      expect(hasFontSize).toBe(false);
+    });
+
+    it('font-size selector remains visible for text tool (not regressed)', () => {
+      const { unmount } = renderPalette({ selectedTool: 'select' });
+      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
+      unmount();
+
+      renderPalette({ selectedTool: 'text' });
+      const groupsWithText = screen.queryAllByRole('radiogroup').length;
+
+      expect(groupsWithText).toBeGreaterThan(groupsWithSelect);
+    });
+
+    it('font-size selector remains visible for callout tool (not regressed)', () => {
+      const { unmount } = renderPalette({ selectedTool: 'select' });
+      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
+      unmount();
+
+      renderPalette({ selectedTool: 'callout' });
+      const groupsWithCallout = screen.queryAllByRole('radiogroup').length;
+
+      expect(groupsWithCallout).toBeGreaterThan(groupsWithSelect);
+    });
+  });
 });

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -145,6 +145,32 @@ export function ToolPalette({
         >
           <CalloutIcon />
         </button>
+
+        <button
+          type="button"
+          aria-pressed={selectedTool === 'measurement'}
+          data-testid="tool-measurement"
+          aria-label={t('toolMeasurement')}
+          className={`${styles.toolButton} ${
+            selectedTool === 'measurement' ? styles.toolButtonActive : ''
+          }`}
+          onClick={() => onSelectTool('measurement')}
+        >
+          <MeasurementIcon />
+        </button>
+
+        <button
+          type="button"
+          aria-pressed={selectedTool === 'freehand'}
+          data-testid="tool-freehand"
+          aria-label={t('toolFreehand')}
+          className={`${styles.toolButton} ${
+            selectedTool === 'freehand' ? styles.toolButtonActive : ''
+          }`}
+          onClick={() => onSelectTool('freehand')}
+        >
+          <FreehandIcon />
+        </button>
       </div>
 
       <div className={styles.divider} aria-hidden="true" />
@@ -204,7 +230,7 @@ export function ToolPalette({
         ))}
       </div>
 
-      {(selectedTool === 'text' || selectedTool === 'callout') && (
+      {(selectedTool === 'text' || selectedTool === 'callout' || selectedTool === 'measurement') && (
         <>
           <div className={styles.divider} aria-hidden="true" />
           <div role="radiogroup" aria-label={t('fontSize')} className={styles.fontSizeGroup}>
@@ -379,6 +405,33 @@ function CalloutIcon() {
         fill="none"
       />
       <path d="M9 15 L6 20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MeasurementIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Horizontal measurement line */}
+      <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      {/* Left tick */}
+      <line x1="4" y1="8" x2="4" y2="16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      {/* Right tick */}
+      <line x1="20" y1="8" x2="20" y2="16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function FreehandIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M4 18 C6 14, 8 10, 10 12 C12 14, 14 8, 16 10 C18 12, 20 8, 21 6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 }

--- a/client/src/components/photos/PhotoAnnotator/geometry.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/geometry.test.ts
@@ -33,6 +33,9 @@ import {
   translateText,
   translateCallout,
   translateTailAnchor,
+  hitTestPolyline,
+  translateMeasurement,
+  translateFreehand,
 } from './geometry.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -1122,5 +1125,204 @@ describe('translateTailAnchor()', () => {
     const result = translateTailAnchor(0, 0, imageWidth, imageHeight);
     expect(result.tailX).toBe(0);
     expect(result.tailY).toBe(0);
+  });
+});
+
+// ─── hitTestPolyline ──────────────────────────────────────────────────────────
+
+describe('hitTestPolyline()', () => {
+  const tolerance = 5;
+
+  it('returns "body" when clicking near the first segment of a polyline', () => {
+    // Polyline: (0,0) → (100,0) → (100,100); click at (50,2) — near first segment
+    const points: [number, number][] = [[0, 0], [100, 0], [100, 100]];
+    const result = hitTestPolyline(50, 2, points, tolerance);
+    expect(result).toBe('body');
+  });
+
+  it('returns "body" when clicking near the second segment of a polyline', () => {
+    // Click at (97, 50) — near the second segment (100,0)→(100,100)
+    const points: [number, number][] = [[0, 0], [100, 0], [100, 100]];
+    const result = hitTestPolyline(97, 50, points, tolerance);
+    expect(result).toBe('body');
+  });
+
+  it('returns null when clicking far from all segments', () => {
+    // Click at (50, 50) — far from (0,0)→(100,0) and (100,0)→(100,100)
+    const points: [number, number][] = [[0, 0], [100, 0], [100, 100]];
+    const result = hitTestPolyline(50, 50, points, tolerance);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a polyline with a single point (no segments)', () => {
+    // A single-point "polyline" has no segments — nothing to hit-test
+    const points: [number, number][] = [[50, 50]];
+    const result = hitTestPolyline(50, 50, points, tolerance);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an empty polyline', () => {
+    const result = hitTestPolyline(50, 50, [], tolerance);
+    expect(result).toBeNull();
+  });
+
+  it('returns "body" for a two-point polyline near the single segment', () => {
+    const points: [number, number][] = [[10, 10], [90, 10]];
+    const result = hitTestPolyline(50, 12, points, tolerance);
+    expect(result).toBe('body');
+  });
+
+  it('returns null when point is beyond the polyline endpoint (clamped projection)', () => {
+    const points: [number, number][] = [[10, 10], [90, 10]];
+    // Beyond the endpoint at (90,10) — perpendicular distance is large
+    const result = hitTestPolyline(120, 30, points, tolerance);
+    expect(result).toBeNull();
+  });
+
+  it('returns "body" for a hit on any one of many segments', () => {
+    // Zigzag polyline — click on third segment
+    const points: [number, number][] = [
+      [0, 0], [20, 20], [40, 0], [60, 20], [80, 0],
+    ];
+    // Click near segment (40,0)→(60,20), specifically at (50,10) which is on the segment
+    const result = hitTestPolyline(50, 10, points, tolerance);
+    expect(result).toBe('body');
+  });
+
+  it('returns null for point far from a diagonal polyline', () => {
+    const points: [number, number][] = [[0, 0], [100, 100]];
+    // Click at (100, 0) — 70px from the line y=x
+    const result = hitTestPolyline(100, 0, points, tolerance);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── translateMeasurement ─────────────────────────────────────────────────────
+
+describe('translateMeasurement()', () => {
+  const imageWidth = 500;
+  const imageHeight = 400;
+
+  it('translates both endpoints by dx/dy', () => {
+    const result = translateMeasurement(10, 20, 100, 80, 15, 25, imageWidth, imageHeight);
+    expect(result.x1).toBe(25);
+    expect(result.y1).toBe(45);
+    expect(result.x2).toBe(115);
+    expect(result.y2).toBe(105);
+  });
+
+  it('translates by negative delta', () => {
+    const result = translateMeasurement(50, 60, 100, 90, -20, -10, imageWidth, imageHeight);
+    expect(result.x1).toBe(30);
+    expect(result.y1).toBe(50);
+    expect(result.x2).toBe(80);
+    expect(result.y2).toBe(80);
+  });
+
+  it('clamps x1 to image left boundary (0)', () => {
+    const result = translateMeasurement(5, 20, 100, 80, -20, 0, imageWidth, imageHeight);
+    expect(result.x1).toBe(0); // clamped from -15 to 0
+    expect(result.x2).toBe(80); // 100-20 = 80
+  });
+
+  it('clamps y1 to image top boundary (0)', () => {
+    const result = translateMeasurement(10, 5, 100, 80, 0, -20, imageWidth, imageHeight);
+    expect(result.y1).toBe(0); // clamped from -15 to 0
+    expect(result.y2).toBe(60); // 80-20 = 60
+  });
+
+  it('clamps x2 to image right boundary (imageWidth)', () => {
+    const result = translateMeasurement(10, 20, 490, 80, 20, 0, imageWidth, imageHeight);
+    expect(result.x2).toBe(imageWidth); // clamped from 510 to 500
+    expect(result.x1).toBe(30); // 10+20 = 30
+  });
+
+  it('clamps y2 to image bottom boundary (imageHeight)', () => {
+    const result = translateMeasurement(10, 20, 100, 390, 0, 20, imageWidth, imageHeight);
+    expect(result.y2).toBe(imageHeight); // clamped from 410 to 400
+    expect(result.y1).toBe(40); // 20+20 = 40
+  });
+
+  it('delegates to translateArrowLine (returns same result as translateArrowLine)', () => {
+    const x1 = 30, y1 = 40, x2 = 130, y2 = 140;
+    const dx = 10, dy = 5;
+    const result = translateMeasurement(x1, y1, x2, y2, dx, dy, imageWidth, imageHeight);
+    // Both x1+dx and x2+dx are within bounds — no clamping needed
+    expect(result).toEqual({
+      x1: x1 + dx,
+      y1: y1 + dy,
+      x2: x2 + dx,
+      y2: y2 + dy,
+    });
+  });
+});
+
+// ─── translateFreehand ────────────────────────────────────────────────────────
+
+describe('translateFreehand()', () => {
+  const imageWidth = 500;
+  const imageHeight = 400;
+
+  it('translates all points by dx/dy', () => {
+    const points: [number, number][] = [[10, 20], [50, 60], [100, 80]];
+    const result = translateFreehand(points, 15, 10, imageWidth, imageHeight);
+    expect(result).toEqual([[25, 30], [65, 70], [115, 90]]);
+  });
+
+  it('translates by negative delta', () => {
+    const points: [number, number][] = [[100, 100], [200, 150]];
+    const result = translateFreehand(points, -30, -20, imageWidth, imageHeight);
+    expect(result).toEqual([[70, 80], [170, 130]]);
+  });
+
+  it('clamps x to 0 (left boundary)', () => {
+    const points: [number, number][] = [[5, 50]];
+    const result = translateFreehand(points, -20, 0, imageWidth, imageHeight);
+    expect(result[0]![0]).toBe(0); // clamped from -15 to 0
+  });
+
+  it('clamps y to 0 (top boundary)', () => {
+    const points: [number, number][] = [[100, 5]];
+    const result = translateFreehand(points, 0, -20, imageWidth, imageHeight);
+    expect(result[0]![1]).toBe(0); // clamped from -15 to 0
+  });
+
+  it('clamps x to imageWidth (right boundary)', () => {
+    const points: [number, number][] = [[490, 100]];
+    const result = translateFreehand(points, 30, 0, imageWidth, imageHeight);
+    expect(result[0]![0]).toBe(imageWidth); // clamped from 520 to 500
+  });
+
+  it('clamps y to imageHeight (bottom boundary)', () => {
+    const points: [number, number][] = [[100, 390]];
+    const result = translateFreehand(points, 0, 30, imageWidth, imageHeight);
+    expect(result[0]![1]).toBe(imageHeight); // clamped from 420 to 400
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = translateFreehand([], 10, 10, imageWidth, imageHeight);
+    expect(result).toEqual([]);
+  });
+
+  it('translates each point independently (mixed clamping)', () => {
+    // First point near left edge, second well within bounds
+    const points: [number, number][] = [[3, 50], [200, 200]];
+    const result = translateFreehand(points, -10, 0, imageWidth, imageHeight);
+    // First point: x=3-10=-7 → clamped to 0; second: x=200-10=190
+    expect(result[0]![0]).toBe(0);
+    expect(result[1]![0]).toBe(190);
+  });
+
+  it('does not mutate the input array', () => {
+    const points: [number, number][] = [[10, 20], [30, 40]];
+    const copy = points.map((p) => [...p] as [number, number]);
+    translateFreehand(points, 5, 5, imageWidth, imageHeight);
+    expect(points).toEqual(copy);
+  });
+
+  it('returns a new array (not the same reference)', () => {
+    const points: [number, number][] = [[10, 20]];
+    const result = translateFreehand(points, 0, 0, imageWidth, imageHeight);
+    expect(result).not.toBe(points);
   });
 });

--- a/client/src/components/photos/PhotoAnnotator/geometry.ts
+++ b/client/src/components/photos/PhotoAnnotator/geometry.ts
@@ -571,3 +571,57 @@ export function translateTailAnchor(
     tailY: clamp(newTailY, 0, imageHeight),
   };
 }
+
+/**
+ * Hit-test a polyline (freehand stroke) for pointer proximity.
+ * Tests each segment of the polyline against the given tolerance.
+ * Returns 'body' if any segment is hit, null otherwise.
+ */
+export function hitTestPolyline(
+  px: number,
+  py: number,
+  points: [number, number][],
+  tolerance: number,
+): 'body' | null {
+  for (let i = 0; i < points.length - 1; i++) {
+    const [x1, y1] = points[i]!;
+    const [x2, y2] = points[i + 1]!;
+    if (hitTestLine(px, py, x1, y1, x2, y2, tolerance) !== null) {
+      return 'body';
+    }
+  }
+  return null;
+}
+
+/**
+ * Translate a measurement shape (two endpoints) by dx, dy, clamped to image bounds.
+ * Delegates to translateArrowLine since measurement shares the same geometry.
+ */
+export function translateMeasurement(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  dx: number,
+  dy: number,
+  imageWidth: number,
+  imageHeight: number,
+): { x1: number; y1: number; x2: number; y2: number } {
+  return translateArrowLine(x1, y1, x2, y2, dx, dy, imageWidth, imageHeight);
+}
+
+/**
+ * Translate a freehand shape's points by dx, dy (clamped to image bounds).
+ */
+export function translateFreehand(
+  points: [number, number][],
+  dx: number,
+  dy: number,
+  imageWidth: number,
+  imageHeight: number,
+): [number, number][] {
+  return points.map(([x, y]) => [
+    clamp(x + dx, 0, imageWidth),
+    clamp(y + dy, 0, imageHeight),
+  ]) as [number, number][];
+}

--- a/client/src/components/photos/PhotoAnnotator/render.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.test.ts
@@ -13,15 +13,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { renderShapeSvgProps, drawShapeOnCanvas, ANNOTATION_FONT_FAMILY } from './render.js';
 import type { SvgRenderResult } from './render.js';
-import type {
-  RectangleShape,
-  HighlightShape,
-  ArrowShape,
-  LineShape,
-  EllipseShape,
-  TextShape,
-  CalloutShape,
-} from './useUndoStack.js';
+import type { RectangleShape, HighlightShape, ArrowShape, LineShape, EllipseShape, TextShape, CalloutShape, MeasurementShape, FreehandShape } from './useUndoStack.js';
 
 // ─── Type-narrowing helpers ───────────────────────────────────────────────────
 
@@ -1073,5 +1065,407 @@ describe('drawShapeOnCanvas() — Callout', () => {
   it('sets lineWidth to 2 for callout box', () => {
     drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeCallout());
     expect(ctx.lineWidth).toBe(2);
+  });
+});
+
+// ─── Helpers for new shape types ──────────────────────────────────────────────
+
+function makeMeasurement(overrides: Partial<MeasurementShape> = {}): MeasurementShape {
+  return {
+    type: 'measurement',
+    id: 'measurement-1',
+    x1: 10,
+    y1: 50,
+    x2: 110,
+    y2: 50,
+    label: '5m',
+    stroke: '#dc2626',
+    strokeWidth: 4,
+    fontSize: 18,
+    color: '#dc2626',
+    ...overrides,
+  };
+}
+
+function makeFreehand(overrides: Partial<FreehandShape> = {}): FreehandShape {
+  return {
+    type: 'freehand',
+    id: 'freehand-1',
+    points: [[10, 10], [30, 40], [50, 20], [70, 50], [90, 10]],
+    stroke: '#3b82f6',
+    strokeWidth: 4,
+    ...overrides,
+  };
+}
+
+/**
+ * Asserts the result is a measurement composite.
+ */
+function getMeasurementParts(result: SvgRenderResult): {
+  lineAttrs: Record<string, string | number>;
+  tick1Attrs: Record<string, string | number>;
+  tick2Attrs: Record<string, string | number>;
+  labelAttrs: Record<string, string | number>;
+  children: string;
+} {
+  if (result.tagName === 'measurement') return result;
+  throw new Error(`Expected measurement SvgRenderResult but got tagName '${result.tagName}'`);
+}
+
+// ─── renderShapeSvgProps — Measurement ───────────────────────────────────────
+
+describe('renderShapeSvgProps() — Measurement', () => {
+  it('returns tagName: "measurement" for a measurement shape', () => {
+    const result = renderShapeSvgProps(makeMeasurement(), false);
+    expect(result.tagName).toBe('measurement');
+  });
+
+  it('lineAttrs include x1/y1/x2/y2 matching shape endpoints', () => {
+    const shape = makeMeasurement({ x1: 10, y1: 50, x2: 110, y2: 50 });
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(lineAttrs.x1).toBe(10);
+    expect(lineAttrs.y1).toBe(50);
+    expect(lineAttrs.x2).toBe(110);
+    expect(lineAttrs.y2).toBe(50);
+  });
+
+  it('lineAttrs include stroke from shape.stroke', () => {
+    const shape = makeMeasurement({ stroke: '#ff0000' });
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(lineAttrs.stroke).toBe('#ff0000');
+  });
+
+  it('lineAttrs include stroke-width from shape.strokeWidth', () => {
+    const shape = makeMeasurement({ strokeWidth: 8 });
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(lineAttrs['stroke-width']).toBe(8);
+  });
+
+  it('committed measurement lineAttrs has stroke-dasharray: "none"', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), false));
+    expect(lineAttrs['stroke-dasharray']).toBe('none');
+  });
+
+  it('draft measurement lineAttrs has stroke-dasharray: "6 4"', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), true));
+    expect(lineAttrs['stroke-dasharray']).toBe('6 4');
+  });
+
+  it('committed measurement lineAttrs has opacity: 1', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), false));
+    expect(lineAttrs.opacity).toBe(1);
+  });
+
+  it('draft measurement lineAttrs has opacity: 0.8', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), true));
+    expect(lineAttrs.opacity).toBe(0.8);
+  });
+
+  it('committed measurement lineAttrs has pointer-events: "stroke"', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), false));
+    expect(lineAttrs['pointer-events']).toBe('stroke');
+  });
+
+  it('draft measurement lineAttrs has pointer-events: "none"', () => {
+    const { lineAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), true));
+    expect(lineAttrs['pointer-events']).toBe('none');
+  });
+
+  it('tick1Attrs have pointer-events: "none"', () => {
+    const { tick1Attrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), false));
+    expect(tick1Attrs['pointer-events']).toBe('none');
+  });
+
+  it('tick2Attrs have pointer-events: "none"', () => {
+    const { tick2Attrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement(), false));
+    expect(tick2Attrs['pointer-events']).toBe('none');
+  });
+
+  it('tick1Attrs x1/x2/y1/y2 span the start endpoint perpendicularly', () => {
+    // Horizontal line from (10,50) to (110,50) — perpendicular is vertical
+    // unit normal (nx, ny) = (0, 1); TICK = strokeWidth*4 = 4*4 = 16
+    const shape = makeMeasurement({ x1: 10, y1: 50, x2: 110, y2: 50, strokeWidth: 4 });
+    const { tick1Attrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    // tick1: x1=10+0*16=10, y1=50+1*16=66, x2=10-0*16=10, y2=50-1*16=34
+    expect(tick1Attrs.x1).toBeCloseTo(10);
+    expect(tick1Attrs.y1).toBeCloseTo(66);
+    expect(tick1Attrs.x2).toBeCloseTo(10);
+    expect(tick1Attrs.y2).toBeCloseTo(34);
+  });
+
+  it('tick2Attrs span the end endpoint perpendicularly', () => {
+    const shape = makeMeasurement({ x1: 10, y1: 50, x2: 110, y2: 50, strokeWidth: 4 });
+    const { tick2Attrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    // TICK=16; tick at end: x1=110, y1=66, x2=110, y2=34
+    expect(tick2Attrs.x1).toBeCloseTo(110);
+    expect(tick2Attrs.y1).toBeCloseTo(66);
+    expect(tick2Attrs.x2).toBeCloseTo(110);
+    expect(tick2Attrs.y2).toBeCloseTo(34);
+  });
+
+  it('children equals shape.label', () => {
+    const shape = makeMeasurement({ label: '3.5m' });
+    const { children } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(children).toBe('3.5m');
+  });
+
+  it('labelAttrs include display:"none" when label is empty string', () => {
+    const shape = makeMeasurement({ label: '' });
+    const { labelAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(labelAttrs.display).toBe('none');
+  });
+
+  it('labelAttrs include font-size when label is non-empty', () => {
+    const shape = makeMeasurement({ label: '5m', fontSize: 24 });
+    const { labelAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(labelAttrs['font-size']).toBe(24);
+  });
+
+  it('labelAttrs include font-family === ANNOTATION_FONT_FAMILY when label is non-empty', () => {
+    const shape = makeMeasurement({ label: '5m' });
+    const { labelAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(labelAttrs['font-family']).toBe(ANNOTATION_FONT_FAMILY);
+  });
+
+  it('labelAttrs include text-anchor: "middle" when label is non-empty', () => {
+    const { labelAttrs } = getMeasurementParts(renderShapeSvgProps(makeMeasurement({ label: '5m' }), false));
+    expect(labelAttrs['text-anchor']).toBe('middle');
+  });
+
+  it('labelAttrs include fill from shape.color when label is non-empty', () => {
+    const shape = makeMeasurement({ label: '5m', color: '#22c55e' });
+    const { labelAttrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(labelAttrs.fill).toBe('#22c55e');
+  });
+
+  it('tick1Attrs include stroke from shape.stroke', () => {
+    const shape = makeMeasurement({ stroke: '#3b82f6' });
+    const { tick1Attrs } = getMeasurementParts(renderShapeSvgProps(shape, false));
+    expect(tick1Attrs.stroke).toBe('#3b82f6');
+  });
+});
+
+// ─── drawShapeOnCanvas — Measurement ─────────────────────────────────────────
+
+describe('drawShapeOnCanvas() — Measurement', () => {
+  let ctx: MockCtx & { textAlign: string; textBaseline: string; lineJoin: CanvasLineJoin };
+
+  beforeEach(() => {
+    ctx = {
+      ...makeCanvasContext(),
+      textAlign: 'start',
+      textBaseline: 'alphabetic',
+      lineJoin: 'miter',
+    };
+  });
+
+  it('calls beginPath at least 3 times (main line + 2 ticks)', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeMeasurement());
+    expect(ctx.beginPath).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls stroke at least 3 times (main line + 2 ticks, possibly more for label)', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeMeasurement());
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls moveTo with x1/y1 (start of main line)', () => {
+    const shape = makeMeasurement({ x1: 10, y1: 50 });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.moveTo).toHaveBeenCalledWith(10, 50);
+  });
+
+  it('calls lineTo with x2/y2 (end of main line)', () => {
+    const shape = makeMeasurement({ x1: 10, y1: 50, x2: 110, y2: 50 });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.lineTo).toHaveBeenCalledWith(110, 50);
+  });
+
+  it('sets strokeStyle to shape.stroke', () => {
+    const shape = makeMeasurement({ stroke: '#22c55e' });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.strokeStyle).toBe('#22c55e');
+  });
+
+  it('sets lineWidth to shape.strokeWidth', () => {
+    const shape = makeMeasurement({ strokeWidth: 8 });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.lineWidth).toBe(8);
+  });
+
+  it('sets lineCap to "round"', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeMeasurement());
+    expect(ctx.lineCap).toBe('round');
+  });
+
+  it('calls fillText with shape.label when label is non-empty', () => {
+    const shape = makeMeasurement({ label: '5m' });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.fillText).toHaveBeenCalledWith('5m', expect.any(Number), expect.any(Number));
+  });
+
+  it('does NOT call fillText when label is empty', () => {
+    const shape = makeMeasurement({ label: '' });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it('sets ctx.font to include shape.fontSize when label is non-empty', () => {
+    const shape = makeMeasurement({ label: '5m', fontSize: 24 });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.font).toContain('24px');
+    expect(ctx.font).toContain(ANNOTATION_FONT_FAMILY);
+  });
+});
+
+// ─── renderShapeSvgProps — Freehand (polyline) ───────────────────────────────
+
+describe('renderShapeSvgProps() — Freehand', () => {
+  it('returns tagName: "polyline" for a freehand shape', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    expect(result.tagName).toBe('polyline');
+  });
+
+  it('attributes include points as space-separated "x,y" pairs', () => {
+    const shape = makeFreehand({ points: [[10, 20], [30, 40], [50, 60]] });
+    const result = renderShapeSvgProps(shape, false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes.points).toBe('10,20 30,40 50,60');
+  });
+
+  it('attributes include stroke from shape.stroke', () => {
+    const shape = makeFreehand({ stroke: '#22c55e' });
+    const result = renderShapeSvgProps(shape, false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes.stroke).toBe('#22c55e');
+  });
+
+  it('attributes include stroke-width from shape.strokeWidth', () => {
+    const shape = makeFreehand({ strokeWidth: 8 });
+    const result = renderShapeSvgProps(shape, false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['stroke-width']).toBe(8);
+  });
+
+  it('committed freehand has stroke-dasharray: "none"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['stroke-dasharray']).toBe('none');
+  });
+
+  it('draft freehand has stroke-dasharray: "6 4"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), true);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['stroke-dasharray']).toBe('6 4');
+  });
+
+  it('committed freehand has opacity: 1', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes.opacity).toBe(1);
+  });
+
+  it('draft freehand has opacity: 0.8', () => {
+    const result = renderShapeSvgProps(makeFreehand(), true);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes.opacity).toBe(0.8);
+  });
+
+  it('has fill: "none"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes.fill).toBe('none');
+  });
+
+  it('has stroke-linecap: "round"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['stroke-linecap']).toBe('round');
+  });
+
+  it('has stroke-linejoin: "round"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['stroke-linejoin']).toBe('round');
+  });
+
+  it('committed freehand has pointer-events: "stroke"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), false);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['pointer-events']).toBe('stroke');
+  });
+
+  it('draft freehand has pointer-events: "none"', () => {
+    const result = renderShapeSvgProps(makeFreehand(), true);
+    if (result.tagName !== 'polyline') throw new Error('expected polyline');
+    expect(result.attributes['pointer-events']).toBe('none');
+  });
+});
+
+// ─── drawShapeOnCanvas — Freehand ─────────────────────────────────────────────
+
+describe('drawShapeOnCanvas() — Freehand', () => {
+  let ctx: MockCtx & { lineJoin: CanvasLineJoin };
+
+  beforeEach(() => {
+    ctx = { ...makeCanvasContext(), lineJoin: 'miter' };
+  });
+
+  it('calls beginPath once', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeFreehand());
+    expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls moveTo with the first point', () => {
+    const shape = makeFreehand({ points: [[10, 20], [50, 60], [90, 30]] });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.moveTo).toHaveBeenCalledWith(10, 20);
+  });
+
+  it('calls lineTo for each subsequent point', () => {
+    const shape = makeFreehand({ points: [[10, 20], [50, 60], [90, 30]] });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.lineTo).toHaveBeenCalledWith(50, 60);
+    expect(ctx.lineTo).toHaveBeenCalledWith(90, 30);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(2); // N-1 calls
+  });
+
+  it('calls stroke', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeFreehand());
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it('does NOT call fill', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeFreehand());
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('sets strokeStyle to shape.stroke', () => {
+    const shape = makeFreehand({ stroke: '#22c55e' });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.strokeStyle).toBe('#22c55e');
+  });
+
+  it('sets lineWidth to shape.strokeWidth', () => {
+    const shape = makeFreehand({ strokeWidth: 8 });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.lineWidth).toBe(8);
+  });
+
+  it('sets lineCap to "round"', () => {
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, makeFreehand());
+    expect(ctx.lineCap).toBe('round');
+  });
+
+  it('does nothing (no beginPath) for freehand with fewer than 2 points', () => {
+    const shape = makeFreehand({ points: [[50, 50]] });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for freehand with 0 points', () => {
+    const shape = makeFreehand({ points: [] });
+    drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
+    expect(ctx.beginPath).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/photos/PhotoAnnotator/render.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.ts
@@ -8,12 +8,18 @@ export const ANNOTATION_FONT_FAMILY = 'system-ui, -apple-system, sans-serif';
 export type SvgRenderResult =
   | { tagName: 'rect' | 'line' | 'ellipse'; attributes: Record<string, string | number> }
   | { tagName: 'text'; attributes: Record<string, string | number>; children: string }
+  | { tagName: 'callout'; boxAttrs: Record<string, string | number>; tailAttrs: Record<string, string | number>; textAttrs: Record<string, string | number>; children: string }
   | {
-      tagName: 'callout';
-      boxAttrs: Record<string, string | number>;
-      tailAttrs: Record<string, string | number>;
-      textAttrs: Record<string, string | number>;
+      tagName: 'measurement';
+      lineAttrs: Record<string, string | number>;
+      tick1Attrs: Record<string, string | number>;
+      tick2Attrs: Record<string, string | number>;
+      labelAttrs: Record<string, string | number>;
       children: string;
+    }
+  | {
+      tagName: 'polyline';
+      attributes: Record<string, string | number>;
     };
 
 /**
@@ -167,6 +173,89 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
       },
       children: calloutShape.text,
     };
+  } else if (shape.type === 'measurement') {
+    // Compute perpendicular tick mark direction
+    const dx = shape.x2 - shape.x1;
+    const dy = shape.y2 - shape.y1;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const nx = -dy / len;  // unit normal
+    const ny = dx / len;
+    const TICK = shape.strokeWidth * 4;  // tick half-length in image-space pixels
+
+    const midX = (shape.x1 + shape.x2) / 2;
+    const midY = (shape.y1 + shape.y2) / 2;
+    // Label sits above the midpoint (perpendicular offset = fontSize * 0.6)
+    const labelOffsetX = -nx * shape.fontSize * 0.6;
+    const labelOffsetY = -ny * shape.fontSize * 0.6;
+
+    return {
+      tagName: 'measurement',
+      lineAttrs: {
+        x1: shape.x1,
+        y1: shape.y1,
+        x2: shape.x2,
+        y2: shape.y2,
+        stroke: shape.stroke,
+        'stroke-width': shape.strokeWidth,
+        'stroke-linecap': 'round',
+        'stroke-dasharray': isDraft ? '6 4' : 'none',
+        opacity: isDraft ? 0.8 : 1,
+        'pointer-events': isDraft ? 'none' : 'stroke',
+      },
+      tick1Attrs: {
+        x1: shape.x1 + nx * TICK,
+        y1: shape.y1 + ny * TICK,
+        x2: shape.x1 - nx * TICK,
+        y2: shape.y1 - ny * TICK,
+        stroke: shape.stroke,
+        'stroke-width': shape.strokeWidth,
+        'stroke-linecap': 'round',
+        opacity: isDraft ? 0.8 : 1,
+        'pointer-events': 'none',
+      },
+      tick2Attrs: {
+        x1: shape.x2 + nx * TICK,
+        y1: shape.y2 + ny * TICK,
+        x2: shape.x2 - nx * TICK,
+        y2: shape.y2 - ny * TICK,
+        stroke: shape.stroke,
+        'stroke-width': shape.strokeWidth,
+        'stroke-linecap': 'round',
+        opacity: isDraft ? 0.8 : 1,
+        'pointer-events': 'none',
+      },
+      labelAttrs: shape.label
+        ? {
+            x: midX + labelOffsetX,
+            y: midY + labelOffsetY,
+            fill: shape.color,
+            'font-size': shape.fontSize,
+            'font-family': ANNOTATION_FONT_FAMILY,
+            'text-anchor': 'middle',
+            'dominant-baseline': 'middle',
+            opacity: isDraft ? 0.8 : 1,
+            'pointer-events': 'none',
+            'user-select': 'none',
+          }
+        : { display: 'none' },  // hidden when label is empty
+      children: shape.label,
+    };
+  } else if (shape.type === 'freehand') {
+    const pointsStr = shape.points.map(([x, y]) => `${x},${y}`).join(' ');
+    return {
+      tagName: 'polyline',
+      attributes: {
+        points: pointsStr,
+        stroke: shape.stroke,
+        'stroke-width': shape.strokeWidth,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+        fill: 'none',
+        'stroke-dasharray': isDraft ? '6 4' : 'none',
+        opacity: isDraft ? 0.8 : 1,
+        'pointer-events': isDraft ? 'none' : 'stroke',
+      },
+    };
   }
 
   // Fallback for unknown shape type
@@ -262,5 +351,63 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.fillStyle = calloutShape.color;
     ctx.font = `${calloutShape.fontSize}px ${ANNOTATION_FONT_FAMILY}`;
     ctx.fillText(calloutShape.text, calloutShape.x + 6, calloutShape.y + calloutShape.fontSize + 4);
+  } else if (shape.type === 'measurement') {
+    const dx = shape.x2 - shape.x1;
+    const dy = shape.y2 - shape.y1;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const nx = -dy / len;
+    const ny = dx / len;
+    const TICK = shape.strokeWidth * 4;
+
+    ctx.strokeStyle = shape.stroke;
+    ctx.lineWidth = shape.strokeWidth;
+    ctx.lineCap = 'round';
+
+    // Main line
+    ctx.beginPath();
+    ctx.moveTo(shape.x1, shape.y1);
+    ctx.lineTo(shape.x2, shape.y2);
+    ctx.stroke();
+
+    // Tick at start
+    ctx.beginPath();
+    ctx.moveTo(shape.x1 + nx * TICK, shape.y1 + ny * TICK);
+    ctx.lineTo(shape.x1 - nx * TICK, shape.y1 - ny * TICK);
+    ctx.stroke();
+
+    // Tick at end
+    ctx.beginPath();
+    ctx.moveTo(shape.x2 + nx * TICK, shape.y2 + ny * TICK);
+    ctx.lineTo(shape.x2 - nx * TICK, shape.y2 - ny * TICK);
+    ctx.stroke();
+
+    // Label
+    if (shape.label) {
+      const midX = (shape.x1 + shape.x2) / 2;
+      const midY = (shape.y1 + shape.y2) / 2;
+      const labelOffsetX = -nx * shape.fontSize * 0.6;
+      const labelOffsetY = -ny * shape.fontSize * 0.6;
+      ctx.fillStyle = shape.color;
+      ctx.font = `${shape.fontSize}px ${ANNOTATION_FONT_FAMILY}`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(shape.label, midX + labelOffsetX, midY + labelOffsetY);
+      ctx.textAlign = 'start';       // reset to default
+      ctx.textBaseline = 'alphabetic';
+    }
+  } else if (shape.type === 'freehand') {
+    if (shape.points.length < 2) return;
+    ctx.strokeStyle = shape.stroke;
+    ctx.lineWidth = shape.strokeWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    const [fx, fy] = shape.points[0]!;
+    ctx.moveTo(fx, fy);
+    for (let i = 1; i < shape.points.length; i++) {
+      const [px, py] = shape.points[i]!;
+      ctx.lineTo(px, py);
+    }
+    ctx.stroke();
   }
 }

--- a/client/src/components/photos/PhotoAnnotator/simplify.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/simplify.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for simplify.ts — Ramer-Douglas-Peucker polyline simplification.
+ *
+ * Story #1477: Photo Annotator — Measurement and Freehand Tools
+ *
+ * Pure function tests — no mocking needed.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { simplifyPolyline, RDP_EPSILON } from './simplify.js';
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe('simplifyPolyline() — edge cases', () => {
+  it('returns empty array for empty input', () => {
+    const result = simplifyPolyline([]);
+    expect(result).toEqual([]);
+  });
+
+  it('returns single point unchanged for single-point input', () => {
+    const result = simplifyPolyline([[10, 20]]);
+    expect(result).toEqual([[10, 20]]);
+  });
+
+  it('returns both points unchanged for two-point input', () => {
+    const result = simplifyPolyline([[0, 0], [100, 100]]);
+    expect(result).toEqual([[0, 0], [100, 100]]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input: [number, number][] = [[0, 0], [50, 0], [100, 0]];
+    const inputCopy = input.map((p) => [...p] as [number, number]);
+    simplifyPolyline(input);
+    expect(input).toEqual(inputCopy);
+  });
+
+  it('returns a copy (not the same reference for single point)', () => {
+    const input: [number, number][] = [[5, 10]];
+    const result = simplifyPolyline(input);
+    expect(result).not.toBe(input);
+  });
+
+  it('returns a copy (not the same reference for two points)', () => {
+    const input: [number, number][] = [[0, 0], [10, 10]];
+    const result = simplifyPolyline(input);
+    expect(result).not.toBe(input);
+  });
+});
+
+// ─── Collinear points ─────────────────────────────────────────────────────────
+
+describe('simplifyPolyline() — collinear sequences', () => {
+  it('reduces 5 collinear horizontal points to just the two endpoints', () => {
+    // Points along y=0: [0,0], [25,0], [50,0], [75,0], [100,0]
+    // All interior points have zero perpendicular distance → all removed
+    const input: [number, number][] = [
+      [0, 0], [25, 0], [50, 0], [75, 0], [100, 0],
+    ];
+    const result = simplifyPolyline(input);
+    expect(result).toEqual([[0, 0], [100, 0]]);
+  });
+
+  it('reduces 6 collinear diagonal points to just the two endpoints', () => {
+    // Points along y=x line
+    const input: [number, number][] = [
+      [0, 0], [20, 20], [40, 40], [60, 60], [80, 80], [100, 100],
+    ];
+    const result = simplifyPolyline(input);
+    expect(result).toEqual([[0, 0], [100, 100]]);
+  });
+
+  it('reduces 10 collinear vertical points to two endpoints', () => {
+    const input: [number, number][] = Array.from({ length: 10 }, (_, i) => [0, i * 10] as [number, number]);
+    const result = simplifyPolyline(input);
+    expect(result).toEqual([[0, 0], [0, 90]]);
+  });
+
+  it('always keeps the first and last point in the result', () => {
+    const input: [number, number][] = [[5, 5], [15, 5], [25, 5], [35, 5]];
+    const result = simplifyPolyline(input);
+    expect(result[0]).toEqual([5, 5]);
+    expect(result[result.length - 1]).toEqual([35, 5]);
+  });
+});
+
+// ─── Curved inputs — simplification ratio ─────────────────────────────────────
+
+describe('simplifyPolyline() — curved/jittered input', () => {
+  it('reduces 50 jittered sine-wave points by at least 50% with default epsilon', () => {
+    // Generate 50 points along a sine wave with jitter
+    const N = 50;
+    const points: [number, number][] = Array.from({ length: N }, (_, i) => {
+      const x = (i / (N - 1)) * 400;
+      const y = 100 + Math.sin((i / (N - 1)) * Math.PI * 4) * 50;
+      // Add ±0.5px jitter within epsilon range of the curve
+      const jitterX = (Math.sin(i * 7.3) * 0.4);
+      const jitterY = (Math.cos(i * 5.7) * 0.4);
+      return [x + jitterX, y + jitterY] as [number, number];
+    });
+
+    const result = simplifyPolyline(points, RDP_EPSILON);
+
+    // Should retain significantly fewer points than the input
+    expect(result.length).toBeLessThan(N * 0.5);
+    // Must keep at least 2 points (endpoints guaranteed)
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('simplification with larger epsilon produces fewer points than smaller epsilon', () => {
+    const N = 40;
+    const points: [number, number][] = Array.from({ length: N }, (_, i) => {
+      const x = i * 5;
+      const y = 50 + Math.sin(i * 0.5) * 30;
+      return [x, y] as [number, number];
+    });
+
+    const resultSmall = simplifyPolyline(points, 0.5);
+    const resultLarge = simplifyPolyline(points, 5.0);
+
+    // Larger epsilon = more aggressive = fewer points
+    expect(resultLarge.length).toBeLessThanOrEqual(resultSmall.length);
+  });
+
+  it('preserves inflection points for a zigzag path with large amplitude', () => {
+    // Zigzag: each peak/valley is 20px away from the baseline — should NOT be simplified away
+    const points: [number, number][] = [
+      [0, 0], [10, 20], [20, 0], [30, 20], [40, 0],
+    ];
+    const result = simplifyPolyline(points, RDP_EPSILON);
+    // The peaks at (10,20) and (30,20) deviate 20px from the line (0,0)-(40,0)
+    // 20 >> epsilon=1.5 so they should be retained
+    expect(result.length).toBeGreaterThan(2);
+    // Must still contain the start and end
+    expect(result[0]).toEqual([0, 0]);
+    expect(result[result.length - 1]).toEqual([40, 0]);
+  });
+});
+
+// ─── Epsilon variants ─────────────────────────────────────────────────────────
+
+describe('simplifyPolyline() — epsilon variants', () => {
+  it('epsilon=0 returns all points unchanged (every point is "significant")', () => {
+    // With epsilon=0, no interior point is within threshold — all kept
+    const input: [number, number][] = [
+      [0, 0], [10, 0.1], [20, 0], [30, 0.1], [40, 0],
+    ];
+    const result = simplifyPolyline(input, 0);
+    // epsilon=0: any deviation > 0 triggers split, so all points are preserved
+    expect(result.length).toBe(input.length);
+  });
+
+  it('very large epsilon collapses all points to just the two endpoints', () => {
+    const input: [number, number][] = [
+      [0, 0], [10, 50], [20, -30], [30, 40], [40, 0],
+    ];
+    // Epsilon of 1000 means everything is within tolerance → endpoints only
+    const result = simplifyPolyline(input, 1000);
+    expect(result).toEqual([[0, 0], [40, 0]]);
+  });
+
+  it('RDP_EPSILON constant is 1.5', () => {
+    expect(RDP_EPSILON).toBe(1.5);
+  });
+
+  it('uses RDP_EPSILON as default when no epsilon argument supplied', () => {
+    const collinear: [number, number][] = [
+      [0, 0], [50, 0], [100, 0],
+    ];
+    // Collinear → simplifies to 2 points with any epsilon > 0
+    const resultDefault = simplifyPolyline(collinear);
+    const resultExplicit = simplifyPolyline(collinear, RDP_EPSILON);
+    expect(resultDefault).toEqual(resultExplicit);
+  });
+});
+
+// ─── Result integrity ─────────────────────────────────────────────────────────
+
+describe('simplifyPolyline() — result integrity', () => {
+  it('result points are a subset of the input points (no new points added)', () => {
+    const input: [number, number][] = [
+      [0, 0], [10, 5], [20, 0], [30, -5], [40, 0], [50, 5], [60, 0],
+    ];
+    const result = simplifyPolyline(input, RDP_EPSILON);
+    for (const pt of result) {
+      const found = input.some(([x, y]) => x === pt[0] && y === pt[1]);
+      expect(found).toBe(true);
+    }
+  });
+
+  it('result order is preserved (same left-to-right sequence as input)', () => {
+    const input: [number, number][] = [
+      [0, 0], [20, 10], [40, 0], [60, -10], [80, 0], [100, 5],
+    ];
+    const result = simplifyPolyline(input, 0.5);
+    // Each result x should be >= the previous
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]![0]).toBeGreaterThanOrEqual(result[i - 1]![0]);
+    }
+  });
+
+  it('result length is always <= input length', () => {
+    const input: [number, number][] = Array.from({ length: 20 }, (_, i) => [i * 5, Math.random() * 10] as [number, number]);
+    const result = simplifyPolyline(input, RDP_EPSILON);
+    expect(result.length).toBeLessThanOrEqual(input.length);
+  });
+
+  it('result length is always >= 1 for non-empty input', () => {
+    const input: [number, number][] = [[42, 17]];
+    const result = simplifyPolyline(input);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles degenerate case where all points are at the same location', () => {
+    // All points at (50, 50) — line length is 0, Euclidean fallback
+    const input: [number, number][] = [
+      [50, 50], [50, 50], [50, 50], [50, 50], [50, 50],
+    ];
+    // With epsilon=1.5: all points have dist=0 from "start" == "end" → interior points within epsilon
+    const result = simplifyPolyline(input, RDP_EPSILON);
+    // Should return just endpoints (both [50,50])
+    expect(result).toEqual([[50, 50], [50, 50]]);
+  });
+});

--- a/client/src/components/photos/PhotoAnnotator/simplify.ts
+++ b/client/src/components/photos/PhotoAnnotator/simplify.ts
@@ -1,0 +1,67 @@
+/**
+ * Ramer-Douglas-Peucker polyline simplification.
+ * Reduces the number of points in a polyline while preserving its shape.
+ *
+ * @param points  Input polyline as [x, y] pairs. Must have at least 2 points.
+ * @param epsilon Maximum allowed distance (in same units as points) from a
+ *                simplified segment to the original point. Larger = more
+ *                aggressive simplification.
+ * @returns       Simplified polyline as [x, y] pairs.
+ *
+ * Edge cases:
+ *   - Empty array → []
+ *   - Single point → [[x, y]]
+ *   - Two points → [[x1, y1], [x2, y2]] (always kept; no simplification)
+ *   - Collinear points → all interior points removed; only endpoints kept
+ */
+export const RDP_EPSILON = 1.5;
+
+export function simplifyPolyline(
+  points: [number, number][],
+  epsilon: number = RDP_EPSILON,
+): [number, number][] {
+  if (points.length <= 2) return points.slice() as [number, number][];
+  return rdp(points, epsilon);
+}
+
+function rdp(points: [number, number][], epsilon: number): [number, number][] {
+  if (points.length <= 2) return points.slice() as [number, number][];
+
+  // Find the point with maximum perpendicular distance from the line
+  // connecting the first and last point
+  const [x1, y1] = points[0]!;
+  const [x2, y2] = points[points.length - 1]!;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const lineLen = Math.sqrt(dx * dx + dy * dy);
+
+  let maxDist = 0;
+  let maxIdx = 0;
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const [px, py] = points[i]!;
+    let dist: number;
+    if (lineLen === 0) {
+      // Start and end are the same point — measure Euclidean distance
+      dist = Math.sqrt((px - x1) ** 2 + (py - y1) ** 2);
+    } else {
+      // Perpendicular distance from point to line segment (infinite line approximation)
+      dist = Math.abs(dy * px - dx * py + x2 * y1 - y2 * x1) / lineLen;
+    }
+    if (dist > maxDist) {
+      maxDist = dist;
+      maxIdx = i;
+    }
+  }
+
+  if (maxDist > epsilon) {
+    // Recursively simplify both halves
+    const left = rdp(points.slice(0, maxIdx + 1), epsilon);
+    const right = rdp(points.slice(maxIdx), epsilon);
+    // Concatenate, removing the duplicate point at the junction
+    return [...left.slice(0, -1), ...right] as [number, number][];
+  } else {
+    // All interior points are within epsilon — keep only endpoints
+    return [points[0]!, points[points.length - 1]!];
+  }
+}

--- a/client/src/components/photos/PhotoAnnotator/tools/FreehandTool.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/FreehandTool.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Unit tests for FreehandTool.ts
+ *
+ * Story #1477: Photo Annotator — Measurement and Freehand Tools
+ *
+ * Tests pointer event sequences for the Freehand drawing tool:
+ *   - onPointerDown: creates draft with single starting point
+ *   - onPointerMove: appends to points array (returns SET_DRAFT each time)
+ *   - onPointerUp: applies RDP simplification; commits if >= 2 points remain
+ *   - Edge case: degenerate tap (< 2 points after simplification) → discarded
+ *   - resetFreehandTool(): clears module state
+ *
+ * nanoid is mapped to a CJS stub in jest.config.ts (moduleNameMapper: nanoid -> nanoidMock.cjs)
+ * so FreehandTool can be statically imported despite nanoid being ESM-only.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { FreehandTool, resetFreehandTool } from './FreehandTool.js';
+import type { AnnotatorState } from '../useAnnotator.js';
+import type { FreehandShape } from '../useUndoStack.js';
+import type { PointerContext } from './SelectTool.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<AnnotatorState> = {}): AnnotatorState {
+  return {
+    shapes: [],
+    draftShape: null,
+    selectedShapeId: null,
+    selectedTool: 'freehand',
+    activeColor: '#dc2626',
+    activeStrokeWidthKey: 'medium',
+    activeFontSize: 18,
+    selectDragState: {
+      mode: null,
+      shapeId: null,
+      handle: null,
+      startImageX: 0,
+      startImageY: 0,
+      startShape: null,
+    },
+    ...overrides,
+  };
+}
+
+function makeCtx(imageX: number, imageY: number): PointerContext {
+  return {
+    imageX,
+    imageY,
+    imageWidth: 800,
+    imageHeight: 600,
+    event: {} as React.PointerEvent<SVGSVGElement>,
+  };
+}
+
+// Generate a curved freehand stroke (many points along a sine wave)
+function makeSineWaveStroke(pointCount: number): [number, number][] {
+  return Array.from({ length: pointCount }, (_, i) => {
+    const x = i * 5;
+    const y = 100 + Math.sin((i / pointCount) * Math.PI * 4) * 50;
+    return [x, y] as [number, number];
+  });
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('FreehandTool', () => {
+  beforeEach(() => {
+    resetFreehandTool();
+  });
+
+  // ─── onPointerDown ─────────────────────────────────────────────────────────
+
+  describe('onPointerDown()', () => {
+    it('returns a single SET_DRAFT action', () => {
+      const actions = FreehandTool.onPointerDown(makeState(), makeCtx(50, 60));
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0]!.type).toBe('SET_DRAFT');
+    });
+
+    it('draft shape has type "freehand"', () => {
+      const actions = FreehandTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape?.type).toBe('freehand');
+    });
+
+    it('draft starts with a single point at the pointer position', () => {
+      const actions = FreehandTool.onPointerDown(makeState(), makeCtx(120, 80));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.points).toHaveLength(1);
+      expect(shape.points[0]).toEqual([120, 80]);
+    });
+
+    it('draft uses activeColor for stroke', () => {
+      const state = makeState({ activeColor: '#3b82f6' });
+      const actions = FreehandTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.stroke).toBe('#3b82f6');
+    });
+
+    it('draft strokeWidth is 2 for "thin" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'thin' });
+      const actions = FreehandTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.strokeWidth).toBe(2);
+    });
+
+    it('draft strokeWidth is 4 for "medium" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'medium' });
+      const actions = FreehandTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.strokeWidth).toBe(4);
+    });
+
+    it('draft strokeWidth is 8 for "thick" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'thick' });
+      const actions = FreehandTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.strokeWidth).toBe(8);
+    });
+
+    it('draft has a non-empty id string', () => {
+      const actions = FreehandTool.onPointerDown(makeState(), makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape?.id).toBeTruthy();
+    });
+
+    it('falls back to strokeWidth=4 (medium) when activeStrokeWidthKey is falsy', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const state = makeState({ activeStrokeWidthKey: '' as any });
+      const actions = FreehandTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.strokeWidth).toBe(4);
+    });
+
+    it('each pointerDown creates a fresh stroke (resets captured points)', () => {
+      // First stroke
+      FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      const draftAfterFirstDown: FreehandShape = {
+        type: 'freehand', id: 'stroke-1',
+        points: [[0, 0]], stroke: '#dc2626', strokeWidth: 4,
+      };
+      FreehandTool.onPointerMove(makeState({ draftShape: draftAfterFirstDown }), makeCtx(50, 50));
+
+      resetFreehandTool(); // simulate tool state between gestures
+
+      // Second stroke — should start fresh
+      const secondDownActions = FreehandTool.onPointerDown(makeState(), makeCtx(200, 200));
+      const action = secondDownActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.points).toHaveLength(1);
+      expect(shape.points[0]).toEqual([200, 200]);
+    });
+  });
+
+  // ─── onPointerMove ─────────────────────────────────────────────────────────
+
+  describe('onPointerMove()', () => {
+    it('returns SET_DRAFT with updated points array', () => {
+      const downActions = FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = FreehandTool.onPointerMove(makeState({ draftShape }), makeCtx(10, 10));
+
+      expect(moveActions).toHaveLength(1);
+      expect(moveActions[0]!.type).toBe('SET_DRAFT');
+    });
+
+    it('appends current pointer position to the points array', () => {
+      const downActions = FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = FreehandTool.onPointerMove(makeState({ draftShape }), makeCtx(30, 40));
+
+      const action = moveActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.points).toHaveLength(2);
+      expect(shape.points[0]).toEqual([0, 0]);
+      expect(shape.points[1]).toEqual([30, 40]);
+    });
+
+    it('accumulates all moved points across multiple moves', () => {
+      const downActions = FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      let draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const positions: [number, number][] = [[10, 5], [20, 15], [30, 25], [40, 10]];
+      for (const [x, y] of positions) {
+        const moveActions = FreehandTool.onPointerMove(makeState({ draftShape }), makeCtx(x, y));
+        draftShape = moveActions[0]!.type === 'SET_DRAFT' ? moveActions[0]!.shape : draftShape;
+      }
+
+      const finalShape = draftShape as FreehandShape;
+      // Started with 1 point, added 4 more = 5 total
+      expect(finalShape.points).toHaveLength(5);
+      expect(finalShape.points[0]).toEqual([0, 0]);
+      expect(finalShape.points[4]).toEqual([40, 10]);
+    });
+
+    it('each onPointerMove call returns a SET_DRAFT action', () => {
+      const downActions = FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      let draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      for (let i = 1; i <= 5; i++) {
+        const moveActions = FreehandTool.onPointerMove(makeState({ draftShape }), makeCtx(i * 10, i * 5));
+        expect(moveActions).toHaveLength(1);
+        expect(moveActions[0]!.type).toBe('SET_DRAFT');
+        draftShape = moveActions[0]!.type === 'SET_DRAFT' ? moveActions[0]!.shape : draftShape;
+      }
+    });
+
+    it('returns empty array when no active draw state (currentDraftId is null)', () => {
+      // No pointerDown first
+      resetFreehandTool();
+      const actions = FreehandTool.onPointerMove(makeState({ draftShape: null }), makeCtx(100, 100));
+      expect(actions).toHaveLength(0);
+    });
+
+    it('returns empty array when draftShape is null in state', () => {
+      // pointerDown was called but state.draftShape is null (unusual edge case)
+      FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      const actions = FreehandTool.onPointerMove(makeState({ draftShape: null }), makeCtx(50, 50));
+      expect(actions).toHaveLength(0);
+    });
+
+    it('preserves stroke and strokeWidth across moves', () => {
+      const state = makeState({ activeColor: '#22c55e', activeStrokeWidthKey: 'thick' });
+      const downActions = FreehandTool.onPointerDown(state, makeCtx(0, 0));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = FreehandTool.onPointerMove(makeState({ draftShape }), makeCtx(20, 20));
+      const action = moveActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as FreehandShape;
+      expect(shape.stroke).toBe('#22c55e');
+      expect(shape.strokeWidth).toBe(8);
+    });
+  });
+
+  // ─── onPointerUp ──────────────────────────────────────────────────────────
+
+  describe('onPointerUp()', () => {
+    it('returns SET_DRAFT + COMMIT_DRAFT when simplified stroke has >= 2 points', () => {
+      // Build a curved stroke that will survive RDP simplification
+      const sinePoints = makeSineWaveStroke(30);
+      const draft: FreehandShape = {
+        type: 'freehand',
+        id: 'freehand-commit',
+        points: sinePoints,
+        stroke: '#dc2626',
+        strokeWidth: 4,
+      };
+
+      // Prime the capturedPoints in the module by simulating pointermoves
+      FreehandTool.onPointerDown(makeState(), makeCtx(sinePoints[0]![0], sinePoints[0]![1]));
+      for (let i = 1; i < sinePoints.length; i++) {
+        const draftSoFar: FreehandShape = {
+          ...draft,
+          points: sinePoints.slice(0, i + 1),
+        };
+        FreehandTool.onPointerMove(makeState({ draftShape: draftSoFar }), makeCtx(sinePoints[i]![0], sinePoints[i]![1]));
+      }
+
+      const actions = FreehandTool.onPointerUp(makeState({ draftShape: draft }), makeCtx(0, 0));
+
+      // Should contain both SET_DRAFT (with simplified points) and COMMIT_DRAFT
+      expect(actions.some((a) => a.type === 'COMMIT_DRAFT')).toBe(true);
+      const setDraftAction = actions.find((a) => a.type === 'SET_DRAFT');
+      expect(setDraftAction).toBeDefined();
+      if (setDraftAction?.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const finalShape = setDraftAction.shape as FreehandShape;
+      // RDP simplified points should be fewer than the raw input
+      expect(finalShape.points.length).toBeLessThan(sinePoints.length);
+      // But must have at least 2 points
+      expect(finalShape.points.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('discards draft with SET_DRAFT(null) when tap produces < 2 points after simplification', () => {
+      // A tap: pointerDown then immediately pointerUp at nearly the same location
+      // This produces 1 or 2 collinear points that RDP collapses to 1 → discard
+      FreehandTool.onPointerDown(makeState(), makeCtx(50, 50));
+      // No moves — capturedPoints has only 1 point
+
+      const draft: FreehandShape = {
+        type: 'freehand',
+        id: 'tap-draft',
+        points: [[50, 50]],
+        stroke: '#dc2626',
+        strokeWidth: 4,
+      };
+
+      const actions = FreehandTool.onPointerUp(makeState({ draftShape: draft }), makeCtx(50, 50));
+
+      expect(actions).toHaveLength(1);
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape).toBeNull();
+    });
+
+    it('discards when only two very close collinear points simplify to 1 point', () => {
+      // Two points at nearly the same location — epsilon=1.5 collapses them to 1 point
+      // Actually with 2 points, simplifyPolyline returns both unchanged.
+      // The edge: captured 3+ nearly identical points that simplify to 1.
+      const nearbyPoints: [number, number][] = [
+        [50, 50], [50.1, 50.1], [50.2, 50.2],
+      ];
+
+      FreehandTool.onPointerDown(makeState(), makeCtx(nearbyPoints[0]![0], nearbyPoints[0]![1]));
+      const draftSoFar: FreehandShape = {
+        type: 'freehand', id: 'nearby',
+        points: [[nearbyPoints[0]![0], nearbyPoints[0]![1]]],
+        stroke: '#dc2626', strokeWidth: 4,
+      };
+      for (let i = 1; i < nearbyPoints.length; i++) {
+        FreehandTool.onPointerMove(
+          makeState({ draftShape: draftSoFar }),
+          makeCtx(nearbyPoints[i]![0], nearbyPoints[i]![1]),
+        );
+      }
+
+      const draft: FreehandShape = {
+        type: 'freehand',
+        id: 'nearby-draft',
+        points: nearbyPoints,
+        stroke: '#dc2626',
+        strokeWidth: 4,
+      };
+
+      const actions = FreehandTool.onPointerUp(makeState({ draftShape: draft }), makeCtx(50.2, 50.2));
+
+      // These 3 nearly collinear points → after RDP simplify → 2 points (endpoints only)
+      // 2 >= 2 threshold so it commits
+      expect(actions.some((a) => a.type === 'COMMIT_DRAFT')).toBe(true);
+    });
+
+    it('returns empty when draftShape is null on pointer up', () => {
+      const actions = FreehandTool.onPointerUp(makeState({ draftShape: null }), makeCtx(100, 100));
+      expect(actions).toHaveLength(0);
+    });
+
+    it('freehand simplification reduces a sine-wave stroke by at least 30%', () => {
+      const sinePoints = makeSineWaveStroke(50);
+
+      FreehandTool.onPointerDown(makeState(), makeCtx(sinePoints[0]![0], sinePoints[0]![1]));
+      let currentDraft: FreehandShape = {
+        type: 'freehand', id: 'sine',
+        points: [[sinePoints[0]![0], sinePoints[0]![1]]],
+        stroke: '#dc2626', strokeWidth: 4,
+      };
+      for (let i = 1; i < sinePoints.length; i++) {
+        const moveActions = FreehandTool.onPointerMove(
+          makeState({ draftShape: currentDraft }),
+          makeCtx(sinePoints[i]![0], sinePoints[i]![1]),
+        );
+        if (moveActions[0]?.type === 'SET_DRAFT') {
+          currentDraft = moveActions[0].shape as FreehandShape;
+        }
+      }
+
+      const actions = FreehandTool.onPointerUp(
+        makeState({ draftShape: currentDraft }),
+        makeCtx(0, 0),
+      );
+
+      const setDraftAction = actions.find((a) => a.type === 'SET_DRAFT');
+      if (setDraftAction?.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const finalShape = setDraftAction.shape as FreehandShape;
+      expect(finalShape.points.length).toBeLessThan(sinePoints.length * 0.7);
+    });
+  });
+
+  // ─── resetFreehandTool ────────────────────────────────────────────────────
+
+  describe('resetFreehandTool()', () => {
+    it('clears module state so onPointerMove returns empty array', () => {
+      // Start a draw
+      FreehandTool.onPointerDown(makeState(), makeCtx(50, 50));
+
+      // Reset
+      resetFreehandTool();
+
+      // Move should return empty (currentDraftId is null after reset)
+      const actions = FreehandTool.onPointerMove(
+        makeState({ draftShape: null }),
+        makeCtx(100, 100),
+      );
+      expect(actions).toHaveLength(0);
+    });
+
+    it('clears captured points so onPointerUp discards (no points)', () => {
+      // Simulate captured points
+      FreehandTool.onPointerDown(makeState(), makeCtx(0, 0));
+      const draftAfterDown: FreehandShape = {
+        type: 'freehand', id: 'reset-test',
+        points: [[0, 0]], stroke: '#dc2626', strokeWidth: 4,
+      };
+      FreehandTool.onPointerMove(makeState({ draftShape: draftAfterDown }), makeCtx(50, 50));
+      FreehandTool.onPointerMove(makeState({ draftShape: draftAfterDown }), makeCtx(100, 0));
+
+      // Reset clears capturedPoints
+      resetFreehandTool();
+
+      // After reset, pointerUp with a draftShape should discard (capturedPoints is empty)
+      const draft: FreehandShape = {
+        type: 'freehand',
+        id: 'reset-test',
+        points: [[0, 0], [50, 50], [100, 0]], // state.draftShape has points but capturedPoints is empty
+        stroke: '#dc2626',
+        strokeWidth: 4,
+      };
+      const actions = FreehandTool.onPointerUp(makeState({ draftShape: draft }), makeCtx(100, 0));
+
+      // With empty capturedPoints, simplifyPolyline([]) = [] which has length 0 < 2 → discard
+      expect(actions).toHaveLength(1);
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape).toBeNull();
+    });
+
+    it('can be called multiple times without error', () => {
+      expect(() => {
+        resetFreehandTool();
+        resetFreehandTool();
+        resetFreehandTool();
+      }).not.toThrow();
+    });
+  });
+
+  // ─── cursor ───────────────────────────────────────────────────────────────
+
+  describe('cursor', () => {
+    it('has cursor "crosshair"', () => {
+      expect(FreehandTool.cursor).toBe('crosshair');
+    });
+  });
+});

--- a/client/src/components/photos/PhotoAnnotator/tools/FreehandTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/FreehandTool.ts
@@ -1,0 +1,85 @@
+import { nanoid } from 'nanoid';
+import type { AnnotatorState, AnnotatorAction } from '../useAnnotator.js';
+import type { FreehandShape } from '../useUndoStack.js';
+import { simplifyPolyline } from '../simplify.js';
+import { ANNOTATION_STROKE_WIDTHS } from '../annotationConstants.js';
+import type { PointerContext, ToolHandler } from './SelectTool.js';
+
+// All captured points from the current gesture (never throttled — always updated)
+let capturedPoints: [number, number][] = [];
+
+// Snapshot of the current draft shape ID
+let currentDraftId: string | null = null;
+
+export const FreehandTool: ToolHandler = {
+  onPointerDown: (state: AnnotatorState, ctx: PointerContext): AnnotatorAction[] => {
+    const { imageX, imageY } = ctx;
+
+    capturedPoints = [[imageX, imageY]];
+    currentDraftId = nanoid();
+
+    const strokeWidth =
+      state.activeStrokeWidthKey
+        ? ANNOTATION_STROKE_WIDTHS[state.activeStrokeWidthKey]
+        : ANNOTATION_STROKE_WIDTHS.medium;
+
+    const newShape: FreehandShape = {
+      type: 'freehand',
+      id: currentDraftId,
+      points: capturedPoints.slice(),
+      stroke: state.activeColor,
+      strokeWidth,
+    };
+
+    return [{ type: 'SET_DRAFT', shape: newShape }];
+  },
+
+  onPointerMove: (state: AnnotatorState, ctx: PointerContext): AnnotatorAction[] => {
+    if (!currentDraftId || !state.draftShape) return [];
+
+    const { imageX, imageY } = ctx;
+
+    // Always capture the point — never drop pointermove events
+    capturedPoints.push([imageX, imageY]);
+
+    // Return synchronous SET_DRAFT with current captured points
+    const updatedDraft: FreehandShape = {
+      ...(state.draftShape as FreehandShape),
+      points: capturedPoints.slice(),
+    };
+
+    return [{ type: 'SET_DRAFT', shape: updatedDraft }];
+  },
+
+  onPointerUp: (state: AnnotatorState, _ctx: PointerContext): AnnotatorAction[] => {
+    currentDraftId = null;
+
+    if (!state.draftShape) return [];
+
+    const shape = state.draftShape as FreehandShape;
+
+    // Apply RDP simplification
+    const simplified = simplifyPolyline(capturedPoints);
+    capturedPoints = [];
+
+    // Discard if fewer than 2 points remain (degenerate tap)
+    if (simplified.length < 2) {
+      return [{ type: 'SET_DRAFT', shape: null }];
+    }
+
+    // Update draft with simplified points and commit
+    const finalShape: FreehandShape = { ...shape, points: simplified };
+    return [
+      { type: 'SET_DRAFT', shape: finalShape },
+      { type: 'COMMIT_DRAFT' },
+    ];
+  },
+
+  cursor: 'crosshair',
+};
+
+/** Reset module-level state (used by tests) */
+export function resetFreehandTool(): void {
+  capturedPoints = [];
+  currentDraftId = null;
+}

--- a/client/src/components/photos/PhotoAnnotator/tools/MeasurementTool.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/MeasurementTool.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Unit tests for MeasurementTool.ts
+ *
+ * Story #1477: Photo Annotator — Measurement and Freehand Tools
+ *
+ * Tests pointer event sequences for the Measurement drawing tool:
+ *   - onPointerDown: creates draft at start position with empty label
+ *   - onPointerMove: updates the second endpoint (x2/y2)
+ *   - onPointerUp: triggers onOpenInlineInput at midpoint, keeps draft (no commit yet)
+ *   - onPointerUp: discards draft when line is too short (< 2px)
+ *   - resetMeasurementTool(): clears module state
+ *
+ * nanoid is mapped to a CJS stub in jest.config.ts (moduleNameMapper: nanoid -> nanoidMock.cjs)
+ * so MeasurementTool can be statically imported despite nanoid being ESM-only.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { MeasurementTool, resetMeasurementTool } from './MeasurementTool.js';
+import type { AnnotatorState } from '../useAnnotator.js';
+import type { MeasurementShape } from '../useUndoStack.js';
+import type { PointerContext } from './SelectTool.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = jest.MockedFunction<(...args: any[]) => any>;
+
+function makeState(overrides: Partial<AnnotatorState> = {}): AnnotatorState {
+  return {
+    shapes: [],
+    draftShape: null,
+    selectedShapeId: null,
+    selectedTool: 'measurement',
+    activeColor: '#dc2626',
+    activeStrokeWidthKey: 'medium',
+    activeFontSize: 18,
+    selectDragState: {
+      mode: null,
+      shapeId: null,
+      handle: null,
+      startImageX: 0,
+      startImageY: 0,
+      startShape: null,
+    },
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  imageX: number,
+  imageY: number,
+  opts: { onOpenInlineInput?: AnyMock } = {},
+): PointerContext {
+  return {
+    imageX,
+    imageY,
+    imageWidth: 800,
+    imageHeight: 600,
+    event: {} as React.PointerEvent<SVGSVGElement>,
+    onOpenInlineInput: opts.onOpenInlineInput,
+  };
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('MeasurementTool', () => {
+  beforeEach(() => {
+    resetMeasurementTool();
+  });
+
+  // ─── onPointerDown ─────────────────────────────────────────────────────────
+
+  describe('onPointerDown()', () => {
+    it('returns a single SET_DRAFT action', () => {
+      const actions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0]!.type).toBe('SET_DRAFT');
+    });
+
+    it('draft shape has type "measurement"', () => {
+      const actions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape?.type).toBe('measurement');
+    });
+
+    it('draft starts at the pointer position (x1===x2===imageX, y1===y2===imageY)', () => {
+      const actions = MeasurementTool.onPointerDown(makeState(), makeCtx(120, 80));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.x1).toBe(120);
+      expect(shape.y1).toBe(80);
+      expect(shape.x2).toBe(120);
+      expect(shape.y2).toBe(80);
+    });
+
+    it('draft has empty label string ""', () => {
+      const actions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.label).toBe('');
+    });
+
+    it('draft uses activeColor for stroke', () => {
+      const state = makeState({ activeColor: '#3b82f6' });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.stroke).toBe('#3b82f6');
+    });
+
+    it('draft uses activeColor for color (label text color)', () => {
+      const state = makeState({ activeColor: '#22c55e' });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.color).toBe('#22c55e');
+    });
+
+    it('draft uses activeFontSize for fontSize', () => {
+      const state = makeState({ activeFontSize: 24 });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.fontSize).toBe(24);
+    });
+
+    it('draft strokeWidth is 2 for "thin" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'thin' });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.strokeWidth).toBe(2);
+    });
+
+    it('draft strokeWidth is 4 for "medium" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'medium' });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.strokeWidth).toBe(4);
+    });
+
+    it('draft strokeWidth is 8 for "thick" activeStrokeWidthKey', () => {
+      const state = makeState({ activeStrokeWidthKey: 'thick' });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.strokeWidth).toBe(8);
+    });
+
+    it('draft has a non-empty id string', () => {
+      const actions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape?.id).toBeTruthy();
+    });
+
+    it('falls back to strokeWidth=4 (medium) when activeStrokeWidthKey is falsy', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const state = makeState({ activeStrokeWidthKey: '' as any });
+      const actions = MeasurementTool.onPointerDown(state, makeCtx(50, 50));
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.strokeWidth).toBe(4);
+    });
+  });
+
+  // ─── onPointerMove ─────────────────────────────────────────────────────────
+
+  describe('onPointerMove()', () => {
+    it('returns SET_DRAFT with updated x2/y2 when draw state is active', () => {
+      const downActions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape }), makeCtx(150, 160));
+
+      expect(moveActions).toHaveLength(1);
+      expect(moveActions[0]!.type).toBe('SET_DRAFT');
+    });
+
+    it('updates x2 and y2 to the current pointer position', () => {
+      const downActions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape }), makeCtx(200, 180));
+
+      const action = moveActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.x2).toBe(200);
+      expect(shape.y2).toBe(180);
+    });
+
+    it('preserves x1/y1 (start point) during move', () => {
+      const downActions = MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape }), makeCtx(200, 180));
+
+      const action = moveActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.x1).toBe(50);
+      expect(shape.y1).toBe(60);
+    });
+
+    it('preserves all other shape fields (stroke, label, fontSize, color) during move', () => {
+      const state = makeState({ activeColor: '#3b82f6', activeFontSize: 24 });
+      const downActions = MeasurementTool.onPointerDown(state, makeCtx(10, 10));
+      const draftShape = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape }), makeCtx(80, 80));
+
+      const action = moveActions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      const shape = action.shape as MeasurementShape;
+      expect(shape.stroke).toBe('#3b82f6');
+      expect(shape.label).toBe('');
+      expect(shape.fontSize).toBe(24);
+    });
+
+    it('returns empty array when draftShape is null (no active draw)', () => {
+      resetMeasurementTool();
+      const actions = MeasurementTool.onPointerMove(makeState({ draftShape: null }), makeCtx(100, 100));
+      expect(actions).toHaveLength(0);
+    });
+  });
+
+  // ─── onPointerUp ──────────────────────────────────────────────────────────
+
+  describe('onPointerUp()', () => {
+    it('calls onOpenInlineInput at the midpoint for a long-enough measurement', () => {
+      // Create draft: from (10, 10) to (110, 10) — horizontal 100px line
+      const downActions = MeasurementTool.onPointerDown(makeState(), makeCtx(10, 10));
+      const draftShape0 = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape: draftShape0 }), makeCtx(110, 10));
+      const longDraft = moveActions[0]!.type === 'SET_DRAFT' ? moveActions[0]!.shape : null;
+
+      const onOpenInlineInput = jest.fn() as AnyMock;
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: longDraft }),
+        makeCtx(110, 10, { onOpenInlineInput }),
+      );
+
+      // midpoint of (10,10)→(110,10) is (60, 10)
+      expect(onOpenInlineInput).toHaveBeenCalledTimes(1);
+      expect(onOpenInlineInput).toHaveBeenCalledWith(60, 10);
+    });
+
+    it('does NOT commit the draft on pointerUp (returns empty actions)', () => {
+      // The host component commits after label entry — pointerUp just opens the inline input
+      const downActions = MeasurementTool.onPointerDown(makeState(), makeCtx(10, 10));
+      const draftShape0 = downActions[0]!.type === 'SET_DRAFT' ? downActions[0]!.shape : null;
+      const moveActions = MeasurementTool.onPointerMove(makeState({ draftShape: draftShape0 }), makeCtx(110, 10));
+      const longDraft = moveActions[0]!.type === 'SET_DRAFT' ? moveActions[0]!.shape : null;
+
+      const onOpenInlineInput = jest.fn() as AnyMock;
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: longDraft }),
+        makeCtx(110, 10, { onOpenInlineInput }),
+      );
+
+      // onPointerUp should return empty — it defers commit to the host
+      expect(actions).toHaveLength(0);
+    });
+
+    it('calls onOpenInlineInput at the correct diagonal midpoint', () => {
+      // Line from (0, 0) to (200, 200) — midpoint is (100, 100)
+      const draft: MeasurementShape = {
+        type: 'measurement',
+        id: 'diag-1',
+        x1: 0, y1: 0, x2: 200, y2: 200,
+        label: '',
+        stroke: '#dc2626',
+        strokeWidth: 4,
+        fontSize: 18,
+        color: '#dc2626',
+      };
+
+      const onOpenInlineInput = jest.fn() as AnyMock;
+      MeasurementTool.onPointerDown(makeState(), makeCtx(0, 0));
+      MeasurementTool.onPointerUp(
+        makeState({ draftShape: draft }),
+        makeCtx(200, 200, { onOpenInlineInput }),
+      );
+
+      expect(onOpenInlineInput).toHaveBeenCalledWith(100, 100);
+    });
+
+    it('discards draft with SET_DRAFT(null) when line is too short (< 2px)', () => {
+      const shortDraft: MeasurementShape = {
+        type: 'measurement',
+        id: 'short-1',
+        x1: 50, y1: 60, x2: 51, y2: 60,  // distance = 1 < 2
+        label: '',
+        stroke: '#dc2626',
+        strokeWidth: 4,
+        fontSize: 18,
+        color: '#dc2626',
+      };
+
+      MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: shortDraft }),
+        makeCtx(51, 60),
+      );
+
+      expect(actions).toHaveLength(1);
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape).toBeNull();
+    });
+
+    it('discards draft (zero-length tap — x1===x2, y1===y2)', () => {
+      const tapDraft: MeasurementShape = {
+        type: 'measurement',
+        id: 'tap-1',
+        x1: 100, y1: 100, x2: 100, y2: 100,  // distance = 0 < 2
+        label: '',
+        stroke: '#dc2626',
+        strokeWidth: 4,
+        fontSize: 18,
+        color: '#dc2626',
+      };
+
+      MeasurementTool.onPointerDown(makeState(), makeCtx(100, 100));
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: tapDraft }),
+        makeCtx(100, 100),
+      );
+
+      expect(actions).toHaveLength(1);
+      const action = actions[0]!;
+      if (action.type !== 'SET_DRAFT') throw new Error('expected SET_DRAFT');
+      expect(action.shape).toBeNull();
+    });
+
+    it('commits exactly at distance=2 (at the threshold)', () => {
+      const atThreshold: MeasurementShape = {
+        type: 'measurement',
+        id: 'threshold-1',
+        x1: 50, y1: 60, x2: 52, y2: 60,  // distance = 2 — AT threshold
+        label: '',
+        stroke: '#dc2626',
+        strokeWidth: 4,
+        fontSize: 18,
+        color: '#dc2626',
+      };
+
+      MeasurementTool.onPointerDown(makeState(), makeCtx(50, 60));
+      const onOpenInlineInput = jest.fn() as AnyMock;
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: atThreshold }),
+        makeCtx(52, 60, { onOpenInlineInput }),
+      );
+
+      // distance=2 passes threshold — should open inline input and NOT discard
+      expect(onOpenInlineInput).toHaveBeenCalledTimes(1);
+      expect(actions).toHaveLength(0);
+    });
+
+    it('does not call onOpenInlineInput when draft is null', () => {
+      const onOpenInlineInput = jest.fn() as AnyMock;
+      const actions = MeasurementTool.onPointerUp(
+        makeState({ draftShape: null }),
+        makeCtx(100, 100, { onOpenInlineInput }),
+      );
+
+      expect(onOpenInlineInput).not.toHaveBeenCalled();
+      expect(actions).toHaveLength(0);
+    });
+
+    it('works without an onOpenInlineInput callback (no crash)', () => {
+      const draft: MeasurementShape = {
+        type: 'measurement',
+        id: 'no-cb-1',
+        x1: 0, y1: 0, x2: 100, y2: 0,
+        label: '',
+        stroke: '#dc2626',
+        strokeWidth: 4,
+        fontSize: 18,
+        color: '#dc2626',
+      };
+
+      MeasurementTool.onPointerDown(makeState(), makeCtx(0, 0));
+      // No onOpenInlineInput in ctx — should not throw
+      expect(() =>
+        MeasurementTool.onPointerUp(makeState({ draftShape: draft }), makeCtx(100, 0)),
+      ).not.toThrow();
+    });
+  });
+
+  // ─── resetMeasurementTool ──────────────────────────────────────────────────
+
+  describe('resetMeasurementTool()', () => {
+    it('clears module-level draw state so onPointerMove returns empty array', () => {
+      // Start a draw
+      MeasurementTool.onPointerDown(makeState(), makeCtx(50, 50));
+
+      // Reset
+      resetMeasurementTool();
+
+      // Move should return empty (drawState is null after reset)
+      const actions = MeasurementTool.onPointerMove(
+        makeState({ draftShape: null }),
+        makeCtx(100, 100),
+      );
+      expect(actions).toHaveLength(0);
+    });
+
+    it('can be called multiple times without error', () => {
+      expect(() => {
+        resetMeasurementTool();
+        resetMeasurementTool();
+        resetMeasurementTool();
+      }).not.toThrow();
+    });
+  });
+
+  // ─── cursor ───────────────────────────────────────────────────────────────
+
+  describe('cursor', () => {
+    it('has cursor "crosshair"', () => {
+      expect(MeasurementTool.cursor).toBe('crosshair');
+    });
+  });
+});

--- a/client/src/components/photos/PhotoAnnotator/tools/MeasurementTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/MeasurementTool.ts
@@ -1,0 +1,81 @@
+import { nanoid } from 'nanoid';
+import type { AnnotatorState, AnnotatorAction } from '../useAnnotator.js';
+import type { MeasurementShape } from '../useUndoStack.js';
+import { distance } from '../geometry.js';
+import { ANNOTATION_STROKE_WIDTHS } from '../annotationConstants.js';
+import type { PointerContext, ToolHandler } from './SelectTool.js';
+
+let drawState: {
+  startX: number;
+  startY: number;
+} | null = null;
+
+export const MeasurementTool: ToolHandler = {
+  onPointerDown: (state: AnnotatorState, ctx: PointerContext): AnnotatorAction[] => {
+    const { imageX, imageY } = ctx;
+
+    drawState = { startX: imageX, startY: imageY };
+
+    const strokeWidth =
+      state.activeStrokeWidthKey
+        ? ANNOTATION_STROKE_WIDTHS[state.activeStrokeWidthKey]
+        : ANNOTATION_STROKE_WIDTHS.medium;
+
+    const newShape: MeasurementShape = {
+      type: 'measurement',
+      id: nanoid(),
+      x1: imageX,
+      y1: imageY,
+      x2: imageX,
+      y2: imageY,
+      label: '',
+      stroke: state.activeColor,
+      strokeWidth,
+      fontSize: state.activeFontSize,
+      color: state.activeColor,
+    };
+
+    return [{ type: 'SET_DRAFT', shape: newShape }];
+  },
+
+  onPointerMove: (state: AnnotatorState, ctx: PointerContext): AnnotatorAction[] => {
+    if (!drawState || !state.draftShape) return [];
+
+    const { imageX, imageY } = ctx;
+
+    const updatedDraft: MeasurementShape = {
+      ...(state.draftShape as MeasurementShape),
+      x2: imageX,
+      y2: imageY,
+    };
+
+    return [{ type: 'SET_DRAFT', shape: updatedDraft }];
+  },
+
+  onPointerUp: (state: AnnotatorState, ctx: PointerContext): AnnotatorAction[] => {
+    drawState = null;
+
+    if (!state.draftShape) return [];
+
+    const shape = state.draftShape as MeasurementShape;
+
+    // Discard if too short (same threshold as ArrowTool)
+    if (distance(shape.x1, shape.y1, shape.x2, shape.y2) < 2) {
+      return [{ type: 'SET_DRAFT', shape: null }];
+    }
+
+    // Open inline input at midpoint — host commits after label entry
+    const midX = (shape.x1 + shape.x2) / 2;
+    const midY = (shape.y1 + shape.y2) / 2;
+    ctx.onOpenInlineInput?.(midX, midY);
+    // Do NOT commit yet — host commits after user enters label
+    return [];
+  },
+
+  cursor: 'crosshair',
+};
+
+/** Reset module-level state (used by tests) */
+export function resetMeasurementTool(): void {
+  drawState = null;
+}

--- a/client/src/components/photos/PhotoAnnotator/tools/SelectTool.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/SelectTool.test.ts
@@ -12,14 +12,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { SelectTool } from './SelectTool.js';
 import type { AnnotatorState } from '../useAnnotator.js';
-import type {
-  AnnotationShape,
-  ArrowShape,
-  LineShape,
-  EllipseShape,
-  TextShape,
-  CalloutShape,
-} from '../useUndoStack.js';
+import type { AnnotationShape, ArrowShape, LineShape, EllipseShape, TextShape, CalloutShape, MeasurementShape, FreehandShape } from '../useUndoStack.js';
 import type { PointerContext } from './SelectTool.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -996,5 +989,318 @@ describe('onPointerMove() — resize callout tail anchor', () => {
     expect(updatedShape.y).toBe(50);
     expect(updatedShape.w).toBe(100);
     expect(updatedShape.h).toBe(80);
+  });
+});
+
+// ─── Measurement shape hit-testing and interaction ─────────────────────────────
+
+describe('onPointerDown() — measurement shape', () => {
+  function makeMeasurementShape(overrides: Partial<MeasurementShape> = {}): MeasurementShape {
+    return {
+      type: 'measurement',
+      id: 'measurement-hit',
+      x1: 50, y1: 100,
+      x2: 250, y2: 100,  // horizontal measurement line
+      label: '5m',
+      stroke: '#dc2626',
+      strokeWidth: 4,
+      fontSize: 18,
+      color: '#dc2626',
+      ...overrides,
+    };
+  }
+
+  it('returns SELECT_SHAPE + START_DRAG(move) when clicking the measurement body', () => {
+    // Measurement is horizontal from (50,100) to (250,100); click midpoint (150,100)
+    const shape = makeMeasurementShape();
+    const state = makeState({ shapes: [shape] });
+
+    const actions = SelectTool.onPointerDown(state, makeCtx(150, 100));
+
+    expect(actions).toHaveLength(2);
+    const selectAction = actions[0]!;
+    if (selectAction.type !== 'SELECT_SHAPE') throw new Error('expected SELECT_SHAPE');
+    expect(selectAction.id).toBe('measurement-hit');
+    const dragAction = actions[1]!;
+    if (dragAction.type !== 'START_DRAG') throw new Error('expected START_DRAG');
+    expect(dragAction.mode).toBe('move');
+  });
+
+  it('returns SELECT_SHAPE + START_DRAG(resize) when clicking the start endpoint handle', () => {
+    // Start endpoint at (50,100); click exactly on it
+    const shape = makeMeasurementShape();
+    const state = makeState({ shapes: [shape] });
+
+    const actions = SelectTool.onPointerDown(state, makeCtx(50, 100));
+
+    expect(actions).toHaveLength(2);
+    const dragAction = actions[1]!;
+    if (dragAction.type !== 'START_DRAG') throw new Error('expected START_DRAG');
+    expect(dragAction.mode).toBe('resize');
+    expect(dragAction.handle).toBe('start');
+  });
+
+  it('returns SELECT_SHAPE + START_DRAG(resize) when clicking the end endpoint handle', () => {
+    // End endpoint at (250,100); click exactly on it
+    const shape = makeMeasurementShape();
+    const state = makeState({ shapes: [shape] });
+
+    const actions = SelectTool.onPointerDown(state, makeCtx(250, 100));
+
+    expect(actions).toHaveLength(2);
+    const dragAction = actions[1]!;
+    if (dragAction.type !== 'START_DRAG') throw new Error('expected START_DRAG');
+    expect(dragAction.mode).toBe('resize');
+    expect(dragAction.handle).toBe('end');
+  });
+
+  it('double-click on measurement body calls onOpenInlineInput at midpoint', () => {
+    const shape = makeMeasurementShape({ x1: 50, y1: 100, x2: 250, y2: 100 });
+    const state = makeState({ shapes: [shape] });
+    const onOpenInlineInput = jest.fn() as jest.MockedFunction<
+      (x: number, y: number, shapeId?: string) => void
+    >;
+
+    const ctx: PointerContext = {
+      imageX: 150,
+      imageY: 100,
+      imageWidth: 800,
+      imageHeight: 600,
+      event: { detail: 2 } as React.PointerEvent<SVGSVGElement>,
+      onOpenInlineInput,
+    };
+
+    const actions = SelectTool.onPointerDown(state, ctx);
+
+    // Midpoint of (50,100)→(250,100) is (150, 100)
+    expect(onOpenInlineInput).toHaveBeenCalledTimes(1);
+    expect(onOpenInlineInput).toHaveBeenCalledWith(150, 100, shape.id);
+    const selectAction = actions.find((a) => a.type === 'SELECT_SHAPE');
+    if (selectAction?.type !== 'SELECT_SHAPE') throw new Error('expected SELECT_SHAPE');
+    expect(selectAction.id).toBe('measurement-hit');
+  });
+
+  it('double-click on measurement passes shape.id as third argument to onOpenInlineInput', () => {
+    const shape = makeMeasurementShape({ id: 'meas-dblclick-id' });
+    const state = makeState({ shapes: [shape] });
+    const onOpenInlineInput = jest.fn() as jest.MockedFunction<
+      (x: number, y: number, shapeId?: string) => void
+    >;
+
+    const ctx: PointerContext = {
+      imageX: 150,
+      imageY: 100,
+      imageWidth: 800,
+      imageHeight: 600,
+      event: { detail: 2 } as React.PointerEvent<SVGSVGElement>,
+      onOpenInlineInput,
+    };
+
+    SelectTool.onPointerDown(state, ctx);
+
+    expect(onOpenInlineInput).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      'meas-dblclick-id',
+    );
+  });
+
+  it('double-click far from measurement body does NOT call onOpenInlineInput', () => {
+    const shape = makeMeasurementShape({ x1: 50, y1: 100, x2: 250, y2: 100 });
+    const state = makeState({ shapes: [shape] });
+    const onOpenInlineInput = jest.fn() as jest.MockedFunction<
+      (x: number, y: number, shapeId?: string) => void
+    >;
+
+    // Double-click 500px away from the measurement line
+    const ctx: PointerContext = {
+      imageX: 600,
+      imageY: 100,
+      imageWidth: 800,
+      imageHeight: 600,
+      event: { detail: 2 } as React.PointerEvent<SVGSVGElement>,
+      onOpenInlineInput,
+    };
+
+    const actions = SelectTool.onPointerDown(state, ctx);
+
+    // Should not call onOpenInlineInput since the double-click missed the line
+    expect(onOpenInlineInput).not.toHaveBeenCalled();
+    // Should deselect and end drag (no hit on any shape)
+    expect(actions).toHaveLength(2);
+    const selectAction = actions[0]!;
+    if (selectAction.type !== 'SELECT_SHAPE') throw new Error('expected SELECT_SHAPE');
+    expect(selectAction.id).toBeNull();
+  });
+});
+
+// ─── onPointerMove() — move measurement ──────────────────────────────────────
+
+describe('onPointerMove() — move measurement shape', () => {
+  it('returns UPDATE_SHAPE with translated endpoints', () => {
+    const shape: MeasurementShape = {
+      type: 'measurement',
+      id: 'meas-move',
+      x1: 50, y1: 100,
+      x2: 150, y2: 100,
+      label: '5m',
+      stroke: '#dc2626',
+      strokeWidth: 4,
+      fontSize: 18,
+      color: '#dc2626',
+    };
+
+    const stateAfterDragStart = makeState({
+      shapes: [shape],
+      selectDragState: {
+        mode: 'move',
+        shapeId: 'meas-move',
+        handle: null,
+        startImageX: 100,
+        startImageY: 100,
+        startShape: shape,
+      },
+    });
+
+    // Move 20px right, 10px down
+    const moveActions = SelectTool.onPointerMove(stateAfterDragStart, makeCtx(120, 110));
+
+    expect(moveActions).toHaveLength(1);
+    const action = moveActions[0]!;
+    if (action.type !== 'UPDATE_SHAPE') throw new Error('expected UPDATE_SHAPE');
+    const updatedShape = action.shape;
+    if (updatedShape.type !== 'measurement') throw new Error('expected measurement shape');
+    expect(updatedShape.x1).toBe(70); // 50+20
+    expect(updatedShape.y1).toBe(110); // 100+10
+    expect(updatedShape.x2).toBe(170); // 150+20
+    expect(updatedShape.y2).toBe(110); // 100+10
+  });
+});
+
+// ─── onPointerMove() — resize measurement (end handle) ───────────────────────
+
+describe('onPointerMove() — resize measurement endpoint', () => {
+  it('returns UPDATE_SHAPE with new x2/y2 when dragging the end endpoint', () => {
+    const shape: MeasurementShape = {
+      type: 'measurement',
+      id: 'meas-resize',
+      x1: 50, y1: 100,
+      x2: 150, y2: 100,
+      label: '',
+      stroke: '#dc2626',
+      strokeWidth: 4,
+      fontSize: 18,
+      color: '#dc2626',
+    };
+
+    const stateAfterDragStart = makeState({
+      shapes: [shape],
+      selectDragState: {
+        mode: 'resize',
+        shapeId: 'meas-resize',
+        handle: 'end',
+        startImageX: 150,
+        startImageY: 100,
+        startShape: shape,
+      },
+    });
+
+    // Drag end point 30px right, 20px up
+    const moveActions = SelectTool.onPointerMove(stateAfterDragStart, makeCtx(180, 80));
+
+    expect(moveActions).toHaveLength(1);
+    const action = moveActions[0]!;
+    if (action.type !== 'UPDATE_SHAPE') throw new Error('expected UPDATE_SHAPE');
+    const updatedShape = action.shape;
+    if (updatedShape.type !== 'measurement') throw new Error('expected measurement shape');
+    expect(updatedShape.x2).toBe(180); // 150+30
+    expect(updatedShape.y2).toBe(80);  // 100-20
+    // x1/y1 unchanged
+    expect(updatedShape.x1).toBe(50);
+    expect(updatedShape.y1).toBe(100);
+  });
+});
+
+// ─── Freehand shape hit-testing and interaction ───────────────────────────────
+
+describe('onPointerDown() — freehand shape', () => {
+  function makeFreehandShape(overrides: Partial<FreehandShape> = {}): FreehandShape {
+    return {
+      type: 'freehand',
+      id: 'freehand-hit',
+      // Horizontal polyline from (50,100) to (150,100)
+      points: [[50, 100], [100, 100], [150, 100]],
+      stroke: '#3b82f6',
+      strokeWidth: 4,
+      ...overrides,
+    };
+  }
+
+  it('returns SELECT_SHAPE + START_DRAG(move) when clicking near the freehand body', () => {
+    // Freehand along y=100; click at (100, 102) — 2px from the line, within tolerance
+    const shape = makeFreehandShape();
+    const state = makeState({ shapes: [shape] });
+
+    const actions = SelectTool.onPointerDown(state, makeCtx(100, 102));
+
+    expect(actions).toHaveLength(2);
+    const selectAction = actions[0]!;
+    if (selectAction.type !== 'SELECT_SHAPE') throw new Error('expected SELECT_SHAPE');
+    expect(selectAction.id).toBe('freehand-hit');
+    const dragAction = actions[1]!;
+    if (dragAction.type !== 'START_DRAG') throw new Error('expected START_DRAG');
+    expect(dragAction.mode).toBe('move');
+  });
+
+  it('returns SELECT_SHAPE(null) + END_DRAG when clicking far from the freehand body', () => {
+    // Click at (100, 150) — 50px from the horizontal polyline
+    const shape = makeFreehandShape();
+    const state = makeState({ shapes: [shape] });
+
+    const actions = SelectTool.onPointerDown(state, makeCtx(100, 150));
+
+    expect(actions).toHaveLength(2);
+    const selectAction = actions[0]!;
+    if (selectAction.type !== 'SELECT_SHAPE') throw new Error('expected SELECT_SHAPE');
+    expect(selectAction.id).toBeNull();
+  });
+});
+
+// ─── onPointerMove() — move freehand ─────────────────────────────────────────
+
+describe('onPointerMove() — move freehand shape', () => {
+  it('returns UPDATE_SHAPE with all translated points', () => {
+    const shape: FreehandShape = {
+      type: 'freehand',
+      id: 'freehand-move',
+      points: [[50, 100], [100, 100], [150, 100]],
+      stroke: '#3b82f6',
+      strokeWidth: 4,
+    };
+
+    const stateAfterDragStart = makeState({
+      shapes: [shape],
+      selectDragState: {
+        mode: 'move',
+        shapeId: 'freehand-move',
+        handle: null,
+        startImageX: 100,
+        startImageY: 100,
+        startShape: shape,
+      },
+    });
+
+    // Move 10px right, 5px down
+    const moveActions = SelectTool.onPointerMove(stateAfterDragStart, makeCtx(110, 105));
+
+    expect(moveActions).toHaveLength(1);
+    const action = moveActions[0]!;
+    if (action.type !== 'UPDATE_SHAPE') throw new Error('expected UPDATE_SHAPE');
+    const updatedShape = action.shape;
+    if (updatedShape.type !== 'freehand') throw new Error('expected freehand shape');
+    // Each point translated by (10, 5)
+    expect(updatedShape.points[0]).toEqual([60, 105]);
+    expect(updatedShape.points[1]).toEqual([110, 105]);
+    expect(updatedShape.points[2]).toEqual([160, 105]);
   });
 });

--- a/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
@@ -5,6 +5,7 @@ import {
   hitTestHighlight,
   hitTestHandles,
   hitTestLine,
+  hitTestPolyline,
   hitTestEllipse,
   hitTestEndpointHandles,
   hitTestCardinalHandles,
@@ -21,6 +22,8 @@ import {
   translateText,
   translateCallout,
   translateTailAnchor,
+  translateMeasurement,
+  translateFreehand,
 } from '../geometry.js';
 
 export interface PointerContext {
@@ -61,6 +64,18 @@ export const SelectTool: ToolHandler = {
         }
       }
 
+      if (ctx.event.detail === 2 && shape.type === 'measurement') {
+        // Re-open inline input at midpoint pre-filled with existing label
+        // Only if the double-click actually hit the measurement line body
+        const hit = hitTestLine(imageX, imageY, shape.x1, shape.y1, shape.x2, shape.y2, 4 + shape.strokeWidth / 2) !== null;
+        if (hit) {
+          const midX = (shape.x1 + shape.x2) / 2;
+          const midY = (shape.y1 + shape.y2) / 2;
+          ctx.onOpenInlineInput?.(midX, midY, shape.id);
+          return [{ type: 'SELECT_SHAPE', id: shape.id }];
+        }
+      }
+
       // Check for handle hit first (only for rect/highlight and arrow/line/ellipse/callout)
       let handleHit: string | null = null;
 
@@ -88,6 +103,16 @@ export const SelectTool: ToolHandler = {
         );
       } else if (shape.type === 'callout') {
         handleHit = hitTestTailHandle(imageX, imageY, shape.tailX, shape.tailY, 8) ? 'tail' : null;
+      } else if (shape.type === 'measurement') {
+        handleHit = hitTestEndpointHandles(
+          imageX,
+          imageY,
+          shape.x1,
+          shape.y1,
+          shape.x2,
+          shape.y2,
+          8,
+        );
       }
 
       if (handleHit) {
@@ -129,6 +154,12 @@ export const SelectTool: ToolHandler = {
         bodyHit = hitTestText(imageX, imageY, shape, 4);
       } else if (shape.type === 'callout') {
         bodyHit = handleHit ? false : hitTestCallout(imageX, imageY, shape);
+      } else if (shape.type === 'measurement') {
+        bodyHit =
+          hitTestLine(imageX, imageY, shape.x1, shape.y1, shape.x2, shape.y2, 4 + shape.strokeWidth / 2) !== null;
+      } else if (shape.type === 'freehand') {
+        bodyHit =
+          hitTestPolyline(imageX, imageY, shape.points, 4 + shape.strokeWidth / 2) !== null;
       }
 
       if (bodyHit) {
@@ -199,6 +230,27 @@ export const SelectTool: ToolHandler = {
       } else if (startShape.type === 'callout') {
         const moved = translateCallout(startShape, dx, dy, imageWidth, imageHeight);
         updatedShape = { ...startShape, ...moved };
+      } else if (startShape.type === 'measurement') {
+        const moved = translateMeasurement(
+          startShape.x1,
+          startShape.y1,
+          startShape.x2,
+          startShape.y2,
+          dx,
+          dy,
+          imageWidth,
+          imageHeight,
+        );
+        updatedShape = { ...startShape, ...moved };
+      } else if (startShape.type === 'freehand') {
+        const movedPoints = translateFreehand(
+          startShape.points,
+          dx,
+          dy,
+          imageWidth,
+          imageHeight,
+        );
+        updatedShape = { ...startShape, points: movedPoints };
       } else {
         updatedShape = startShape;
       }
@@ -249,6 +301,19 @@ export const SelectTool: ToolHandler = {
           imageHeight,
         );
         updatedShape = { ...startShape, ...newTail };
+      } else if (startShape.type === 'measurement') {
+        const resized = resizeArrowLine(
+          startShape.x1,
+          startShape.y1,
+          startShape.x2,
+          startShape.y2,
+          selectDragState.handle as 'start' | 'end',
+          dx,
+          dy,
+          imageWidth,
+          imageHeight,
+        );
+        updatedShape = { ...startShape, ...resized };
       } else {
         updatedShape = startShape;
       }

--- a/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
+++ b/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
@@ -11,15 +11,7 @@ import type { UseUndoStackResult } from './useUndoStack.js';
 import type { ANNOTATION_STROKE_WIDTHS } from './annotationConstants.js';
 import { DEFAULT_COLOR, DEFAULT_STROKE_WIDTH, DEFAULT_FONT_SIZE } from './annotationConstants.js';
 
-export type ToolName =
-  | 'select'
-  | 'rectangle'
-  | 'highlight'
-  | 'arrow'
-  | 'line'
-  | 'ellipse'
-  | 'text'
-  | 'callout';
+export type ToolName = 'select' | 'rectangle' | 'highlight' | 'arrow' | 'line' | 'ellipse' | 'text' | 'callout' | 'measurement' | 'freehand';
 
 export type StrokeWidthKey = keyof typeof ANNOTATION_STROKE_WIDTHS;
 
@@ -32,6 +24,8 @@ export type {
   EllipseShape,
   TextShape,
   CalloutShape,
+  MeasurementShape,
+  FreehandShape,
 } from './useUndoStack.js';
 
 export type DragMode = 'move' | 'resize' | null;

--- a/client/src/components/photos/PhotoAnnotator/useUndoStack.ts
+++ b/client/src/components/photos/PhotoAnnotator/useUndoStack.ts
@@ -80,6 +80,28 @@ export interface CalloutShape {
   color: string; // text color
 }
 
+export interface MeasurementShape {
+  type: 'measurement';
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  label: string;
+  stroke: string;
+  strokeWidth: number;
+  fontSize: number;
+  color: string;
+}
+
+export interface FreehandShape {
+  type: 'freehand';
+  id: string;
+  points: [number, number][];
+  stroke: string;
+  strokeWidth: number;
+}
+
 export type AnnotationShape =
   | RectangleShape
   | HighlightShape
@@ -87,7 +109,9 @@ export type AnnotationShape =
   | LineShape
   | EllipseShape
   | TextShape
-  | CalloutShape;
+  | CalloutShape
+  | MeasurementShape
+  | FreehandShape;
 
 export interface UndoStack {
   past: AnnotationShape[][];

--- a/client/src/i18n/de/photoAnnotator.json
+++ b/client/src/i18n/de/photoAnnotator.json
@@ -9,6 +9,8 @@
   "toolEllipse": "Ellipsen-Werkzeug",
   "toolText": "Text-Werkzeug",
   "toolCallout": "Sprechblasen-Werkzeug",
+  "toolMeasurement": "Maß-Werkzeug",
+  "toolFreehand": "Freihand-Werkzeug",
   "colorRed": "Rot",
   "colorYellow": "Gelb",
   "colorGreen": "Grün",
@@ -32,6 +34,8 @@
   "shapeAddedEllipse": "Ellipse hinzugefügt",
   "shapeAddedText": "Text hinzugefügt",
   "shapeAddedCallout": "Sprechblase hinzugefügt",
+  "shapeAddedMeasurement": "Maß hinzugefügt",
+  "shapeAddedFreehand": "Freihandlinie hinzugefügt",
   "shapeDeleted": "Form gelöscht",
   "undoPerformed": "Rückgängig gemacht",
   "redoPerformed": "Wiederholt",
@@ -46,5 +50,7 @@
   "fontSizeXlarge": "Sehr groß",
   "editText": "Text bearbeiten",
   "editCallout": "Sprechblasentext bearbeiten",
+  "editMeasurement": "Maßbeschriftung bearbeiten",
+  "measurementPlaceholder": "Maß eingeben",
   "calloutTailPositioning": "Zeiger der Sprechblase positionieren"
 }

--- a/client/src/i18n/en/photoAnnotator.json
+++ b/client/src/i18n/en/photoAnnotator.json
@@ -9,6 +9,8 @@
   "toolEllipse": "Ellipse tool",
   "toolText": "Text tool",
   "toolCallout": "Callout tool",
+  "toolMeasurement": "Measurement tool",
+  "toolFreehand": "Freehand tool",
   "colorRed": "Red",
   "colorYellow": "Yellow",
   "colorGreen": "Green",
@@ -32,6 +34,8 @@
   "shapeAddedEllipse": "Ellipse added",
   "shapeAddedText": "Text added",
   "shapeAddedCallout": "Callout added",
+  "shapeAddedMeasurement": "Measurement added",
+  "shapeAddedFreehand": "Freehand path added",
   "shapeDeleted": "Shape deleted",
   "undoPerformed": "Undo performed",
   "redoPerformed": "Redo performed",
@@ -46,5 +50,7 @@
   "fontSizeXlarge": "Extra large",
   "editText": "Edit text",
   "editCallout": "Edit callout text",
+  "editMeasurement": "Edit measurement label",
+  "measurementPlaceholder": "Enter distance",
   "calloutTailPositioning": "Drag to position callout tail"
 }

--- a/client/src/i18n/glossary.json
+++ b/client/src/i18n/glossary.json
@@ -2,7 +2,7 @@
   "_meta": {
     "description": "Single source of truth for domain terminology translations. The translator agent enforces these.",
     "locales": ["de"],
-    "lastUpdated": "2026-05-17"
+    "lastUpdated": "2026-05-18"
   },
   "terms": {
     "Work Item": { "de": { "singular": "Arbeitspaket", "plural": "Arbeitspakete" } },
@@ -28,6 +28,7 @@
     "Final payment": { "de": { "singular": "Schlusszahlung" } },
     "Draft": { "de": { "singular": "Entwurf", "plural": "Entwürfe" } },
     "Annotation": { "de": { "singular": "Annotation", "plural": "Annotationen" } },
-    "Callout": { "de": { "singular": "Sprechblase", "plural": "Sprechblasen" } }
+    "Callout": { "de": { "singular": "Sprechblase", "plural": "Sprechblasen" } },
+    "Freehand": { "de": { "singular": "Freihand" } }
   }
 }


### PR DESCRIPTION
## Summary

- **MeasurementTool**: draws a line with a user-entered text label; double-click to edit an existing label; shift-constrain for horizontal/vertical snapping
- **FreehandTool**: records a pointer-event polyline simplified at commit-time via the Ramer–Douglas–Peucker algorithm (`simplify.ts`, ε = 3 px) to reduce stored point count without visible quality loss
- Extends `geometry.ts` (distance/midpoint helpers), `render.ts` (measurement + freehand renderers), `SelectTool` hit-testing (segment + label hit, polyline proximity), and `useUndoStack`
- Adds 6 new English + German i18n keys in the `photoAnnotator` namespace and a "Freehand" glossary entry

Closes #1477

## Test plan

- [ ] MeasurementTool.test.ts — draw, shift-constrain, double-click label edit, hit-test
- [ ] FreehandTool.test.ts — draw, commit (RDP simplification applied), cancel
- [ ] simplify.test.ts — RDP unit tests (identity, straight line, corner reduction)
- [ ] geometry.test.ts — distance/midpoint helper coverage
- [ ] render.test.ts — measurement and freehand render paths
- [ ] SelectTool.test.ts — measurement and freehand hit-test paths
- [ ] PhotoAnnotator.test.tsx — tool registration, palette rendering
- [ ] ToolPalette.test.tsx — measurement + freehand button presence
- [ ] Quality Gates pass (typecheck + unit tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude qa-integration-tester (Sonnet 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude translator (Sonnet 4.6) <noreply@anthropic.com>