### PR TITLE
fix(photo-annotator): sync undoStack with UPDATE_SHAPE so live edits render

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
+++ b/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
@@ -122,9 +122,11 @@ export function annotatorReducer(
     case 'SELECT_SHAPE':
       return { ...state, selectedShapeId: action.id };
 
-    case 'UPDATE_SHAPE':
+    case 'UPDATE_SHAPE': {
       const updatedShapes = state.shapes.map((s) => (s.id === action.shape.id ? action.shape : s));
+      undoStack?.replace(updatedShapes);
       return { ...state, shapes: updatedShapes };
+    }
 
     case 'DELETE_SELECTED':
       if (!state.selectedShapeId) return state;


### PR DESCRIPTION
## Summary

`useAnnotator` returns `state.shapes = undoStack.shapes`, so the reducer's `UPDATE_SHAPE` mutations were invisible to consumers. The select tool's drag-to-move dispatched `UPDATE_SHAPE` per pointer-move but the screen never updated. The color/stroke/font pickers added in #1514 only "worked" because they explicitly called `undoStack.commit` after each picker change.

`UPDATE_SHAPE` now also calls `undoStack.replace(updatedShapes)` — replace updates the present without touching past/future, so live drags render in real time. The eventual `undoStack.commit(state.shapes)` on pointer-up still records the final move into undo history.

## Test plan

- [x] All 741 PhotoAnnotator unit tests pass
- [x] Typecheck green
- [ ] Manual: select a shape and drag it — shape follows the cursor
- [ ] Manual: select a shape and change colour / stroke / font — change applies immediately
- [ ] Manual: undo after a drag — shape snaps back to its previous position