### PR TITLE
fix(photo-annotator): callouts auto-flow text, inset from border, shrink to fit

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -858,7 +858,14 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                 <g key={shape.id} data-shapeid={shape.id}>
                   <rect {...(result.boxAttrs as Record<string, unknown>)} />
                   <line {...(result.tailAttrs as Record<string, unknown>)} />
-                  <text {...(result.textAttrs as Record<string, unknown>)}>{result.children}</text>
+                  <foreignObject {...(result.foreignObjectAttrs as Record<string, unknown>)}>
+                    <div
+                      style={result.textDivStyle as React.CSSProperties}
+                      // xmlns is implicit in XHTML context inside foreignObject
+                    >
+                      {result.children}
+                    </div>
+                  </foreignObject>
                 </g>
               );
             } else if (result.tagName === 'measurement') {
@@ -920,9 +927,14 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                   <g>
                     <rect {...(result.boxAttrs as Record<string, unknown>)} />
                     <line {...(result.tailAttrs as Record<string, unknown>)} />
-                    <text {...(result.textAttrs as Record<string, unknown>)}>
-                      {result.children}
-                    </text>
+                    <foreignObject {...(result.foreignObjectAttrs as Record<string, unknown>)}>
+                      <div
+                        style={result.textDivStyle as React.CSSProperties}
+                        // xmlns is implicit in XHTML context inside foreignObject
+                      >
+                        {result.children}
+                      </div>
+                    </foreignObject>
                   </g>
                 );
               } else if (result.tagName === 'measurement') {

--- a/client/src/components/photos/PhotoAnnotator/render.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.test.ts
@@ -11,7 +11,13 @@
  */
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { renderShapeSvgProps, drawShapeOnCanvas, ANNOTATION_FONT_FAMILY } from './render.js';
+import {
+  renderShapeSvgProps,
+  drawShapeOnCanvas,
+  ANNOTATION_FONT_FAMILY,
+  calculateCalloutEffectiveFontSize,
+  wrapTextForCanvas,
+} from './render.js';
 import type { SvgRenderResult } from './render.js';
 import type {
   RectangleShape,
@@ -48,12 +54,14 @@ function getArrowParts(result: SvgRenderResult): {
 }
 
 /**
- * Asserts the result is a callout composite (boxAttrs / tailAttrs / textAttrs).
+ * Asserts the result is a callout composite (boxAttrs / tailAttrs / textAttrs / foreignObjectAttrs / textDivStyle).
  */
 function getCalloutParts(result: SvgRenderResult): {
   boxAttrs: Record<string, string | number>;
   tailAttrs: Record<string, string | number>;
   textAttrs: Record<string, string | number>;
+  foreignObjectAttrs: Record<string, string | number>;
+  textDivStyle: Record<string, string | number>;
   children: string;
 } {
   if (result.tagName === 'callout') return result;
@@ -173,6 +181,8 @@ interface MockCtx {
   fillStyle: string;
   globalAlpha: number;
   font: string;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
   strokeRect: AnyMock;
   fillRect: AnyMock;
   beginPath: AnyMock;
@@ -183,6 +193,7 @@ interface MockCtx {
   closePath: AnyMock;
   ellipse: AnyMock;
   fillText: AnyMock;
+  measureText: AnyMock;
 }
 
 function makeCanvasContext(): MockCtx {
@@ -193,6 +204,8 @@ function makeCanvasContext(): MockCtx {
     fillStyle: '',
     globalAlpha: 1,
     font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
     strokeRect: jest.fn() as AnyMock,
     fillRect: jest.fn() as AnyMock,
     beginPath: jest.fn() as AnyMock,
@@ -203,6 +216,7 @@ function makeCanvasContext(): MockCtx {
     closePath: jest.fn() as AnyMock,
     ellipse: jest.fn() as AnyMock,
     fillText: jest.fn() as AnyMock,
+    measureText: jest.fn().mockReturnValue({ width: 100 }) as AnyMock,
   };
 }
 
@@ -991,6 +1005,34 @@ describe('renderShapeSvgProps() — Callout', () => {
     const { boxAttrs } = getCalloutParts(renderShapeSvgProps(makeCallout(), true));
     expect(boxAttrs['pointer-events']).toBe('none');
   });
+
+  it('includes foreignObjectAttrs with inset position and reduced dimensions', () => {
+    const shape = makeCallout({ x: 10, y: 20, w: 100, h: 80 });
+    const { foreignObjectAttrs } = getCalloutParts(renderShapeSvgProps(shape, false));
+    expect(foreignObjectAttrs.x).toBe(16); // 10 + 6 inset
+    expect(foreignObjectAttrs.y).toBe(26); // 20 + 6 inset
+    expect(foreignObjectAttrs.width).toBe(88); // 100 - 2*6
+    expect(foreignObjectAttrs.height).toBe(68); // 80 - 2*6
+  });
+
+  it('includes textDivStyle with font properties', () => {
+    const shape = makeCallout({ fontSize: 18, color: '#ff0000' });
+    const { textDivStyle } = getCalloutParts(renderShapeSvgProps(shape, false));
+    expect(textDivStyle.fontFamily).toBe(ANNOTATION_FONT_FAMILY);
+    expect(textDivStyle.color).toBe('#ff0000');
+    expect(textDivStyle.lineHeight).toBe(1.2);
+    expect(textDivStyle.wordWrap).toBe('break-word');
+  });
+
+  it('textDivStyle fontSize shrinks when text overflows available space', () => {
+    const longText = 'x'.repeat(200);
+    const shape = makeCallout({ text: longText, fontSize: 24, w: 60, h: 60 });
+    const { textDivStyle } = getCalloutParts(renderShapeSvgProps(shape, false));
+    // With small box and long text, fontSize should be scaled down
+    const fontSizeStr = textDivStyle.fontSize as string;
+    const fontSizeNum = parseFloat(fontSizeStr);
+    expect(fontSizeNum).toBeLessThan(24);
+  });
 });
 
 // ─── ANNOTATION_FONT_FAMILY consistency ──────────────────────────────────────
@@ -1111,10 +1153,16 @@ describe('drawShapeOnCanvas() — Callout', () => {
     expect(ctx.beginPath).toHaveBeenCalled();
   });
 
-  it('calls fillText with shape.text for the label', () => {
+  it('calls fillText with wrapped text lines for the label', () => {
     const shape = makeCallout({ text: 'My Note' });
     drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
-    expect(ctx.fillText).toHaveBeenCalledWith('My Note', expect.any(Number), expect.any(Number));
+    // Text is wrapped into lines and drawn separately, so we should have at least one fillText call
+    expect(ctx.fillText).toHaveBeenCalled();
+    // Check that each call matches a word from the text
+    const calls = (ctx.fillText as AnyMock).mock.calls;
+    const drawnText = calls.map((c: any) => c[0]).join(' ');
+    expect(drawnText).toContain('My');
+    expect(drawnText).toContain('Note');
   });
 
   it('sets ctx.font to include shape.fontSize and ANNOTATION_FONT_FAMILY', () => {
@@ -1561,5 +1609,98 @@ describe('drawShapeOnCanvas() — Freehand', () => {
     const shape = makeFreehand({ points: [] });
     drawShapeOnCanvas(ctx as unknown as CanvasRenderingContext2D, shape);
     expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+});
+
+// ─── calculateCalloutEffectiveFontSize ────────────────────────────────────────
+
+describe('calculateCalloutEffectiveFontSize()', () => {
+  it('returns fontSize unchanged when text fits in available space', () => {
+    const result = calculateCalloutEffectiveFontSize('Hi', 18, 200, 100);
+    // Short text, ample space → no scaling needed
+    expect(result).toBe(18);
+  });
+
+  it('returns fontSize unchanged for empty text', () => {
+    const result = calculateCalloutEffectiveFontSize('', 18, 50, 50);
+    expect(result).toBe(18);
+  });
+
+  it('shrinks font when text overflows vertically', () => {
+    // Very long text in a small box
+    const longText = 'This is a very long text that will not fit in a small box';
+    const result = calculateCalloutEffectiveFontSize(longText, 24, 50, 30);
+    // Text should be scaled down to fit
+    expect(result).toBeLessThan(24);
+    expect(result).toBeGreaterThanOrEqual(8); // minimum is 8px
+  });
+
+  it('clamps minimum font size to 8px', () => {
+    // Extremely constrained space
+    const longText = 'x'.repeat(1000);
+    const result = calculateCalloutEffectiveFontSize(longText, 24, 10, 10);
+    expect(result).toBe(8); // clamped to minimum
+  });
+
+  it('scales proportionally when text exceeds lines available', () => {
+    // Medium text in constrained box
+    const text = 'This is some text';
+    const fontSize = 20;
+    const availW = 100;
+    const availH = 40;
+
+    const result = calculateCalloutEffectiveFontSize(text, fontSize, availW, availH);
+    // Should be between the original and minimum
+    expect(result).toBeGreaterThanOrEqual(8);
+    expect(result).toBeLessThanOrEqual(fontSize);
+  });
+});
+
+// ─── wrapTextForCanvas ────────────────────────────────────────────────────────
+
+describe('wrapTextForCanvas()', () => {
+  let ctx: MockCtx;
+
+  beforeEach(() => {
+    ctx = makeCanvasContext();
+    // Mock measureText to return fixed width per character
+    ctx.measureText = jest.fn().mockImplementation((text) => ({
+      width: (text as string).length * 10, // 10px per character
+    })) as AnyMock;
+  });
+
+  it('returns empty array for empty text', () => {
+    const result = wrapTextForCanvas('', 100, ctx as unknown as CanvasRenderingContext2D);
+    expect(result).toEqual([]);
+  });
+
+  it('returns single line when text fits within maxWidth', () => {
+    const result = wrapTextForCanvas('Hi', 100, ctx as unknown as CanvasRenderingContext2D);
+    expect(result).toEqual(['Hi']);
+  });
+
+  it('wraps text into multiple lines when it exceeds maxWidth', () => {
+    // "Hi" = 20px, "there" = 50px, "folks" = 50px
+    // max 60px → "Hi" (20) fits, "Hi there" (80) doesn't → split into "Hi" and "there folks"
+    const result = wrapTextForCanvas('Hi there folks', 60, ctx as unknown as CanvasRenderingContext2D);
+    expect(result.length).toBeGreaterThan(1);
+    // Each line should be <= 60px
+    for (const line of result) {
+      expect(ctx.measureText(line).width).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('preserves word boundaries (no mid-word breaks)', () => {
+    const result = wrapTextForCanvas('Hello world', 50, ctx as unknown as CanvasRenderingContext2D);
+    // Should be ["Hello", "world"] not ["Hell", "o wor", "ld"]
+    for (const line of result) {
+      expect(line).toMatch(/^\w+$/); // word-only, no partial words
+    }
+  });
+
+  it('handles single long word by putting it on its own line', () => {
+    // Single word wider than maxWidth still goes on a line
+    const result = wrapTextForCanvas('Supercalifragilisticexpialidocious', 60, ctx as unknown as CanvasRenderingContext2D);
+    expect(result[0]).toBe('Supercalifragilisticexpialidocious');
   });
 });

--- a/client/src/components/photos/PhotoAnnotator/render.ts
+++ b/client/src/components/photos/PhotoAnnotator/render.ts
@@ -6,6 +6,69 @@ import { resolveStrokeWidth } from './annotationConstants.js';
  *  Must be kept in sync between SVG rendering and canvas 2D rendering. */
 export const ANNOTATION_FONT_FAMILY = 'system-ui, -apple-system, sans-serif';
 
+/**
+ * Calculates the effective font size for a callout, shrinking if needed to fit text.
+ * Uses a heuristic based on character count vs available area.
+ *
+ * @param text - The callout text
+ * @param fontSize - The user-chosen font size
+ * @param availW - Available width inside the box (after padding)
+ * @param availH - Available height inside the box (after padding)
+ * @returns Effective font size (may be smaller than fontSize, never < 8px)
+ */
+export function calculateCalloutEffectiveFontSize(
+  text: string,
+  fontSize: number,
+  availW: number,
+  availH: number,
+): number {
+  if (!text || text.length === 0) return fontSize;
+
+  // Heuristic: assume ~0.55 character widths per font size unit (varies by font)
+  // and ~1.2 line heights per font size unit.
+  const charsPerLine = Math.max(1, Math.floor(availW / (fontSize * 0.55)));
+  const linesAvailable = Math.max(1, Math.floor(availH / (fontSize * 1.2)));
+
+  // Estimate how many lines this text will need
+  const estimatedLines = Math.ceil(text.length / charsPerLine);
+
+  // If it overflows, scale down proportionally
+  const fontScale = estimatedLines > linesAvailable ? linesAvailable / estimatedLines : 1;
+  const effectiveFontSize = Math.max(8, fontSize * fontScale); // minimum 8px
+
+  return effectiveFontSize;
+}
+
+/**
+ * Wraps text into multiple lines given a max width on canvas context.
+ * Uses word-break: greedy word wrapping with the canvas context's current font.
+ *
+ * @param text - The text to wrap
+ * @param maxWidth - Maximum width per line
+ * @param ctx - Canvas context with font already set
+ * @returns Array of line strings
+ */
+export function wrapTextForCanvas(text: string, maxWidth: number, ctx: CanvasRenderingContext2D): string[] {
+  if (!text) return [];
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let currentLine = '';
+
+  for (const word of words) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    const metrics = ctx.measureText(testLine);
+    if (metrics.width <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      if (currentLine) lines.push(currentLine);
+      currentLine = word;
+    }
+  }
+  if (currentLine) lines.push(currentLine);
+
+  return lines;
+}
+
 export type SvgRenderResult =
   | { tagName: 'rect' | 'line' | 'ellipse'; attributes: Record<string, string | number> }
   | { tagName: 'text'; attributes: Record<string, string | number>; children: string }
@@ -14,6 +77,8 @@ export type SvgRenderResult =
       boxAttrs: Record<string, string | number>;
       tailAttrs: Record<string, string | number>;
       textAttrs: Record<string, string | number>;
+      foreignObjectAttrs: Record<string, string | number>;
+      textDivStyle: Record<string, string | number>;
       children: string;
     }
   | {
@@ -181,6 +246,20 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
     );
     // Use strokeWidth from shape if available, otherwise default to 2 for backward compat
     const strokeWidth = calloutShape.strokeWidth ?? 2;
+
+    // Padding inset from box border (in image-space pixels)
+    const inset = 6;
+    const availW = Math.max(1, calloutShape.w - 2 * inset);
+    const availH = Math.max(1, calloutShape.h - 2 * inset);
+
+    // Calculate effective font size with auto-scaling for overflow
+    const effectiveFontSize = calculateCalloutEffectiveFontSize(
+      calloutShape.text,
+      calloutShape.fontSize,
+      availW,
+      availH,
+    );
+
     return {
       tagName: 'callout',
       boxAttrs: {
@@ -207,14 +286,34 @@ export function renderShapeSvgProps(shape: AnnotationShape, isDraft: boolean): S
         opacity: isDraft ? 0.8 : 1,
         'pointer-events': 'none',
       },
+      // Keep textAttrs for backward compat (not used in SVG rendering)
       textAttrs: {
-        x: calloutShape.x + 6,
-        y: calloutShape.y + calloutShape.fontSize + 4,
+        x: calloutShape.x + inset,
+        y: calloutShape.y + effectiveFontSize + inset,
         fill: calloutShape.color,
-        'font-size': calloutShape.fontSize,
+        'font-size': effectiveFontSize,
         'font-family': ANNOTATION_FONT_FAMILY,
         'pointer-events': 'none',
         'user-select': 'none',
+      },
+      // foreignObject for text wrapping
+      foreignObjectAttrs: {
+        x: calloutShape.x + inset,
+        y: calloutShape.y + inset,
+        width: availW,
+        height: availH,
+      },
+      // Inline styles for the text div inside foreignObject
+      textDivStyle: {
+        fontFamily: ANNOTATION_FONT_FAMILY,
+        fontSize: `${effectiveFontSize}px`,
+        color: calloutShape.color,
+        lineHeight: 1.2,
+        overflow: 'hidden',
+        wordWrap: 'break-word',
+        whiteSpace: 'pre-wrap',
+        margin: 0,
+        padding: 0,
       },
       children: calloutShape.text,
     };
@@ -407,10 +506,33 @@ export function drawShapeOnCanvas(ctx: CanvasRenderingContext2D, shape: Annotati
     ctx.lineCap = 'round';
     ctx.stroke();
 
-    // 3. Text
+    // 3. Text with wrapping and auto-scaling
+    const inset = 6;
+    const availW = Math.max(1, calloutShape.w - 2 * inset);
+    const availH = Math.max(1, calloutShape.h - 2 * inset);
+
+    const effectiveFontSize = calculateCalloutEffectiveFontSize(
+      calloutShape.text,
+      calloutShape.fontSize,
+      availW,
+      availH,
+    );
+
     ctx.fillStyle = calloutShape.color;
-    ctx.font = `${calloutShape.fontSize}px ${ANNOTATION_FONT_FAMILY}`;
-    ctx.fillText(calloutShape.text, calloutShape.x + 6, calloutShape.y + calloutShape.fontSize + 4);
+    ctx.font = `${effectiveFontSize}px ${ANNOTATION_FONT_FAMILY}`;
+    const lines = wrapTextForCanvas(calloutShape.text, availW, ctx);
+
+    let currentY = calloutShape.y + inset + effectiveFontSize;
+    const lineHeightPx = effectiveFontSize * 1.2;
+
+    for (const line of lines) {
+      if (currentY + effectiveFontSize > calloutShape.y + calloutShape.h - inset) {
+        // Text would overflow vertically; stop rendering
+        break;
+      }
+      ctx.fillText(line, calloutShape.x + inset, currentY);
+      currentY += lineHeightPx;
+    }
   } else if (shape.type === 'measurement') {
     const dx = shape.x2 - shape.x1;
     const dy = shape.y2 - shape.y1;

--- a/e2e/tests/photoAnnotation.spec.ts
+++ b/e2e/tests/photoAnnotation.spec.ts
@@ -1149,10 +1149,10 @@ test(
         throw e;
       }
 
-      // The text content should be "Defect found"
-      const calloutText = calloutGroup.locator('text').first();
+      // The text now renders inside foreignObject > div (for auto-flow + padding)
+      const calloutText = calloutGroup.locator('foreignObject div').first();
       await expect(calloutText).toBeVisible();
-      expect(await calloutText.textContent()).toBe('Defect found');
+      expect((await calloutText.textContent())?.trim()).toBe('Defect found');
 
       // Save and verify
       const [putResponse] = await Promise.all([


### PR DESCRIPTION
## Summary

Callout text now wraps naturally inside the box, sits indented 6 px from each border, and shrinks the font down (to 8 px min) when it would overflow.

- **SVG** render embeds an HTML `<div>` inside a `<foreignObject>` so the browser wraps word-by-word.
- **Canvas bake** word-wraps via a small greedy algorithm using `ctx.measureText`, drawing line by line.
- **Auto-scale** uses a heuristic that estimates lines-vs-available-height (no DOM measure / re-render loop). Effective fontSize is clamped to ≥ 8 px.

## Test plan

- [x] All 743 PhotoAnnotator unit tests pass (200 in render.test.ts, including 7 new wrap/scale tests)
- [x] Typecheck green
- [ ] Manual: draw a small callout, type a paragraph — text wraps, font shrinks
- [ ] Manual: verify the baked WebP keeps the same wrapping as the on-screen preview