### PR TITLE
fix(photo-annotator): text uses font dropdown only; eraser icon; drop redundant Reset

### DIFF
--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -356,28 +356,13 @@ describe('PhotoAnnotator', () => {
     }
   });
 
-  it('shows Reset button when photo.annotatedAt is set', async () => {
-    const annotatedAt = '2026-05-17T10:00:00.000Z';
-    await renderAnnotator({ annotatedAt });
-    // Reset button — text from t('reset') = "Reset to original"
-    expect(screen.getByRole('button', { name: /Reset to original/i })).toBeInTheDocument();
-  });
-
-  it('clicking Reset button opens confirmation modal', async () => {
+  it('does NOT show in-annotator Reset button on an annotated photo', async () => {
+    // Reset button was removed; the PhotoViewer "Clear annotations" entry-point covers this.
     await renderAnnotator({ annotatedAt: '2026-05-17T10:00:00.000Z' });
-
-    const resetBtn = screen.getByRole('button', { name: /Reset to original/i });
-    fireEvent.click(resetBtn);
-
-    // Modal renders with a dialog role (from the Modal stub)
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('annotator-reset')).not.toBeInTheDocument();
   });
 
-  it('does NOT show Reset button when photo has no annotations (annotatedAt is null)', async () => {
-    // Reset button is conditional on photo.annotatedAt — it only appears for previously-annotated
-    // photos. When annotatedAt is null the button must be absent (E2E compatibility: round-7 behavior).
+  it('does NOT show Reset button when photo has no annotations', async () => {
     await renderAnnotator({ annotatedAt: null });
     expect(screen.queryByTestId('annotator-reset')).not.toBeInTheDocument();
   });

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -67,8 +67,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
 
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
-  const [isShowingOriginal, setIsShowingOriginal] = useState(false);
+  const [isShowingOriginal] = useState(false);
 
   const [inlineInput, setInlineInput] = useState<InlineInputState>({
     isOpen: false,
@@ -126,12 +125,15 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     if (!transformerRef.current) return;
 
     const selectedShape = state.shapes.find((s) => s.id === state.selectedShapeId);
-    const isLineLike =
+    // Line-family shapes get custom endpoint Circle handles instead of the 2D Transformer.
+    // Text shapes are sized via the Font Size dropdown, not by dragging anchors.
+    const skipsTransformer =
       selectedShape?.type === 'arrow' ||
       selectedShape?.type === 'line' ||
-      selectedShape?.type === 'measurement';
+      selectedShape?.type === 'measurement' ||
+      selectedShape?.type === 'text';
 
-    if (!state.selectedShapeId || isLineLike) {
+    if (!state.selectedShapeId || skipsTransformer) {
       transformerRef.current.nodes([]);
       return;
     }
@@ -669,17 +671,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     }
   }, [photo, canonicalUrl, undoStack, onSave, t]);
 
-  const handleReset = useCallback(() => {
-    setIsShowingOriginal(true);
-    undoStack.clear();
-    setDraftShape(null);
-    dispatch({ type: 'SELECT_SHAPE', id: null });
-    setShowResetConfirm(false);
-    if (liveRegionRef.current) {
-      liveRegionRef.current.textContent = t('resetComplete');
-    }
-  }, [undoStack, dispatch, t]);
-
   const handleCancel = useCallback(() => {
     onCancel();
   }, [onCancel]);
@@ -978,16 +969,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
         >
           {t('cancel')}
         </button>
-        {photo.annotatedAt && (
-          <button
-            type="button"
-            onClick={() => setShowResetConfirm(true)}
-            className={styles.resetButton}
-            data-testid="annotator-reset"
-          >
-            {t('reset')}
-          </button>
-        )}
         <button
           type="button"
           onClick={handleSave}
@@ -1000,18 +981,6 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       </div>
 
       {saveError && <FormError message={saveError} />}
-
-      {showResetConfirm && (
-        <Modal onClose={() => setShowResetConfirm(false)} title={t('resetConfirmTitle')}>
-          <p>{t('resetConfirmBody')}</p>
-          <div className={styles.modalActions}>
-            <button onClick={() => setShowResetConfirm(false)}>{t('cancel')}</button>
-            <button onClick={handleReset} className={styles.confirmButton}>
-              {t('reset')}
-            </button>
-          </div>
-        </Modal>
-      )}
 
       <div ref={liveRegionRef} role="status" aria-live="polite" aria-atomic />
     </section>

--- a/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
+++ b/client/src/components/photos/PhotoAnnotator/ToolPalette.tsx
@@ -176,27 +176,31 @@ export function ToolPalette({
         ))}
       </div>
 
-      <div className={styles.divider} aria-hidden="true" />
+      {selectedTool !== 'text' && (
+        <>
+          <div className={styles.divider} aria-hidden="true" />
 
-      {/* Stroke width picker */}
-      <div className={styles.sizeDropdown}>
-        <label htmlFor="stroke-width-select" className={styles.sizeDropdownLabel}>
-          {t('strokeWidth')}
-        </label>
-        <select
-          id="stroke-width-select"
-          aria-label={t('strokeWidth')}
-          data-testid="annotator-stroke-width"
-          className={styles.sizeDropdownSelect}
-          value={activeStrokeWidthKey}
-          onChange={(e) => onSelectStrokeWidth(e.target.value as StrokeWidthKey)}
-        >
-          <option value="extra-thin">{t('strokeExtra-thin')}</option>
-          <option value="thin">{t('strokeThin')}</option>
-          <option value="medium">{t('strokeMedium')}</option>
-          <option value="thick">{t('strokeThick')}</option>
-        </select>
-      </div>
+          {/* Stroke width picker — irrelevant for the text tool */}
+          <div className={styles.sizeDropdown}>
+            <label htmlFor="stroke-width-select" className={styles.sizeDropdownLabel}>
+              {t('strokeWidth')}
+            </label>
+            <select
+              id="stroke-width-select"
+              aria-label={t('strokeWidth')}
+              data-testid="annotator-stroke-width"
+              className={styles.sizeDropdownSelect}
+              value={activeStrokeWidthKey}
+              onChange={(e) => onSelectStrokeWidth(e.target.value as StrokeWidthKey)}
+            >
+              <option value="extra-thin">{t('strokeExtra-thin')}</option>
+              <option value="thin">{t('strokeThin')}</option>
+              <option value="medium">{t('strokeMedium')}</option>
+              <option value="thick">{t('strokeThick')}</option>
+            </select>
+          </div>
+        </>
+      )}
 
       {(selectedTool === 'text' || selectedTool === 'measurement') && (
         <>

--- a/client/src/components/photos/PhotoViewer.tsx
+++ b/client/src/components/photos/PhotoViewer.tsx
@@ -287,7 +287,7 @@ export function PhotoViewer({
                   data-testid="photo-viewer-clear-annotations"
                   onClick={() => setShowClearConfirm(true)}
                 >
-                  <TrashIcon />
+                  <EraserIcon />
                 </button>
               )}
 
@@ -445,6 +445,26 @@ function TrashIcon() {
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function EraserIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M16.24 3.56l4.95 4.94a2 2 0 010 2.83l-8.49 8.49H7.05L3.51 16.27a2 2 0 010-2.83l9.9-9.88a2 2 0 012.83 0z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.5 7.5l7 7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
       />
     </svg>
   );


### PR DESCRIPTION
## Summary

Three small UI fixes for the photo annotator:

- **Text shape**: no longer attaches the Konva Transformer (size is controlled via the Font Size dropdown, so the 8-anchor box was noise that could stretch glyphs).
- **Toolbar**: hides the Stroke Width dropdown when the Text tool is active (stroke width has no effect on filled text).
- **Clear Annotations button** in the PhotoViewer chrome now uses a distinct eraser glyph instead of the trash glyph it shared with Delete Photo.
- **Removed** the in-annotator "Reset to original" button + confirm modal. The eraser button in the viewer chrome already covers this destructive action; surfacing the same action twice was confusing.

## Test plan

- [x] `npx jest client/src/components/photos/ --maxWorkers=1` — green.
- [x] `npx tsc --noEmit -p client/tsconfig.json` — green.
- [ ] Manual: pick the Text tool — toolbar shows Font Size dropdown only (no Stroke Width).
- [ ] Manual: open the annotator on a previously-annotated photo — no Reset button in the action bar.
- [ ] Manual: open the viewer on a previously-annotated photo — Clear Annotations button shows an eraser glyph; Delete Photo button still shows trash.