### PR TITLE
feat(photo-annotator): edit from annotated image with Reset button

### DIFF
--- a/.claude/agent-memory/frontend-developer/photo-metadata-sidepanel.md
+++ b/.claude/agent-memory/frontend-developer/photo-metadata-sidepanel.md
@@ -1,0 +1,117 @@
+---
+name: photo-metadata-sidepanel-implementation
+description: Photo metadata sidepanel feature implementation for photo viewer modal
+metadata:
+  type: project
+---
+
+## Implementation Summary
+
+Built a metadata sidepanel inside the photo viewer modal (PR feature/photo-metadata-sidepanel).
+
+### Files Created
+
+1. **PhotoMetadataSidepanel.tsx** — React component rendering upload date, editable caption, and area picker
+   - Uses `SearchPicker` shared component for area selection
+   - Handles independent metadata updates via `PATCH /api/photos/:id`
+   - Shows "Saving..." state and error handling
+   - Auto-hides save button when no changes detected
+
+2. **PhotoMetadataSidepanel.module.css** — Sidebar layout and styling
+   - Desktop: fixed-width sidebar (320px) on desktop, positioned right of viewer
+   - Mobile: bottom sheet (60vh max) with rounded top corners
+   - Uses design tokens exclusively (no hardcoded colors)
+   - Responsive collapse/expand animation with `transform: translateX()` on desktop, `translateY()` on mobile
+
+3. **PhotoMetadataSidepanel.test.tsx** — Unit tests for metadata component
+   - Tests: renders when open, hides when closed, displays formatted upload date, renders description textarea
+   - Tests: loads areas list on mount, resets form when photo changes, handles null caption
+   - Mocks photoApi and areasApi using jest.mock()
+
+4. **PhotoMetadataPanel locale strings** (EN + DE)
+   - EN: Added 10 new keys to `en/photoViewer.json` (metadataTitle, uploadDate, description, area, noArea, saveButton, saving, saveError, etc.)
+   - DE: Added placeholder empty strings in `de/photoViewer.json` for translator to fill
+
+### Files Modified
+
+1. **PhotoViewer.tsx**
+   - Imported PhotoMetadataSidepanel component
+   - Added `isSidepanelOpen` state and `currentPhoto` state (to track updates from sidepanel)
+   - Added metadata info button in toolbar (uses new InfoIcon SVG)
+   - Added button to toggle sidebar visibility with aria-pressed
+   - Wrapped photo/nav/infobar in `.mainViewer` div for layout restructuring
+   - Added `handlePhotoUpdated` callback to update currentPhoto when metadata changes
+
+2. **PhotoViewer.module.css**
+   - Changed `.container` to flexbox row (was column) for desktop layout
+   - Added `.mainViewer` flex wrapper for photo + controls
+   - Desktop: sidebar appears right of photo (flex-direction: row)
+   - Mobile: sidebar appears below photo (flex-direction: column via @media)
+   - Responsive: sidebar transforms to bottom sheet on mobile
+
+3. **PhotoViewer.test.tsx**
+   - Added mock for PhotoMetadataSidepanel component
+   - Added 6 new tests for metadata button: visibility, aria-pressed state, toggle open/close, default hidden state
+
+4. **Test fixtures** — Updated Photo mock objects in:
+   - PhotoCard.test.tsx — added `areaId: null`
+   - PhotoUpload.test.tsx — makePhoto helper now includes `areaId: null`
+   - photoApi.test.ts — makePhoto helper now includes `areaId: null`
+   - PhotoViewer.test.tsx — makePhoto helper now includes `areaId: null`
+
+### API Integration
+
+- Uses existing `updatePhoto(id, { caption?, areaId?, sortOrder? })` from photoApi
+- Calls `fetchAreas(params?)` to populate area dropdown
+- SearchPicker component handles area search/selection with special option for "no area"
+
+### Design & Layout
+
+**Desktop layout:**
+- Photo viewer centered in modal
+- Info bar at bottom with buttons and counter
+- Metadata sidebar fixed on right (320px wide), scrollable
+- Toggle button in toolbar opens/closes sidebar smoothly
+
+**Mobile layout:**
+- Photo viewer full width
+- Info bar at bottom with buttons
+- Metadata sidepanel slides up from bottom as sheet (max 60vh)
+- Rounded top corners, smooth slide animation
+
+**Visual hierarchy:**
+- Upload date: read-only display
+- Description: multi-line editable textarea
+- Area: SearchPicker dropdown with area hierarchy
+- Error state: red banner with error message
+- Save button: only visible when changes detected
+
+### Key Design Decisions
+
+1. **SearchPicker for area selection** — Reused shared component instead of custom dropdown (per component reuse policy)
+2. **Independent save** — Metadata saves don't trigger annotation flow; separate `PATCH /api/photos/:id` call
+3. **Auto-hide save button** — No save button shown unless caption or area actually changed
+4. **Responsive sheet vs sidebar** — Bottom sheet pattern on mobile is more natural than cramped sidebar
+5. **Uncontrolled form** — Form state managed locally in sidepanel, only updates parent photo when saved
+
+### i18n Keys Added
+
+```json
+metadataTitle        // "Photo Metadata"
+uploadDate          // "Upload Date"
+description         // "Description"
+descriptionPlaceholder  // "Add a description..."
+area               // "Area"
+areaPlaceholder     // "Select an area..."
+noArea              // "(no area)"
+saveButton          // "Save"
+saving              // "Saving..."
+saveError           // "Failed to save metadata"  
+```
+
+### Verification
+
+✓ TypeScript: `npx tsc --noEmit -p client/tsconfig.json` passes
+✓ Tests: Photo component tests passing (mocks updated for areaId field)
+✓ Design tokens: All CSS uses tokens, no hardcoded colors
+✓ Accessibility: aria-labels, aria-pressed on toggle, semantic HTML

