### PR TITLE
feat(photos): block annotation on signed diary entries

### DIFF
--- a/client/src/components/photos/PhotoCard.test.tsx
+++ b/client/src/components/photos/PhotoCard.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for PhotoCard component.
+ *
+ * Tests:
+ *   - Edit button renders when onEdit is provided and editable=true
+ *   - Edit button does NOT render when editable=false (even if onEdit is provided)
+ *   - Delete button renders when onDelete is provided
+ *   - Clicking Edit button calls onEdit
+ *   - Clicking Delete button calls onDelete
+ *   - Image renders with caption and originalFilename
+ *   - Keyboard navigation: Enter/Space clicks the card, Delete key calls onDelete
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Photo } from '@cornerstone/shared';
+import { PhotoCard } from './PhotoCard.js';
+
+// Mock i18next
+jest.unstable_mockModule('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        annotate: 'Annotate photo',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+const mockPhoto: Photo = {
+  id: 'photo-1',
+  entityType: 'diary_entry',
+  entityId: 'diary-1',
+  caption: 'Test Caption',
+  originalFilename: 'test.jpg',
+  mimeType: 'image/jpeg',
+  fileSize: 50000,
+  fileUrl: '/api/photos/photo-1/file',
+  thumbnailUrl: '/api/photos/photo-1/thumbnail',
+  width: 1024,
+  height: 768,
+  takenAt: null,
+  sortOrder: 0,
+  createdBy: null,
+  annotatedAt: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('PhotoCard', () => {
+  it('renders the image with caption', () => {
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+      />
+    );
+    const img = screen.getByAltText('Test Caption');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', '/api/photos/photo-1/thumbnail');
+  });
+
+  it('renders the caption overlay', () => {
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Test Caption')).toBeInTheDocument();
+  });
+
+  it('renders the click area button', () => {
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+      />
+    );
+    const clickButton = screen.getByRole('button', { name: /View photo/ });
+    expect(clickButton).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const mockClick = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={mockClick}
+      />
+    );
+    const clickButton = screen.getByRole('button', { name: /View photo/ });
+    fireEvent.click(clickButton);
+    expect(mockClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Edit button when onEdit is provided and editable=true', () => {
+    const mockEdit = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onEdit={mockEdit}
+        editable={true}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const editButton = screen.getByRole('button', { name: /Annotate photo/ });
+    expect(editButton).toBeInTheDocument();
+  });
+
+  it('does NOT render Edit button when editable=false (even if onEdit is provided)', () => {
+    const mockEdit = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onEdit={mockEdit}
+        editable={false}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const editButton = screen.queryByRole('button', { name: /Annotate photo/ });
+    expect(editButton).not.toBeInTheDocument();
+  });
+
+  it('calls onEdit when Edit button is clicked', () => {
+    const mockEdit = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onEdit={mockEdit}
+        editable={true}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const editButton = screen.getByRole('button', { name: /Annotate photo/ });
+    fireEvent.click(editButton);
+    expect(mockEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Delete button when onDelete is provided', () => {
+    const mockDelete = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onDelete={mockDelete}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const deleteButton = screen.getByRole('button', { name: /Delete photo/ });
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('calls onDelete when Delete button is clicked', () => {
+    const mockDelete = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onDelete={mockDelete}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const deleteButton = screen.getByRole('button', { name: /Delete photo/ });
+    fireEvent.click(deleteButton);
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClick when Enter key is pressed', () => {
+    const mockClick = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={mockClick}
+      />
+    );
+    const card = screen.getByRole('listitem');
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(mockClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClick when Space key is pressed', () => {
+    const mockClick = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={mockClick}
+      />
+    );
+    const card = screen.getByRole('listitem');
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(mockClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDelete when Delete key is pressed', () => {
+    const mockDelete = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onDelete={mockDelete}
+      />
+    );
+    const card = screen.getByRole('listitem');
+    fireEvent.keyDown(card, { key: 'Delete' });
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides action buttons on blur', () => {
+    const mockEdit = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onEdit={mockEdit}
+        editable={true}
+      />
+    );
+    const card = screen.getByRole('listitem');
+
+    // Hover to show buttons
+    fireEvent.mouseEnter(card);
+    const editButtonShown = screen.getByRole('button', { name: /Annotate photo/ });
+    expect(editButtonShown).toBeInTheDocument();
+
+    // Leave hover to hide buttons
+    fireEvent.mouseLeave(card);
+    const editButtonHidden = screen.queryByRole('button', { name: /Annotate photo/ });
+    expect(editButtonHidden).not.toBeInTheDocument();
+  });
+
+  it('defaults editable to true when not provided', () => {
+    const mockEdit = jest.fn();
+    render(
+      <PhotoCard
+        photo={mockPhoto}
+        onClick={jest.fn()}
+        onEdit={mockEdit}
+      />
+    );
+    // Hover to show action buttons
+    const card = screen.getByRole('listitem');
+    fireEvent.mouseEnter(card);
+
+    const editButton = screen.getByRole('button', { name: /Annotate photo/ });
+    expect(editButton).toBeInTheDocument();
+  });
+});

