### PR TITLE
fix(photos): cache-bust thumbnail URL when annotation changes

### DIFF
--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -73,6 +73,9 @@ let sessionService: typeof import('../services/sessionService.js');
 // ─── Test fixtures ────────────────────────────────────────────────────────────
 
 function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  const updatedAt = '2026-03-01T12:00:00.000Z';
+  const annotatedAt = null;
+  const cacheVersion = annotatedAt ?? updatedAt;
   return {
     id: '33333333-3333-3333-3333-333333333333',
     entityType: 'test',
@@ -88,10 +91,10 @@ function makePhoto(overrides: Partial<Photo> = {}): Photo {
     sortOrder: 0,
     createdBy: { id: 'user-id', displayName: 'Test User' },
     createdAt: '2026-03-01T12:00:00.000Z',
-    updatedAt: '2026-03-01T12:00:00.000Z',
-    annotatedAt: null,
+    updatedAt,
+    annotatedAt,
     fileUrl: '/api/photos/33333333-3333-3333-3333-333333333333/file',
-    thumbnailUrl: '/api/photos/33333333-3333-3333-3333-333333333333/thumbnail',
+    thumbnailUrl: `/api/photos/33333333-3333-3333-3333-333333333333/thumbnail?v=${encodeURIComponent(cacheVersion)}`,
     ...overrides,
   };
 }

--- a/server/src/services/photoAnnotationService.test.ts
+++ b/server/src/services/photoAnnotationService.test.ts
@@ -183,6 +183,7 @@ describe('photoAnnotationService', () => {
               .where(eq(schema.users.id, row.createdBy))
               .get()
           : null;
+        const cacheVersion = row.annotatedAt ?? row.updatedAt;
         return {
           id: row.id,
           entityType: row.entityType,
@@ -200,7 +201,7 @@ describe('photoAnnotationService', () => {
           createdAt: row.createdAt,
           updatedAt: row.updatedAt,
           fileUrl: `/api/photos/${row.id}/file`,
-          thumbnailUrl: `/api/photos/${row.id}/thumbnail`,
+          thumbnailUrl: `/api/photos/${row.id}/thumbnail?v=${encodeURIComponent(cacheVersion)}`,
         } as Photo;
       };
     }

--- a/server/src/services/photoService.test.ts
+++ b/server/src/services/photoService.test.ts
@@ -186,7 +186,9 @@ describe('photoService', () => {
       expect(photo.caption).toBeNull();
       expect(photo.sortOrder).toBe(0);
       expect(photo.fileUrl).toBe(`/api/photos/${photo.id}/file`);
-      expect(photo.thumbnailUrl).toBe(`/api/photos/${photo.id}/thumbnail`);
+      expect(photo.thumbnailUrl).toMatch(
+        new RegExp(`^/api/photos/${photo.id}/thumbnail\\?v=`),
+      );
       expect(photo.createdBy).toEqual({ id: userId, displayName: 'Test User' });
       expect(photo.createdAt).toBeDefined();
       expect(photo.updatedAt).toBeDefined();
@@ -586,7 +588,9 @@ describe('photoService', () => {
 
       const result = photoService.getPhoto(db, uploaded.id);
       expect(result!.fileUrl).toBe(`/api/photos/${uploaded.id}/file`);
-      expect(result!.thumbnailUrl).toBe(`/api/photos/${uploaded.id}/thumbnail`);
+      expect(result!.thumbnailUrl).toMatch(
+        new RegExp(`^/api/photos/${uploaded.id}/thumbnail\\?v=`),
+      );
     });
   });
 

--- a/server/src/services/photoService.ts
+++ b/server/src/services/photoService.ts
@@ -53,11 +53,16 @@ function getExtensionForMimeType(mimeType: string): string {
 
 /**
  * Map a photos DB row + user to a Photo shape.
+ * Includes cache-buster version param in thumbnailUrl based on annotatedAt (or updatedAt as fallback).
  */
 function toPhoto(
   row: typeof photos.$inferSelect,
   user: typeof users.$inferSelect | null | undefined,
 ): Photo {
+  // Use annotatedAt if present (annotation was made), otherwise use updatedAt for cache busting
+  const cacheVersion = row.annotatedAt ?? row.updatedAt;
+  const thumbnailUrl = `/api/photos/${row.id}/thumbnail?v=${encodeURIComponent(cacheVersion)}`;
+
   return {
     id: row.id,
     entityType: row.entityType,
@@ -76,7 +81,7 @@ function toPhoto(
     updatedAt: row.updatedAt,
     annotatedAt: row.annotatedAt ?? null,
     fileUrl: `/api/photos/${row.id}/file`,
-    thumbnailUrl: `/api/photos/${row.id}/thumbnail`,
+    thumbnailUrl,
   };
 }
 


### PR DESCRIPTION
## Summary

Saving an annotation already regenerated the thumbnail server-side, but the photo grid kept showing the old image because the thumbnail URL was a stable `/api/photos/:id/thumbnail`. The browser cached it indefinitely.

`photoService.toPhoto` now appends `?v=<annotatedAt | updatedAt>` to the URL. The query string flips every time the photo is re-annotated, so the browser fetches the fresh thumbnail automatically.

## Test plan

- [x] Server typecheck + photo tests green
- [x] Photo grid `<img src>` consumers pick up the new URL automatically (no client change needed)
- [ ] Manual: annotate a photo, save, go back to the grid — annotated thumbnail appears