### PR TITLE
fix(photo-annotator): repair line-family drag (endpoints, body, undoStack)

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -914,9 +914,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         });
                       }}
                       onDragEnd={(e) => {
-                        const pos = e.target.position();
-                        const updated = { ...sel, x1: pos.x, y1: pos.y };
-                        undoStack.commit(state.shapes.map((s) => (s.id === sel.id ? updated : s)));
+                        const newX1 = e.target.x();
+                        const newY1 = e.target.y();
+                        const updated = { ...sel, x1: newX1, y1: newY1 };
+                        undoStack.commit(undoStack.shapes.map((s) => (s.id === sel.id ? updated : s)));
                       }}
                     />
                     <Circle
@@ -936,9 +937,10 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
                         });
                       }}
                       onDragEnd={(e) => {
-                        const pos = e.target.position();
-                        const updated = { ...sel, x2: pos.x, y2: pos.y };
-                        undoStack.commit(state.shapes.map((s) => (s.id === sel.id ? updated : s)));
+                        const newX2 = e.target.x();
+                        const newY2 = e.target.y();
+                        const updated = { ...sel, x2: newX2, y2: newY2 };
+                        undoStack.commit(undoStack.shapes.map((s) => (s.id === sel.id ? updated : s)));
                       }}
                     />
                   </>
@@ -1102,7 +1104,16 @@ function renderKonvaShape(
         onDragEnd={(e) => {
           const target = e.target as Konva.Arrow;
           const points = target.points();
-          onChange(shape.id, { x1: points[0], y1: points[1], x2: points[2], y2: points[3] });
+          if (!points) return;
+          const dx = target.x();
+          const dy = target.y();
+          onChange(shape.id, {
+            x1: (points[0] ?? 0) + dx,
+            y1: (points[1] ?? 0) + dy,
+            x2: (points[2] ?? 0) + dx,
+            y2: (points[3] ?? 0) + dy,
+          });
+          target.position({ x: 0, y: 0 });
         }}
       />
     );
@@ -1126,7 +1137,16 @@ function renderKonvaShape(
         onDragEnd={(e) => {
           const target = e.target as Konva.Line;
           const points = target.points();
-          onChange(shape.id, { x1: points[0], y1: points[1], x2: points[2], y2: points[3] });
+          if (!points) return;
+          const dx = target.x();
+          const dy = target.y();
+          onChange(shape.id, {
+            x1: (points[0] ?? 0) + dx,
+            y1: (points[1] ?? 0) + dy,
+            x2: (points[2] ?? 0) + dx,
+            y2: (points[3] ?? 0) + dy,
+          });
+          target.position({ x: 0, y: 0 });
         }}
       />
     );
@@ -1204,6 +1224,18 @@ function renderKonvaShape(
             shapesNodesRef.current.set(shape.id, node);
           }
         }}
+        onDragEnd={(e) => {
+          const target = e.target as Konva.Group;
+          const dx = target.x();
+          const dy = target.y();
+          onChange(shape.id, {
+            x1: shape.x1 + dx,
+            y1: shape.y1 + dy,
+            x2: shape.x2 + dx,
+            y2: shape.y2 + dy,
+          });
+          target.position({ x: 0, y: 0 });
+        }}
       >
         <Arrow
           points={[shape.x1, shape.y1, shape.x2, shape.y2]}
@@ -1251,11 +1283,15 @@ function renderKonvaShape(
         onDragEnd={(e) => {
           const target = e.target as Konva.Line;
           const points = target.points();
-          const newPoints = [];
+          if (!points) return;
+          const dx = target.x();
+          const dy = target.y();
+          const newPoints: [number, number][] = [];
           for (let i = 0; i < points.length; i += 2) {
-            newPoints.push([points[i], points[i + 1]]);
+            newPoints.push([(points[i] ?? 0) + dx, (points[i + 1] ?? 0) + dy]);
           }
-          onChange(shape.id, { points: newPoints as [number, number][] });
+          onChange(shape.id, { points: newPoints });
+          target.position({ x: 0, y: 0 });
         }}
       />
     );

--- a/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
+++ b/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
@@ -102,7 +102,8 @@ export function annotatorReducer(
 
     case 'COMMIT_DRAFT':
       if (!state.draftShape) return state;
-      const newShapes = [...state.shapes, state.draftShape];
+      const liveShapesOnCommit = undoStack?.shapes ?? state.shapes;
+      const newShapes = [...liveShapesOnCommit, state.draftShape];
       undoStack?.commit(newShapes);
       return {
         ...state,
@@ -115,14 +116,16 @@ export function annotatorReducer(
       return { ...state, selectedShapeId: action.id };
 
     case 'UPDATE_SHAPE': {
-      const updatedShapes = state.shapes.map((s) => (s.id === action.shape.id ? action.shape : s));
+      const liveShapesOnUpdate = undoStack?.shapes ?? state.shapes;
+      const updatedShapes = liveShapesOnUpdate.map((s) => (s.id === action.shape.id ? action.shape : s));
       undoStack?.replace(updatedShapes);
       return { ...state, shapes: updatedShapes };
     }
 
     case 'DELETE_SELECTED':
       if (!state.selectedShapeId) return state;
-      const filtered = state.shapes.filter((s) => s.id !== state.selectedShapeId);
+      const liveShapesOnDelete = undoStack?.shapes ?? state.shapes;
+      const filtered = liveShapesOnDelete.filter((s) => s.id !== state.selectedShapeId);
       undoStack?.commit(filtered);
       return {
         ...state,


### PR DESCRIPTION
## Summary

Three coupled bugs from PR #1535 caused line-family drag to corrupt other shapes' positions.

- Reducer's `UPDATE_SHAPE`, `COMMIT_DRAFT`, and `DELETE_SELECTED` now use `undoStack.shapes` (live) as the base list instead of the reducer-internal `state.shapes` snapshot. Previously, every endpoint dragMove dispatched UPDATE_SHAPE, which `replace()`d the live undoStack with a stale snapshot — erasing every previously-dragged shape.
- Arrow/Line/Freehand body drag now reads `target.x()/y()` (the offset Konva accumulates on the node during draggable) and adds it to the points before committing, then resets node position to (0, 0). Previously, the points array was unchanged so the commit was a no-op.
- The Measurement Group now has an `onDragEnd` (it had none). The handler applies the same offset-based commit as the other line shapes.

## Test plan

- [x] `npx jest client/src/components/photos/PhotoAnnotator/ --maxWorkers=1` — 108/114 pass (rest todo).
- [x] `npx tsc --noEmit -p client/tsconfig.json` — clean.
- [ ] Manual: select arrow, drag endpoint slowly — line follows. Drag arrow body — line stays in new position.
- [ ] Manual: drag a rectangle to (200, 200). Then drag an arrow's endpoint. The rectangle stays at (200, 200) — does not snap back.