--- a/.claude/agent-memory/qa-integration-tester/MEMORY.md
+++ b/.claude/agent-memory/qa-integration-tester/MEMORY.md
@@ -3,6 +3,25 @@
 > Detailed notes live in topic files. This index links to them.
 > See: `budget-categories-story-142.md`, `e2e-pom-patterns.md`, `e2e-parallel-isolation.md`, `story-358-document-linking.md`, `story-360-document-a11y.md`, `story-epic08-e2e.md`, `story-509-manage-page.md`, `story-471-dashboard.md`
 
+## jest.mock vs jest.unstable_mockModule for Child Component Mocks (2026-05-19)
+
+When a test needs to mock child components (e.g., `PhotoAnnotator`, `Modal`) and the API modules they call, use `jest.mock` (synchronous CJS form) — NOT `jest.unstable_mockModule`. The systemic `jest.unstable_mockModule` non-interception applies to ALL module types (components AND lib modules), not just context modules. Pattern:
+
+- `jest.mock('./ChildComponent.js', () => ({ ChildComponent: (props) => React.createElement(...) }))` — works locally and in CI
+- To get a spy reference from a `jest.mock`-ed module: `const mockFn = (require('../../lib/api.js') as typeof import('../../lib/api.js')).fnName as AnyMock;` (place AFTER `jest.mock` factory, NOT inside it). The `require()` call gets the already-mocked module.
+- Variable referenced inside `jest.mock` factory must start with `mock` prefix (jest hoisting rule) — or just use inline `jest.fn()` in the factory and `require()` to get the reference afterward.
+
+## LocaleProvider Wrapper Pattern for useFormatters() Components (2026-05-19)
+
+When a component calls `useFormatters()` (which calls `useLocale()` → requires `LocaleContext`), mocking `LocaleContext.js` via `jest.unstable_mockModule` doesn't intercept locally. The fix:
+1. Mock `../../lib/configApi.js` and `../../lib/preferencesApi.js` (prevent real network calls from LocaleProvider)
+2. Also mock `../../contexts/LocaleContext.js` (for CI where it intercepts)
+3. Dynamically import `LocaleProvider` alongside the component under test
+4. Wrap all `render()` calls: `React.createElement(LocaleProvider, { children: React.createElement(Component, props) })`
+5. In CI, the LocaleProvider mock is a passthrough `({ children }) => children`. Locally, it's the real provider (safe because API mocks prevent network calls).
+6. Use dual-path text assertions: `screen.queryByText('t-key') ?? screen.queryByText('Real Translation')` to work in both environments.
+7. Tests that assert `mockFetchAreas.toHaveBeenCalled()` (module-mock dependent) fail locally — name them "(CI only — module mock must intercept)" and add `{ timeout: 2000 }` to `waitFor`.
+
 ## Resolution-Aware Sizing Refactor — PhotoAnnotator Test Patterns (2026-05-18)
 
 **Approach**: When tool code switches from fixed pixel constants to `resolveStrokeWidth(key, w, h)` / `resolveFontSize(key, w, h)`, replace hardcoded pixel assertions in tool tests with calls to the resolve helpers using the test's image dims (e.g. `resolveStrokeWidth('medium', 800, 600)`). The test's `makeCtx()` always sets `imageWidth: 800, imageHeight: 600`, so expected values = `Math.max(1, Math.round(min(800,600) * ratio))`.
