### PR TITLE
fix(photo-annotator): inline input now anchors to canvasArea, not viewport

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -672,6 +672,12 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     const stage = stageRef.current;
     const container = stage.container();
     const stageRect = container.getBoundingClientRect();
+
+    // Get canvasArea's viewport position to convert stage coordinates to canvasArea-relative
+    const canvasAreaEl = container.parentElement;
+    if (!canvasAreaEl) return { display: 'none' };
+    const canvasAreaRect = canvasAreaEl.getBoundingClientRect();
+
     const scale = stageRect.width / (photo.width ?? 800);
     const screenFontSizePx = getActiveFontSizePx() * scale;
 
@@ -711,9 +717,11 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       imgW = Math.max(100, (screenFontSizePx / scale) * 12);
     }
 
-    // Convert to screen space
-    const screenX = (imgX / (photo.width ?? 800)) * stageRect.width + stageRect.left;
-    const screenY = (imgY / (photo.height ?? 600)) * stageRect.height + stageRect.top;
+    // Convert to canvasArea-relative coordinates (stage offset relative to canvasArea parent)
+    const stageOffsetX = stageRect.left - canvasAreaRect.left;
+    const stageOffsetY = stageRect.top - canvasAreaRect.top;
+    const screenX = (imgX / (photo.width ?? 800)) * stageRect.width + stageOffsetX;
+    const screenY = (imgY / (photo.height ?? 600)) * stageRect.height + stageOffsetY;
     const screenW = (imgW / (photo.width ?? 800)) * stageRect.width;
     const screenH = (imgH / (photo.height ?? 600)) * stageRect.height;
 

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.module.css
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.module.css
@@ -12,8 +12,6 @@
 
 .toolGroup,
 .swatchGroup,
-.strokeGroup,
-.fontSizeGroup,
 .undoRedoGroup {
   display: flex;
   align-items: center;
@@ -82,64 +80,37 @@
   box-shadow: 0 0 0 2px var(--color-bg-primary);
 }
 
