### PR TITLE
fix(photo-annotator): use Unicode glyphs for select/undo/redo icons

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -296,9 +296,9 @@ export function ToolPalette({
 
 function SelectIcon() {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M5 3V21M5 5H19L11 12L19 19H5" stroke="currentColor" strokeWidth="2" />
-    </svg>
+    <span aria-hidden="true" style={{ fontSize: '22px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      ↖
+    </span>
   );
 }
 
@@ -320,29 +320,17 @@ function HighlightIcon() {
 
 function UndoIcon() {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M4 12C4 16.4183 7.58172 20 12 20C15.0583 20 17.7158 18.2957 18.9995 15.5M4 12H8M4 12V8M20 12C20 7.58172 16.4183 4 12 4C8.94172 4 6.28423 5.70433 5.00049 8.5"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span aria-hidden="true" style={{ fontSize: '22px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      ↶
+    </span>
   );
 }
 
 function RedoIcon() {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M20 12C20 16.4183 16.4183 20 12 20C8.94172 20 6.28423 18.2957 5.00049 15.5M20 12H16M20 12V8M4 12C4 7.58172 7.58172 4 12 4C15.0583 4 17.7158 5.70433 18.9995 8.5"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span aria-hidden="true" style={{ fontSize: '22px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      ↷
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Three toolbar icons were hard to read at icon size and the user asked for predefined glyphs:

- Select tool: classic NW-pointing cursor (`↖`)
- Undo: anticlockwise arc (`↶`)
- Redo: clockwise arc (`↷`)

All three render as 22 px Unicode glyphs with `aria-hidden="true"`. Existing testids and aria-labels unchanged.

## Test plan

- [x] ToolPalette tests (36) pass
- [x] Typecheck green
- [ ] Manual: tool palette shows the new glyphs at expected weight