@@ -22,6 +41,16 @@
 **geometry.test.ts letterbox regression tests**: Added 3 pure-function tests at end of `describe('screenToImage()')` block documenting the coordinate contract for letterboxed images. These tests document the diff between using imgRect vs containerRect.
 
 **Canvas naturalWidth test in JSDOM**: Works by overriding `globalThis.Image` before the save flow runs. Use setters to capture `canvas.width` and `canvas.height` assignments. Wrap in `await act(async () => { ...; await new Promise<void>((r) => setTimeout(r, 10)); })` to let the Image onload timer fire.
+
+## PR #1496 — photos.test.ts diaryService Mock Fix (2026-05-18)
+
+**Problem**: `jest.unstable_mockModule('../services/diaryService.js', () => ({ getDiaryEntry: mockGetDiaryEntry }))` was a partial mock — it replaced the entire module with one export. CI failed with `SyntaxError: The requested module './diaryService.js' does not provide an export named 'createAutomaticDiaryEntry'` because `diaryAutoEventService.ts` (transitively imported by the app) needed other diaryService exports.
+
+**Root cause of wrong approach**: `photos.ts` never imports `diaryService` — it uses `isDiaryEntrySigned()` which queries `diaryEntries` table directly via Drizzle. The mock was attempting to control a code path that doesn't exist.
+
+**Fix applied (Option B — clean)**: Removed the `diaryService` mock entirely. Added an `insertDiaryEntry()` DB seeding helper inside the test suite (same pattern as `diary.test.ts`). Signed/unsigned tests now seed real diary entries into the real test DB. `mockGetPhoto` returns a photo whose `entityId` matches the seeded entry ID — the production code's DB query picks it up correctly.
+
+**Key pattern**: When a route uses a direct Drizzle DB query (not a service), tests MUST seed the DB — mocking the service won't work. Use `app.db.insert(table).values({...}).run()` to seed synchronously in SQLite.
 
 ## Story #1478 — PhotoAnnotator Polish Tests (2026-05-18)
 

--- a/.claude/agent-memory/translator/MEMORY.md
+++ b/.claude/agent-memory/translator/MEMORY.md
@@ -192,3 +192,4 @@ Note: `claimed` here uses "Beantragt" (applied/requested for subsidy) rather tha
 - Compound rule: "Annotations-" (noun stem) NOT "Annotierungs-" (gerund stem) — three keys fixed: `region`, `canvas`, `actions`
 - "Annotate" verb added to glossary: `{ "de": { "verb": "annotieren" } }` — loanword preferred over "markieren" (used for Highlight) or "anmerken"
 - `photoViewer.json` achieved exact parity (8 EN = 8 DE) with all #1475–#1477 keys present
+- `photoViewer.json` — 10 metadata sidepanel keys added 2026-05-19: `saving` → "Wird gespeichert..." (NOT "Speichern..."); `noArea` uses parenthesised lowercase `(kein Bereich)` as inline field fallback (distinct from `areas.noArea` = "Kein Bereich" heading form); parity now 19 EN = 19 DE

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"ec4d1f60-085a-482c-91c6-f95a0e76fc3d","pid":244,"procStart":"697","acquiredAt":1779095491812}
+{"sessionId":"ec4d1f60-085a-482c-91c6-f95a0e76fc3d","pid":241,"procStart":"419","acquiredAt":1779120594476}

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css
@@ -66,6 +66,11 @@
   min-height: 44px;
 }
 
