### PR TITLE
fix(photo-annotator): widen handle hit-area, raise click-vs-drag threshold

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -585,7 +585,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         const dx = imageX - prevClickInfo.startImageX;
         const dy = imageY - prevClickInfo.startImageY;
         const clickDist = Math.sqrt(dx * dx + dy * dy);
-        const CLICK_THRESHOLD = 3; // Allow 3px of drift before considering it a drag
+        const CLICK_THRESHOLD = 5; // Require at least 5px of movement to avoid accidental edit opens during slow drags
         const wasActualDrag = clickDist > CLICK_THRESHOLD;
 
         // If this is the same shape and pointer didn't move much, try to open inline input

--- a/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
+++ b/client/src/components/photos/PhotoAnnotator/tools/SelectTool.ts
@@ -107,9 +107,10 @@ export const SelectTool: ToolHandler = {
 
       // Check for handle hit first (only for rect/highlight and arrow/line/ellipse/callout)
       let handleHit: string | null = null;
+      const HANDLE_HIT_TOLERANCE = 14; // Increased from 8 for better touch target accuracy
 
       if (shape.type === 'rectangle' || shape.type === 'highlight') {
-        handleHit = hitTestHandles(imageX, imageY, shape, 8);
+        handleHit = hitTestHandles(imageX, imageY, shape, HANDLE_HIT_TOLERANCE);
       } else if (shape.type === 'arrow' || shape.type === 'line') {
         handleHit = hitTestEndpointHandles(
           imageX,
@@ -118,7 +119,7 @@ export const SelectTool: ToolHandler = {
           shape.y1,
           shape.x2,
           shape.y2,
-          8,
+          HANDLE_HIT_TOLERANCE,
         );
       } else if (shape.type === 'ellipse') {
         handleHit = hitTestCardinalHandles(
@@ -128,10 +129,10 @@ export const SelectTool: ToolHandler = {
           shape.cy,
           shape.rx,
           shape.ry,
-          8,
+          HANDLE_HIT_TOLERANCE,
         );
       } else if (shape.type === 'callout') {
-        handleHit = hitTestTailHandle(imageX, imageY, shape.tailX, shape.tailY, 8) ? 'tail' : null;
+        handleHit = hitTestTailHandle(imageX, imageY, shape.tailX, shape.tailY, HANDLE_HIT_TOLERANCE) ? 'tail' : null;
       } else if (shape.type === 'measurement') {
         handleHit = hitTestEndpointHandles(
           imageX,
@@ -140,7 +141,7 @@ export const SelectTool: ToolHandler = {
           shape.y1,
           shape.x2,
           shape.y2,
-          8,
+          HANDLE_HIT_TOLERANCE,
         );
       }
 


### PR DESCRIPTION
## Summary

User reported handles are hard to hit and text shapes disappear when starting a drag.

- Bumped the resize-handle hit-test tolerance from 8 → 14 image pixels (corner, endpoint, cardinal and callout-tail handles).
- Raised the click-vs-drag threshold from 3 → 5 px so a tiny jitter when starting a drag doesn't get misclassified as a "click again to edit" and open the inline input on top of the text shape.

## Test plan

- [x] All PhotoAnnotator unit tests pass (16 suites)
- [x] Typecheck green
- [ ] Manual: select a shape, grab a handle in one go — easier to land. Drag a text shape — it tracks the cursor without disappearing.