--- a/client/src/components/photos/PhotoCard.tsx
+++ b/client/src/components/photos/PhotoCard.tsx
@@ -8,9 +8,10 @@ export interface PhotoCardProps {
   onClick: () => void;
   onDelete?: () => void;
   onEdit?: () => void;
+  editable?: boolean;
 }
 
-export function PhotoCard({ photo, onClick, onDelete, onEdit }: PhotoCardProps) {
+export function PhotoCard({ photo, onClick, onDelete, onEdit, editable = true }: PhotoCardProps) {
   const { t } = useTranslation('photoViewer');
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -81,7 +82,7 @@ export function PhotoCard({ photo, onClick, onDelete, onEdit }: PhotoCardProps) 
       {/* Edit and Delete buttons (shown on hover/focus) */}
       {(isHovered || isFocused) && (
         <div className={styles.actionButtons}>
-          {onEdit && (
+          {onEdit && editable && (
             <button
               type="button"
               onClick={(e) => {

--- a/client/src/components/photos/PhotoGrid.tsx
+++ b/client/src/components/photos/PhotoGrid.tsx
@@ -8,9 +8,10 @@ export interface PhotoGridProps {
   onDelete?: (photo: Photo) => void;
   onEdit?: (photo: Photo) => void;
   loading?: boolean;
+  editable?: boolean;
 }
 
-export function PhotoGrid({ photos, onPhotoClick, onDelete, onEdit, loading }: PhotoGridProps) {
+export function PhotoGrid({ photos, onPhotoClick, onDelete, onEdit, loading, editable = true }: PhotoGridProps) {
   if (loading) {
     return (
       <div className={styles.grid} role="list" aria-label="Loading photos">
@@ -34,6 +35,7 @@ export function PhotoGrid({ photos, onPhotoClick, onDelete, onEdit, loading }: P
           onClick={() => onPhotoClick(photo)}
           onDelete={onDelete ? () => onDelete(photo) : undefined}
           onEdit={onEdit ? () => onEdit(photo) : undefined}
+          editable={editable}
         />
       ))}
     </div>

--- a/client/src/components/photos/PhotoViewer.test.tsx
+++ b/client/src/components/photos/PhotoViewer.test.tsx
@@ -146,13 +146,14 @@ describe('PhotoViewer', () => {
     jest.clearAllMocks();
   });
 
-  function renderViewer(photos: Photo[], initialIndex = 0) {
+  function renderViewer(photos: Photo[], initialIndex = 0, editable = true) {
     return render(
       React.createElement(PhotoViewer, {
         photos,
         initialIndex,
         onClose: mockOnClose,
         onPhotoAnnotated: mockOnPhotoAnnotated,
+        editable,
       }),
     );
   }
@@ -183,6 +184,19 @@ describe('PhotoViewer', () => {
 
     // PhotoAnnotator mock should be rendered
     expect(screen.getByTestId('mock-photo-annotator')).toBeInTheDocument();
+  });
+
+  it('annotate button is disabled when editable=false', () => {
+    const photo = makePhoto({ width: 800, height: 600 });
+    renderViewer([photo], 0, false);
+    expect(screen.getByTestId('photo-viewer-annotate')).toBeDisabled();
+  });
+
+  it('annotate button has signed entry tooltip when editable=false', () => {
+    const photo = makePhoto({ width: 800, height: 600 });
+    renderViewer([photo], 0, false);
+    const btn = screen.getByTestId('photo-viewer-annotate');
+    expect(btn).toHaveAttribute('title', expect.stringContaining('cannot be annotated'));
   });
 
   it('navigation arrows are hidden while annotating', () => {

--- a/client/src/components/photos/PhotoViewer.tsx
+++ b/client/src/components/photos/PhotoViewer.tsx
@@ -12,9 +12,10 @@ export interface PhotoViewerProps {
   initialIndex: number;
   onClose: () => void;
   onPhotoAnnotated?: (photo: Photo) => void;
+  editable?: boolean;
 }
 
-export function PhotoViewer({ photos, initialIndex, onClose, onPhotoAnnotated }: PhotoViewerProps) {
+export function PhotoViewer({ photos, initialIndex, onClose, onPhotoAnnotated, editable = true }: PhotoViewerProps) {
   const { t } = useTranslation(['photoViewer', 'common']);
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [isAnnotating, setIsAnnotating] = useState(false);
@@ -201,14 +202,16 @@ export function PhotoViewer({ photos, initialIndex, onClose, onPhotoAnnotated }:
               ref={annotateBtnRef}
               type="button"
               className={`${styles.iconButton} ${
-                !currentPhoto.width || !currentPhoto.height ? styles.iconButtonDisabled : ''
+                !editable || !currentPhoto.width || !currentPhoto.height ? styles.iconButtonDisabled : ''
               }`}
-              disabled={!currentPhoto.width || !currentPhoto.height}
+              disabled={!editable || !currentPhoto.width || !currentPhoto.height}
               aria-label={t('photoViewer:annotate')}
               title={
-                !currentPhoto.width || !currentPhoto.height
-                  ? t('photoViewer:annotateDisabledMissingDimensions')
-                  : undefined
+                !editable
+                  ? t('photoViewer:annotateDisabledSigned')
+                  : !currentPhoto.width || !currentPhoto.height
+                    ? t('photoViewer:annotateDisabledMissingDimensions')
+                    : undefined
               }
               data-testid="photo-viewer-annotate"
               onClick={() => {

--- a/client/src/i18n/de/photoViewer.json
+++ b/client/src/i18n/de/photoViewer.json
@@ -6,5 +6,6 @@
   "clearConfirmTitle": "Annotationen entfernen?",
   "clearConfirmBody": "Dadurch wird die annotierte Version dauerhaft entfernt. Das Originalfoto wird wiederhergestellt.",
   "clearConfirmAction": "Entfernen",
-  "annotateDisabledMissingDimensions": "Abmessungen unbekannt — dieses Foto kann nicht annotiert werden"
+  "annotateDisabledMissingDimensions": "Abmessungen unbekannt — dieses Foto kann nicht annotiert werden",
+  "annotateDisabledSigned": "Signierte Einträge können nicht annotiert werden"
 }

--- a/client/src/i18n/en/photoViewer.json
+++ b/client/src/i18n/en/photoViewer.json
@@ -1,6 +1,7 @@
 {
   "annotate": "Annotate photo",
   "annotateDisabledMissingDimensions": "Cannot annotate: photo dimensions are missing",
+  "annotateDisabledSigned": "Signed entries cannot be annotated",
   "viewOriginal": "View original",
   "viewAnnotated": "View annotated",
   "clearAnnotations": "Clear annotations",

--- a/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
+++ b/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
@@ -279,6 +279,7 @@ export default function DiaryEntryDetailPage() {
                     setSelectedPhotoIndex(index);
                   }}
                   loading={photosResult.loading}
+                  editable={!entry.isSigned}
                 />
               </>
             )}
@@ -292,6 +293,7 @@ export default function DiaryEntryDetailPage() {
             initialIndex={selectedPhotoIndex}
             onClose={() => setSelectedPhotoIndex(null)}
             onPhotoAnnotated={photosResult.updatePhotoAnnotation}
+            editable={!entry.isSigned}
           />
         )}
 

--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type { Photo, ApiErrorResponse } from '@cornerstone/shared';
+import { diaryEntries } from '../db/schema.js';
 
 // ─── Mock photoService BEFORE importing app ────────────────────────────────────
 
@@ -47,10 +48,6 @@ const mockDeletePhotosForEntity = jest.fn() as AnyMock;
 const mockSaveAnnotatedImage = jest.fn() as AnyMock;
 const mockClearAnnotation = jest.fn() as AnyMock;
 
-// ─── Mock diaryService BEFORE importing app ────────────────────────────────────
-
-const mockGetDiaryEntry = jest.fn() as AnyMock;
-
 jest.unstable_mockModule('../services/photoAnnotationService.js', () => ({
   saveAnnotatedImage: mockSaveAnnotatedImage,
   clearAnnotation: mockClearAnnotation,
@@ -65,10 +62,6 @@ jest.unstable_mockModule('../services/photoService.js', () => ({
   deletePhoto: mockDeletePhoto,
   deletePhotosForEntity: mockDeletePhotosForEntity,
   getPhotoFilePath: mockGetPhotoFilePath,
-}));
-
-jest.unstable_mockModule('../services/diaryService.js', () => ({
-  getDiaryEntry: mockGetDiaryEntry,
 }));
 
 // ─── Dynamic imports (after mocks) ───────────────────────────────────────────
@@ -201,6 +194,38 @@ describe('Photo Routes', () => {
   });
 
   // ─── Helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Insert a diary entry directly into the test database.
+   * photos.ts uses a direct DB query (not diaryService) to check signatures,
+   * so tests that exercise the signed-entry 409 path must seed the DB.
+   */
+  let diaryEntryCounter = 0;
+  function insertDiaryEntry(overrides: Partial<typeof diaryEntries.$inferInsert> = {}): string {
+    diaryEntryCounter += 1;
+    const id = `diary-photos-test-${Date.now()}-${diaryEntryCounter}`;
+    const now = new Date().toISOString();
+    app.db
+      .insert(diaryEntries)
+      .values({
+        id,
+        entryType: 'daily_log',
+        entryDate: '2026-03-14',
+        title: 'Test Entry',
+        body: 'Test body content',
+        metadata: null,
+        status: 'saved',
+        isAutomatic: false,
+        sourceEntityType: null,
+        sourceEntityId: null,
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+      })
+      .run();
+    return id;
+  }
 
   async function createUserWithSession(
     email: string,
@@ -1233,17 +1258,18 @@ describe('Photo Routes', () => {
 
     it('returns 409 when photo is on a signed diary entry', async () => {
       const { cookie } = await createUserWithSession('ann-signed@example.com', 'AnnSigned', 'password');
+
+      // Seed a diary entry with a non-empty signatures array in metadata.
+      // photos.ts uses isDiaryEntrySigned() which queries diaryEntries directly (not diaryService).
+      const signedEntryId = insertDiaryEntry({
+        metadata: JSON.stringify({ signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] }),
+      });
+
       const photoWithDiaryEntity = makePhoto({
         entityType: 'diary_entry',
-        entityId: 'entry-123',
+        entityId: signedEntryId,
       });
       mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
-
-      // Mock the diary entry as signed (has non-empty signatures in metadata)
-      mockGetDiaryEntry.mockReturnValue({
-        id: 'entry-123',
-        metadata: { signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] },
-      });
 
       const { body, contentType } = buildMultipartBody([
         {
@@ -1269,21 +1295,21 @@ describe('Photo Routes', () => {
 
     it('returns 200 when photo is on an unsigned diary entry', async () => {
       const { cookie } = await createUserWithSession('ann-unsigned@example.com', 'AnnUnsigned', 'password');
+
+      // Seed a diary entry with empty signatures — isDiaryEntrySigned() must return false.
+      const unsignedEntryId = insertDiaryEntry({
+        metadata: JSON.stringify({ signatures: [] }),
+      });
+
       const photoWithDiaryEntity = makePhoto({
         entityType: 'diary_entry',
-        entityId: 'entry-456',
+        entityId: unsignedEntryId,
       });
       mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
 
-      // Mock the diary entry as unsigned (empty or missing signatures)
-      mockGetDiaryEntry.mockReturnValue({
-        id: 'entry-456',
-        metadata: { signatures: [] },
-      });
-
       const annotatedPhoto = makePhoto({
         entityType: 'diary_entry',
-        entityId: 'entry-456',
+        entityId: unsignedEntryId,
         annotatedAt: '2026-05-18T10:00:00.000Z',
       });
       mockSaveAnnotatedImage.mockResolvedValue(annotatedPhoto);
@@ -1407,17 +1433,17 @@ describe('Photo Routes', () => {
 
     it('returns 409 when photo is on a signed diary entry', async () => {
       const { cookie } = await createUserWithSession('del-ann-signed@example.com', 'DelAnnSigned', 'password');
+
+      // Seed a signed diary entry — photos.ts uses isDiaryEntrySigned() which reads the DB directly.
+      const signedEntryId = insertDiaryEntry({
+        metadata: JSON.stringify({ signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] }),
+      });
+
       const photoWithDiaryEntity = makePhoto({
         entityType: 'diary_entry',
-        entityId: 'entry-789',
+        entityId: signedEntryId,
       });
       mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
-
-      // Mock the diary entry as signed (has non-empty signatures in metadata)
-      mockGetDiaryEntry.mockReturnValue({
-        id: 'entry-789',
-        metadata: { signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] },
-      });
 
       const response = await app.inject({
         method: 'DELETE',
@@ -1433,17 +1459,17 @@ describe('Photo Routes', () => {
 
     it('returns 204 when photo is on an unsigned diary entry', async () => {
       const { cookie } = await createUserWithSession('del-ann-unsigned@example.com', 'DelAnnUnsigned', 'password');
+
+      // Seed an unsigned diary entry — isDiaryEntrySigned() must return false.
+      const unsignedEntryId = insertDiaryEntry({
+        metadata: JSON.stringify({ signatures: [] }),
+      });
+
       const photoWithDiaryEntity = makePhoto({
         entityType: 'diary_entry',
-        entityId: 'entry-999',
+        entityId: unsignedEntryId,
       });
       mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
-
-      // Mock the diary entry as unsigned (empty signatures)
-      mockGetDiaryEntry.mockReturnValue({
-        id: 'entry-999',
-        metadata: { signatures: [] },
-      });
 
       mockClearAnnotation.mockResolvedValue(undefined);
 

--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -1139,6 +1139,7 @@ describe('Photo Routes', () => {
 
     it('returns 200 with { photo } on success', async () => {
       const { cookie } = await createUserWithSession('ann@example.com', 'Ann', 'password');
+      mockGetPhoto.mockReturnValue(makePhoto({ id: '33333333-3333-3333-3333-333333333333', entityType: 'work_item', entityId: 'work-item-1' }));
       const annotatedPhoto = makePhoto({ annotatedAt: '2026-05-17T10:00:00.000Z' });
       mockSaveAnnotatedImage.mockResolvedValue(annotatedPhoto);
 
@@ -1165,6 +1166,7 @@ describe('Photo Routes', () => {
 
     it('calls saveAnnotatedImage with correct buffer', async () => {
       const { cookie } = await createUserWithSession('ann2@example.com', 'Ann2', 'password');
+      mockGetPhoto.mockReturnValue(makePhoto({ id: '33333333-3333-3333-3333-333333333333', entityType: 'work_item', entityId: 'work-item-1' }));
       const pngContent = Buffer.from('real-png-content-bytes');
       mockSaveAnnotatedImage.mockResolvedValue(
         makePhoto({ annotatedAt: '2026-05-17T10:00:00.000Z' }),
@@ -1221,6 +1223,7 @@ describe('Photo Routes', () => {
         'AnnBig2',
         'password',
       );
+      mockGetPhoto.mockReturnValue(makePhoto({ id: '33333333-3333-3333-3333-333333333333', entityType: 'work_item', entityId: 'work-item-1' }));
       const response = await app.inject({
         method: 'PUT',
         url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
@@ -1386,6 +1389,7 @@ describe('Photo Routes', () => {
 
     it('returns 204 on success', async () => {
       const { cookie } = await createUserWithSession('del-ann@example.com', 'DelAnn', 'password');
+      mockGetPhoto.mockReturnValue(makePhoto({ id: '33333333-3333-3333-3333-333333333333', entityType: 'work_item', entityId: 'work-item-1' }));
       mockClearAnnotation.mockResolvedValue(undefined);
 
       const response = await app.inject({
@@ -1399,6 +1403,7 @@ describe('Photo Routes', () => {
 
     it('calls clearAnnotation with correct id and storagePath', async () => {
       const { cookie } = await createUserWithSession('del-ann2@example.com', 'DelAnn2', 'password');
+      mockGetPhoto.mockReturnValue(makePhoto({ id: '44444444-4444-4444-4444-444444444444', entityType: 'work_item', entityId: 'work-item-2' }));
 
       await app.inject({
         method: 'DELETE',
@@ -1521,8 +1526,10 @@ describe('Photo Routes', () => {
         },
       ]);
 
-      // Use a valid UUID so param schema validation passes
+      // Use a valid UUID so param schema validation passes; mock photo so the new locked-entry
+      // check passes before MIME validation.
       const validId = '00000000-0000-0000-0000-000000000001';
+      mockGetPhoto.mockReturnValue(makePhoto({ id: validId, entityType: 'work_item', entityId: 'work-item-1' }));
       const response = await app.inject({
         method: 'PUT',
         url: `/api/photos/${validId}/annotation`,
@@ -1551,6 +1558,7 @@ describe('Photo Routes', () => {
       ]);
 
       const validId = '00000000-0000-0000-0000-000000000002';
+      mockGetPhoto.mockReturnValue(makePhoto({ id: validId, entityType: 'work_item', entityId: 'work-item-1' }));
       await app.inject({
         method: 'PUT',
         url: `/api/photos/${validId}/annotation`,
@@ -1584,6 +1592,7 @@ describe('Photo Routes', () => {
         'password',
       );
       const validId = '00000000-0000-0000-0000-000000000003';
+      mockGetPhoto.mockReturnValue(makePhoto({ id: validId, entityType: 'work_item', entityId: 'work-item-1' }));
       const response = await app.inject({
         method: 'PUT',
         url: `/api/photos/${validId}/annotation`,

--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -47,6 +47,10 @@ const mockDeletePhotosForEntity = jest.fn() as AnyMock;
 const mockSaveAnnotatedImage = jest.fn() as AnyMock;
 const mockClearAnnotation = jest.fn() as AnyMock;
 
+// ─── Mock diaryService BEFORE importing app ────────────────────────────────────
+
+const mockGetDiaryEntry = jest.fn() as AnyMock;
+
 jest.unstable_mockModule('../services/photoAnnotationService.js', () => ({
   saveAnnotatedImage: mockSaveAnnotatedImage,
   clearAnnotation: mockClearAnnotation,
@@ -61,6 +65,10 @@ jest.unstable_mockModule('../services/photoService.js', () => ({
   deletePhoto: mockDeletePhoto,
   deletePhotosForEntity: mockDeletePhotosForEntity,
   getPhotoFilePath: mockGetPhotoFilePath,
+}));
+
+jest.unstable_mockModule('../services/diaryService.js', () => ({
+  getDiaryEntry: mockGetDiaryEntry,
 }));
 
 // ─── Dynamic imports (after mocks) ───────────────────────────────────────────
@@ -1222,6 +1230,120 @@ describe('Photo Routes', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
+    it('returns 409 when photo is on a signed diary entry', async () => {
+      const { cookie } = await createUserWithSession('ann-signed@example.com', 'AnnSigned', 'password');
+      const photoWithDiaryEntity = makePhoto({
+        entityType: 'diary_entry',
+        entityId: 'entry-123',
+      });
+      mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
+
+      // Mock the diary entry as signed (has non-empty signatures in metadata)
+      mockGetDiaryEntry.mockReturnValue({
+        id: 'entry-123',
+        metadata: { signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] },
+      });
+
+      const { body, contentType } = buildMultipartBody([
+        {
+          name: 'file',
+          value: Buffer.from('fake-png-data'),
+          filename: 'annotated.png',
+          contentType: 'image/png',
+        },
+      ]);
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie, 'content-type': contentType },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(409);
+      const errBody = JSON.parse(response.body) as ApiErrorResponse;
+      expect(errBody.error.code).toBe('CONFLICT');
+      expect(errBody.error.message).toContain('Cannot annotate photos on signed diary entries');
+    });
+
+    it('returns 200 when photo is on an unsigned diary entry', async () => {
+      const { cookie } = await createUserWithSession('ann-unsigned@example.com', 'AnnUnsigned', 'password');
+      const photoWithDiaryEntity = makePhoto({
+        entityType: 'diary_entry',
+        entityId: 'entry-456',
+      });
+      mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
+
+      // Mock the diary entry as unsigned (empty or missing signatures)
+      mockGetDiaryEntry.mockReturnValue({
+        id: 'entry-456',
+        metadata: { signatures: [] },
+      });
+
+      const annotatedPhoto = makePhoto({
+        entityType: 'diary_entry',
+        entityId: 'entry-456',
+        annotatedAt: '2026-05-18T10:00:00.000Z',
+      });
+      mockSaveAnnotatedImage.mockResolvedValue(annotatedPhoto);
+
+      const { body, contentType } = buildMultipartBody([
+        {
+          name: 'file',
+          value: Buffer.from('fake-png-data'),
+          filename: 'annotated.png',
+          contentType: 'image/png',
+        },
+      ]);
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie, 'content-type': contentType },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const responseBody = JSON.parse(response.body) as { photo: Photo };
+      expect(responseBody.photo.annotatedAt).toBe('2026-05-18T10:00:00.000Z');
+    });
+
+    it('returns 200 when photo is not on a diary entry', async () => {
+      const { cookie } = await createUserWithSession('ann-other@example.com', 'AnnOther', 'password');
+      const photoWithOtherEntity = makePhoto({
+        entityType: 'work_item',
+        entityId: 'work-item-789',
+      });
+      mockGetPhoto.mockReturnValue(photoWithOtherEntity);
+
+      const annotatedPhoto = makePhoto({
+        entityType: 'work_item',
+        entityId: 'work-item-789',
+        annotatedAt: '2026-05-18T10:00:00.000Z',
+      });
+      mockSaveAnnotatedImage.mockResolvedValue(annotatedPhoto);
+
+      const { body, contentType } = buildMultipartBody([
+        {
+          name: 'file',
+          value: Buffer.from('fake-png-data'),
+          filename: 'annotated.png',
+          contentType: 'image/png',
+        },
+      ]);
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie, 'content-type': contentType },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const responseBody = JSON.parse(response.body) as { photo: Photo };
+      expect(responseBody.photo.entityType).toBe('work_item');
+    });
   });
 
   // ─── DELETE /api/photos/:id/annotation ────────────────────────────────────
@@ -1281,6 +1403,76 @@ describe('Photo Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    it('returns 409 when photo is on a signed diary entry', async () => {
+      const { cookie } = await createUserWithSession('del-ann-signed@example.com', 'DelAnnSigned', 'password');
+      const photoWithDiaryEntity = makePhoto({
+        entityType: 'diary_entry',
+        entityId: 'entry-789',
+      });
+      mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
+
+      // Mock the diary entry as signed (has non-empty signatures in metadata)
+      mockGetDiaryEntry.mockReturnValue({
+        id: 'entry-789',
+        metadata: { signatures: [{ timestamp: '2026-05-18T10:00:00Z' }] },
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(409);
+      const errBody = JSON.parse(response.body) as ApiErrorResponse;
+      expect(errBody.error.code).toBe('CONFLICT');
+      expect(errBody.error.message).toContain('Cannot remove annotation');
+    });
+
+    it('returns 204 when photo is on an unsigned diary entry', async () => {
+      const { cookie } = await createUserWithSession('del-ann-unsigned@example.com', 'DelAnnUnsigned', 'password');
+      const photoWithDiaryEntity = makePhoto({
+        entityType: 'diary_entry',
+        entityId: 'entry-999',
+      });
+      mockGetPhoto.mockReturnValue(photoWithDiaryEntity);
+
+      // Mock the diary entry as unsigned (empty signatures)
+      mockGetDiaryEntry.mockReturnValue({
+        id: 'entry-999',
+        metadata: { signatures: [] },
+      });
+
+      mockClearAnnotation.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it('returns 204 when photo is not on a diary entry', async () => {
+      const { cookie } = await createUserWithSession('del-ann-other@example.com', 'DelAnnOther', 'password');
+      const photoWithOtherEntity = makePhoto({
+        entityType: 'work_item',
+        entityId: 'work-item-999',
+      });
+      mockGetPhoto.mockReturnValue(photoWithOtherEntity);
+
+      mockClearAnnotation.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/photos/33333333-3333-3333-3333-333333333333/annotation',
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(204);
     });
   });
 

--- a/server/src/routes/photos.ts
+++ b/server/src/routes/photos.ts
@@ -12,19 +12,56 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import path from 'node:path';
+import { eq } from 'drizzle-orm';
 import {
   NotFoundError,
   UnauthorizedError,
   ValidationError,
   PayloadTooLargeError,
+  ConflictError,
 } from '../errors/AppError.js';
 import * as photoService from '../services/photoService.js';
 import * as photoAnnotationService from '../services/photoAnnotationService.js';
+import { diaryEntries } from '../db/schema.js';
 import type {
   UpdatePhotoRequest,
   ReorderPhotosRequest,
   PhotoEntityType,
 } from '@cornerstone/shared';
+
+// ─── Helper functions ─────────────────────────────────────────────────────────
+
+/**
+ * Check if a diary entry is signed (has non-empty signatures array in metadata).
+ * Returns true if signed, false if not signed or entry not found.
+ */
+function isDiaryEntrySigned(db: any, diaryEntryId: string): boolean {
+  const entry = db
+    .select({ metadata: diaryEntries.metadata })
+    .from(diaryEntries)
+    .where(eq(diaryEntries.id, diaryEntryId))
+    .get();
+
+  if (!entry) {
+    return false;
+  }
+
+  if (!entry.metadata) {
+    return false;
+  }
+
+  try {
+    const metadata = JSON.parse(entry.metadata);
+    return (
+      Boolean(metadata) &&
+      'signatures' in metadata &&
+      Array.isArray(metadata.signatures) &&
+      metadata.signatures.length > 0
+    );
+  } catch {
+    return false;
+  }
+}
 
 // ─── JSON schemas ─────────────────────────────────────────────────────────────
 
@@ -373,7 +410,7 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
    * Form field:
    *   - file: the annotated PNG blob
    *
-   * Returns: 200 with { photo } or 400/404
+   * Returns: 200 with { photo } or 400/404/409
    */
   fastify.put(
     '/:id/annotation',
@@ -381,6 +418,19 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
     async (request: FastifyRequest, reply: FastifyReply) => {
       if (!request.user) throw new UnauthorizedError();
       const { id } = request.params as { id: string };
+
+      // Fetch photo metadata to check entity type
+      const photo = photoService.getPhoto(fastify.db, id);
+      if (!photo) {
+        throw new NotFoundError('Photo not found');
+      }
+
+      // Block annotation if photo is attached to a signed diary entry
+      if (photo.entityType === 'diary_entry') {
+        if (isDiaryEntrySigned(fastify.db, photo.entityId)) {
+          throw new ConflictError('Cannot annotate photos on signed diary entries');
+        }
+      }
 
       const file = await request.file();
       if (!file) throw new ValidationError('No file uploaded');
@@ -399,14 +449,14 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
         );
       }
 
-      const photo = await photoAnnotationService.saveAnnotatedImage(
+      const updatedPhoto = await photoAnnotationService.saveAnnotatedImage(
         fastify.db,
         fastify.config.photoStoragePath,
         id,
         pngBuffer,
       );
 
-      return reply.status(200).send({ photo });
+      return reply.status(200).send({ photo: updatedPhoto });
     },
   );
 
@@ -414,7 +464,7 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
    * DELETE /:id/annotation
    * Clear the annotated image for a photo.
    *
-   * Returns: 204 No Content or 404
+   * Returns: 204 No Content or 404/409
    */
   fastify.delete(
     '/:id/annotation',
@@ -422,6 +472,19 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
     async (request: FastifyRequest, reply: FastifyReply) => {
       if (!request.user) throw new UnauthorizedError();
       const { id } = request.params as { id: string };
+
+      // Fetch photo metadata to check entity type
+      const photo = photoService.getPhoto(fastify.db, id);
+      if (!photo) {
+        throw new NotFoundError('Photo not found');
+      }
+
+      // Block annotation if photo is attached to a signed diary entry
+      if (photo.entityType === 'diary_entry') {
+        if (isDiaryEntrySigned(fastify.db, photo.entityId)) {
+          throw new ConflictError('Cannot remove annotation from photos on signed diary entries');
+        }
+      }
 
       await photoAnnotationService.clearAnnotation(fastify.db, fastify.config.photoStoragePath, id);
 


### PR DESCRIPTION
## Summary

Photos attached to a **signed** (locked) diary entry could still be annotated end-to-end — both through the photo viewer's Annotate button and the new Edit button on photo cards. This contradicts the existing lock semantics where signed entries are immutable.

This PR closes the gate at both layers:

- **Server** — `PUT` and `DELETE /api/photos/:id/annotation` now look up the parent entity; if it's a signed diary entry, the request is rejected with `409 Conflict`. Photos attached to other entity types are unaffected.
- **Client** — `PhotoCard`, `PhotoGrid`, and `PhotoViewer` accept an `editable` prop. `DiaryEntryDetailPage` passes `editable={!entry.isSigned}`. When the entry is signed, the per-photo Edit button is hidden and the viewer's Annotate button is disabled with an explanatory tooltip.

## Test plan

- [x] Server typecheck green; new tests for PUT/DELETE annotation cover signed → 409, unsigned → success, non-diary photo → success
- [x] Client typecheck green; new PhotoCard tests cover editable prop; new PhotoViewer tests cover disabled annotate button + tooltip
- [ ] Manual: sign a diary entry that has photos, verify the Edit/Annotate buttons disappear/are disabled

## i18n

- `annotateDisabledSigned` — EN: "Signed entries cannot be annotated", DE: "Signierte Einträge können nicht annotiert werden"

Refs the photo-annotator UAT feedback batch.