+.resetButton {
+  composes: btnSecondary from '../../../styles/shared.module.css';
+  min-height: 44px;
+}
+
 /* Shared iconButton sub-pattern (dark surface — used by PhotoViewer info bar buttons) */
 .iconButton {
   display: flex;
@@ -100,6 +105,15 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
+}
+
+/* Modal buttons (for reset confirmation) */
+.modalButtonSecondary {
+  composes: btnSecondary from '../../../styles/shared.module.css';
+}
+
+.modalButtonPrimary {
+  composes: btnPrimary from '../../../styles/shared.module.css';
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -191,6 +191,50 @@ describe('PhotoAnnotator', () => {
     expect(screen.getByTestId('annotator-save')).toBeInTheDocument();
   });
 
+  it('loads annotated image when photo.annotatedAt is set', () => {
+    const annotatedAt = '2026-05-17T10:00:00.000Z';
+    renderAnnotator({ annotatedAt });
+
+    const img = screen.getByRole('img') as HTMLImageElement;
+    // The annotated version should be loaded (default behavior: prefer annotated)
+    // The URL should NOT contain variant=original
+    expect(img.src).toContain('/api/photos/photo-annotator-test/file');
+    expect(img.src).not.toContain('variant=original');
+  });
+
+  it('loads original image when reset button is used', async () => {
+    const annotatedAt = '2026-05-17T10:00:00.000Z';
+    renderAnnotator({ annotatedAt });
+
+    // Reset button should be visible when annotatedAt is set
+    const resetBtn = screen.getByTestId('annotator-reset');
+    expect(resetBtn).toBeInTheDocument();
+
+    // Click reset — should show confirmation modal
+    fireEvent.click(resetBtn);
+    // The modal title should be visible
+    const modalTitle = await screen.findByText(/Reset to original photo/);
+    expect(modalTitle).toBeInTheDocument();
+
+    // Find the confirm button by looking for buttons in the document and selecting the Reset one
+    // (there will be Cancel and Reset in the modal footer)
+    const buttons = screen.getAllByRole('button');
+    const confirmBtn = buttons.find((btn) => btn.textContent === 'Reset' && btn !== resetBtn);
+    expect(confirmBtn).toBeDefined();
+
+    // Confirm reset
+    fireEvent.click(confirmBtn!);
+
+    // After reset, the image src should include variant=original
+    const img = screen.getByRole('img') as HTMLImageElement;
+    expect(img.src).toContain('variant=original');
+  });
+
+  it('does NOT show reset button when photo has no annotations', () => {
+    renderAnnotator({ annotatedAt: null });
+    expect(screen.queryByTestId('annotator-reset')).not.toBeInTheDocument();
+  });
+
   // ─── Tool Palette ──────────────────────────────────────────────────────────
 
   it('shows ToolPalette with three tool buttons', () => {

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -25,6 +25,7 @@ import type { PointerContext } from './tools/SelectTool.js';
 import { screenToImage, imageToScreen, clamp } from './geometry.js';
 import { renderShapeSvgProps, drawShapeOnCanvas, ANNOTATION_FONT_FAMILY } from './render.js';
 import { FormError } from '../../FormError/FormError.js';
+import { Modal } from '../../Modal/Modal.js';
 import { getBaseUrl } from '../../../lib/apiClient.js';
 import { uploadAnnotation } from '../../../lib/photoApi.js';
 import styles from './PhotoAnnotator.module.css';
@@ -41,6 +42,8 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [isShowingOriginal, setIsShowingOriginal] = useState(false);
 
   // Inline edit state
   interface InlineInputState {
@@ -76,7 +79,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   }>({ shapeId: null, startImageX: 0, startImageY: 0 });
 
   // Calculate canonical URL
-  const canonicalUrl = `${getBaseUrl()}/photos/${photo.id}/file`;
+  // When editing an annotated photo, start from the annotated image (unless showing original).
+  // isShowingOriginal switches to the original for a fresh start if user wants to reset.
+  const canonicalUrl = isShowingOriginal
+    ? `${getBaseUrl()}/photos/${photo.id}/file?variant=original`
+    : `${getBaseUrl()}/photos/${photo.id}/file`;
 
   // Helper to get the active font size key for the current tool
   function getActiveFontSizeKey(): FontSizeKey {
@@ -748,6 +755,21 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   const handleCancel = useCallback(() => {
     onCancel();
   }, [onCancel]);
+
+  const handleReset = useCallback(() => {
+    // Switch to original image and clear any in-progress annotations
+    setIsShowingOriginal(true);
+    // Clear the undo stack of any new shapes drawn since opening the annotator
+    undoStack.clear();
+    // Clear draft shape if any
+    dispatch({ type: 'SET_DRAFT', shape: null });
+    // Deselect any selected shape
+    dispatch({ type: 'SELECT_SHAPE', id: null });
+    setShowResetConfirm(false);
+    if (liveRegionRef.current) {
+      liveRegionRef.current.textContent = t('resetComplete');
+    }
+  }, [undoStack, dispatch, t]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -1571,6 +1593,17 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         >
           {t('cancel')}
         </button>
+        {photo.annotatedAt && !isShowingOriginal && (
+          <button
+            type="button"
+            onClick={() => setShowResetConfirm(true)}
+            data-testid="annotator-reset"
+            className={styles.resetButton}
+            aria-label={t('reset')}
+          >
+            {t('reset')}
+          </button>
+        )}
         <button
           type="button"
           onClick={handleSave}
@@ -1582,6 +1615,34 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           {isSaving ? t('saving') : t('save')}
         </button>
       </div>
+
+      {/* Reset confirmation modal */}
+      {showResetConfirm && (
+        <Modal
+          title={t('resetTitle')}
+          onClose={() => setShowResetConfirm(false)}
+          footer={
+            <>
+              <button
+                type="button"
+                className={styles.modalButtonSecondary}
+                onClick={() => setShowResetConfirm(false)}
+              >
+                {t('cancel')}
+              </button>
+              <button
+                type="button"
+                className={styles.modalButtonPrimary}
+                onClick={handleReset}
+              >
+                {t('resetConfirm')}
+              </button>
+            </>
+          }
+        >
+          <p>{t('resetBody')}</p>
+        </Modal>
+      )}
     </section>
   );
 }

--- a/client/src/i18n/en/photoAnnotator.json
+++ b/client/src/i18n/en/photoAnnotator.json
@@ -55,5 +55,10 @@
   "editCallout": "Edit callout text",
   "editMeasurement": "Edit measurement label",
   "measurementPlaceholder": "Enter distance",
-  "calloutTailPositioning": "Drag to position callout tail"
+  "calloutTailPositioning": "Drag to position callout tail",
+  "reset": "Reset to original",
+  "resetTitle": "Reset to original photo?",
+  "resetBody": "This will discard all current annotations and start from the original photo. Your previously saved annotations will be preserved.",
+  "resetConfirm": "Reset",
+  "resetComplete": "Reset to original photo complete"
 }


### PR DESCRIPTION
## Summary

When editing a previously annotated photo, the annotator now loads the annotated image as the base, allowing new shapes to be drawn on top of existing annotations. This preserves annotation history while enabling incremental improvements.

**New feature:** Reset button (visible only when `photo.annotatedAt` is set) lets users switch back to the original photo and start fresh with a clean canvas.

## How it works

- **Base image loading:** The `canonicalUrl` now switches based on `isShowingOriginal` state
  - When `false` (default): loads annotated.webp if present (via the `/api/photos/:id/file` endpoint's default behavior of preferring annotated)
  - When `true`: forces the original with `?variant=original` query parameter
- **Reset flow:** Confirmation modal → switches to original → clears undo stack and selected shapes
- **Save behavior:** The canvas bake captures whatever's rendered (annotated base + any new shapes), so saving after a reset produces the original + new shapes seamlessly

## Files changed

- `client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx` — state management, Reset button UI, modal
- `client/src/components/photos/PhotoAnnotator/PhotoAnnotator.module.css` — button and modal styling
- `client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx` — tests for annotated image loading and Reset behavior
- `client/src/i18n/en/photoAnnotator.json` — i18n keys for Reset label and confirmation copy

## Verification

✅ TypeScript: `npx tsc --noEmit -p client/tsconfig.json` — zero errors
✅ Tests: `npx jest client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.ts --maxWorkers=1` — all pass (33/33, 3 todo)
✅ Build: `npm run build` — succeeded

## Design & UX notes

- Reset button only renders when `photo.annotatedAt !== null` (no point showing it for unannotated photos)
- Confirmation modal prevents accidental loss of work
- When reset is used, the image changes to original, but the user can still save to create a new baked version
- Dark mode: inherited from PhotoViewer's dark background (action bar uses `rgba(0,0,0,0.7)`)
- Accessibility: live region announces completion; buttons are keyboard accessible

🤖 Generated with Claude Code