### PR TITLE
fix(photo-annotator): keep pointer events within the image bounds

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
@@ -23,11 +23,8 @@
 }
 
 .svgOverlay {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  touch-action: none;
+  /* Position, width, height, and touch-action are set via inline styles
+     to match the actual image layout and prevent pointer events in letterbox/pillarbox areas */
 }
 
 .inlineTextInput {

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -37,6 +37,20 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
+  // SVG overlay position and size (matched to image layout within container)
+  interface SvgPosition {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }
+  const [svgPosition, setSvgPosition] = useState<SvgPosition>({
+    top: 0,
+    left: 0,
+    width: 0,
+    height: 0,
+  });
+
   // Inline edit state
   interface InlineInputState {
     isOpen: boolean;
@@ -66,6 +80,39 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   // Calculate canonical URL
   const canonicalUrl = `${getBaseUrl()}/photos/${photo.id}/file`;
+
+  // Track SVG overlay position to match image layout within container
+  // This prevents pointer events in letterbox/pillarbox padding from creating out-of-bounds shapes
+  useEffect(() => {
+    if (!imgRef.current || !imgRef.current.parentElement) return;
+
+    const updateSvgPosition = () => {
+      const imgRect = imgRef.current!.getBoundingClientRect();
+      const containerRect = imgRef.current!.parentElement!.getBoundingClientRect();
+
+      setSvgPosition({
+        top: imgRect.top - containerRect.top,
+        left: imgRect.left - containerRect.left,
+        width: imgRect.width,
+        height: imgRect.height,
+      });
+    };
+
+    // Update on mount and whenever image dimensions change
+    updateSvgPosition();
+
+    // Use ResizeObserver to track changes to the image's rendered size
+    const resizeObserver = new ResizeObserver(updateSvgPosition);
+    resizeObserver.observe(imgRef.current);
+
+    // Also listen to window resize
+    window.addEventListener('resize', updateSvgPosition);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateSvgPosition);
+    };
+  }, []);
 
   // Helper to get the active font size key for the current tool
   function getActiveFontSizeKey(): FontSizeKey {
@@ -410,13 +457,17 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       if (!svgRef.current || !imgRef.current) return;
 
       const imgRect = imgRef.current.getBoundingClientRect();
-      const { x: imageX, y: imageY } = screenToImage(
+      let { x: imageX, y: imageY } = screenToImage(
         e.clientX,
         e.clientY,
         imgRect,
         photo.width!,
         photo.height!,
       );
+
+      // Clamp to image bounds (defense against letterbox/pillarbox clicks)
+      imageX = clamp(imageX, 0, photo.width!);
+      imageY = clamp(imageY, 0, photo.height!);
 
       const ctx: PointerContext = {
         imageX,
@@ -455,13 +506,17 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       if (!svgRef.current || !imgRef.current) return;
 
       const imgRect = imgRef.current.getBoundingClientRect();
-      const { x: imageX, y: imageY } = screenToImage(
+      let { x: imageX, y: imageY } = screenToImage(
         e.clientX,
         e.clientY,
         imgRect,
         photo.width!,
         photo.height!,
       );
+
+      // Clamp to image bounds (defense against letterbox/pillarbox movement)
+      imageX = clamp(imageX, 0, photo.width!);
+      imageY = clamp(imageY, 0, photo.height!);
 
       const ctx: PointerContext = {
         imageX,
@@ -500,13 +555,17 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       if (!svgRef.current || !imgRef.current) return;
 
       const imgRect = imgRef.current.getBoundingClientRect();
-      const { x: imageX, y: imageY } = screenToImage(
+      let { x: imageX, y: imageY } = screenToImage(
         e.clientX,
         e.clientY,
         imgRect,
         photo.width!,
         photo.height!,
       );
+
+      // Clamp to image bounds (defense against letterbox/pillarbox release)
+      imageX = clamp(imageX, 0, photo.width!);
+      imageY = clamp(imageY, 0, photo.height!);
 
       const ctx: PointerContext = {
         imageX,
@@ -711,6 +770,14 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           preserveAspectRatio="xMinYMin meet"
+          style={{
+            position: 'absolute',
+            top: `${svgPosition.top}px`,
+            left: `${svgPosition.left}px`,
+            width: `${svgPosition.width}px`,
+            height: `${svgPosition.height}px`,
+            touchAction: 'none',
+          }}
         >
           {/* SVG arrowhead marker */}
           <defs>

--- a/client/src/test/setupTests.ts
+++ b/client/src/test/setupTests.ts
@@ -40,3 +40,17 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     }),
   });
 }
+
+// Polyfill ResizeObserver for jsdom (not implemented in jsdom by default).
+// PhotoAnnotator uses ResizeObserver to track image layout changes.
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(window, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverPolyfill,
+  });
+}


### PR DESCRIPTION
## Summary

The previous coordinate fix (#1492) made `screenToImage` use the image's bounding rect, but the SVG overlay still spanned the full canvas container with `inset: 0`. When the browser window aspect didn't match the photo aspect, clicks in the letterbox/pillarbox padding still reached the annotator and produced image-space coordinates **outside** `[0, width] × [0, height]`. Shapes appeared to be drawn far away from the cursor.

This PR:

- Repositions the `<svg>` overlay so it covers exactly the rendered image. A `ResizeObserver` on `imgRef.current` tracks layout changes and updates the inline `top` / `left` / `width` / `height` style. The SVG no longer captures pointer events in the padding around the photo.
- Clamps the result of every `screenToImage` call to the image's pixel range, as a safety net for edge-case rounding or stale-rect races.

Manual reproduction (from user report): "If I align the browser size with the picture, the mapping is correct. However the drawing happens 'out of bounds' relative to the window origin and not relative to the picture origin." — both halves of that complaint should be resolved now.

## Test plan

- [x] All 730 PhotoAnnotator unit tests pass
- [x] Typecheck green
- [ ] Manual: open a photo whose aspect doesn't match the browser viewport, draw in different corners — every shape lands where the cursor was