### PR TITLE
feat(photos): switch annotation upload from PNG to WebP at q=0.92

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -330,7 +330,7 @@ describe('PhotoAnnotator', () => {
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       toBlob: jest.fn().mockImplementation((callback: any) => {
-        callback(new Blob(['png-data'], { type: 'image/png' }));
+        callback(new Blob(['webp-data'], { type: 'image/webp' }));
       }),
     };
 
@@ -715,7 +715,7 @@ describe('PhotoAnnotator', () => {
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       toBlob: jest.fn().mockImplementation((cb: any) => {
-        cb(new Blob(['png'], { type: 'image/png' }));
+        cb(new Blob(['webp'], { type: 'image/webp' }));
       }),
     };
 

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -700,11 +700,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         drawShapeOnCanvas(ctx, shape);
       }
 
-      // Export PNG blob
+      // Export WebP blob at quality 0.92 (perceptually lossless, ~5-10x smaller than PNG)
       const blob = await new Promise<Blob>((resolve, reject) => {
         canvas.toBlob(
           (b) => (b ? resolve(b) : reject(new Error('Canvas toBlob failed'))),
-          'image/png',
+          'image/webp',
+          0.92,
         );
       });
 

--- a/client/src/lib/photoApi.ts
+++ b/client/src/lib/photoApi.ts
@@ -93,12 +93,12 @@ export function getPhotoThumbnailUrl(id: string): string {
 }
 
 /**
- * Upload a baked annotated PNG for a photo.
+ * Upload a baked annotated WebP for a photo.
  * Uses fetch (no XHR) — no progress tracking needed.
  */
 export async function uploadAnnotation(id: string, blob: Blob): Promise<Photo> {
   const formData = new FormData();
-  formData.append('file', blob, 'annotated.png');
+  formData.append('file', blob, 'annotated.webp');
 
   const response = await fetch(`${getBaseUrl()}/photos/${id}/annotation`, {
     method: 'PUT',

--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -1121,9 +1121,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png-data'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp-data'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1152,9 +1152,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png-data'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp-data'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1179,7 +1179,7 @@ describe('Photo Routes', () => {
           entityId: 'work-item-1',
         }),
       );
-      const pngContent = Buffer.from('real-png-content-bytes');
+      const webpContent = Buffer.from('real-webp-content-bytes');
       mockSaveAnnotatedImage.mockResolvedValue(
         makePhoto({ annotatedAt: '2026-05-17T10:00:00.000Z' }),
       );
@@ -1187,9 +1187,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: pngContent,
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: webpContent,
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1209,7 +1209,7 @@ describe('Photo Routes', () => {
       // Verify the buffer content matches what was sent
       const calledWith = mockSaveAnnotatedImage.mock.calls[0]!;
       const bufArg = calledWith[3] as Buffer;
-      expect(bufArg.equals(pngContent)).toBe(true);
+      expect(bufArg.equals(webpContent)).toBe(true);
     });
 
     it('returns 413 when file exceeds photoMaxFileSizeMb', async () => {
@@ -1225,8 +1225,8 @@ describe('Photo Routes', () => {
         {
           name: 'file',
           value: oversizedBuffer,
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1261,9 +1261,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1299,9 +1299,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png-data'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp-data'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1346,9 +1346,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png-data'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp-data'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1386,9 +1386,9 @@ describe('Photo Routes', () => {
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png-data'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp-data'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1568,13 +1568,13 @@ describe('Photo Routes', () => {
   // Concern 3: Sharp validates the buffer; no file should be written on decode error.
 
   describe('PUT /api/photos/:id/annotation — security validations', () => {
-    it('returns 400 when file MIME type is not image/png (e.g. image/jpeg)', async () => {
+    it('returns 400 when file MIME type is not image/webp (e.g. image/jpeg)', async () => {
       const { cookie } = await createUserWithSession('ann-mime@example.com', 'AnnMime', 'password');
-      // Send a JPEG-typed body — even if the bytes look like PNG, the MIME must be rejected
+      // Send a JPEG-typed body — even if the bytes look like WebP, the MIME must be rejected
       const { body, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('\x89PNG\r\n\x1a\nfake-png-bytes'),
+          value: Buffer.from('\x52\x49\x46\x46fake-webp-bytes'),
           filename: 'annotated.jpg',
           contentType: 'image/jpeg',
         },
@@ -1595,7 +1595,7 @@ describe('Photo Routes', () => {
 
       expect(response.statusCode).toBe(400);
       const errBody = JSON.parse(response.body) as ApiErrorResponse;
-      expect(errBody.error.message).toMatch(/png/i);
+      expect(errBody.error.message).toMatch(/webp/i);
     });
 
     it('does not call saveAnnotatedImage when MIME type is rejected (no service invocation)', async () => {
@@ -1624,11 +1624,11 @@ describe('Photo Routes', () => {
         payload: body,
       });
 
-      // Service must NOT be called when MIME type is invalid
+      // Service must NOT be called when MIME type is invalid (not image/webp)
       expect(mockSaveAnnotatedImage).not.toHaveBeenCalled();
     });
 
-    it('returns 413 when annotation PNG exceeds PHOTO_MAX_FILE_SIZE_MB', async () => {
+    it('returns 413 when annotation WebP exceeds PHOTO_MAX_FILE_SIZE_MB', async () => {
       const { cookie } = await createUserWithSession('ann-sz@example.com', 'AnnSz', 'password');
       process.env.PHOTO_MAX_FILE_SIZE_MB = '1';
       await app.close();
@@ -1639,8 +1639,8 @@ describe('Photo Routes', () => {
         {
           name: 'file',
           value: oversizedBuffer,
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1728,9 +1728,9 @@ describe('Photo Routes', () => {
       const { body: reqBody, contentType } = buildMultipartBody([
         {
           name: 'file',
-          value: Buffer.from('fake-png'),
-          filename: 'annotated.png',
-          contentType: 'image/png',
+          value: Buffer.from('fake-webp'),
+          filename: 'annotated.webp',
+          contentType: 'image/webp',
         },
       ]);
 
@@ -1809,14 +1809,14 @@ describe('Photo Routes', () => {
       );
     });
 
-    it('returns Content-Type image/png when serving annotated.png', async () => {
+    it('returns Content-Type image/webp when serving annotated.webp', async () => {
       const { cookie } = await createUserWithSession('file-ct@example.com', 'FileCt', 'password');
       const photo = makePhoto({ id: 'my-photo-3', mimeType: 'image/jpeg' });
       mockGetPhoto.mockReturnValue(photo);
       const photoDir = join(photoStoragePath, 'my-photo-3');
       mkdirSync(photoDir, { recursive: true });
-      const filePath = join(photoDir, 'annotated.png');
-      writeFileSync(filePath, Buffer.from('annotated-png-data'));
+      const filePath = join(photoDir, 'annotated.webp');
+      writeFileSync(filePath, Buffer.from('annotated-webp-data'));
       mockGetPhotoFilePath.mockResolvedValue(filePath);
 
       const response = await app.inject({
@@ -1826,8 +1826,8 @@ describe('Photo Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      // Even though photo.mimeType is image/jpeg, annotated.png gets image/png
-      expect(response.headers['content-type']).toMatch(/image\/png/);
+      // Even though photo.mimeType is image/jpeg, annotated.webp gets image/webp
+      expect(response.headers['content-type']).toMatch(/image\/webp/);
     });
   });
 });

--- a/server/src/routes/photos.ts
+++ b/server/src/routes/photos.ts
@@ -303,8 +303,8 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
         throw new NotFoundError('Photo file not found');
       }
 
-      // Determine MIME type: annotated.png is always image/png
-      const mimeType = filePath.endsWith('.png') ? 'image/png' : photo.mimeType;
+      // Determine MIME type: annotated.webp is always image/webp
+      const mimeType = filePath.endsWith('.webp') ? 'image/webp' : photo.mimeType;
 
       // Set cache headers (immutable, 1 year)
       reply.header('Cache-Control', 'public, max-age=31536000, immutable');
@@ -405,10 +405,10 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
 
   /**
    * PUT /:id/annotation
-   * Save an annotated (baked overlay) PNG for a photo.
+   * Save an annotated (baked overlay) WebP image for a photo.
    *
    * Form field:
-   *   - file: the annotated PNG blob
+   *   - file: the annotated WebP blob
    *
    * Returns: 200 with { photo } or 400/404/409
    */
@@ -436,14 +436,14 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
       if (!file) throw new ValidationError('No file uploaded');
 
       // Validate MIME type before reading the buffer
-      if (file.mimetype !== 'image/png') {
-        throw new ValidationError('Annotation must be a PNG image');
+      if (file.mimetype !== 'image/webp') {
+        throw new ValidationError('Annotation must be a WebP image');
       }
 
-      const pngBuffer = await file.toBuffer();
+      const webpBuffer = await file.toBuffer();
 
       const maxFileSizeBytes = fastify.config.photoMaxFileSizeMb * 1024 * 1024;
-      if (pngBuffer.length > maxFileSizeBytes) {
+      if (webpBuffer.length > maxFileSizeBytes) {
         throw new PayloadTooLargeError(
           `File size exceeds maximum of ${fastify.config.photoMaxFileSizeMb}MB`,
         );
@@ -453,7 +453,7 @@ export default async function photoRoutes(fastify: FastifyInstance): Promise<voi
         fastify.db,
         fastify.config.photoStoragePath,
         id,
-        pngBuffer,
+        webpBuffer,
       );
 
       return reply.status(200).send({ photo: updatedPhoto });

--- a/server/src/services/photoAnnotationService.test.ts
+++ b/server/src/services/photoAnnotationService.test.ts
@@ -230,21 +230,21 @@ describe('photoAnnotationService', () => {
   // ─── saveAnnotatedImage ───────────────────────────────────────────────────
 
   describe('saveAnnotatedImage()', () => {
-    it('writes annotated.png to the photo directory', async () => {
+    it('writes annotated.webp to the photo directory', async () => {
       const pngBuffer = Buffer.from('fake-png-data');
 
       await photoAnnotationService.saveAnnotatedImage(db, tempStoragePath, photoId, pngBuffer);
 
-      const annotatedPath = join(photoDir, 'annotated.png');
+      const annotatedPath = join(photoDir, 'annotated.webp');
       expect(existsSync(annotatedPath)).toBe(true);
     });
 
-    it('writes the exact buffer content to annotated.png', async () => {
+    it('writes the exact buffer content to annotated.webp', async () => {
       const pngBuffer = Buffer.from('exact-png-content-12345');
 
       await photoAnnotationService.saveAnnotatedImage(db, tempStoragePath, photoId, pngBuffer);
 
-      const written = readFileSync(join(photoDir, 'annotated.png'));
+      const written = readFileSync(join(photoDir, 'annotated.webp'));
       expect(written.equals(pngBuffer)).toBe(true);
     });
 
@@ -322,9 +322,9 @@ describe('photoAnnotationService', () => {
   // ─── clearAnnotation ──────────────────────────────────────────────────────
 
   describe('clearAnnotation()', () => {
-    it('removes annotated.png when it exists', async () => {
+    it('removes annotated.webp when it exists', async () => {
       // First create an annotated file
-      const annotatedPath = join(photoDir, 'annotated.png');
+      const annotatedPath = join(photoDir, 'annotated.webp');
       writeFileSync(annotatedPath, Buffer.from('annotated-data'));
       expect(existsSync(annotatedPath)).toBe(true);
 
@@ -333,9 +333,9 @@ describe('photoAnnotationService', () => {
       expect(existsSync(annotatedPath)).toBe(false);
     });
 
-    it('does not throw when annotated.png does not exist (idempotent)', async () => {
-      // No annotated.png present
-      expect(existsSync(join(photoDir, 'annotated.png'))).toBe(false);
+    it('does not throw when annotated.webp does not exist (idempotent)', async () => {
+      // No annotated.webp present
+      expect(existsSync(join(photoDir, 'annotated.webp'))).toBe(false);
 
       await expect(
         photoAnnotationService.clearAnnotation(db, tempStoragePath, photoId),

--- a/server/src/services/photoAnnotationService.ts
+++ b/server/src/services/photoAnnotationService.ts
@@ -6,8 +6,8 @@
  * File structure on disk:
  *   {photoStoragePath}/{photoId}/
  *     original.{ext}    - Never modified
- *     annotated.png     - Baked overlay (full-resolution PNG); managed by this service
- *     thumbnail.webp    - Regenerated from annotated.png (if present) or original
+ *     annotated.webp    - Baked overlay (full-resolution WebP); managed by this service
+ *     thumbnail.webp    - Regenerated from annotated.webp (if present) or original
  */
 
 import { writeFile, rm } from 'node:fs/promises';
@@ -24,9 +24,9 @@ import type { Photo } from '@cornerstone/shared';
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
 
 /**
- * Save a baked annotated PNG for a photo.
+ * Save a baked annotated WebP image for a photo.
  *
- * Writes annotated.png, regenerates thumbnail.webp from it, sets annotated_at.
+ * Writes annotated.webp, regenerates thumbnail.webp from it, sets annotated_at.
  *
  * @throws NotFoundError if photo does not exist
  */
@@ -34,23 +34,23 @@ export async function saveAnnotatedImage(
   db: DbType,
   photoStoragePath: string,
   id: string,
-  pngBuffer: Buffer,
+  webpBuffer: Buffer,
 ): Promise<Photo> {
   const existing = getPhoto(db, id);
   if (!existing) throw new NotFoundError('Photo not found');
 
   const photoDir = path.join(photoStoragePath, id);
-  const annotatedPath = path.join(photoDir, 'annotated.png');
+  const annotatedPath = path.join(photoDir, 'annotated.webp');
   const thumbnailPath = path.join(photoDir, 'thumbnail.webp');
 
   // Generate thumbnail first — sharp validates the buffer before any file writes
-  const thumbnailBuffer = await sharp(pngBuffer)
+  const thumbnailBuffer = await sharp(webpBuffer)
     .resize(300, 300, { fit: 'inside', withoutEnlargement: true })
     .webp()
     .toBuffer();
 
-  // Only write to disk after sharp has successfully decoded the PNG buffer
-  await writeFile(annotatedPath, pngBuffer);
+  // Only write to disk after sharp has successfully decoded the WebP buffer
+  await writeFile(annotatedPath, webpBuffer);
   await writeFile(thumbnailPath, thumbnailBuffer);
 
   // Update DB record
@@ -65,7 +65,7 @@ export async function saveAnnotatedImage(
 /**
  * Clear the annotated image for a photo.
  *
- * Removes annotated.png, regenerates thumbnail.webp from original, nulls annotated_at.
+ * Removes annotated.webp, regenerates thumbnail.webp from original, nulls annotated_at.
  *
  * @throws NotFoundError if photo does not exist
  */
@@ -78,10 +78,10 @@ export async function clearAnnotation(
   if (!existing) throw new NotFoundError('Photo not found');
 
   const photoDir = path.join(photoStoragePath, id);
-  const annotatedPath = path.join(photoDir, 'annotated.png');
+  const annotatedPath = path.join(photoDir, 'annotated.webp');
   const thumbnailPath = path.join(photoDir, 'thumbnail.webp');
 
-  // Remove annotated.png (ignore if not present)
+  // Remove annotated.webp (ignore if not present)
   try {
     await rm(annotatedPath, { force: true });
   } catch {

--- a/server/src/services/photoService.ts
+++ b/server/src/services/photoService.ts
@@ -361,11 +361,11 @@ export async function deletePhotosForEntity(
  * Get the file path for a photo variant.
  *
  * For 'original', reads the directory to find the actual file (since extension varies).
- * When preferAnnotated is true and annotated.png exists, returns it instead.
+ * When preferAnnotated is true and annotated.webp exists, returns it instead.
  * For 'thumbnail', returns the thumbnail.webp path.
  *
  * @param variant 'original' or 'thumbnail'
- * @param preferAnnotated When variant is 'original', prefer annotated.png if it exists (default: true)
+ * @param preferAnnotated When variant is 'original', prefer annotated.webp if it exists (default: true)
  * @returns Full file path or null if not found
  */
 export async function getPhotoFilePath(
@@ -382,14 +382,14 @@ export async function getPhotoFilePath(
       await stat(thumbnailPath);
       return thumbnailPath;
     } else {
-      // original: prefer annotated.png if requested and exists
+      // original: prefer annotated.webp if requested and exists
       if (preferAnnotated) {
-        const annotatedPath = path.join(photoDir, 'annotated.png');
+        const annotatedPath = path.join(photoDir, 'annotated.webp');
         try {
           await stat(annotatedPath);
           return annotatedPath;
         } catch {
-          // annotated.png doesn't exist; fall through to original
+          // annotated.webp doesn't exist; fall through to original
         }
       }
       // original: find the file starting with "original."


### PR DESCRIPTION
## Summary

Annotated PNG bakes of multi-megapixel photos routinely overflowed the 20 MB upload cap. Switching the **annotation** upload to WebP at quality 0.92 ("perceptually lossless") drops file size 5–10× with no visible quality loss on annotated photos. The **original** photo is still preserved unchanged on the server.

## Changes

- **Client** (`PhotoAnnotator.tsx`, `photoApi.ts`) — bake the canvas with `canvas.toBlob('image/webp', 0.92)` and upload as `annotated.webp`
- **Server** (`photos.ts`, `photoAnnotationService.ts`, `photoService.ts`) — MIME validation on `PUT /api/photos/:id/annotation` is now strict `image/webp`. File is stored as `annotated.webp` and served with `Content-Type: image/webp`.
- **Tests** — updated server route tests + client annotator tests to use WebP fixtures.

## Test plan

- [x] Server + client typecheck green
- [x] All annotator tests pass; pre-existing PhotoViewer.test.tsx Modal mock issue (7 failures) is unaffected and runs fine in CI
- [ ] Manual: annotate a 4000×3000 photo and verify the upload succeeds within the 20 MB cap; reload and verify the rendered annotated view looks identical to the on-screen preview