### PR TITLE
fix(photo-annotator): inline text input renders as the committed text

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
@@ -29,23 +29,18 @@
 
 .inlineTextInput {
   position: absolute;
-  background: rgba(0, 0, 0, 0.6);
-  color: var(--color-text-inverse);
-  border: 1px solid var(--color-primary);
+  background: transparent;
+  border: 2px dashed var(--color-primary);
   border-radius: var(--radius-sm);
   padding: var(--spacing-1) var(--spacing-2);
   outline: none;
-  font-family:
-    system-ui,
-    -apple-system,
-    sans-serif;
   min-width: 80px;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
   z-index: var(--z-dropdown);
 }
 
 .inlineTextInput:focus {
-  box-shadow: 0 0 0 2px var(--color-primary);
+  outline: 1px solid var(--color-primary);
+  outline-offset: 1px;
 }
 
 .actionBar {

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -18,7 +18,7 @@ import { FreehandTool } from './tools/FreehandTool.js';
 import { SelectTool } from './tools/SelectTool.js';
 import type { PointerContext } from './tools/SelectTool.js';
 import { screenToImage, imageToScreen, clamp } from './geometry.js';
-import { renderShapeSvgProps, drawShapeOnCanvas } from './render.js';
+import { renderShapeSvgProps, drawShapeOnCanvas, ANNOTATION_FONT_FAMILY } from './render.js';
 import { FormError } from '../../FormError/FormError.js';
 import { getBaseUrl } from '../../../lib/apiClient.js';
 import { uploadAnnotation } from '../../../lib/photoApi.js';
@@ -699,7 +699,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     [state, photo.width, photo.height, dispatch, undoStack, openInlineInput, inlineInput.isOpen, t],
   );
 
-  // Floating input positioning
+  // Floating input positioning and styling
   const inlineInputStyle = useMemo((): React.CSSProperties => {
     if (!inlineInput.isOpen || !imgRef.current) return { display: 'none' };
     const imgRect = imgRef.current.getBoundingClientRect();
@@ -712,13 +712,30 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     );
     // Position is relative to the `.canvasArea` container; subtract its top-left
     const containerRect = imgRef.current.parentElement!.getBoundingClientRect();
+
+    // Determine the text color to use:
+    // - If editing an existing text/callout shape, use its color
+    // - Otherwise, use the currently-selected active color
+    let textColor = state.activeColor;
+    if (inlineInput.editingShapeId) {
+      const editingShape = state.shapes.find((s) => s.id === inlineInput.editingShapeId);
+      if (editingShape && (editingShape.type === 'text' || editingShape.type === 'callout')) {
+        textColor = editingShape.color;
+      }
+    }
+
+    const screenFontSizePx = getActiveFontSizePx() * (imgRect.width / photo.width!);
+
     return {
       position: 'absolute',
       left: screenX - containerRect.left,
       top: screenY - containerRect.top,
-      fontSize: `${getActiveFontSizePx() * (imgRect.width / photo.width!)}px`,
+      fontSize: `${screenFontSizePx}px`,
+      color: textColor,
+      fontFamily: ANNOTATION_FONT_FAMILY,
+      background: 'transparent',
     };
-  }, [inlineInput, photo.width, photo.height, state.activeFontSizeKey]);
+  }, [inlineInput, photo.width, photo.height, state.activeFontSizeKey, state.activeColor, state.shapes]);
 
   const handleCancel = useCallback(() => {
     onCancel();


### PR DESCRIPTION
## Summary

The inline editor had its own dark overlay + a fixed light text color. On dark photo backgrounds, the input dissolved into the image and the user couldn't tell what their committed text would look like.

The input now renders WYSIWYG:

- Background is `transparent` (no special input chrome)
- `color` uses the shape's actual annotation color (or `state.activeColor` for new shapes)
- `fontSize` is the resolved screen-space pixel size (matches the rendered SVG `<text>` / `foreignObject`)
- `fontFamily` matches `ANNOTATION_FONT_FAMILY` so the strokes look identical pre- and post-commit
- Only visual cue: a 2 px dashed primary-color border — same style as the selection halo
- Focus outline preserved for keyboard accessibility

## Test plan

- [x] All 746 PhotoAnnotator tests pass
- [x] Typecheck green
- [ ] Manual: in dark mode, choose a light annotation color and type into the input — text is fully readable, matches the committed look