### PR TITLE
fix(photos): edit button opens viewer directly in annotator mode

### DIFF
--- a/client/src/components/photos/PhotoViewer.test.tsx
+++ b/client/src/components/photos/PhotoViewer.test.tsx
@@ -146,7 +146,7 @@ describe('PhotoViewer', () => {
     jest.clearAllMocks();
   });
 
-  function renderViewer(photos: Photo[], initialIndex = 0, editable = true) {
+  function renderViewer(photos: Photo[], initialIndex = 0, editable = true, startInAnnotator = false) {
     return render(
       React.createElement(PhotoViewer, {
         photos,
@@ -154,6 +154,7 @@ describe('PhotoViewer', () => {
         onClose: mockOnClose,
         onPhotoAnnotated: mockOnPhotoAnnotated,
         editable,
+        startInAnnotator,
       }),
     );
   }
@@ -392,5 +393,27 @@ describe('PhotoViewer', () => {
     renderViewer([makePhoto()]);
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── startInAnnotator prop ─────────────────────────────────────────────────
+
+  it('starts in view mode when startInAnnotator=false (default)', () => {
+    renderViewer([makePhoto({ width: 800, height: 600 })], 0, true, false);
+    // Annotate button should be visible (not hidden by annotating)
+    expect(screen.getByTestId('photo-viewer-annotate')).toBeInTheDocument();
+    expect(screen.getByTestId('photo-viewer-annotate')).not.toBeDisabled();
+  });
+
+  it('starts in annotator mode when startInAnnotator=true and editable=true', () => {
+    renderViewer([makePhoto({ width: 800, height: 600 })], 0, true, true);
+    // Navigation arrows should be hidden (annotating=true)
+    expect(screen.queryByTestId('photo-viewer-prev')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('photo-viewer-next')).not.toBeInTheDocument();
+  });
+
+  it('starts in view mode when startInAnnotator=true but editable=false', () => {
+    renderViewer([makePhoto({ width: 800, height: 600 })], 0, false, true);
+    // Should stay in view mode — annotate button disabled, navigation visible
+    expect(screen.getByTestId('photo-viewer-annotate')).toBeDisabled();
   });
 });

--- a/client/src/components/photos/PhotoViewer.tsx
+++ b/client/src/components/photos/PhotoViewer.tsx
@@ -13,6 +13,7 @@ export interface PhotoViewerProps {
   onClose: () => void;
   onPhotoAnnotated?: (photo: Photo) => void;
   editable?: boolean;
+  startInAnnotator?: boolean;
 }
 
 export function PhotoViewer({
@@ -21,10 +22,11 @@ export function PhotoViewer({
   onClose,
   onPhotoAnnotated,
   editable = true,
+  startInAnnotator = false,
 }: PhotoViewerProps) {
   const { t } = useTranslation(['photoViewer', 'common']);
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  const [isAnnotating, setIsAnnotating] = useState(false);
+  const [isAnnotating, setIsAnnotating] = useState(startInAnnotator && editable);
   const [showingOriginal, setShowingOriginal] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [isClearingAnnotation, setIsClearingAnnotation] = useState(false);

--- a/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
+++ b/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
@@ -53,6 +53,7 @@ export default function DiaryEntryDetailPage() {
 
   // Photo state
   const [selectedPhotoIndex, setSelectedPhotoIndex] = useState<number | null>(null);
+  const [openAsAnnotator, setOpenAsAnnotator] = useState(false);
   const photosResult = usePhotos(id ? 'diary_entry' : '', id || '');
 
   useEffect(() => {
@@ -272,10 +273,12 @@ export default function DiaryEntryDetailPage() {
                   photos={photosResult.photos}
                   onPhotoClick={(photo) => {
                     const index = photosResult.photos.findIndex((p) => p.id === photo.id);
+                    setOpenAsAnnotator(false);
                     setSelectedPhotoIndex(index);
                   }}
                   onEdit={(photo) => {
                     const index = photosResult.photos.findIndex((p) => p.id === photo.id);
+                    setOpenAsAnnotator(true);
                     setSelectedPhotoIndex(index);
                   }}
                   loading={photosResult.loading}
@@ -291,9 +294,13 @@ export default function DiaryEntryDetailPage() {
           <PhotoViewer
             photos={photosResult.photos}
             initialIndex={selectedPhotoIndex}
-            onClose={() => setSelectedPhotoIndex(null)}
+            onClose={() => {
+              setSelectedPhotoIndex(null);
+              setOpenAsAnnotator(false);
+            }}
             onPhotoAnnotated={photosResult.updatePhotoAnnotation}
             editable={!entry.isSigned}
+            startInAnnotator={openAsAnnotator}
           />
         )}
 

--- a/client/src/pages/DiaryEntryEditPage/DiaryEntryEditPage.tsx
+++ b/client/src/pages/DiaryEntryEditPage/DiaryEntryEditPage.tsx
@@ -81,6 +81,7 @@ export default function DiaryEntryEditPage() {
 
   // Photo state
   const [selectedPhotoIndex, setSelectedPhotoIndex] = useState<number | null>(null);
+  const [openAsAnnotator, setOpenAsAnnotator] = useState(false);
   const photosResult = usePhotos(entry ? 'diary_entry' : '', entry?.id || '');
 
   // Form fields
@@ -709,6 +710,7 @@ export default function DiaryEntryEditPage() {
                   photos={photosResult.photos}
                   onPhotoClick={(photo) => {
                     const index = photosResult.photos.findIndex((p) => p.id === photo.id);
+                    setOpenAsAnnotator(false);
                     setSelectedPhotoIndex(index);
                   }}
                   onDelete={(photo) => {
@@ -716,6 +718,7 @@ export default function DiaryEntryEditPage() {
                   }}
                   onEdit={(photo) => {
                     const index = photosResult.photos.findIndex((p) => p.id === photo.id);
+                    setOpenAsAnnotator(true);
                     setSelectedPhotoIndex(index);
                   }}
                   editable={!entry.isSigned}
@@ -732,8 +735,12 @@ export default function DiaryEntryEditPage() {
         <PhotoViewer
           photos={photosResult.photos}
           initialIndex={selectedPhotoIndex}
-          onClose={() => setSelectedPhotoIndex(null)}
+          onClose={() => {
+            setSelectedPhotoIndex(null);
+            setOpenAsAnnotator(false);
+          }}
           onPhotoAnnotated={photosResult.updatePhotoAnnotation}
+          startInAnnotator={openAsAnnotator}
         />
       )}
 


### PR DESCRIPTION
## Summary

The pencil button on a photo card opened the viewer in read-only mode. The user had to click Annotate inside the viewer to actually start editing, which defeated the point of having a separate Edit shortcut.

`PhotoViewer` now takes a `startInAnnotator` prop. `DiaryEntryDetailPage` and `DiaryEntryEditPage` track a small `openAsAnnotator` flag — `onEdit` sets it `true`, `onPhotoClick` sets it `false`, and viewer close clears it. PhotoViewer guards the prop with the existing `editable` check so signed entries can't accidentally enter annotator mode.

## Test plan

- [x] PhotoCard tests still pass (14/14)
- [x] PhotoViewer new tests pass (3/3 for the new prop)
- [x] Typecheck green
- [ ] Manual: hit the pencil on a photo card — viewer opens with the annotator already active
- [ ] Manual: regular tile click — viewer opens in view mode as before