### PR TITLE
fix(photo-annotator): use SVG getScreenCTM for clicks, drop stale position state

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
@@ -23,8 +23,10 @@
 }
 
 .svgOverlay {
-  /* Position, width, height, and touch-action are set via inline styles
-     to match the actual image layout and prevent pointer events in letterbox/pillarbox areas */
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+  /* SVG fills container with preserveAspectRatio="xMidYMid meet" (center-fit like object-fit: contain) */
 }
 
 .inlineTextInput {

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
@@ -25,6 +25,8 @@
 .svgOverlay {
   position: absolute;
   inset: 0;
+  width: 100%;
+  height: 100%;
   touch-action: none;
   /* SVG fills container with preserveAspectRatio="xMidYMid meet" (center-fit like object-fit: contain) */
 }

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -63,9 +63,8 @@ jest.unstable_mockModule('../../FormError/FormError.js', () => ({
 }));
 
 // ─── Mock geometry to make screenToImage pass-through (clientX→imageX) ────────
-// JSDOM SVGElement.getBoundingClientRect always returns 0x0 so screenToImage
-// produces NaN. We mock screenToImage to return clientX/clientY directly,
-// making pointer tests independent of bounding rect behavior.
+// The new screenToImage uses SVG.getScreenCTM() which JSDOM doesn't implement.
+// We mock screenToImage/imageToScreen as simple pass-through functions for testing.
 
 jest.unstable_mockModule('./geometry.js', () => ({
   screenToImage: (screenX: number, screenY: number) => ({ x: screenX, y: screenY }),

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -37,20 +37,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  // SVG overlay position and size (matched to image layout within container)
-  interface SvgPosition {
-    top: number;
-    left: number;
-    width: number;
-    height: number;
-  }
-  const [svgPosition, setSvgPosition] = useState<SvgPosition>({
-    top: 0,
-    left: 0,
-    width: 0,
-    height: 0,
-  });
-
   // Inline edit state
   interface InlineInputState {
     isOpen: boolean;
@@ -86,62 +72,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   // Calculate canonical URL
   const canonicalUrl = `${getBaseUrl()}/photos/${photo.id}/file`;
-
-  // Callback to recalculate SVG position when image loads
-  // This is critical for portrait images where the initial render may not have the final layout yet
-  const handleImageLoad = useCallback(() => {
-    if (!imgRef.current || !imgRef.current.parentElement) return;
-    requestAnimationFrame(() => {
-      if (!imgRef.current || !imgRef.current.parentElement) return;
-      const imgRect = imgRef.current.getBoundingClientRect();
-      const containerRect = imgRef.current.parentElement!.getBoundingClientRect();
-
-      setSvgPosition({
-        top: imgRect.top - containerRect.top,
-        left: imgRect.left - containerRect.left,
-        width: imgRect.width,
-        height: imgRect.height,
-      });
-    });
-  }, []);
-
-  // Track SVG overlay position to match image layout within container
-  // This prevents pointer events in letterbox/pillarbox padding from creating out-of-bounds shapes
-  useEffect(() => {
-    if (!imgRef.current || !imgRef.current.parentElement) return;
-
-    const updateSvgPosition = () => {
-      // Defer to post-layout to ensure measurements are accurate
-      // (especially important for portrait images where flexbox centering may not be complete)
-      requestAnimationFrame(() => {
-        if (!imgRef.current || !imgRef.current.parentElement) return;
-        const imgRect = imgRef.current.getBoundingClientRect();
-        const containerRect = imgRef.current.parentElement!.getBoundingClientRect();
-
-        setSvgPosition({
-          top: imgRect.top - containerRect.top,
-          left: imgRect.left - containerRect.left,
-          width: imgRect.width,
-          height: imgRect.height,
-        });
-      });
-    };
-
-    // Update on mount and whenever image dimensions change
-    updateSvgPosition();
-
-    // Use ResizeObserver to track changes to the image's rendered size
-    const resizeObserver = new ResizeObserver(updateSvgPosition);
-    resizeObserver.observe(imgRef.current);
-
-    // Also listen to window resize
-    window.addEventListener('resize', updateSvgPosition);
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', updateSvgPosition);
-    };
-  }, []);
 
   // Helper to get the active font size key for the current tool
   function getActiveFontSizeKey(): FontSizeKey {
@@ -483,18 +413,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   // Pointer event handlers for drawing/editing
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      if (!svgRef.current || !imgRef.current) return;
+      if (!svgRef.current) return;
 
-      const imgRect = imgRef.current.getBoundingClientRect();
-      let { x: imageX, y: imageY } = screenToImage(
-        e.clientX,
-        e.clientY,
-        imgRect,
-        photo.width!,
-        photo.height!,
-      );
+      let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);
 
-      // Clamp to image bounds (defense against letterbox/pillarbox clicks)
+      // Clamp to image bounds (defense against out-of-bounds clicks)
       imageX = clamp(imageX, 0, photo.width!);
       imageY = clamp(imageY, 0, photo.height!);
 
@@ -539,18 +462,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      if (!svgRef.current || !imgRef.current) return;
+      if (!svgRef.current) return;
 
-      const imgRect = imgRef.current.getBoundingClientRect();
-      let { x: imageX, y: imageY } = screenToImage(
-        e.clientX,
-        e.clientY,
-        imgRect,
-        photo.width!,
-        photo.height!,
-      );
+      let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);
 
-      // Clamp to image bounds (defense against letterbox/pillarbox movement)
+      // Clamp to image bounds (defense against out-of-bounds movement)
       imageX = clamp(imageX, 0, photo.width!);
       imageY = clamp(imageY, 0, photo.height!);
 
@@ -588,18 +504,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      if (!svgRef.current || !imgRef.current) return;
+      if (!svgRef.current) return;
 
-      const imgRect = imgRef.current.getBoundingClientRect();
-      let { x: imageX, y: imageY } = screenToImage(
-        e.clientX,
-        e.clientY,
-        imgRect,
-        photo.width!,
-        photo.height!,
-      );
+      let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);
 
-      // Clamp to image bounds (defense against letterbox/pillarbox release)
+      // Clamp to image bounds (defense against out-of-bounds release)
       imageX = clamp(imageX, 0, photo.width!);
       imageY = clamp(imageY, 0, photo.height!);
 
@@ -701,17 +610,14 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   // Floating input positioning and styling
   const inlineInputStyle = useMemo((): React.CSSProperties => {
-    if (!inlineInput.isOpen || !imgRef.current) return { display: 'none' };
-    const imgRect = imgRef.current.getBoundingClientRect();
+    if (!inlineInput.isOpen || !svgRef.current) return { display: 'none' };
     const { x: screenX, y: screenY } = imageToScreen(
       inlineInput.anchorImageX,
       inlineInput.anchorImageY,
-      imgRect,
-      photo.width!,
-      photo.height!,
+      svgRef.current,
     );
     // Position is relative to the `.canvasArea` container; subtract its top-left
-    const containerRect = imgRef.current.parentElement!.getBoundingClientRect();
+    const containerRect = svgRef.current.parentElement!.getBoundingClientRect();
 
     // Determine the text color to use:
     // - If editing an existing text/callout shape, use its color
@@ -724,7 +630,9 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       }
     }
 
-    const screenFontSizePx = getActiveFontSizePx() * (imgRect.width / photo.width!);
+    // Get SVG bounding rect to calculate scale factor for font size
+    const svgRect = svgRef.current.getBoundingClientRect();
+    const screenFontSizePx = getActiveFontSizePx() * (svgRect.width / photo.width!);
 
     return {
       position: 'absolute',
@@ -738,7 +646,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   }, [
     inlineInput,
     photo.width,
-    photo.height,
     state.activeFontSizeKey,
     state.activeColor,
     state.shapes,
@@ -841,7 +748,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           src={canonicalUrl}
           alt={photo.caption || photo.originalFilename}
           className={styles.baseImage}
-          onLoad={handleImageLoad}
         />
 
         <svg
@@ -854,15 +760,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
-          preserveAspectRatio="xMinYMin meet"
-          style={{
-            position: 'absolute',
-            top: `${svgPosition.top}px`,
-            left: `${svgPosition.left}px`,
-            width: `${svgPosition.width}px`,
-            height: `${svgPosition.height}px`,
-            touchAction: 'none',
-          }}
+          preserveAspectRatio="xMidYMid meet"
         >
           {/* Committed shapes */}
           {undoStack.shapes.map((shape) => {

--- a/client/src/components/photos/PhotoAnnotator/geometry.test.ts
+++ b/client/src/components/photos/PhotoAnnotator/geometry.test.ts
@@ -40,108 +40,135 @@ import {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function makeSvgRect(left: number, top: number, width: number, height: number): DOMRect {
-  return {
-    left,
-    top,
-    width,
-    height,
-    right: left + width,
-    bottom: top + height,
-    x: left,
-    y: top,
-    toJSON: () => ({}),
-  } as DOMRect;
+/**
+ * Create a mock SVG element with getScreenCTM() support.
+ * The CTM represents the transformation from viewBox image-space to screen-space.
+ * For a simple scale+translate (no rotation), the matrix is:
+ *   [a, b, c, d, e, f] where x' = a*x + c*y + e, y' = b*x + d*y + f
+ * For center-fit (xMidYMid meet) with scale uniformly:
+ *   a=d=scale, b=c=0, e=translate_x, f=translate_y
+ * @param imageWidth Image viewBox width
+ * @param imageHeight Image viewBox height
+ * @param screenX Screen left position
+ * @param screenY Screen top position
+ * @param screenWidth Screen rendered width
+ * @param screenHeight Screen rendered height
+ */
+function makeMockSvg(
+  imageWidth: number,
+  imageHeight: number,
+  screenX: number,
+  screenY: number,
+  screenWidth: number,
+  screenHeight: number,
+): SVGSVGElement {
+  // Compute scale (meet fit: uniform scale, smaller ratio to fit both dimensions)
+  const scaleX = screenWidth / imageWidth;
+  const scaleY = screenHeight / imageHeight;
+  const scale = Math.min(scaleX, scaleY);
+
+  // Compute translate for centering
+  const scaledImageWidth = imageWidth * scale;
+  const scaledImageHeight = imageHeight * scale;
+  const tx = screenX + (screenWidth - scaledImageWidth) / 2;
+  const ty = screenY + (screenHeight - scaledImageHeight) / 2;
+
+  // The inverse CTM: converts screen → image space
+  const invScale = 1 / scale;
+  const invTx = -tx * invScale;
+  const invTy = -ty * invScale;
+
+  const mockSvg = {
+    getScreenCTM: () => ({
+      a: scale,
+      b: 0,
+      c: 0,
+      d: scale,
+      e: tx,
+      f: ty,
+      inverse: () => ({
+        a: invScale,
+        b: 0,
+        c: 0,
+        d: invScale,
+        e: invTx,
+        f: invTy,
+      }),
+    }),
+    createSVGPoint: () => ({
+      x: 0,
+      y: 0,
+      matrixTransform(matrix: any) {
+        return {
+          x: matrix.a * this.x + matrix.c * this.y + matrix.e,
+          y: matrix.b * this.x + matrix.d * this.y + matrix.f,
+        };
+      },
+    }),
+  } as unknown as SVGSVGElement;
+
+  return mockSvg;
 }
 
 // ─── screenToImage ────────────────────────────────────────────────────────────
 
 describe('screenToImage()', () => {
   it('converts screen-left to image-left (x=0) for image filling SVG', () => {
-    const svgRect = makeSvgRect(100, 50, 400, 300);
-    const result = screenToImage(100, 50, svgRect, 800, 600);
+    // SVG 400×300 at screen (100, 50), image 800×600
+    // Scale = min(400/800, 300/600) = 0.5
+    // Scaled image is 400×300, centered in 400×300 screen → tx=100, ty=50
+    const svg = makeMockSvg(800, 600, 100, 50, 400, 300);
+    const result = screenToImage(100, 50, svg);
     expect(result.x).toBeCloseTo(0);
     expect(result.y).toBeCloseTo(0);
   });
 
   it('converts screen-right to image-right for image filling SVG', () => {
-    const svgRect = makeSvgRect(100, 50, 400, 300);
-    const result = screenToImage(500, 350, svgRect, 800, 600);
+    // SVG 400×300 at screen (100, 50), image 800×600
+    const svg = makeMockSvg(800, 600, 100, 50, 400, 300);
+    const result = screenToImage(500, 350, svg);
     expect(result.x).toBeCloseTo(800);
     expect(result.y).toBeCloseTo(600);
   });
 
   it('converts screen-center to image-center', () => {
-    const svgRect = makeSvgRect(0, 0, 400, 300);
-    const result = screenToImage(200, 150, svgRect, 800, 600);
+    // SVG 400×300 at screen (0, 0), image 800×600
+    // Scale = 0.5, centered → tx=0, ty=0
+    const svg = makeMockSvg(800, 600, 0, 0, 400, 300);
+    const result = screenToImage(200, 150, svg);
     expect(result.x).toBeCloseTo(400);
     expect(result.y).toBeCloseTo(300);
   });
 
-  it('scales correctly with non-square aspect ratios', () => {
-    // SVG is 200px wide, 100px tall; image is 1000px wide, 500px tall
-    const svgRect = makeSvgRect(0, 0, 200, 100);
-    const result = screenToImage(50, 25, svgRect, 1000, 500);
-    // 50/200 * 1000 = 250; 25/100 * 500 = 125
+  it('scales correctly with non-square aspect ratios (portrait image)', () => {
+    // SVG 200×300 at screen (0, 0), image 1000×500 (wider than tall)
+    // Scale = min(200/1000, 300/500) = min(0.2, 0.6) = 0.2 (limited by width)
+    // Scaled: 200×100. Center vertically: tx=0, ty=(300-100)/2=100
+    const svg = makeMockSvg(1000, 500, 0, 0, 200, 300);
+    // Click at screen (50, 100+50) = (50, 150) → should be image (250, 250)
+    const result = screenToImage(50, 150, svg);
     expect(result.x).toBeCloseTo(250);
-    expect(result.y).toBeCloseTo(125);
+    expect(result.y).toBeCloseTo(250);
   });
 
-  // ── Letterbox (pillarbox) regression — fix for coord-dimension-bugs ────────
-  //
-  // Context: PhotoAnnotator previously passed `svgRef.getBoundingClientRect()` to
-  // screenToImage, but the SVG covers the full container while the image is centred
-  // with `object-fit: contain`, producing letterbox/pillarbox padding.  The fix
-  // changed all four callsites to pass `imgRef.getBoundingClientRect()` instead.
-  //
-  // These tests document the *expected* semantics of screenToImage when the rect
-  // argument represents the image element itself (not the surrounding container).
-  // Because screenToImage is a pure function that treats the rect as its coordinate
-  // origin and scale, passing the image rect yields correct image-space coordinates
-  // regardless of any surrounding letterbox.
+  it('handles letterboxed layout with center-fit', () => {
+    // SVG container 400×450 at screen (0, 0), image 2000×1500
+    // Scale = min(400/2000, 450/1500) = min(0.2, 0.3) = 0.2
+    // Scaled: 400×300. Center vertically: ty = (450-300)/2 = 75
+    const svg = makeMockSvg(2000, 1500, 0, 0, 400, 450);
+    // Click at SVG top-left (0, 0) → in letterbox, above image → negative y
+    const resultTopLeft = screenToImage(0, 0, svg);
+    expect(resultTopLeft.y).toBeLessThan(0); // In letterbox area
 
-  it('regression: click at image top-left in a letterboxed layout maps to (0, 0)', () => {
-    // Scenario: 400×450 container (SVG), but the image is 400×300 centred vertically.
-    // imgRect = { left:0, top:75, width:400, height:300 }  (75px top/bottom letterbox)
-    // A click at screen (0, 75) — the image's top-left corner — must map to image (0, 0).
-    const imgRect = makeSvgRect(0, 75, 400, 300);
-    const result = screenToImage(0, 75, imgRect, 2000, 1500);
-    expect(result.x).toBeCloseTo(0);
-    expect(result.y).toBeCloseTo(0);
-  });
+    // Click at image top-left (0, 75) → image (0, 0)
+    const resultImageTopLeft = screenToImage(0, 75, svg);
+    expect(resultImageTopLeft.x).toBeCloseTo(0);
+    expect(resultImageTopLeft.y).toBeCloseTo(0);
 
-  it('regression: click at image center in a letterboxed layout maps to image center', () => {
-    // Same letterboxed layout: imgRect top=75, height=300.
-    // Image is 2000×1500.  Screen click at image center (200, 225) must map to (1000, 750).
-    const imgRect = makeSvgRect(0, 75, 400, 300);
-    const result = screenToImage(200, 225, imgRect, 2000, 1500);
-    // (200 - 0) / 400 * 2000 = 1000; (225 - 75) / 300 * 1500 = 750
-    expect(result.x).toBeCloseTo(1000);
-    expect(result.y).toBeCloseTo(750);
-  });
-
-  it('regression: using SVG container rect instead of image rect produces wrong coords for letterboxed photo', () => {
-    // This test documents the WRONG behaviour that existed before the fix.
-    // With a letterboxed image (imgRect top=75) a click at screen (200, 150) should be
-    // inside the letterbox — above the image — and NOT inside the image at all.
-    // If the caller mistakenly passes the SVG/container rect (top=0, height=450) instead,
-    // screenToImage would compute (1000, 500) instead of a negative y, masking the bug.
-    // The correct answer when the IMAGE rect is passed: y = (150 - 75) / 300 * 1500 = 375
-    // (inside the image at the top quarter), not 500.
-    const imgRect = makeSvgRect(0, 75, 400, 300); // correct: image rect
-    const containerRect = makeSvgRect(0, 0, 400, 450); // wrong:  SVG/container rect
-    const screenY = 150; // 75px below the container top, but only 75px below the IMAGE top
-
-    const correctResult = screenToImage(200, screenY, imgRect, 2000, 1500);
-    const wrongResult = screenToImage(200, screenY, containerRect, 2000, 1500);
-
-    // Correct: y relative to image top = 150 - 75 = 75px into the 300px-tall img → 375
-    expect(correctResult.y).toBeCloseTo(375);
-    // Wrong: y relative to container top = 150 - 0 = 150px into 450px → 500 (inflated)
-    expect(wrongResult.y).toBeCloseTo(500);
-
-    // The two results must differ — proving that passing the wrong rect changes coordinates.
-    expect(correctResult.y).not.toBeCloseTo(wrongResult.y);
+    // Click at image center (200, 75+150) = (200, 225) → image (1000, 750)
+    const resultCenter = screenToImage(200, 225, svg);
+    expect(resultCenter.x).toBeCloseTo(1000);
+    expect(resultCenter.y).toBeCloseTo(750);
   });
 });
 
@@ -149,40 +176,29 @@ describe('screenToImage()', () => {
 
 describe('imageToScreen()', () => {
   it('converts image-origin to screen-origin (SVG top-left)', () => {
-    const svgRect = makeSvgRect(100, 50, 400, 300);
-    const result = imageToScreen(0, 0, svgRect, 800, 600);
+    // SVG 400×300 at screen (100, 50), image 800×600
+    const svg = makeMockSvg(800, 600, 100, 50, 400, 300);
+    const result = imageToScreen(0, 0, svg);
     expect(result.x).toBeCloseTo(100);
     expect(result.y).toBeCloseTo(50);
   });
 
   it('is the exact inverse of screenToImage', () => {
-    const svgRect = makeSvgRect(100, 50, 400, 300);
-    const imageWidth = 1920;
-    const imageHeight = 1080;
-
+    // SVG 400×300 at screen (100, 50), image 1920×1080
+    const svg = makeMockSvg(1920, 1080, 100, 50, 400, 300);
     const originalScreen = { x: 250, y: 175 };
-    const imageCoords = screenToImage(
-      originalScreen.x,
-      originalScreen.y,
-      svgRect,
-      imageWidth,
-      imageHeight,
-    );
-    const backToScreen = imageToScreen(
-      imageCoords.x,
-      imageCoords.y,
-      svgRect,
-      imageWidth,
-      imageHeight,
-    );
+
+    const imageCoords = screenToImage(originalScreen.x, originalScreen.y, svg);
+    const backToScreen = imageToScreen(imageCoords.x, imageCoords.y, svg);
 
     expect(backToScreen.x).toBeCloseTo(originalScreen.x);
     expect(backToScreen.y).toBeCloseTo(originalScreen.y);
   });
 
   it('converts image-right to screen-right', () => {
-    const svgRect = makeSvgRect(0, 0, 400, 300);
-    const result = imageToScreen(800, 600, svgRect, 800, 600);
+    // SVG 400×300 at screen (0, 0), image 800×600
+    const svg = makeMockSvg(800, 600, 0, 0, 400, 300);
+    const result = imageToScreen(800, 600, svg);
     expect(result.x).toBeCloseTo(400);
     expect(result.y).toBeCloseTo(300);
   });

--- a/client/src/components/photos/PhotoAnnotator/geometry.ts
+++ b/client/src/components/photos/PhotoAnnotator/geometry.ts
@@ -1,36 +1,49 @@
 /**
- * Converts screen-space point to image-space coordinates.
- * @param screenX X coordinate relative to SVG element's bounding rect
- * @param screenY Y coordinate relative to SVG element's bounding rect
- * @param svgRect The SVG element's bounding rect (from getBoundingClientRect)
- * @param imageWidth Native image width in pixels
- * @param imageHeight Native image height in pixels
+ * Converts screen-space (viewport) coordinates to image-space coordinates using SVG's native CTM.
+ * This approach avoids staleness issues from tracking SVG position in state — the SVG's CTM
+ * reflects the current layout and `preserveAspectRatio` meet-fit transform in real time.
+ * @param clientX X coordinate in viewport
+ * @param clientY Y coordinate in viewport
+ * @param svg The SVG element
  */
 export function screenToImage(
-  screenX: number,
-  screenY: number,
-  svgRect: DOMRect,
-  imageWidth: number,
-  imageHeight: number,
+  clientX: number,
+  clientY: number,
+  svg: SVGSVGElement,
 ): { x: number; y: number } {
-  const imageX = ((screenX - svgRect.left) / svgRect.width) * imageWidth;
-  const imageY = ((screenY - svgRect.top) / svgRect.height) * imageHeight;
-  return { x: imageX, y: imageY };
+  // Graceful fallback for test environments where getScreenCTM is not available
+  if (!svg || !svg.getScreenCTM) {
+    return { x: clientX, y: clientY };
+  }
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return { x: 0, y: 0 };
+  const point = svg.createSVGPoint();
+  point.x = clientX;
+  point.y = clientY;
+  const local = point.matrixTransform(ctm.inverse());
+  return { x: local.x, y: local.y };
 }
 
 /**
- * Converts image-space coordinates to screen-space. Inverse of screenToImage.
+ * Converts image-space coordinates to screen-space (viewport) coordinates using SVG's native CTM.
+ * Inverse of screenToImage.
  */
 export function imageToScreen(
   imageX: number,
   imageY: number,
-  svgRect: DOMRect,
-  imageWidth: number,
-  imageHeight: number,
+  svg: SVGSVGElement,
 ): { x: number; y: number } {
-  const screenX = (imageX / imageWidth) * svgRect.width + svgRect.left;
-  const screenY = (imageY / imageHeight) * svgRect.height + svgRect.top;
-  return { x: screenX, y: screenY };
+  // Graceful fallback for test environments where getScreenCTM is not available
+  if (!svg || !svg.getScreenCTM) {
+    return { x: imageX, y: imageY };
+  }
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return { x: 0, y: 0 };
+  const point = svg.createSVGPoint();
+  point.x = imageX;
+  point.y = imageY;
+  const screen = point.matrixTransform(ctm);
+  return { x: screen.x, y: screen.y };
 }
 
 /**

--- a/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
@@ -56,7 +56,7 @@ export const SelectTool: ToolHandler = {
       if (ctx.event.detail === 2 && (shape.type === 'text' || shape.type === 'callout')) {
         const bodyHit =
           shape.type === 'text'
-            ? hitTestText(imageX, imageY, shape, 4)
+            ? hitTestText(imageX, imageY, shape, 12)
             : hitTestCallout(imageX, imageY, shape);
         if (bodyHit) {
           ctx.onOpenInlineInput?.(shape.x, shape.y, shape.id);
@@ -75,7 +75,7 @@ export const SelectTool: ToolHandler = {
             shape.y1,
             shape.x2,
             shape.y2,
-            4 + shape.strokeWidth / 2,
+            12 + shape.strokeWidth / 2,
           ) !== null;
         if (hit) {
           const midX = (shape.x1 + shape.x2) / 2;
@@ -139,14 +139,14 @@ export const SelectTool: ToolHandler = {
         ];
       }
 
-      // Then check for body hit
+      // Then check for body hit (with generous tolerance for easier selection)
       let bodyHit = false;
       if (shape.type === 'rectangle') {
-        bodyHit = hitTestRectangle(imageX, imageY, shape, shape.strokeWidth, 0) !== null;
+        bodyHit = hitTestRectangle(imageX, imageY, shape, shape.strokeWidth, 12) !== null;
       } else if (shape.type === 'highlight') {
         bodyHit = hitTestHighlight(imageX, imageY, shape);
       } else if (shape.type === 'arrow' || shape.type === 'line') {
-        bodyHit = hitTestLine(imageX, imageY, shape.x1, shape.y1, shape.x2, shape.y2, 4) !== null;
+        bodyHit = hitTestLine(imageX, imageY, shape.x1, shape.y1, shape.x2, shape.y2, 12) !== null;
       } else if (shape.type === 'ellipse') {
         bodyHit =
           hitTestEllipse(
@@ -157,10 +157,10 @@ export const SelectTool: ToolHandler = {
             shape.rx,
             shape.ry,
             shape.strokeWidth,
-            0,
+            12,
           ) !== null;
       } else if (shape.type === 'text') {
-        bodyHit = hitTestText(imageX, imageY, shape, 4);
+        bodyHit = hitTestText(imageX, imageY, shape, 12);
       } else if (shape.type === 'callout') {
         bodyHit = handleHit ? false : hitTestCallout(imageX, imageY, shape);
       } else if (shape.type === 'measurement') {
@@ -172,10 +172,10 @@ export const SelectTool: ToolHandler = {
             shape.y1,
             shape.x2,
             shape.y2,
-            4 + shape.strokeWidth / 2,
+            12 + shape.strokeWidth / 2,
           ) !== null;
       } else if (shape.type === 'freehand') {
-        bodyHit = hitTestPolyline(imageX, imageY, shape.points, 4 + shape.strokeWidth / 2) !== null;
+        bodyHit = hitTestPolyline(imageX, imageY, shape.points, 12 + shape.strokeWidth / 2) !== null;
       }
 
       if (bodyHit) {


### PR DESCRIPTION
## Summary

Three previous attempts at fixing the coord offset (#1492, #1497, #1502) all kept an `svgPosition` state in sync with the image's bounding rect. Every approach was vulnerable to staleness — header collapse, lazy image load, scroll, etc. — and the user kept reporting the shape drifts up from the cursor.

Switched to `SVG.getScreenCTM().inverse()` for the screen→image transform. The browser updates the CTM on every layout pass, so there is no stale state to maintain. The SVG now spans the entire container (`inset: 0`) with `preserveAspectRatio="xMidYMid meet"`, matching the img's `object-fit: contain`, so the two visually overlap regardless of aspect mismatch.

Also widened the SelectTool body hit-test tolerance from 4 to 12 image pixels — the previous margin felt too tight.

## Test plan

- [x] All 744 PhotoAnnotator tests pass (geometry tests rewritten for the CTM-based implementation)
- [x] Typecheck green
- [ ] Manual: draw on landscape, portrait, scroll, resize the window — shape always lands under the cursor
- [ ] Manual: clicking on an existing shape selects it on the first try