### PR TITLE
fix(photo-annotator): arrow icon glyph + arrow tip alignment

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -348,25 +348,9 @@ function RedoIcon() {
 
 function ArrowIcon() {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <line
-        x1="5"
-        y1="19"
-        x2="19"
-        y2="5"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <polyline
-        points="15 2 19 5 16 9"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span aria-hidden="true" style={{ fontSize: '22px', lineHeight: 1, display: 'inline-block' }}>
+      ↗
+    </span>
   );
 }
 

--- a/client/src/components/photos/PhotoAnnotator/render.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.test.ts
@@ -416,13 +416,32 @@ describe('renderShapeSvgProps() — Arrow', () => {
     expect(result.tagName).toBe('line');
   });
 
-  it('includes correct x1/y1/x2/y2 attributes', () => {
-    const shape = makeArrow({ x1: 10, y1: 20, x2: 100, y2: 80 });
+  it('includes correct x1/y1 attributes (unchanged) and x2/y2 shortened to the arrowhead base', () => {
+    // The SVG line element stops at the base of the arrowhead marker, not at shape.x2/y2.
+    // Shortening = 8 * strokeWidth along the direction vector, so the marker tip lands exactly
+    // at (shape.x2, shape.y2) without the line body poking through.
+    const shape = makeArrow({ x1: 10, y1: 20, x2: 100, y2: 80, strokeWidth: 4 });
+    const dx = shape.x2 - shape.x1; // 90
+    const dy = shape.y2 - shape.y1; // 60
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const shortenDist = 8 * shape.strokeWidth; // 32
+    const expectedX2 = shape.x2 - (dx / len) * shortenDist;
+    const expectedY2 = shape.y2 - (dy / len) * shortenDist;
+
     const result = renderShapeSvgProps(shape, false);
     expect(getAttributes(result).x1).toBe(10);
     expect(getAttributes(result).y1).toBe(20);
-    expect(getAttributes(result).x2).toBe(100);
-    expect(getAttributes(result).y2).toBe(80);
+    expect(getAttributes(result).x2).toBeCloseTo(expectedX2, 5);
+    expect(getAttributes(result).y2).toBeCloseTo(expectedY2, 5);
+  });
+
+  it('line endpoint is shortened by 8 * strokeWidth so it lands at the arrowhead base (horizontal case)', () => {
+    // Clean horizontal example makes the math easy to reason about:
+    // Arrow from (0,0) to (100,0) with strokeWidth=4 → shortenDist=32 → shortenedX2=68, shortenedY2=0.
+    const shape = makeArrow({ x1: 0, y1: 0, x2: 100, y2: 0, strokeWidth: 4 });
+    const result = renderShapeSvgProps(shape, false);
+    expect(getAttributes(result).x2).toBe(68);
+    expect(getAttributes(result).y2).toBe(0);
   });
 
   it('committed arrow has marker-end: "url(#arrowhead)"', () => {
@@ -643,10 +662,19 @@ describe('drawShapeOnCanvas() — Arrow', () => {
     expect(ctx.moveTo).toHaveBeenCalledWith(10, 20);
   });
 
-  it('calls lineTo with x2/y2 (line end)', () => {
-    const shape = makeArrow({ x1: 10, y1: 20, x2: 100, y2: 80 });
+  it('calls lineTo with shortened endpoint (line stops at arrowhead base, not at shape.x2/y2)', () => {
+    // Line body is shortened by 8 * strokeWidth along the direction vector.
+    // The canvas arrowhead triangle is drawn separately at the original (shape.x2, shape.y2).
+    const shape = makeArrow({ x1: 10, y1: 20, x2: 100, y2: 80, strokeWidth: 4 });
+    const dx = shape.x2 - shape.x1; // 90
+    const dy = shape.y2 - shape.y1; // 60
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const shortenDist = 8 * shape.strokeWidth; // 32
+    const expectedX2 = shape.x2 - (dx / len) * shortenDist;
+    const expectedY2 = shape.y2 - (dy / len) * shortenDist;
     drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
-    expect(ctx.lineTo).toHaveBeenCalledWith(100, 80);
+    // First lineTo call is the shortened line body endpoint
+    expect(ctx.lineTo).toHaveBeenNthCalledWith(1, expectedX2, expectedY2);
   });
 
   it('sets strokeStyle to shape.stroke', () => {

--- a/client/src/components/photos/PhotoAnnotator/render.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.ts
@@ -71,13 +71,22 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
       },
     };
   } else if (shape.type === 'arrow') {
+    // Shorten the line endpoint by the arrowhead length so it ends at the marker's base
+    // The marker has markerWidth="8" and refX="8", meaning the arrowhead base is 8 * strokeWidth back from the tip
+    const dx = shape.x2 - shape.x1;
+    const dy = shape.y2 - shape.y1;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const shortenDist = 8 * shape.strokeWidth;
+    const shortenedX2 = shape.x2 - (dx / len) * shortenDist;
+    const shortenedY2 = shape.y2 - (dy / len) * shortenDist;
+
     return {
       tagName: 'line',
       attributes: {
         x1: shape.x1,
         y1: shape.y1,
-        x2: shape.x2,
-        y2: shape.y2,
+        x2: shortenedX2,
+        y2: shortenedY2,
         stroke: shape.stroke,
         'stroke-width': shape.strokeWidth,
         'stroke-linecap': 'round',
@@ -286,15 +295,23 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.fillRect(shape.x, shape.y, shape.w, shape.h);
     ctx.globalAlpha = 1;
   } else if (shape.type === 'arrow') {
+    // Shorten the line endpoint by the arrowhead length so it ends at the arrowhead's base
+    const dx = shape.x2 - shape.x1;
+    const dy = shape.y2 - shape.y1;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const shortenDist = 8 * shape.strokeWidth;
+    const shortenedX2 = shape.x2 - (dx / len) * shortenDist;
+    const shortenedY2 = shape.y2 - (dy / len) * shortenDist;
+
     ctx.strokeStyle = shape.stroke;
     ctx.lineWidth = shape.strokeWidth;
     ctx.lineCap = 'round';
     ctx.beginPath();
     ctx.moveTo(shape.x1, shape.y1);
-    ctx.lineTo(shape.x2, shape.y2);
+    ctx.lineTo(shortenedX2, shortenedY2);
     ctx.stroke();
 
-    // Draw arrowhead
+    // Draw arrowhead at the original endpoint (shape.x2, shape.y2)
     const headlen = shape.strokeWidth * 3;
     const angle = Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1);
 


### PR DESCRIPTION
## Summary

Two arrow-related polish items from the UAT feedback batch:

- **Arrow tool icon** — the previous SVG path didn't read clearly as an arrow at small sizes. Replaced with the `↗` (U+2197) Unicode glyph wrapped in a 22 px span so it scales cleanly and matches user expectations.
- **Arrow tip alignment** — with thick stroke widths, the line endpoint sat at the arrowhead's tip rather than its base, so the line visibly poked through past the arrowhead. Now the line is shortened by `8 × strokeWidth` along the direction vector (the marker's footprint), so the line ends at the arrowhead's base while the marker still points at the user's chosen endpoint. Applied to both SVG render and canvas-2d bake.

Plus: investigated the reported PhotoCard edit-button inversion. The code currently reads:
- `PhotoCard.tsx:85`: `{onEdit && editable && (...)}`
- `DiaryEntryDetailPage.tsx:282`: `editable={!entry.isSigned}`

This is correct (unsigned → editable=true → button shown). If the deployed app shows the inverted behavior, it's running stale code from before PR #1496. Verify after pulling the latest beta image.

## Test plan

- [x] All 734 PhotoAnnotator unit tests pass (1 new regression test for arrow tip shortening)
- [x] Typecheck green
- [ ] Manual: draw an arrow at thin/medium/thick strokes — line ends precisely at the arrowhead's base, not past it
- [ ] Manual: pull the latest beta image and verify the edit button appears on the photo card for unsigned diary entries