### PR TITLE
fix(photo-annotator): selection visibility, reduced default sizes, scaling callout strokes

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -889,13 +889,27 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
             <>
               {(selectedShape.type === 'rectangle' || selectedShape.type === 'highlight') && (
                 <>
+                  {/* Outer dark stroke for visibility on any background */}
+                  <rect
+                    x={selectedShape.x}
+                    y={selectedShape.y}
+                    width={selectedShape.w}
+                    height={selectedShape.h}
+                    stroke="#000000"
+                    strokeWidth="3"
+                    strokeDasharray="4 2"
+                    fill="none"
+                    pointerEvents="none"
+                    opacity="0.4"
+                  />
+                  {/* Inner bright dashed stroke (primary color) */}
                   <rect
                     x={selectedShape.x}
                     y={selectedShape.y}
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="var(--color-primary)"
-                    strokeWidth="1"
+                    strokeWidth="1.5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -938,13 +952,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     return (
                       <rect
                         key={pos}
-                        x={cx - 4}
-                        y={cy - 4}
-                        width={8}
-                        height={8}
+                        x={cx - 5}
+                        y={cy - 5}
+                        width={10}
+                        height={10}
                         fill="var(--color-bg-primary)"
                         stroke="var(--color-primary)"
-                        strokeWidth="1.5"
+                        strokeWidth="2"
                         style={{ cursor: cursors[pos] }}
                       />
                     );
@@ -954,15 +968,30 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
               {(selectedShape.type === 'arrow' || selectedShape.type === 'line') && (
                 <>
+                  {/* Outer dark stroke for visibility */}
+                  <line
+                    x1={selectedShape.x1}
+                    y1={selectedShape.y1}
+                    x2={selectedShape.x2}
+                    y2={selectedShape.y2}
+                    stroke="#000000"
+                    strokeWidth="3"
+                    strokeDasharray="4 2"
+                    pointerEvents="none"
+                    opacity="0.4"
+                    strokeLinecap="round"
+                  />
+                  {/* Inner bright dashed stroke */}
                   <line
                     x1={selectedShape.x1}
                     y1={selectedShape.y1}
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="var(--color-primary)"
-                    strokeWidth="1"
+                    strokeWidth="1.5"
                     strokeDasharray="4 2"
                     pointerEvents="none"
+                    strokeLinecap="round"
                   />
                   {/* Start and end handles */}
                   {[
@@ -971,13 +1000,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   ].map(({ pos, x, y }) => (
                     <rect
                       key={pos}
-                      x={x - 4}
-                      y={y - 4}
-                      width={8}
-                      height={8}
+                      x={x - 5}
+                      y={y - 5}
+                      width={10}
+                      height={10}
                       fill="var(--color-bg-primary)"
                       stroke="var(--color-primary)"
-                      strokeWidth="1.5"
+                      strokeWidth="2"
                       style={{ cursor: 'move' }}
                     />
                   ))}
@@ -986,13 +1015,27 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
               {selectedShape.type === 'ellipse' && (
                 <>
+                  {/* Outer dark stroke for visibility */}
+                  <ellipse
+                    cx={selectedShape.cx}
+                    cy={selectedShape.cy}
+                    rx={selectedShape.rx}
+                    ry={selectedShape.ry}
+                    stroke="#000000"
+                    strokeWidth="3"
+                    strokeDasharray="4 2"
+                    fill="none"
+                    pointerEvents="none"
+                    opacity="0.4"
+                  />
+                  {/* Inner bright dashed stroke */}
                   <ellipse
                     cx={selectedShape.cx}
                     cy={selectedShape.cy}
                     rx={selectedShape.rx}
                     ry={selectedShape.ry}
                     stroke="var(--color-primary)"
-                    strokeWidth="1"
+                    strokeWidth="1.5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -1006,13 +1049,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   ].map(({ pos, x, y }) => (
                     <rect
                       key={pos}
-                      x={x - 4}
-                      y={y - 4}
-                      width={8}
-                      height={8}
+                      x={x - 5}
+                      y={y - 5}
+                      width={10}
+                      height={10}
                       fill="var(--color-bg-primary)"
                       stroke="var(--color-primary)"
-                      strokeWidth="1.5"
+                      strokeWidth="2"
                       style={{
                         cursor: pos === 'north' || pos === 'south' ? 'ns-resize' : 'ew-resize',
                       }}
@@ -1027,13 +1070,27 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   if (!bbox) return null;
                   return (
                     <>
+                      {/* Outer dark stroke for visibility */}
+                      <rect
+                        x={bbox.x}
+                        y={bbox.y}
+                        width={bbox.width}
+                        height={bbox.height}
+                        stroke="#000000"
+                        strokeWidth="3"
+                        strokeDasharray="4 2"
+                        fill="none"
+                        pointerEvents="none"
+                        opacity="0.4"
+                      />
+                      {/* Inner bright dashed stroke */}
                       <rect
                         x={bbox.x}
                         y={bbox.y}
                         width={bbox.width}
                         height={bbox.height}
                         stroke="var(--color-primary)"
-                        strokeWidth="1"
+                        strokeWidth="1.5"
                         strokeDasharray="4 2"
                         fill="none"
                         pointerEvents="none"
@@ -1047,13 +1104,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                       ].map(({ pos, x, y }) => (
                         <rect
                           key={pos}
-                          x={x - 4}
-                          y={y - 4}
-                          width={8}
-                          height={8}
+                          x={x - 5}
+                          y={y - 5}
+                          width={10}
+                          height={10}
                           fill="var(--color-bg-primary)"
                           stroke="var(--color-primary)"
-                          strokeWidth="1.5"
+                          strokeWidth="2"
                           style={{ cursor: 'move' }}
                         />
                       ))}
@@ -1063,13 +1120,27 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
               {selectedShape.type === 'callout' && (
                 <>
+                  {/* Outer dark stroke for visibility */}
+                  <rect
+                    x={selectedShape.x}
+                    y={selectedShape.y}
+                    width={selectedShape.w}
+                    height={selectedShape.h}
+                    stroke="#000000"
+                    strokeWidth="3"
+                    strokeDasharray="4 2"
+                    fill="none"
+                    pointerEvents="none"
+                    opacity="0.4"
+                  />
+                  {/* Inner bright dashed stroke */}
                   <rect
                     x={selectedShape.x}
                     y={selectedShape.y}
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="var(--color-primary)"
-                    strokeWidth="1"
+                    strokeWidth="1.5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -1112,13 +1183,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     return (
                       <rect
                         key={pos}
-                        x={cx - 4}
-                        y={cy - 4}
-                        width={8}
-                        height={8}
+                        x={cx - 5}
+                        y={cy - 5}
+                        width={10}
+                        height={10}
                         fill="var(--color-bg-primary)"
                         stroke="var(--color-primary)"
-                        strokeWidth="1.5"
+                        strokeWidth="2"
                         style={{ cursor: cursors[pos] }}
                       />
                     );
@@ -1127,10 +1198,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   <circle
                     cx={selectedShape.tailX}
                     cy={selectedShape.tailY}
-                    r={5}
+                    r={6}
                     fill="var(--color-primary)"
                     stroke="var(--color-bg-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="2"
                     style={{ cursor: 'move' }}
                   />
                 </>
@@ -1138,15 +1209,30 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
               {selectedShape.type === 'measurement' && (
                 <>
+                  {/* Outer dark stroke for visibility */}
+                  <line
+                    x1={selectedShape.x1}
+                    y1={selectedShape.y1}
+                    x2={selectedShape.x2}
+                    y2={selectedShape.y2}
+                    stroke="#000000"
+                    strokeWidth="3"
+                    strokeDasharray="4 2"
+                    pointerEvents="none"
+                    opacity="0.4"
+                    strokeLinecap="round"
+                  />
+                  {/* Inner bright dashed stroke */}
                   <line
                     x1={selectedShape.x1}
                     y1={selectedShape.y1}
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="var(--color-primary)"
-                    strokeWidth="1"
+                    strokeWidth="1.5"
                     strokeDasharray="4 2"
                     pointerEvents="none"
+                    strokeLinecap="round"
                   />
                   {/* Endpoint handles (start and end) — same as arrow/line */}
                   {[
@@ -1155,13 +1241,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   ].map(({ pos, x, y }) => (
                     <rect
                       key={pos}
-                      x={x - 4}
-                      y={y - 4}
-                      width={8}
-                      height={8}
+                      x={x - 5}
+                      y={y - 5}
+                      width={10}
+                      height={10}
                       fill="var(--color-bg-primary)"
                       stroke="var(--color-primary)"
-                      strokeWidth="1.5"
+                      strokeWidth="2"
                       style={{ cursor: 'move' }}
                     />
                   ))}
@@ -1179,17 +1265,33 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   const maxX = Math.max(...xs);
                   const maxY = Math.max(...ys);
                   return (
-                    <rect
-                      x={minX - 4}
-                      y={minY - 4}
-                      width={maxX - minX + 8}
-                      height={maxY - minY + 8}
-                      stroke="var(--color-primary)"
-                      strokeWidth="1"
-                      strokeDasharray="4 2"
-                      fill="none"
-                      pointerEvents="none"
-                    />
+                    <>
+                      {/* Outer dark stroke for visibility */}
+                      <rect
+                        x={minX - 4}
+                        y={minY - 4}
+                        width={maxX - minX + 8}
+                        height={maxY - minY + 8}
+                        stroke="#000000"
+                        strokeWidth="3"
+                        strokeDasharray="4 2"
+                        fill="none"
+                        pointerEvents="none"
+                        opacity="0.4"
+                      />
+                      {/* Inner bright dashed stroke */}
+                      <rect
+                        x={minX - 4}
+                        y={minY - 4}
+                        width={maxX - minX + 8}
+                        height={maxY - minY + 8}
+                        stroke="var(--color-primary)"
+                        strokeWidth="1.5"
+                        strokeDasharray="4 2"
+                        fill="none"
+                        pointerEvents="none"
+                      />
+                    </>
                   );
                 })()}
             </>

--- a/client/src/components/photos/PhotoAnnotator/annotationConstants.ts
+++ b/client/src/components/photos/PhotoAnnotator/annotationConstants.ts
@@ -16,10 +16,10 @@ export type AnnotationColor = (typeof ANNOTATION_COLORS)[keyof typeof ANNOTATION
  * These scale stroke widths to match the image resolution.
  */
 export const ANNOTATION_STROKE_WIDTH_RATIOS = {
-  thin: 0.008,
-  medium: 0.014,
-  thick: 0.024,
-  'extra-thick': 0.04,
+  thin: 0.005,
+  medium: 0.009,
+  thick: 0.015,
+  'extra-thick': 0.025,
 } as const;
 
 export type StrokeWidthKey = keyof typeof ANNOTATION_STROKE_WIDTH_RATIOS;
@@ -29,11 +29,11 @@ export type StrokeWidthKey = keyof typeof ANNOTATION_STROKE_WIDTH_RATIOS;
  * These scale font sizes to match the image resolution.
  */
 export const ANNOTATION_FONT_SIZE_RATIOS = {
-  small: 0.024,
-  medium: 0.04,
-  large: 0.056,
-  xlarge: 0.08,
-  xxlarge: 0.12,
+  small: 0.018,
+  medium: 0.028,
+  large: 0.04,
+  xlarge: 0.056,
+  xxlarge: 0.08,
 } as const;
 
 export type FontSizeKey = keyof typeof ANNOTATION_FONT_SIZE_RATIOS;

--- a/client/src/components/photos/PhotoAnnotator/render.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.ts
@@ -1,5 +1,6 @@
 import type { AnnotationShape, TextShape, CalloutShape } from './useUndoStack.js';
 import { nearestBoxEdgePoint } from './geometry.js';
+import { resolveStrokeWidth } from './annotationConstants.js';
 
 /** Canonical UI sans-serif font family for all text annotations.
  *  Must be kept in sync between SVG rendering and canvas 2D rendering. */
@@ -151,6 +152,8 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
       calloutShape.tailX,
       calloutShape.tailY,
     );
+    // Use strokeWidth from shape if available, otherwise default to 2 for backward compat
+    const strokeWidth = calloutShape.strokeWidth ?? 2;
     return {
       tagName: 'callout',
       boxAttrs: {
@@ -159,7 +162,7 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
         width: calloutShape.w,
         height: calloutShape.h,
         stroke: calloutShape.stroke,
-        'stroke-width': 2,
+        'stroke-width': strokeWidth,
         'stroke-dasharray': isDraft ? '6 4' : 'none',
         fill: calloutShape.fill,
         'fill-opacity': 0.15,
@@ -172,7 +175,7 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
         x2: calloutShape.tailX,
         y2: calloutShape.tailY,
         stroke: calloutShape.stroke,
-        'stroke-width': 2,
+        'stroke-width': strokeWidth,
         'stroke-linecap': 'round',
         opacity: isDraft ? 0.8 : 1,
         'pointer-events': 'none',
@@ -349,9 +352,11 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.fillText(textShape.text, textShape.x, textShape.y + textShape.fontSize); // baseline offset
   } else if (shape.type === 'callout') {
     const calloutShape = shape as CalloutShape;
+    // Use strokeWidth from shape if available, otherwise default to 2 for backward compat
+    const strokeWidth = calloutShape.strokeWidth ?? 2;
     // 1. Box
     ctx.strokeStyle = calloutShape.stroke;
-    ctx.lineWidth = 2;
+    ctx.lineWidth = strokeWidth;
     ctx.fillStyle = calloutShape.fill;
     ctx.globalAlpha = 0.15;
     ctx.fillRect(calloutShape.x, calloutShape.y, calloutShape.w, calloutShape.h);
@@ -367,6 +372,7 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.beginPath();
     ctx.moveTo(ax, ay);
     ctx.lineTo(calloutShape.tailX, calloutShape.tailY);
+    ctx.lineWidth = strokeWidth;
     ctx.lineCap = 'round';
     ctx.stroke();
 

--- a/client/src/components/photos/PhotoAnnotator/tools/CalloutTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/CalloutTool.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 import type { AnnotatorState, AnnotatorAction } from '../useAnnotator.js';
 import type { CalloutShape } from '../useUndoStack.js';
 import { normalizeRect, clamp } from '../geometry.js';
-import { resolveFontSize } from '../annotationConstants.js';
+import { resolveFontSize, resolveStrokeWidth } from '../annotationConstants.js';
 import type { PointerContext, ToolHandler } from './SelectTool.js';
 
 type CalloutPhase = 'box' | 'tail' | null;
@@ -22,6 +22,7 @@ export const CalloutTool: ToolHandler = {
       pendingId = nanoid();
 
       const fontSize = resolveFontSize(state.activeFontSizeKey, imageWidth, imageHeight);
+      const strokeWidth = resolveStrokeWidth(state.activeStrokeWidthKey, imageWidth, imageHeight);
 
       const draft: CalloutShape = {
         type: 'callout',
@@ -37,6 +38,7 @@ export const CalloutTool: ToolHandler = {
         fill: state.activeColor,
         fontSize,
         color: state.activeColor,
+        strokeWidth,
       };
       return [{ type: 'SET_DRAFT', shape: draft }];
     }

--- a/client/src/components/photos/PhotoAnnotator/useUndoStack.ts
+++ b/client/src/components/photos/PhotoAnnotator/useUndoStack.ts
@@ -78,6 +78,7 @@ export interface CalloutShape {
   fill: string; // semi-transparent fill for the box
   fontSize: number;
   color: string; // text color
+  strokeWidth?: number; // image-space pixels for box/tail stroke (backward compat: defaults to 2 if missing)
 }
 
 export interface MeasurementShape {


### PR DESCRIPTION
## Summary

Three visual polish items from the UAT feedback batch:

- **Selection indicator** — was a thin dashed outline that disappeared against busy photo backgrounds. Now uses a double-stroke pattern (3 px black outer at 40 % opacity, then the existing primary-color dashed inner on top) so the boundary is visible on any photo. Selection handles are larger (10×10) with a thicker stroke for the same reason.
- **Reduced default sizes** — the ratios from #1495 were too aggressive. Cut all stroke ratios by ~37 % and all font-size ratios by ~30 %, keeping the relative spacing between tiers.
- **Callout strokes scale with image** — the callout box and tail had a hardcoded 2 px stroke that didn't scale. `CalloutShape` now carries an optional `strokeWidth` resolved from the active stroke key at commit time (same pattern as the other geometric shapes). Older committed callouts without `strokeWidth` fall back to 2 px so saved annotations keep rendering.

## Test plan

- [x] All 731 PhotoAnnotator unit tests pass
- [x] Typecheck green
- [ ] Manual: draw a shape, select it on a busy photo — boundary should be clearly visible
- [ ] Manual: medium stroke and medium font on both a hi-res and a lo-res photo should feel proportionate, no longer dominating the image