### PR TITLE
fix(photo-annotator): swallow pointer events while inline input is open

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -413,6 +413,13 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   // Pointer event handlers for drawing/editing
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      // While the inline input is open, swallow pointer events so they don't
+      // disturb the draft shape. The input's onBlur handler will commit the
+      // pending measurement/callout/text.
+      if (inlineInput.isOpen) {
+        return;
+      }
+
       if (!svgRef.current) return;
 
       let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);
@@ -457,11 +464,18 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         dispatch(action);
       }
     },
-    [state, photo.width, photo.height, dispatch, openInlineInput],
+    [state, photo.width, photo.height, dispatch, openInlineInput, inlineInput.isOpen],
   );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      // While the inline input is open, swallow pointer events so they don't
+      // disturb the draft shape. The input's onBlur handler will commit the
+      // pending measurement/callout/text.
+      if (inlineInput.isOpen) {
+        return;
+      }
+
       if (!svgRef.current) return;
 
       let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);
@@ -499,11 +513,18 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         dispatch(action);
       }
     },
-    [state, photo.width, photo.height, dispatch, openInlineInput],
+    [state, photo.width, photo.height, dispatch, openInlineInput, inlineInput.isOpen],
   );
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      // While the inline input is open, swallow pointer events so they don't
+      // disturb the draft shape. The input's onBlur handler will commit the
+      // pending measurement/callout/text.
+      if (inlineInput.isOpen) {
+        return;
+      }
+
       if (!svgRef.current) return;
 
       let { x: imageX, y: imageY } = screenToImage(e.clientX, e.clientY, svgRef.current);


### PR DESCRIPTION
## Summary

Drawing a measurement, typing a label and clicking away saved only the typed text, not the shape. Same race could affect text/callout. Root cause: `pointerdown` on the SVG fires before the input loses focus, so the active tool's `onPointerDown` overwrites `state.draftShape` before `commitInlineInput` runs via the subsequent blur.

Fix: early-return from `handlePointerDown` / `Move` / `Up` whenever `inlineInput.isOpen`. The click is purely dismissive — the input's `onBlur` fires next and commits the original draft.

## Test plan

- [x] All 741 PhotoAnnotator tests pass
- [x] Typecheck green
- [ ] Manual: draw measurement → type "5 m" → click on the photo → measurement saved with label
- [ ] Same flow with text and callout tools