### PR TITLE
fix(photo-annotator): real fixes for arrow tip, icon, selection, edit-page button

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -780,17 +780,17 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
             touchAction: 'none',
           }}
         >
-          {/* SVG arrowhead marker */}
-          <defs>
-            <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-              <polygon points="0 0, 8 3, 0 6" fill="context-stroke" />
-            </marker>
-          </defs>
-
           {/* Committed shapes */}
           {undoStack.shapes.map((shape) => {
             const result = renderShapeSvgProps(shape, false);
-            if (result.tagName === 'callout') {
+            if (result.tagName === 'arrow') {
+              return (
+                <g key={shape.id} data-shapeid={shape.id}>
+                  <line {...(result.lineAttrs as Record<string, unknown>)} />
+                  <polygon {...(result.arrowheadAttrs as Record<string, unknown>)} />
+                </g>
+              );
+            } else if (result.tagName === 'callout') {
               return (
                 <g key={shape.id} data-shapeid={shape.id}>
                   <rect {...(result.boxAttrs as Record<string, unknown>)} />
@@ -845,7 +845,14 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           {state.draftShape &&
             (() => {
               const result = renderShapeSvgProps(state.draftShape, true);
-              if (result.tagName === 'callout') {
+              if (result.tagName === 'arrow') {
+                return (
+                  <g>
+                    <line {...(result.lineAttrs as Record<string, unknown>)} />
+                    <polygon {...(result.arrowheadAttrs as Record<string, unknown>)} />
+                  </g>
+                );
+              } else if (result.tagName === 'callout') {
                 return (
                   <g>
                     <rect {...(result.boxAttrs as Record<string, unknown>)} />
@@ -897,11 +904,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="#000000"
-                    strokeWidth="3"
+                    strokeWidth="5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
-                    opacity="0.4"
+                    opacity="0.6"
                   />
                   {/* Inner bright dashed stroke (primary color) */}
                   <rect
@@ -910,7 +917,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="var(--color-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="3"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -951,13 +958,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     };
 
                     return (
-                      <rect
+                      <circle
                         key={pos}
-                        x={cx - 5}
-                        y={cy - 5}
-                        width={10}
-                        height={10}
-                        fill="var(--color-bg-primary)"
+                        cx={cx}
+                        cy={cy}
+                        r={6}
+                        fill="white"
                         stroke="var(--color-primary)"
                         strokeWidth="2"
                         style={{ cursor: cursors[pos] }}
@@ -976,10 +982,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="#000000"
-                    strokeWidth="3"
+                    strokeWidth="5"
                     strokeDasharray="4 2"
                     pointerEvents="none"
-                    opacity="0.4"
+                    opacity="0.6"
                     strokeLinecap="round"
                   />
                   {/* Inner bright dashed stroke */}
@@ -989,7 +995,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="var(--color-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="3"
                     strokeDasharray="4 2"
                     pointerEvents="none"
                     strokeLinecap="round"
@@ -999,13 +1005,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     { pos: 'start', x: selectedShape.x1, y: selectedShape.y1 },
                     { pos: 'end', x: selectedShape.x2, y: selectedShape.y2 },
                   ].map(({ pos, x, y }) => (
-                    <rect
+                    <circle
                       key={pos}
-                      x={x - 5}
-                      y={y - 5}
-                      width={10}
-                      height={10}
-                      fill="var(--color-bg-primary)"
+                      cx={x}
+                      cy={y}
+                      r={6}
+                      fill="white"
                       stroke="var(--color-primary)"
                       strokeWidth="2"
                       style={{ cursor: 'move' }}
@@ -1023,11 +1028,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     rx={selectedShape.rx}
                     ry={selectedShape.ry}
                     stroke="#000000"
-                    strokeWidth="3"
+                    strokeWidth="5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
-                    opacity="0.4"
+                    opacity="0.6"
                   />
                   {/* Inner bright dashed stroke */}
                   <ellipse
@@ -1036,7 +1041,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     rx={selectedShape.rx}
                     ry={selectedShape.ry}
                     stroke="var(--color-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="3"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -1048,13 +1053,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     { pos: 'east', x: selectedShape.cx + selectedShape.rx, y: selectedShape.cy },
                     { pos: 'west', x: selectedShape.cx - selectedShape.rx, y: selectedShape.cy },
                   ].map(({ pos, x, y }) => (
-                    <rect
+                    <circle
                       key={pos}
-                      x={x - 5}
-                      y={y - 5}
-                      width={10}
-                      height={10}
-                      fill="var(--color-bg-primary)"
+                      cx={x}
+                      cy={y}
+                      r={6}
+                      fill="white"
                       stroke="var(--color-primary)"
                       strokeWidth="2"
                       style={{
@@ -1078,11 +1082,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         width={bbox.width}
                         height={bbox.height}
                         stroke="#000000"
-                        strokeWidth="3"
+                        strokeWidth="5"
                         strokeDasharray="4 2"
                         fill="none"
                         pointerEvents="none"
-                        opacity="0.4"
+                        opacity="0.6"
                       />
                       {/* Inner bright dashed stroke */}
                       <rect
@@ -1091,7 +1095,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         width={bbox.width}
                         height={bbox.height}
                         stroke="var(--color-primary)"
-                        strokeWidth="1.5"
+                        strokeWidth="3"
                         strokeDasharray="4 2"
                         fill="none"
                         pointerEvents="none"
@@ -1103,13 +1107,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         { pos: 'sw', x: bbox.x, y: bbox.y + bbox.height },
                         { pos: 'se', x: bbox.x + bbox.width, y: bbox.y + bbox.height },
                       ].map(({ pos, x, y }) => (
-                        <rect
+                        <circle
                           key={pos}
-                          x={x - 5}
-                          y={y - 5}
-                          width={10}
-                          height={10}
-                          fill="var(--color-bg-primary)"
+                          cx={x}
+                          cy={y}
+                          r={6}
+                          fill="white"
                           stroke="var(--color-primary)"
                           strokeWidth="2"
                           style={{ cursor: 'move' }}
@@ -1128,11 +1131,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="#000000"
-                    strokeWidth="3"
+                    strokeWidth="5"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
-                    opacity="0.4"
+                    opacity="0.6"
                   />
                   {/* Inner bright dashed stroke */}
                   <rect
@@ -1141,7 +1144,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     width={selectedShape.w}
                     height={selectedShape.h}
                     stroke="var(--color-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="3"
                     strokeDasharray="4 2"
                     fill="none"
                     pointerEvents="none"
@@ -1182,13 +1185,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     };
 
                     return (
-                      <rect
+                      <circle
                         key={pos}
-                        x={cx - 5}
-                        y={cy - 5}
-                        width={10}
-                        height={10}
-                        fill="var(--color-bg-primary)"
+                        cx={cx}
+                        cy={cy}
+                        r={6}
+                        fill="white"
                         stroke="var(--color-primary)"
                         strokeWidth="2"
                         style={{ cursor: cursors[pos] }}
@@ -1199,9 +1201,9 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   <circle
                     cx={selectedShape.tailX}
                     cy={selectedShape.tailY}
-                    r={6}
-                    fill="var(--color-primary)"
-                    stroke="var(--color-bg-primary)"
+                    r={7}
+                    fill="white"
+                    stroke="var(--color-primary)"
                     strokeWidth="2"
                     style={{ cursor: 'move' }}
                   />
@@ -1217,10 +1219,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="#000000"
-                    strokeWidth="3"
+                    strokeWidth="5"
                     strokeDasharray="4 2"
                     pointerEvents="none"
-                    opacity="0.4"
+                    opacity="0.6"
                     strokeLinecap="round"
                   />
                   {/* Inner bright dashed stroke */}
@@ -1230,7 +1232,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     x2={selectedShape.x2}
                     y2={selectedShape.y2}
                     stroke="var(--color-primary)"
-                    strokeWidth="1.5"
+                    strokeWidth="3"
                     strokeDasharray="4 2"
                     pointerEvents="none"
                     strokeLinecap="round"
@@ -1240,13 +1242,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                     { pos: 'start', x: selectedShape.x1, y: selectedShape.y1 },
                     { pos: 'end', x: selectedShape.x2, y: selectedShape.y2 },
                   ].map(({ pos, x, y }) => (
-                    <rect
+                    <circle
                       key={pos}
-                      x={x - 5}
-                      y={y - 5}
-                      width={10}
-                      height={10}
-                      fill="var(--color-bg-primary)"
+                      cx={x}
+                      cy={y}
+                      r={6}
+                      fill="white"
                       stroke="var(--color-primary)"
                       strokeWidth="2"
                       style={{ cursor: 'move' }}
@@ -1274,11 +1275,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         width={maxX - minX + 8}
                         height={maxY - minY + 8}
                         stroke="#000000"
-                        strokeWidth="3"
+                        strokeWidth="5"
                         strokeDasharray="4 2"
                         fill="none"
                         pointerEvents="none"
-                        opacity="0.4"
+                        opacity="0.6"
                       />
                       {/* Inner bright dashed stroke */}
                       <rect
@@ -1287,7 +1288,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         width={maxX - minX + 8}
                         height={maxY - minY + 8}
                         stroke="var(--color-primary)"
-                        strokeWidth="1.5"
+                        strokeWidth="3"
                         strokeDasharray="4 2"
                         fill="none"
                         pointerEvents="none"

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -348,9 +348,10 @@ function RedoIcon() {
 
 function ArrowIcon() {
   return (
-    <span aria-hidden="true" style={{ fontSize: '22px', lineHeight: 1, display: 'inline-block' }}>
-      ↗
-    </span>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="4" y1="20" x2="16" y2="8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <polygon points="16,8 20,4 21,12" fill="currentColor" />
+    </svg>
   );
 }
 

--- a/client/src/components/photos/PhotoAnnotator/render.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.test.ts
@@ -37,6 +37,17 @@ function getAttributes(result: SvgRenderResult): Record<string, string | number>
 }
 
 /**
+ * Asserts the result is an arrow composite (lineAttrs / arrowheadAttrs).
+ */
+function getArrowParts(result: SvgRenderResult): {
+  lineAttrs: Record<string, string | number>;
+  arrowheadAttrs: Record<string, string | number>;
+} {
+  if (result.tagName === 'arrow') return result;
+  throw new Error(`Expected arrow SvgRenderResult but got tagName '${result.tagName}'`);
+}
+
+/**
  * Asserts the result is a callout composite (boxAttrs / tailAttrs / textAttrs).
  */
 function getCalloutParts(result: SvgRenderResult): {
@@ -411,15 +422,14 @@ describe('drawShapeOnCanvas() — Highlight', () => {
 // ─── renderShapeSvgProps — Arrow ─────────────────────────────────────────────
 
 describe('renderShapeSvgProps() — Arrow', () => {
-  it('returns tagName: "line" for arrow', () => {
+  it('returns tagName: "arrow" for arrow', () => {
     const result = renderShapeSvgProps(makeArrow(), false);
-    expect(result.tagName).toBe('line');
+    expect(result.tagName).toBe('arrow');
   });
 
-  it('includes correct x1/y1 attributes (unchanged) and x2/y2 shortened to the arrowhead base', () => {
-    // The SVG line element stops at the base of the arrowhead marker, not at shape.x2/y2.
-    // Shortening = 8 * strokeWidth along the direction vector, so the marker tip lands exactly
-    // at (shape.x2, shape.y2) without the line body poking through.
+  it('has lineAttrs with x1/y1 unchanged and x2/y2 shortened to the arrowhead base', () => {
+    // The line stops at the base of the arrowhead, not at shape.x2/y2.
+    // Shortening = 8 * strokeWidth along the direction vector.
     const shape = makeArrow({ x1: 10, y1: 20, x2: 100, y2: 80, strokeWidth: 4 });
     const dx = shape.x2 - shape.x1; // 90
     const dy = shape.y2 - shape.y1; // 60
@@ -429,10 +439,11 @@ describe('renderShapeSvgProps() — Arrow', () => {
     const expectedY2 = shape.y2 - (dy / len) * shortenDist;
 
     const result = renderShapeSvgProps(shape, false);
-    expect(getAttributes(result).x1).toBe(10);
-    expect(getAttributes(result).y1).toBe(20);
-    expect(getAttributes(result).x2).toBeCloseTo(expectedX2, 5);
-    expect(getAttributes(result).y2).toBeCloseTo(expectedY2, 5);
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs.x1).toBe(10);
+    expect(arrow.lineAttrs.y1).toBe(20);
+    expect(arrow.lineAttrs.x2).toBeCloseTo(expectedX2, 5);
+    expect(arrow.lineAttrs.y2).toBeCloseTo(expectedY2, 5);
   });
 
   it('line endpoint is shortened by 8 * strokeWidth so it lands at the arrowhead base (horizontal case)', () => {
@@ -440,60 +451,79 @@ describe('renderShapeSvgProps() — Arrow', () => {
     // Arrow from (0,0) to (100,0) with strokeWidth=4 → shortenDist=32 → shortenedX2=68, shortenedY2=0.
     const shape = makeArrow({ x1: 0, y1: 0, x2: 100, y2: 0, strokeWidth: 4 });
     const result = renderShapeSvgProps(shape, false);
-    expect(getAttributes(result).x2).toBe(68);
-    expect(getAttributes(result).y2).toBe(0);
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs.x2).toBe(68);
+    expect(arrow.lineAttrs.y2).toBe(0);
   });
 
-  it('committed arrow has marker-end: "url(#arrowhead)"', () => {
-    const result = renderShapeSvgProps(makeArrow(), false);
-    expect(getAttributes(result)['marker-end']).toBe('url(#arrowhead)');
-  });
-
-  it('draft arrow has marker-end: "none"', () => {
-    const result = renderShapeSvgProps(makeArrow(), true);
-    expect(getAttributes(result)['marker-end']).toBe('none');
+  it('arrowhead points triangle has tip at shape.x2/y2 and base at the shortened endpoint', () => {
+    // Simple horizontal case: arrow from (0,0) to (100,0), strokeWidth=4
+    // Base = (68, 0), tip = (100, 0), tipHalfWidth = 16
+    const shape = makeArrow({ x1: 0, y1: 0, x2: 100, y2: 0, strokeWidth: 4 });
+    const result = renderShapeSvgProps(shape, false);
+    const arrow = getArrowParts(result);
+    // Points format: "pt1x,pt1y pt2x,pt2y pt3x,pt3y"
+    const pointsStr = arrow.arrowheadAttrs.points as string;
+    const points = pointsStr.split(' ').map(p => p.split(',').map(Number));
+    // pt2 (middle) should be at the tip (100, 0)
+    expect(points[1]).toBeDefined();
+    expect(points[1]![0]).toBe(100);
+    expect(points[1]![1]).toBe(0);
   });
 
   it('committed arrow has stroke-dasharray: "none"', () => {
     const result = renderShapeSvgProps(makeArrow(), false);
-    expect(getAttributes(result)['stroke-dasharray']).toBe('none');
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs['stroke-dasharray']).toBe('none');
   });
 
   it('draft arrow has stroke-dasharray: "6 4"', () => {
     const result = renderShapeSvgProps(makeArrow(), true);
-    expect(getAttributes(result)['stroke-dasharray']).toBe('6 4');
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs['stroke-dasharray']).toBe('6 4');
   });
 
-  it('committed arrow has opacity: 1', () => {
+  it('committed arrow has opacity: 1 on both line and arrowhead', () => {
     const result = renderShapeSvgProps(makeArrow(), false);
-    expect(getAttributes(result).opacity).toBe(1);
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs.opacity).toBe(1);
+    expect(arrow.arrowheadAttrs.opacity).toBe(1);
   });
 
-  it('draft arrow has opacity: 0.8', () => {
+  it('draft arrow has opacity: 0.8 on both line and arrowhead', () => {
     const result = renderShapeSvgProps(makeArrow(), true);
-    expect(getAttributes(result).opacity).toBe(0.8);
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs.opacity).toBe(0.8);
+    expect(arrow.arrowheadAttrs.opacity).toBe(0.8);
   });
 
-  it('uses shape.stroke for the stroke color', () => {
+  it('uses shape.stroke for both line and arrowhead fill', () => {
     const shape = makeArrow({ stroke: '#ff0000' });
     const result = renderShapeSvgProps(shape, false);
-    expect(getAttributes(result).stroke).toBe('#ff0000');
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs.stroke).toBe('#ff0000');
+    expect(arrow.arrowheadAttrs.fill).toBe('#ff0000');
   });
 
-  it('includes stroke-width attribute', () => {
+  it('includes stroke-width attribute on line', () => {
     const shape = makeArrow({ strokeWidth: 8 });
     const result = renderShapeSvgProps(shape, false);
-    expect(getAttributes(result)['stroke-width']).toBe(8);
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs['stroke-width']).toBe(8);
   });
 
-  it('committed arrow has pointer-events: "stroke"', () => {
+  it('committed arrow has pointer-events: "stroke" on line, "none" on arrowhead', () => {
     const result = renderShapeSvgProps(makeArrow(), false);
-    expect(getAttributes(result)['pointer-events']).toBe('stroke');
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs['pointer-events']).toBe('stroke');
+    expect(arrow.arrowheadAttrs['pointer-events']).toBe('none');
   });
 
-  it('draft arrow has pointer-events: "none"', () => {
+  it('draft arrow has pointer-events: "none" on both line and arrowhead', () => {
     const result = renderShapeSvgProps(makeArrow(), true);
-    expect(getAttributes(result)['pointer-events']).toBe('none');
+    const arrow = getArrowParts(result);
+    expect(arrow.lineAttrs['pointer-events']).toBe('none');
+    expect(arrow.arrowheadAttrs['pointer-events']).toBe('none');
   });
 });
 

--- a/client/src/components/photos/PhotoAnnotator/render.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.ts
@@ -25,6 +25,11 @@ export type SvgRenderResult =
       children: string;
     }
   | {
+      tagName: 'arrow';
+      lineAttrs: Record<string, string | number>;
+      arrowheadAttrs: Record<string, string | number>;
+    }
+  | {
       tagName: 'polyline';
       attributes: Record<string, string | number>;
     };
@@ -72,29 +77,51 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
       },
     };
   } else if (shape.type === 'arrow') {
-    // Shorten the line endpoint by the arrowhead length so it ends at the marker's base
-    // The marker has markerWidth="8" and refX="8", meaning the arrowhead base is 8 * strokeWidth back from the tip
+    // Compute arrowhead base and triangle points
     const dx = shape.x2 - shape.x1;
     const dy = shape.y2 - shape.y1;
     const len = Math.sqrt(dx * dx + dy * dy) || 1;
-    const shortenDist = 8 * shape.strokeWidth;
-    const shortenedX2 = shape.x2 - (dx / len) * shortenDist;
-    const shortenedY2 = shape.y2 - (dy / len) * shortenDist;
+    const unitX = dx / len;
+    const unitY = dy / len;
+
+    // Arrowhead dimensions (proportional to stroke width)
+    const tipLen = 8 * shape.strokeWidth; // length of arrowhead along line direction
+    const tipHalfWidth = 4 * shape.strokeWidth; // half the perpendicular width
+
+    // Base of arrowhead (where line ends)
+    const baseX = shape.x2 - unitX * tipLen;
+    const baseY = shape.y2 - unitY * tipLen;
+
+    // Perpendicular unit vector
+    const perpX = -unitY;
+    const perpY = unitX;
+
+    // Triangle vertices
+    const pt1x = baseX + perpX * tipHalfWidth;
+    const pt1y = baseY + perpY * tipHalfWidth;
+    const pt3x = baseX - perpX * tipHalfWidth;
+    const pt3y = baseY - perpY * tipHalfWidth;
 
     return {
-      tagName: 'line',
-      attributes: {
+      tagName: 'arrow',
+      lineAttrs: {
         x1: shape.x1,
         y1: shape.y1,
-        x2: shortenedX2,
-        y2: shortenedY2,
+        x2: baseX,
+        y2: baseY,
         stroke: shape.stroke,
         'stroke-width': shape.strokeWidth,
         'stroke-linecap': 'round',
         'stroke-dasharray': isDraft ? '6 4' : 'none',
-        'marker-end': isDraft ? 'none' : 'url(#arrowhead)',
         opacity: isDraft ? 0.8 : 1,
         'pointer-events': isDraft ? 'none' : 'stroke',
+      },
+      arrowheadAttrs: {
+        points: `${pt1x},${pt1y} ${shape.x2},${shape.y2} ${pt3x},${pt3y}`,
+        fill: shape.stroke,
+        stroke: 'none',
+        opacity: isDraft ? 0.8 : 1,
+        'pointer-events': 'none',
       },
     };
   } else if (shape.type === 'line') {
@@ -298,37 +325,41 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.fillRect(shape.x, shape.y, shape.w, shape.h);
     ctx.globalAlpha = 1;
   } else if (shape.type === 'arrow') {
-    // Shorten the line endpoint by the arrowhead length so it ends at the arrowhead's base
+    // Draw line from start to arrowhead base
     const dx = shape.x2 - shape.x1;
     const dy = shape.y2 - shape.y1;
     const len = Math.sqrt(dx * dx + dy * dy) || 1;
-    const shortenDist = 8 * shape.strokeWidth;
-    const shortenedX2 = shape.x2 - (dx / len) * shortenDist;
-    const shortenedY2 = shape.y2 - (dy / len) * shortenDist;
+    const unitX = dx / len;
+    const unitY = dy / len;
+
+    const tipLen = 8 * shape.strokeWidth;
+    const tipHalfWidth = 4 * shape.strokeWidth;
+
+    const baseX = shape.x2 - unitX * tipLen;
+    const baseY = shape.y2 - unitY * tipLen;
 
     ctx.strokeStyle = shape.stroke;
     ctx.lineWidth = shape.strokeWidth;
     ctx.lineCap = 'round';
     ctx.beginPath();
     ctx.moveTo(shape.x1, shape.y1);
-    ctx.lineTo(shortenedX2, shortenedY2);
+    ctx.lineTo(baseX, baseY);
     ctx.stroke();
 
-    // Draw arrowhead at the original endpoint (shape.x2, shape.y2)
-    const headlen = shape.strokeWidth * 3;
-    const angle = Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1);
+    // Draw arrowhead triangle
+    const perpX = -unitY;
+    const perpY = unitX;
+
+    const pt1x = baseX + perpX * tipHalfWidth;
+    const pt1y = baseY + perpY * tipHalfWidth;
+    const pt3x = baseX - perpX * tipHalfWidth;
+    const pt3y = baseY - perpY * tipHalfWidth;
 
     ctx.fillStyle = shape.stroke;
     ctx.beginPath();
-    ctx.moveTo(shape.x2, shape.y2);
-    ctx.lineTo(
-      shape.x2 - headlen * Math.cos(angle - Math.PI / 6),
-      shape.y2 - headlen * Math.sin(angle - Math.PI / 6),
-    );
-    ctx.lineTo(
-      shape.x2 - headlen * Math.cos(angle + Math.PI / 6),
-      shape.y2 - headlen * Math.sin(angle + Math.PI / 6),
-    );
+    ctx.moveTo(pt1x, pt1y);
+    ctx.lineTo(shape.x2, shape.y2);
+    ctx.lineTo(pt3x, pt3y);
     ctx.closePath();
     ctx.fill();
   } else if (shape.type === 'line') {

--- a/client/src/pages/DiaryEntryEditPage/DiaryEntryEditPage.tsx
+++ b/client/src/pages/DiaryEntryEditPage/DiaryEntryEditPage.tsx
@@ -714,6 +714,11 @@ export default function DiaryEntryEditPage() {
                   onDelete={(photo) => {
                     void photosResult.deletePhoto(photo.id);
                   }}
+                  onEdit={(photo) => {
+                    const index = photosResult.photos.findIndex((p) => p.id === photo.id);
+                    setSelectedPhotoIndex(index);
+                  }}
+                  editable={!entry.isSigned}
                   loading={photosResult.loading}
                 />
               </div>


### PR DESCRIPTION
## Summary

Four UAT items the previous rounds did not actually resolve:

- **Arrow tip alignment** — the prior shortening fix put the marker's tip 8 × strokeWidth behind the user's click. Replaced the `marker-end` approach with a hand-drawn polygon arrowhead. The line now ends at the arrow's base and the polygon's apex lands exactly on the click point. SVG and canvas-2D paths both updated. `SvgRenderResult` union gained an `'arrow'` compound variant.
- **Arrow tool icon** — the Unicode glyph (↗) never sat well at icon size. Switched to an inline SVG with a stroked shaft and a filled triangular head, matching the 24×24 tool-icon style.
- **Selection indicator** — bumped outer stroke to 5 px @ 0.6 opacity and inner to 3 px, plus circle handles with white fill and a primary-color border.
- **Edit-page annotate button** — DiaryEntryEditPage never passed `onEdit`/`editable` to its PhotoGrid, so the annotate button was missing in edit mode. Added the same wiring DiaryEntryDetailPage uses.

## Test plan

- [x] All 730 PhotoAnnotator tests pass
- [x] Typecheck green
- [ ] Manual: draw an arrow with thick stroke — point lands exactly under the cursor, line ends at the arrow's base
- [ ] Manual: select a shape on a busy photo — outline is unmistakable
- [ ] Manual: open a diary entry in edit mode — the annotate button appears on photo cards