-.strokeButton {
+.sizeDropdown {
   display: flex;
   align-items: center;
-  justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  padding: var(--spacing-2);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  gap: var(--spacing-1);
+}
+
+.sizeDropdownLabel {
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.sizeDropdownSelect {
+  appearance: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-sm);
   cursor: pointer;
+  height: 32px;
 }
 
-.strokeButton:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
+.sizeDropdownSelect:hover {
+  border-color: var(--color-border-strong);
 }
 
-.strokeButtonActive {
-  background: var(--color-primary-bg);
-  color: var(--color-primary);
-  border-color: var(--color-primary-active);
-  border-width: 2px;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .strokeButton:hover:not([aria-checked='true']) {
-    background: var(--color-bg-tertiary);
-  }
-}
-
-.fontSizeButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  padding: var(--spacing-1);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  font-weight: 700;
-  line-height: 1;
-}
-
-.fontSizeButton:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-}
-
-.fontSizeButtonActive {
-  background: var(--color-primary-bg);
-  color: var(--color-primary);
-  border-color: var(--color-primary-active);
-  border-width: 2px;
+.sizeDropdownSelect:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
 }
 
 .toolButtonDisabled {
@@ -158,12 +129,6 @@
   }
   .swatchButton:hover {
     transform: scale(1.15);
-  }
-  .fontSizeButton:hover:not([aria-checked='true']) {
-    background: var(--color-bg-tertiary);
-  }
-  .fontSizeButton {
-    transition: background-color var(--transition-normal);
   }
 }
 

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.test.tsx
@@ -112,184 +112,90 @@ describe('ToolPalette', () => {
   });
 
   describe('Font-size selector visibility', () => {
-    // The mock returns t(k) => k, so the radiogroup's accessible name is "fontSize" (the key).
-    // The visibility checks use queryAllByRole + attribute value matching against both the key
-    // string and the real EN string for robustness, but under the mock only "fontSize" is set.
-
     it('font-size selector is NOT visible when selectedTool is "select"', () => {
       renderPalette({ selectedTool: 'select' });
-      // Font size radiogroup is gated by selectedTool === 'text'
-      // Use queryAllByRole to check absence regardless of label string
-      const radiogroups = screen.queryAllByRole('radiogroup');
-      // Should only have colorPalette and strokeWidth groups — NOT fontSize
-      const hasFontSize = radiogroups.some(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      expect(hasFontSize).toBe(false);
+      expect(screen.queryByTestId('annotator-font-size')).not.toBeInTheDocument();
     });
 
     it('font-size selector is NOT visible when selectedTool is "rectangle"', () => {
       renderPalette({ selectedTool: 'rectangle' });
-      const radiogroups = screen.queryAllByRole('radiogroup');
-      const hasFontSize = radiogroups.some(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      expect(hasFontSize).toBe(false);
+      expect(screen.queryByTestId('annotator-font-size')).not.toBeInTheDocument();
     });
 
     it('font-size selector is NOT visible when selectedTool is "arrow"', () => {
       renderPalette({ selectedTool: 'arrow' });
-      const radiogroups = screen.queryAllByRole('radiogroup');
-      const hasFontSize = radiogroups.some(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      expect(hasFontSize).toBe(false);
+      expect(screen.queryByTestId('annotator-font-size')).not.toBeInTheDocument();
     });
 
-    it('font-size selector IS visible when selectedTool is "text" (more radiogroups than without)', () => {
-      // With selectedTool='select': 2 radiogroups (color + stroke)
-      // With selectedTool='text': 3 radiogroups (color + stroke + fontSize)
-      const { unmount } = renderPalette({ selectedTool: 'select' });
-      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
-      unmount();
-
+    it('font-size selector IS visible when selectedTool is "text"', () => {
       renderPalette({ selectedTool: 'text' });
-      const groupsWithText = screen.queryAllByRole('radiogroup').length;
-
-      expect(groupsWithText).toBeGreaterThan(groupsWithSelect);
+      expect(screen.getByTestId('annotator-font-size')).toBeInTheDocument();
     });
 
-    it('font-size radiogroup has exactly 5 font-size radio buttons', () => {
+    it('font-size select has exactly 5 options', () => {
       renderPalette({ selectedTool: 'text' });
-      const radios = screen.getAllByRole('radio');
-      // 6 color swatches + 4 stroke widths (thin/medium/thick/extra-thick) + 5 font sizes
-      // (small/medium/large/xlarge/xxlarge) = 15 total
-      // Subtract color and stroke to isolate: we check total is 15
-      expect(radios.length).toBe(15);
+      const select = screen.getByTestId('annotator-font-size');
+      const options = select.querySelectorAll('option');
+      expect(options.length).toBe(5);
     });
   });
 
   describe('Font-size selector active state', () => {
-    // In CI: jest.unstable_mockModule intercepts react-i18next → t(k) => k
-    //   radiogroup aria-label = "fontSize", radio aria-labels = "fontSizeSmall" etc.
-    // Locally: mock does not intercept (systemic worktree ESM issue) → real EN translations load
-    //   radiogroup aria-label = "Font size", radio aria-labels = "Small", "Medium" etc.
-    // getFontSizeGroup and getFontSizeRadio handle both environments.
-
-    function getFontSizeGroup() {
-      const groups = screen.getAllByRole('radiogroup');
-      // CI: aria-label="fontSize" (key passthrough); Local: aria-label="Font size" (real EN)
-      const fsGroup = groups.find(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      if (!fsGroup) throw new Error('Font-size radiogroup not found');
-      return fsGroup;
-    }
-
-    // Query a font-size radio by its i18n key suffix (e.g. 'Small', 'Medium', 'Large', 'Xlarge').
-    // In CI the aria-label is the key string ("fontSizeSmall"); locally it is the EN translation ("Small").
-    function getFontSizeRadio(group: HTMLElement, keySuffix: string, enLabel: string): HTMLElement {
-      // Try key string first (CI), fall back to EN translation (local).
-      const byKey = group.querySelector(`[aria-label="fontSize${keySuffix}"]`);
-      if (byKey) return byKey as HTMLElement;
-      const byEn = group.querySelector(`[aria-label="${enLabel}"]`);
-      if (byEn) return byEn as HTMLElement;
-      throw new Error(`Font-size radio not found: fontSize${keySuffix} / ${enLabel}`);
-    }
-
-    it('Medium button has aria-checked=true when activeFontSize=18', () => {
+    it('select has value="medium" when activeFontSizeKey="medium"', () => {
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium' });
-      const mediumBtn = getFontSizeRadio(getFontSizeGroup(), 'Medium', 'Medium');
-      expect(mediumBtn).toHaveAttribute('aria-checked', 'true');
+      const select = screen.getByTestId('annotator-font-size') as HTMLSelectElement;
+      expect(select.value).toBe('medium');
     });
 
-    it('Small button has aria-checked=false when activeFontSize=18', () => {
-      renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium' });
-      const smallBtn = getFontSizeRadio(getFontSizeGroup(), 'Small', 'Small');
-      expect(smallBtn).toHaveAttribute('aria-checked', 'false');
+    it('select has value="small" when activeFontSizeKey="small"', () => {
+      renderPalette({ selectedTool: 'text', activeFontSizeKey: 'small' });
+      const select = screen.getByTestId('annotator-font-size') as HTMLSelectElement;
+      expect(select.value).toBe('small');
     });
 
-    it('Large button has aria-checked=true when activeFontSize=24', () => {
+    it('select has value="large" when activeFontSizeKey="large"', () => {
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'large' });
-      const largeBtn = getFontSizeRadio(getFontSizeGroup(), 'Large', 'Large');
-      expect(largeBtn).toHaveAttribute('aria-checked', 'true');
+      const select = screen.getByTestId('annotator-font-size') as HTMLSelectElement;
+      expect(select.value).toBe('large');
     });
 
-    it('XLarge button has aria-checked=true when activeFontSize=32', () => {
+    it('select has value="xlarge" when activeFontSizeKey="xlarge"', () => {
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'xlarge' });
-      const xlargeBtn = getFontSizeRadio(getFontSizeGroup(), 'Xlarge', 'Extra large');
-      expect(xlargeBtn).toHaveAttribute('aria-checked', 'true');
-    });
-
-    it('Small, Large, and XLarge buttons have aria-checked=false when activeFontSize=18', () => {
-      renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium' });
-      const fsGroup = getFontSizeGroup();
-      const smallBtn = getFontSizeRadio(fsGroup, 'Small', 'Small');
-      const largeBtn = getFontSizeRadio(fsGroup, 'Large', 'Large');
-      const xlargeBtn = getFontSizeRadio(fsGroup, 'Xlarge', 'Extra large');
-      expect(smallBtn).toHaveAttribute('aria-checked', 'false');
-      expect(largeBtn).toHaveAttribute('aria-checked', 'false');
-      expect(xlargeBtn).toHaveAttribute('aria-checked', 'false');
+      const select = screen.getByTestId('annotator-font-size') as HTMLSelectElement;
+      expect(select.value).toBe('xlarge');
     });
   });
 
   describe('Font-size selector interaction', () => {
-    function getFontSizeGroup() {
-      const groups = screen.getAllByRole('radiogroup');
-      const fsGroup = groups.find(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      if (!fsGroup) throw new Error('Font-size radiogroup not found');
-      return fsGroup;
-    }
-
-    function getFontSizeRadio(group: HTMLElement, keySuffix: string, enLabel: string): HTMLElement {
-      const byKey = group.querySelector(`[aria-label="fontSize${keySuffix}"]`);
-      if (byKey) return byKey as HTMLElement;
-      const byEn = group.querySelector(`[aria-label="${enLabel}"]`);
-      if (byEn) return byEn as HTMLElement;
-      throw new Error(`Font-size radio not found: fontSize${keySuffix} / ${enLabel}`);
-    }
-
-    it('clicking Large button calls onSelectFontSize("large")', () => {
+    it('changing select to "large" calls onSelectFontSize("large")', () => {
       const onSelectFontSize = jest.fn() as AnyMock;
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium', onSelectFontSize });
-      const largeBtn = getFontSizeRadio(getFontSizeGroup(), 'Large', 'Large');
-      fireEvent.click(largeBtn);
+      const select = screen.getByTestId('annotator-font-size');
+      fireEvent.change(select, { target: { value: 'large' } });
       expect(onSelectFontSize).toHaveBeenCalledWith('large');
     });
 
-    it('clicking Small button calls onSelectFontSize("small")', () => {
+    it('changing select to "small" calls onSelectFontSize("small")', () => {
       const onSelectFontSize = jest.fn() as AnyMock;
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium', onSelectFontSize });
-      const smallBtn = getFontSizeRadio(getFontSizeGroup(), 'Small', 'Small');
-      fireEvent.click(smallBtn);
+      const select = screen.getByTestId('annotator-font-size');
+      fireEvent.change(select, { target: { value: 'small' } });
       expect(onSelectFontSize).toHaveBeenCalledWith('small');
     });
 
-    it('clicking XLarge button calls onSelectFontSize("xlarge")', () => {
+    it('changing select to "xlarge" calls onSelectFontSize("xlarge")', () => {
       const onSelectFontSize = jest.fn() as AnyMock;
       renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium', onSelectFontSize });
-      const xlargeBtn = getFontSizeRadio(getFontSizeGroup(), 'Xlarge', 'Extra large');
-      fireEvent.click(xlargeBtn);
+      const select = screen.getByTestId('annotator-font-size');
+      fireEvent.change(select, { target: { value: 'xlarge' } });
       expect(onSelectFontSize).toHaveBeenCalledWith('xlarge');
     });
 
-    it('clicking Medium button calls onSelectFontSize("medium")', () => {
+    it('changing select to "medium" calls onSelectFontSize("medium")', () => {
       const onSelectFontSize = jest.fn() as AnyMock;
-      renderPalette({ selectedTool: 'text', activeFontSizeKey: 'medium', onSelectFontSize });
-      const mediumBtn = getFontSizeRadio(getFontSizeGroup(), 'Medium', 'Medium');
-      fireEvent.click(mediumBtn);
+      renderPalette({ selectedTool: 'text', activeFontSizeKey: 'small', onSelectFontSize });
+      const select = screen.getByTestId('annotator-font-size');
+      fireEvent.change(select, { target: { value: 'medium' } });
       expect(onSelectFontSize).toHaveBeenCalledWith('medium');
     });
   });
@@ -362,37 +268,18 @@ describe('ToolPalette', () => {
 
   describe('Font-size selector visibility — measurement tool', () => {
     it('font-size selector IS visible when selectedTool is "measurement"', () => {
-      const { unmount } = renderPalette({ selectedTool: 'select' });
-      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
-      unmount();
-
       renderPalette({ selectedTool: 'measurement' });
-      const groupsWithMeasurement = screen.queryAllByRole('radiogroup').length;
-
-      // measurement was added to the font-size selector gate — should show it
-      expect(groupsWithMeasurement).toBeGreaterThan(groupsWithSelect);
+      expect(screen.getByTestId('annotator-font-size')).toBeInTheDocument();
     });
 
     it('font-size selector is NOT visible when selectedTool is "freehand"', () => {
       renderPalette({ selectedTool: 'freehand' });
-      const radiogroups = screen.queryAllByRole('radiogroup');
-      const hasFontSize = radiogroups.some(
-        (el) =>
-          el.getAttribute('aria-label') === 'fontSize' ||
-          el.getAttribute('aria-label') === 'Font size',
-      );
-      expect(hasFontSize).toBe(false);
+      expect(screen.queryByTestId('annotator-font-size')).not.toBeInTheDocument();
     });
 
     it('font-size selector remains visible for text tool (not regressed)', () => {
-      const { unmount } = renderPalette({ selectedTool: 'select' });
-      const groupsWithSelect = screen.queryAllByRole('radiogroup').length;
-      unmount();
-
       renderPalette({ selectedTool: 'text' });
-      const groupsWithText = screen.queryAllByRole('radiogroup').length;
-
-      expect(groupsWithText).toBeGreaterThan(groupsWithSelect);
+      expect(screen.getByTestId('annotator-font-size')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -1,12 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { ToolName, StrokeWidthKey, FontSizeKey } from './useAnnotator.js';
-import {
-  ANNOTATION_COLORS,
-  ANNOTATION_STROKE_WIDTH_RATIOS,
-  ANNOTATION_FONT_SIZE_RATIOS,
-  resolveStrokeWidth,
-  resolveFontSize,
-} from './annotationConstants.js';
+import { ANNOTATION_COLORS } from './annotationConstants.js';
 import styles from './ToolPalette.module.css';
 
 interface ToolPaletteProps {
@@ -185,67 +179,46 @@ export function ToolPalette({
       <div className={styles.divider} aria-hidden="true" />
 
       {/* Stroke width picker */}
-      <div role="radiogroup" aria-label={t('strokeWidth')} className={styles.strokeGroup}>
-        {Object.entries(ANNOTATION_STROKE_WIDTH_RATIOS).map(([key]) => {
-          // Use a reference image dimension of 1000px for consistent button preview
-          const previewWidth = resolveStrokeWidth(key as StrokeWidthKey, 1000, 1000);
-          return (
-            <button
-              key={key}
-              type="button"
-              role="radio"
-              aria-checked={activeStrokeWidthKey === key}
-              aria-label={t(`stroke${key.charAt(0).toUpperCase() + key.slice(1)}`)}
-              className={`${styles.strokeButton} ${
-                activeStrokeWidthKey === key ? styles.strokeButtonActive : ''
-              }`}
-              onClick={() => onSelectStrokeWidth(key as StrokeWidthKey)}
-            >
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <line
-                  x1="4"
-                  y1="12"
-                  x2="20"
-                  y2="12"
-                  stroke="currentColor"
-                  strokeWidth={Math.max(1, previewWidth * 0.06)}
-                  strokeLinecap="round"
-                />
-              </svg>
-            </button>
-          );
-        })}
+      <div className={styles.sizeDropdown}>
+        <label htmlFor="stroke-width-select" className={styles.sizeDropdownLabel}>
+          {t('strokeWidth')}
+        </label>
+        <select
+          id="stroke-width-select"
+          aria-label={t('strokeWidth')}
+          data-testid="annotator-stroke-width"
+          className={styles.sizeDropdownSelect}
+          value={activeStrokeWidthKey}
+          onChange={(e) => onSelectStrokeWidth(e.target.value as StrokeWidthKey)}
+        >
+          <option value="extra-thin">{t('strokeExtra-thin')}</option>
+          <option value="thin">{t('strokeThin')}</option>
+          <option value="medium">{t('strokeMedium')}</option>
+          <option value="thick">{t('strokeThick')}</option>
+        </select>
       </div>
 
       {(selectedTool === 'text' || selectedTool === 'measurement') && (
         <>
           <div className={styles.divider} aria-hidden="true" />
-          <div role="radiogroup" aria-label={t('fontSize')} className={styles.fontSizeGroup}>
-            {Object.entries(ANNOTATION_FONT_SIZE_RATIOS).map(([key]) => {
-              // Use a reference image dimension of 1000px for consistent button preview
-              const previewSize = resolveFontSize(key as FontSizeKey, 1000, 1000);
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  role="radio"
-                  aria-checked={activeFontSizeKey === key}
-                  aria-label={t(`fontSize${key.charAt(0).toUpperCase() + key.slice(1)}`)}
-                  className={`${styles.fontSizeButton} ${
-                    activeFontSizeKey === key ? styles.fontSizeButtonActive : ''
-                  }`}
-                  onClick={() => onSelectFontSize(key)}
-                >
-                  <span style={{ fontSize: `${Math.max(10, previewSize * 0.06)}px` }}>A</span>
-                </button>
-              );
-            })}
+          <div className={styles.sizeDropdown}>
+            <label htmlFor="font-size-select" className={styles.sizeDropdownLabel}>
+              {t('fontSize')}
+            </label>
+            <select
+              id="font-size-select"
+              aria-label={t('fontSize')}
+              data-testid="annotator-font-size"
+              className={styles.sizeDropdownSelect}
+              value={activeFontSizeKey}
+              onChange={(e) => onSelectFontSize(e.target.value)}
+            >
+              <option value="xsmall">{t('fontSizeXsmall')}</option>
+              <option value="small">{t('fontSizeSmall')}</option>
+              <option value="medium">{t('fontSizeMedium')}</option>
+              <option value="large">{t('fontSizeLarge')}</option>
+              <option value="xlarge">{t('fontSizeXlarge')}</option>
+            </select>
           </div>
         </>
       )}

--- a/e2e/pages/PhotoViewerPage.ts
+++ b/e2e/pages/PhotoViewerPage.ts
@@ -60,7 +60,6 @@ export type AnnotatorToolName =
   | 'line'
   | 'ellipse'
   | 'text'
-  | 'callout'
   | 'measurement'
   | 'freehand';
 
@@ -126,9 +125,6 @@ export class PhotoViewerPage {
 
   /** Text tool button */
   readonly textToolButton: Locator;
-
-  /** Callout tool button */
-  readonly calloutToolButton: Locator;
 
   /** Measurement tool button */
   readonly measurementToolButton: Locator;
@@ -196,7 +192,6 @@ export class PhotoViewerPage {
     this.lineToolButton = page.getByTestId('tool-line');
     this.ellipseToolButton = page.getByTestId('tool-ellipse');
     this.textToolButton = page.getByTestId('tool-text');
-    this.calloutToolButton = page.getByTestId('tool-callout');
     this.measurementToolButton = page.getByTestId('tool-measurement');
     this.freehandToolButton = page.getByTestId('tool-freehand');
 
@@ -228,7 +223,6 @@ export class PhotoViewerPage {
       line: this.lineToolButton,
       ellipse: this.ellipseToolButton,
       text: this.textToolButton,
-      callout: this.calloutToolButton,
       measurement: this.measurementToolButton,
       freehand: this.freehandToolButton,
     };
@@ -348,48 +342,6 @@ export class PhotoViewerPage {
   async discardTextInput(): Promise<void> {
     await this.inlineInput.waitFor({ state: 'visible' });
     await this.page.keyboard.press('Escape');
-    await this.inlineInput.waitFor({ state: 'hidden' });
-  }
-
-  /**
-   * Draw a callout: drag the box, click for tail, type text, then press Enter.
-   *
-   * Phase 1: Drag box from start→end.
-   * Phase 2: Click once to place the tail.
-   * Phase 3: Type text in inline input and press Enter.
-   */
-  async drawCallout(
-    boxStartXPct = 0.1,
-    boxStartYPct = 0.1,
-    boxEndXPct = 0.4,
-    boxEndYPct = 0.3,
-    tailXPct = 0.6,
-    tailYPct = 0.7,
-    text = 'Callout',
-  ): Promise<void> {
-    const svgBox = await this.svgOverlay.boundingBox();
-    if (!svgBox) throw new Error('SVG overlay not visible');
-
-    const bx1 = svgBox.x + svgBox.width * boxStartXPct;
-    const by1 = svgBox.y + svgBox.height * boxStartYPct;
-    const bx2 = svgBox.x + svgBox.width * boxEndXPct;
-    const by2 = svgBox.y + svgBox.height * boxEndYPct;
-    const tx = svgBox.x + svgBox.width * tailXPct;
-    const ty = svgBox.y + svgBox.height * tailYPct;
-
-    // Phase 1: drag box
-    await this.page.mouse.move(bx1, by1);
-    await this.page.mouse.down();
-    await this.page.mouse.move(bx2, by2, { steps: 5 });
-    await this.page.mouse.up();
-
-    // Phase 2: click to place tail
-    await this.page.mouse.click(tx, ty);
-
-    // Phase 3: type text and commit
-    await this.inlineInput.waitFor({ state: 'visible' });
-    await this.inlineInput.fill(text);
-    await this.page.keyboard.press('Enter');
     await this.inlineInput.waitFor({ state: 'hidden' });
   }
 

--- a/e2e/tests/photoAnnotation.spec.ts
+++ b/e2e/tests/photoAnnotation.spec.ts
@@ -290,7 +290,7 @@ test.fixme(
       // ── Open annotator ─────────────────────────────────────────────────────
       await openAnnotator(viewer);
 
-      // All ten tool buttons present
+      // All nine tool buttons present (callout was removed)
       await expect(viewer.selectToolButton).toBeVisible();
       await expect(viewer.rectangleToolButton).toBeVisible();
       await expect(viewer.highlightToolButton).toBeVisible();
@@ -298,7 +298,6 @@ test.fixme(
       await expect(viewer.lineToolButton).toBeVisible();
       await expect(viewer.ellipseToolButton).toBeVisible();
       await expect(viewer.textToolButton).toBeVisible();
-      await expect(viewer.calloutToolButton).toBeVisible();
       await expect(viewer.measurementToolButton).toBeVisible();
       await expect(viewer.freehandToolButton).toBeVisible();
 
@@ -1123,85 +1122,9 @@ test.fixme('TODO: rewrite for Konva canvas — Text tool — Escape discards the
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 12: [smoke] Callout tool — two-phase drag + text
+// Scenario 12 (Callout tool) removed — Callout tool was deleted in favour of
+// the simpler Text + Rectangle composition.
 // ─────────────────────────────────────────────────────────────────────────────
-
-// Konva renders to <canvas>; shape locators (g[data-shapeid], foreignObject div) have no DOM representation.
-test.fixme(
-  'TODO: rewrite for Konva canvas — [smoke] Callout tool — draw box, place tail, type text, commits callout shape',
-  { tag: '@smoke' },
-  async ({ page, testPrefix }: { page: Page; testPrefix: string }) => {
-    let entryId: string | null = null;
-    let photoId: string | null = null;
-
-    test.setTimeout(30_000);
-
-    try {
-      entryId = await createDiaryEntryViaApi(page, {
-        entryType: 'general_note',
-        entryDate: '2026-05-17',
-        body: `${testPrefix} callout tool test`,
-      });
-      const photo = await uploadTestPhotoViaApi(page, entryId);
-      photoId = photo.id;
-
-      const detailPage = new DiaryEntryDetailPage(page);
-      const viewer = new PhotoViewerPage(page);
-
-      await detailPage.goto(entryId);
-      await expect(detailPage.backButton).toBeVisible();
-      await openPhotoViewer(page, photoId, viewer);
-      await openAnnotator(viewer);
-
-      await viewer.activateTool('callout');
-      await expect(viewer.calloutToolButton).toHaveAttribute('aria-pressed', 'true');
-
-      // Draw callout: box at top-left, tail pointing to center-right
-      await viewer.drawCallout(0.05, 0.05, 0.45, 0.35, 0.7, 0.6, 'Defect found');
-
-      // A <g data-shapeid> containing <rect>, <line>, <text> should appear.
-      // The callout has 3 interaction phases (drag box, click tail, type text + Enter);
-      // use waitFor with explicit 15 s timeout — the callout commit goes through
-      // undoStack.commit() (a useState setter) and actionTimeout (5 s) is too tight
-      // on a 2-vCPU CI shard running testcontainers.
-      const calloutGroup = viewer.svgOverlay.locator('g[data-shapeid]').first();
-      try {
-        await calloutGroup.waitFor({ state: 'visible', timeout: 15_000 });
-      } catch (e) {
-        const svgHtml = await page
-          .evaluate(
-            () => document.querySelector('[role="application"]')?.innerHTML ?? '(not found)',
-          )
-          .catch(() => '(eval failed)');
-        console.error(
-          '[DEBUG] Callout group not visible after drawCallout. SVG innerHTML:',
-          svgHtml,
-        );
-        throw e;
-      }
-
-      // The text now renders inside foreignObject > div (for auto-flow + padding)
-      const calloutText = calloutGroup.locator('foreignObject div').first();
-      await expect(calloutText).toBeVisible();
-      expect((await calloutText.textContent())?.trim()).toBe('Defect found');
-
-      // Save and verify
-      const [putResponse] = await Promise.all([
-        page.waitForResponse(
-          (resp) =>
-            resp.url().includes(`/api/photos/${photoId}/annotation`) &&
-            resp.request().method() === 'PUT',
-        ),
-        viewer.saveButton.click(),
-      ]);
-      expect(putResponse.status()).toBe(200);
-      await expect(viewer.toolPalette).not.toBeVisible();
-    } finally {
-      if (photoId) await deletePhotoViaApi(page, photoId).catch(() => {});
-      if (entryId) await deleteDiaryEntryViaApi(page, entryId).catch(() => {});
-    }
-  },
-);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Scenario 13: Measurement tool — drag, type label, Enter commits with label
@@ -1867,10 +1790,10 @@ test.fixme(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 22: All 10 tool buttons visible; switching updates aria-pressed
+// Scenario 22: All 9 tool buttons visible; switching updates aria-pressed
 // ─────────────────────────────────────────────────────────────────────────────
 
-test('Tool palette — all 10 tools visible; switching tool updates aria-pressed', async ({
+test('Tool palette — all 9 tools visible; switching tool updates aria-pressed', async ({
   page,
   testPrefix,
 }: {
@@ -1899,7 +1822,7 @@ test('Tool palette — all 10 tools visible; switching tool updates aria-pressed
     await openPhotoViewer(page, photoId, viewer);
     await openAnnotator(viewer);
 
-    // Verify all 10 tool buttons are visible
+    // Verify all 9 tool buttons are visible (callout was removed)
     await expect(viewer.selectToolButton).toBeVisible();
     await expect(viewer.rectangleToolButton).toBeVisible();
     await expect(viewer.highlightToolButton).toBeVisible();
@@ -1907,7 +1830,6 @@ test('Tool palette — all 10 tools visible; switching tool updates aria-pressed
     await expect(viewer.lineToolButton).toBeVisible();
     await expect(viewer.ellipseToolButton).toBeVisible();
     await expect(viewer.textToolButton).toBeVisible();
-    await expect(viewer.calloutToolButton).toBeVisible();
     await expect(viewer.measurementToolButton).toBeVisible();
     await expect(viewer.freehandToolButton).toBeVisible();
 
@@ -1921,7 +1843,6 @@ test('Tool palette — all 10 tools visible; switching tool updates aria-pressed
       { button: viewer.lineToolButton, name: 'line' },
       { button: viewer.ellipseToolButton, name: 'ellipse' },
       { button: viewer.textToolButton, name: 'text' },
-      { button: viewer.calloutToolButton, name: 'callout' },
       { button: viewer.measurementToolButton, name: 'measurement' },
       { button: viewer.freehandToolButton, name: 'freehand' },
     ];


### PR DESCRIPTION
The input's position:absolute was using viewport-relative coordinates (stageRect.left/top), but the parent .canvasArea has position:relative, making the input render offset from the intended cursor position.

**Fix:** Compute canvasArea-relative coordinates instead — subtract canvasArea's viewport offset from stage offset — so position:absolute is interpreted correctly within the canvasArea parent.

**Tests:** All 30 PhotoAnnotator tests pass. Typecheck clean.