### PR TITLE
docs: update documentation for release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,8 @@ SECURE_COOKIES=true
 
 # ─── Diary ─────────────────────────────────────────────
 # DIARY_AUTO_EVENTS=true                                # Set to false to disable automatic diary event logging
-# PHOTO_STORAGE_PATH=/app/data/photos                   # Directory for diary photo attachments
+# DIARY_DRAFT_RETENTION_DAYS=30                         # Days a draft entry sits untouched before automatic cleanup (0 = disabled)
+# PHOTO_STORAGE_PATH=/app/data/photos                   # Directory for diary photo attachments (originals + annotated copies)
 # PHOTO_MAX_FILE_SIZE_MB=20                             # Maximum photo upload size in MB
 
 # ─── OIDC ──────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ A self-hosted home building project management tool for homeowners. Track work i
 
 - **Work Items** -- Manage construction tasks with statuses, dates, area assignments, notes, subtasks, dependencies, and keyboard shortcuts -- every work item shows its full area ancestor path (e.g. `House / Ground Floor / Kitchen`) as a breadcrumb across lists, detail pages, pickers, and every place it is referenced
 - **Areas & Trades** -- Organize your project with hierarchical areas (rooms, floors, zones) and trade specialties (Electrical, Plumbing, etc.) for vendors; a dedicated "No Area" filter surfaces items that have not been classified yet
-- **Budget Management** -- Budget categories, financing sources with inline expansion and mass-move of attached lines, multi-budget-line invoice linking with itemized amounts, subsidies with caps, quotation tracking, and an area-grouped overview dashboard with source attribution badges on every line, a per-source filter (URL-persisted, server-side) that updates totals and subsidy math, clickable summary tiles, and print-friendly export
+- **Budget Management** -- Budget categories, financing sources with inline expansion and mass-move of attached lines, multi-budget-line invoice linking with itemized amounts, staged-payment deposits for invoices paid in instalments (deposit-aware paid/claimed rollups), subsidies with caps, quotation tracking, and an area-grouped overview dashboard with source attribution badges on every line, a per-source filter (URL-persisted, server-side) that updates totals and subsidy math, clickable summary tiles, and print-friendly export
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, area assignment, delivery scheduling, budget integration, and work item linking
 - **Project Dashboard** -- At-a-glance project health with budget, timeline, invoice, and subsidy cards, mini Gantt preview, and customizable layout
-- **Construction Diary** -- Daily logs, site visits, delivery records, automatic system events, photo attachments, and digital signature capture
+- **Construction Diary** -- Daily logs, site visits, delivery records, automatic system events, photo attachments with in-browser annotation (rectangles, arrows, text, measurements, freehand), auto-saved drafts, and digital signature capture
 - **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices
 - **Advanced List Views** -- Filter, sort, paginate, and customize columns across all list pages with the shared DataTable system
 - **Backup & Restore** -- Manual and scheduled backups with configurable retention, restore from the settings UI

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,20 +1,65 @@
-# v2.5.0 Release Summary
+# v2.6.0 Release Summary
 
-A focused release that adds **Backup & Restore**, tightens budget VAT handling, and slims down the Budget Overview page. Migration 0031 backfills `includes_vat` on existing budget lines, runs automatically on first start, and requires no manual intervention.
+A feature-packed release that brings **in-browser photo annotation**, **staged-payment deposits** for invoices, and a much smoother **diary draft flow**. Migration 0032 (invoice deposits) runs automatically on first start -- no manual steps required.
 
 ## What's New
 
-- **Backup & Restore** -- Cornerstone now ships with a built-in backup feature that snapshots your entire app data directory (SQLite database + diary photos) into a single `tar.gz` archive. Trigger backups manually from the admin UI, run them on a cron schedule, set a retention limit, and restore from any archive in two clicks. Mount a separate volume to `/backups` (or wherever you point `BACKUP_DIR`) and you're set. See the [Backups guide](https://steilerDev.github.io/cornerstone/guides/backup) for setup, scheduling, and restore steps. (#1386)
+### Photo Annotation
 
-## Improvements
+Mark up diary photos directly in the browser. Open any diary photo in the viewer, click **Annotate**, and you get a full drawing canvas with nine tools:
 
-- **Consistent VAT handling across budget lines** (#1385) -- Direct pricing mode now applies the same VAT multiplier as unit pricing (quantity × unit price), so the **Price includes VAT** checkbox behaves identically regardless of which pricing mode you use. Planned amounts are now always stored as gross internally, which means the Budget Overview, Available Funds row, and printed reports compare every line on a like-for-like basis. The `includes_vat` flag is now `NOT NULL` at the database level (defaults to `true`); migration 0031 backfills any pre-existing `NULL` values.
+- **Select**, **Rectangle**, **Highlight**, **Arrow**, **Line**, **Ellipse**, **Text**, **Measurement** (dimension line with end ticks and a movable label), and **Freehand**
+- Six colours, four stroke widths, five font sizes -- pick before you draw, or change them on a selected shape to update it live
+- Drag to move, endpoint handles to reshape, undo/redo for everything including live edits
+- Annotated copies are saved as separate WebP files (quality 0.92); the original is preserved, and you can switch between **View original** and **View annotated** at any time
+- A **Reset to original** button discards your current annotations and starts over
+- Photo grids and viewers expose a quick-action **Edit** button that opens the viewer directly in annotation mode
 
-## Bug Fixes
+Signed diary entries cannot be annotated -- finish your markup before collecting signatures.
 
-- **Budget Overview is now the breakdown** (#1389) -- The Budget Health hero card has been removed from the top of the page. The overview now goes straight from the title bar into the Cost Breakdown Table. The Min / Avg / Max perspective toggle, source-filter, and Available Funds row all live inside the table and remain unchanged. The page is faster, prints cleaner, and removes a layer of summary metrics that mostly duplicated what the breakdown already shows.
-- **Source name now prints on the Budget Overview** (#1390) -- Print viewports (around 600-720 px) used to trigger the mobile breakpoint, which collapsed the source attribution badge to just a colored dot -- great on a phone, useless on a printout. Print mode now forces the full source name visible with a border-based color treatment, so the printed report shows the actual source attached to each budget line.
-- **Broken docs links on the Budget Overview page** (#1384) -- The "Related Pages" links to Work Items and Household Items pointed to non-existent `/overview` sub-paths and now point to the correct guide indices.
+See the [Photo Annotation guide](https://steilerDev.github.io/cornerstone/guides/diary/photo-annotation) for the full walkthrough.
+
+### Invoice Deposits (Staged Payments)
+
+Track invoices that are paid in stages -- a deposit on signing, a milestone payment, and a final balance.
+
+- Add any number of deposits to an invoice from the **Deposits** section on the invoice detail page
+- Each deposit has its own amount, due date, status (Pending / Paid / Claimed), paid/claimed dates, and optional description
+- The form refuses to save if deposits would exceed the invoice total
+- Quick actions to **mark paid** and **mark claimed** -- with revert support to fix mistakes
+- Budget rollups across every linked work item and household item are now **deposit-aware**: `actualCostPaid` and `actualCostClaimed` reflect deposit-level status, so paid and claimed amounts show real cash flow rather than waiting for the full invoice to settle
+- Deposits cascade-delete with the parent invoice
+
+See the [Invoice Deposits guide](https://steilerDev.github.io/cornerstone/guides/budget/invoice-deposits).
+
+### Diary Drafts Overhaul
+
+Creating a diary entry no longer needs a separate "create" step.
+
+- Click a type card (Daily Log, Site Visit, Delivery, Issue, General Note) and Cornerstone immediately creates a **draft entry** and opens the edit page -- you start typing right away
+- Photos uploaded to a draft persist immediately, so you don't have to remember to "save" before attaching them
+- Auto-save runs continuously with a live status indicator (`Saving...`, `Saved`, or "save failed -- will retry")
+- Drafts are tagged with a **Draft** badge and **hidden from the diary list by default**; a dedicated **Drafts** filter chip toggles their visibility
+- Click **Save** to promote the draft to a full entry, or **Discard Draft** to delete it (and its photos) permanently
+- Abandoned drafts are cleaned up automatically after `DIARY_DRAFT_RETENTION_DAYS` days (default: 30; set to `0` to disable)
+
+### Photo Viewer Improvements
+
+- New **photo metadata sidepanel** with upload date, description, and area assignment
+- **Edit** quick-action button on the photo grid that opens the viewer directly in annotation mode
+- **Delete photo** action from the lightbox for entries that aren't signed
+- Thumbnail cache busting -- annotated thumbnails update immediately
+- Mobile-friendly: the metadata sidepanel collapses on small screens
+
+## Configuration
+
+New environment variable:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DIARY_DRAFT_RETENTION_DAYS` | `30` | Days an untouched draft sits before automatic cleanup. Set to `0` to disable. |
+
+No other configuration changes are required. Migration 0032 adds the `invoice_deposits` table and runs automatically on container start.
 
 ## What to Update
 
@@ -22,21 +67,4 @@ A focused release that adds **Backup & Restore**, tightens budget VAT handling, 
 docker pull steilerdev/cornerstone:latest
 ```
 
-Restart your container. Migration 0031 runs automatically on first start.
-
-If you want to enable the new backup feature, mount a backup volume:
-
-```bash
-docker run -d \
-  --name cornerstone \
-  -p 3000:3000 \
-  -v cornerstone-data:/app/data \
-  -v cornerstone-backups:/backups \
-  steilerdev/cornerstone:latest
-```
-
-Optionally set `BACKUP_CADENCE` (e.g., `0 2 * * *` for daily at 2 AM) and `BACKUP_RETENTION` (e.g., `7` to keep a week's worth of archives).
-
----
-
-_Released: 2026-05-03_
+Restart your container. Schema migrations run on first boot.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -41,6 +41,7 @@ const sidebars = {
         'guides/budget/financing-sources',
         'guides/budget/work-item-budgets',
         'guides/budget/vendors-and-invoices',
+        'guides/budget/invoice-deposits',
         'guides/budget/subsidies',
         'guides/budget/budget-overview',
       ],
@@ -83,6 +84,7 @@ const sidebars = {
       items: [
         'guides/diary/manual-entries',
         'guides/diary/automatic-events',
+        'guides/diary/photo-annotation',
         'guides/diary/signatures',
       ],
     },

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -60,7 +60,8 @@ The OIDC callback URL is automatically derived as `<EXTERNAL_URL>/api/auth/oidc/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DIARY_AUTO_EVENTS` | `true` | Whether the construction diary automatically logs system events (status changes, invoice updates, etc.). Set to `false` to disable automatic entries. |
-| `PHOTO_STORAGE_PATH` | `<data-dir>/photos` | Directory where diary photo attachments are stored. Defaults to a `photos` folder next to the database file. |
+| `DIARY_DRAFT_RETENTION_DAYS` | `30` | Days a draft diary entry can sit untouched before the daily orphan cleanup deletes it. Set to `0` to disable the cleanup and keep drafts forever. |
+| `PHOTO_STORAGE_PATH` | `<data-dir>/photos` | Directory where diary photos are stored (both originals and annotated copies). Defaults to a `photos` folder next to the database file. |
 | `PHOTO_MAX_FILE_SIZE_MB` | `20` | Maximum file size in megabytes for photo uploads |
 
 :::note

--- a/docs/src/guides/budget/budget-overview.md
+++ b/docs/src/guides/budget/budget-overview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Budget Overview
 ---
 

--- a/docs/src/guides/budget/invoice-deposits.md
+++ b/docs/src/guides/budget/invoice-deposits.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 5
+title: Invoice Deposits
+---
+
+# Invoice Deposits
+
+Many construction invoices are paid in stages -- a deposit on signing, a progress payment at milestones, and a final payment on handover. Cornerstone lets you track these staged payments as **deposits** within a single parent invoice, so your budget rollups reflect what has actually been paid out at any point in time rather than waiting for the full invoice to settle.
+
+## What is a Deposit?
+
+A deposit is a partial payment recorded against an invoice. Each deposit has its own amount, due date, status, and (optionally) a description. The amounts you record as deposits eat into the invoice total -- whatever is left after the deposits is the **final payment**, which uses the parent invoice's status.
+
+The math is simple:
+
+- `Σ deposits + final payment = invoice total`
+- Deposit total **must not exceed** the invoice total. The form refuses to save if it would.
+
+Each deposit is one of three statuses, mirroring the parent invoice status model:
+
+| Status | Meaning |
+|--------|---------|
+| **Pending** | Deposit is scheduled (or due) but not yet paid |
+| **Paid** | Deposit has been paid to the vendor |
+| **Claimed** | Deposit has been claimed back from / reimbursed by a financing source |
+
+Allowed transitions: `pending → paid`, `paid → claimed`, and the reverse path (`claimed → paid → pending`) to correct mistakes.
+
+## Adding a Deposit
+
+Open any invoice's detail page. The **Deposits** section appears below the invoice header and shows:
+
+- The current deposit count
+- A list of existing deposits with amount, due date, status badge, and description
+- An **Add deposit** button
+
+Click **Add deposit** to open the form:
+
+| Field | Description |
+|-------|-------------|
+| **Amount** | Deposit amount. Must be positive and must keep the running total at or below the invoice total. |
+| **Due date** | When the deposit is owed -- used for the schedule and for the overdue indicator. |
+| **Status** | Pending (default), Paid, or Claimed. |
+| **Paid date** | Shown when status is Paid or Claimed -- defaults to today, change if it was paid earlier. |
+| **Claimed date** | Shown when status is Claimed -- defaults to today, change if it was claimed earlier. |
+| **Description** | Optional free-text label (e.g., "30% on contract signing", "Milestone payment after framing"). |
+
+Save the form to record the deposit. The Deposits list re-renders with the new entry, and the budget rollups across linked work items and household items update immediately to reflect the contribution.
+
+## Editing and Deleting Deposits
+
+Each deposit row has an overflow menu with **Edit** and **Delete**.
+
+- **Edit** opens the same form with the deposit's current values. Status changes are restricted to the allowed transitions above; for example, you cannot move directly from Pending to Claimed -- mark it Paid first.
+- **Delete** removes the deposit. If the deposit is Paid or Claimed, the modal warns you that deleting will reduce the paid/claimed amount rolled up against budget lines.
+
+You can also mark a deposit as Paid or Claimed without editing it: the **mark paid** and **mark claimed** quick actions in the overflow menu open a small confirmation modal where you can set the paid or claimed date.
+
+If you mark a deposit Paid or Claimed by mistake, use the same menu to revert it -- the action is allowed and shows a transient error banner if the revert fails (for example, due to a network glitch).
+
+## How Deposits Affect Budget Rollups
+
+Deposits change the **timing** of cost recognition, not the total. Cornerstone splits each invoice across its deposits proportionally for every budget line the invoice is linked to:
+
+- **`actualCost`** (total) -- the full itemized amount counts toward the budget line regardless of deposit status. Even a Pending deposit contributes to actualCost, because the invoice as a whole is a committed cost.
+- **`actualCostPaid`** -- only the portion of the itemized amount covered by **Paid** or **Claimed** deposits, plus the residual final payment if the parent invoice is itself Paid or Claimed.
+- **`actualCostClaimed`** -- only the portion covered by **Claimed** deposits, plus the residual final payment if the parent invoice is Claimed.
+
+In practice: if you have a €10,000 invoice linked to a budget line at its full €10,000, and you record a €3,000 Paid deposit while the invoice itself is still Pending, the budget line shows €10,000 actual cost but only €3,000 paid. The remaining €7,000 stays as a pending obligation until either the parent invoice transitions to Paid or you add more Paid deposits to cover it.
+
+The **status breakdown summary** on each invoice list and the per-source budget overview both use this deposit-aware math, so paid and claimed amounts always reflect real cash flow rather than waiting for the entire invoice to settle.
+
+## Quotations and Deposits
+
+Quotation invoices accept deposits the same way as regular invoices, but quotation amounts are treated with a ±5% projection margin in the budget overview ([ADR-029](https://github.com/steilerDev/cornerstone/wiki/ADR-029)). Deposits against a Quotation invoice contribute to `actualCost` but only contribute to `actualCostPaid` / `actualCostClaimed` if their own status is Paid or Claimed.
+
+## Cascade Behaviour
+
+Deposits are owned by the parent invoice. Deleting an invoice cascades and removes all its deposits in the same transaction -- you do not need to delete deposits one by one before deleting the invoice.
+
+## Next Steps
+
+- [Invoices & Vendors](vendors-and-invoices) -- creating invoices and linking them to budget lines
+- [Budget Overview](budget-overview) -- how deposit-aware totals roll up across categories and sources
+- [Subsidies](subsidies) -- subsidy calculations also use itemized amounts and respect deposit status

--- a/docs/src/guides/budget/subsidies.md
+++ b/docs/src/guides/budget/subsidies.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Subsidies
 ---
 

--- a/docs/src/guides/budget/vendors-and-invoices.md
+++ b/docs/src/guides/budget/vendors-and-invoices.md
@@ -69,9 +69,15 @@ Use the **Quotation** status for vendor quotes that you want to track alongside 
 
 ### Invoice Detail
 
-Click an invoice to see its full detail page with the invoice amount, current status, and the **Linked Budget Lines** section.
+Click an invoice to see its full detail page with the invoice amount, current status, the **Deposits** section (for tracking staged payments), and the **Linked Budget Lines** section.
 
 If you have [Paperless-ngx configured](/guides/documents/setup), you can also link documents (invoice PDFs, receipts, supporting files) directly to invoices from the detail page. See [Linking Documents](/guides/documents/linking-documents) for details.
+
+### Staged Payments (Deposits)
+
+Many invoices are paid in stages -- a deposit on signing, progress payments at milestones, and a final balance. Cornerstone supports this with **invoice deposits**: each deposit is a partial payment with its own due date, status, and description. The remaining (final) payment uses the parent invoice's status. Budget rollups respect deposit status so `actualCostPaid` reflects real cash flow.
+
+See [Invoice Deposits](invoice-deposits) for the full guide.
 
 ![Invoice detail page](/img/screenshots/budget-invoice-detail-light.png)
 

--- a/docs/src/guides/diary/index.md
+++ b/docs/src/guides/diary/index.md
@@ -14,8 +14,10 @@ The diary provides:
 - **Manual Entries** -- Write daily logs, record site visits, track deliveries, flag issues, and add general notes
 - **Automatic Events** -- System-generated entries for work item status changes, invoice creation and status changes, milestone delays, budget breaches, schedule changes, and subsidy changes
 - **Photo Attachments** -- Attach photos to manual entries for visual documentation
+- **Photo Annotation** -- Mark up photos with rectangles, arrows, text, measurements, and more, directly in the browser
+- **Drafts** -- Pick an entry type and start drafting immediately; the entry is saved as a draft until you promote it to a full entry, with auto-save while you type
 - **Signature Capture** -- Collect digital signatures from users or vendors with a drawing canvas; signed entries become immutable
-- **Filtering** -- Filter the diary by All, Manual, or Automatic entries with type-specific filter chips
+- **Filtering** -- Filter the diary by All, Manual, or Automatic entries with type-specific filter chips, plus a separate Drafts chip to show or hide unfinished work
 
 ## Entry Types
 
@@ -57,10 +59,13 @@ At the top of the diary page, filter chips let you narrow the view:
 
 When the Automatic filter is active, additional type-specific chips appear for finer control (e.g., "Invoice" groups both invoice creation and status change events).
 
+A separate **Drafts** chip controls whether unfinished draft entries are included in the view. Drafts are hidden by default so your diary stays focused on finalized entries -- toggle the chip on to surface them.
+
 ## Next Steps
 
 - [Manual Entries](manual-entries) -- Creating and editing diary entries
 - [Automatic Events](automatic-events) -- How system events are generated
+- [Photo Annotation](photo-annotation) -- Marking up diary photos with shapes, text, and measurements
 - [Signatures](signatures) -- Digital signature capture and immutability
 
 ![Diary page](/img/screenshots/diary-list-light.png)

--- a/docs/src/guides/diary/manual-entries.md
+++ b/docs/src/guides/diary/manual-entries.md
@@ -21,18 +21,31 @@ Choose the type that best fits what you are recording:
 
 1. Navigate to the diary page at `/diary`
 2. Click **New Entry**
-3. Fill in the entry form:
+3. Pick an entry type card (Daily Log, Site Visit, Delivery, Issue, or General Note). The moment you click a card, Cornerstone creates a **draft entry** and opens the edit page -- no extra "create" step needed.
+4. Fill in the entry form:
 
 | Field | Description |
 |-------|-------------|
-| **Type** | Select the entry type (daily log, site visit, delivery, issue, or general note) |
 | **Date** | The date of the entry (defaults to today) |
 | **Weather** | Temperature and conditions (sunny, cloudy, rainy, snowy, windy, foggy) -- optional |
 | **Title** | A short summary of the entry |
 | **Body** | Detailed description (or "Items" for delivery entries) |
 
-4. Optionally attach photos (see below)
-5. Click **Save**
+5. Optionally attach photos (see below)
+6. Click **Save** to promote the draft to a full entry, or **Discard Draft** to remove it entirely
+
+## Drafts and Auto-Save
+
+While you are editing an entry, Cornerstone auto-saves changes in the background and shows a small status indicator (`Saving...`, `Saved`, or "save failed — will retry on next change") so you always know whether your work is persisted.
+
+Entries created from the **New Entry** flow start in **draft** state. Drafts:
+
+- Are tagged with a **Draft** badge wherever they appear
+- Are **hidden by default** from the diary list -- toggle the **Drafts** filter chip to surface them
+- Can be discarded with the **Discard Draft** button -- this permanently removes the draft and any photos you have uploaded to it
+- Are promoted to a regular entry when you click **Save**
+
+If you start a draft and abandon it without saving or discarding, the server cleans it up automatically after `DIARY_DRAFT_RETENTION_DAYS` days of inactivity (default: 30). Set the environment variable to `0` to disable the cleanup, or to another integer to shorten or extend retention. See [Configuration](/getting-started/configuration#diary) for details.
 
 ## Weather Tracking
 
@@ -43,12 +56,17 @@ Each entry can record the weather conditions at the time. This is useful for tra
 
 ## Photo Attachments
 
-You can attach photos directly when creating or editing a diary entry. Photos are added inline during the creation flow -- there is no separate upload step.
+You can attach photos directly when editing a diary entry. Photos upload as soon as you pick them -- the upload queue shows progress for each file and lets you retry failed uploads without re-selecting them. There is no separate "attach" or "submit" step; uploaded photos are immediately part of the entry.
 
-Photos provide visual documentation of progress, deliveries, issues, or site conditions.
+Photos provide visual documentation of progress, deliveries, issues, or site conditions. Each photo can be opened in a viewer where you can:
+
+- View the original or, if it has been edited, the annotated copy
+- Edit metadata (description, area assignment)
+- [Annotate the photo](photo-annotation) with rectangles, arrows, text, measurements, and other markup
+- Delete the photo (only when the entry is not signed)
 
 :::caution
-Once an entry is signed, the photo section is hidden when no photos are attached, and no new photos can be added. Attach photos before collecting signatures.
+Once an entry is signed, the photo section is hidden when no photos are attached, and no new photos can be added. Existing photos remain visible but cannot be deleted or annotated. Attach and annotate photos before collecting signatures.
 :::
 
 ## Editing Entries

--- a/docs/src/guides/diary/photo-annotation.md
+++ b/docs/src/guides/diary/photo-annotation.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+title: Photo Annotation
+---
+
+# Photo Annotation
+
+Diary photos can be annotated directly in the browser so you can call out details on a delivery photo, mark a defect, or label a measurement on a site shot. Annotations are saved as a new copy of the photo alongside the original -- you can always switch back to the unedited image, and you can reset and re-annotate as often as you like until the entry is signed.
+
+## Opening the Annotator
+
+Annotations are launched from the **photo viewer**, which opens when you click any photo thumbnail attached to a diary entry. The viewer has two ways into the annotator:
+
+- **Annotate** -- in the viewer toolbar, opens the photo on a drawing canvas with the tool palette
+- **Edit** -- a quick-action button on the photo grid that opens the viewer already in annotation mode, so you skip the intermediate step
+
+If a photo has already been annotated, the viewer shows toggles for **View original** and **View annotated** so you can compare them. Clicking **Annotate** on an annotated photo opens the annotator with your previous shapes in place -- you can continue editing where you left off.
+
+:::caution Signed entries cannot be annotated
+Once a diary entry has been [signed](signatures), the **Annotate** button is disabled. Finalize your annotations before collecting signatures.
+:::
+
+## The Tool Palette
+
+The toolbar groups tools by purpose. The active tool is highlighted; tap it again or pick a different tool to switch.
+
+### Drawing Tools
+
+| Tool | Use it for |
+|------|-----------|
+| **Select** | Pick an existing shape to move, resize, recolour, or delete |
+| **Rectangle** | Outline a defect, area, or zone of interest |
+| **Highlight** | Translucent fill -- shade a region of the photo without hiding what is underneath |
+| **Arrow** | Point from a label to a specific feature |
+| **Line** | Plain segment without arrowhead -- useful for axes or alignment marks |
+| **Ellipse** | Circle or oval outline |
+| **Text** | Type a label anywhere on the photo |
+| **Measurement** | Draw a dimension line with end ticks and a movable label (e.g., "1.20 m") |
+| **Freehand** | Trace an irregular shape -- the path is smoothed automatically |
+
+### Style Controls
+
+After choosing a tool, the next group of controls sets its style:
+
+- **Color swatches** -- Red, Yellow, Green, Blue, Black, White. Picking a swatch while a shape is selected re-colours that shape, including the stroke of non-text shapes.
+- **Stroke width** dropdown (`Extra thin` / `Thin` / `Medium` / `Thick`) -- shown for every tool except plain text. Stroke widths scale to the photo's resolution so a thick line on a high-megapixel photo still looks thick when the image is opened on a smaller screen.
+- **Font size** dropdown (`Extra small` / `Small` / `Medium` / `Large` / `Extra large`) -- shown for text and measurement tools. Pick the size before placing the shape; you can resize an existing shape later by selecting it and changing the dropdown.
+
+:::tip Sizing happens via the dropdown, not by dragging
+Text and measurement labels are sized exclusively through the **Font size** dropdown. There are no drag handles for resizing text -- this keeps annotations crisp and consistent across photos.
+:::
+
+### Undo, Redo, and History
+
+The right edge of the toolbar has **Undo** and **Redo** buttons that step through your annotation history. Every shape you add, move, recolour, resize, or delete is a step on the stack, and live edits (such as recolouring a selected shape) are also tracked -- if you change your mind, undo will take you back accurately.
+
+## Working with Shapes
+
+### Placing a Shape
+
+For rectangles, highlights, arrows, lines, ellipses, measurements, and freehand: pick the tool, then drag from one corner / endpoint to the other on the photo. Release to commit. Text and measurement labels open an inline input where you type the content and press **Enter** or click outside the input to commit.
+
+The measurement tool uses two endpoint handles -- you can drag either endpoint after placement to extend or rotate the dimension line. Lines and arrows behave the same way.
+
+### Selecting and Editing
+
+Switch to the **Select** tool and click any shape to select it. A selection halo highlights the shape and exposes:
+
+- **Drag handles** at corners (rectangles, ellipses, highlights) or endpoints (lines, arrows, measurements) to resize or reshape
+- **Body drag** -- click anywhere inside the shape and drag to reposition it
+- **Color, stroke width, and font size** controls in the toolbar update the selected shape live
+
+Click a measurement label or text shape directly to re-open the inline editor and change the text.
+
+To delete a selected shape, press `Delete` or `Backspace`.
+
+### Inline Text Input
+
+When you place text, callouts, or measurement labels, an inline editor appears anchored to the rendered shape position. The text in the editor matches what will be rendered (same font, size, and colour) so you can see your label in context as you type.
+
+## Saving and Resetting
+
+The annotator has two save flows:
+
+- **Save annotations** writes the annotated photo as a separate copy (encoded as WebP at quality 0.92 to keep file sizes small) and links it to the original. The original photo is preserved -- you can view it any time from the photo viewer.
+- **Cancel** discards your current session and returns to the viewer without writing changes.
+
+If you have already annotated a photo and want to start over, click **Reset to original** in the annotator. This discards the current draft and re-opens the annotator on the original photo. Your previously saved annotated copy stays available until you save over it.
+
+When you save, the photo thumbnail in the diary entry updates to show the annotated version. You can still switch to **View original** in the viewer afterwards if you want to compare.
+
+## Tips and Limitations
+
+- Annotations are stored per-photo, not per-diary-entry -- if you attach the same photo to two entries (uncommon but possible), they share the annotated copy.
+- The annotator works on touch devices, but precision drawing is easier with a mouse or trackpad. Tap-and-hold a handle to start a drag.
+- On portrait photos, the canvas waits for the layout to settle before placing your first stroke so coordinates stay aligned with the rendered image -- there is a brief moment after opening when the canvas readies itself.
+- EXIF orientation is honoured: a photo rotated by your camera is annotated in its display orientation, not the underlying file orientation.
+
+## Next Steps
+
+- [Manual Entries](manual-entries) -- attaching and managing photos on diary entries
+- [Signatures](signatures) -- signing entries locks photos and disables annotation

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -32,7 +32,7 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 ## Key Features
 
 - **Work Items** -- Create and manage construction tasks with statuses, dates, assignments, areas, notes, subtasks, and dependencies -- each work item surfaces its full area ancestor path (e.g. `House / Ground Floor / Kitchen`) as a breadcrumb wherever it appears
-- **Budget Management** -- Track costs with budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, subsidies, and an area-grouped overview dashboard with multiple projection perspectives, clickable summary tiles, and print-friendly export
+- **Budget Management** -- Track costs with budget categories, financing sources, multi-budget-line invoice linking with itemized amounts, **staged-payment deposits** for invoices paid in instalments, subsidies, and an area-grouped overview dashboard with multiple projection perspectives, clickable summary tiles, and print-friendly export
 - **Hierarchical Financing Sources** -- Click any source to expand it inline, see every attached budget line grouped by area and work item, and mass-move selected lines between sources
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path highlighting, zoom controls, milestones, and automatic scheduling via the Critical Path Method
 - **Calendar View** -- Monthly and weekly calendar grids showing work items and milestones
@@ -41,7 +41,7 @@ Cornerstone is designed for **homeowners managing a construction or renovation p
 - **Areas & Trades** -- Hierarchical project areas (rooms, floors, zones) and trade specialties (Electrical, Plumbing, etc.) for organizing work and linking vendors
 - **Authentication** -- Local accounts with first-run setup wizard, plus OIDC single sign-on for existing identity providers
 - **User Management** -- Admin and Member roles with a dedicated admin panel
-- **Construction Diary** -- Maintain a construction diary (Bautagebuch) with daily logs, site visits, delivery records, issue tracking, automatic system events, photo attachments, and digital signature capture
+- **Construction Diary** -- Maintain a construction diary (Bautagebuch) with daily logs, site visits, delivery records, issue tracking, automatic system events, photo attachments with in-browser annotation (rectangles, arrows, text, measurements, freehand), auto-saved drafts, and digital signature capture
 - **Project Dashboard** -- At-a-glance project health with budget summary, timeline status, invoice and subsidy pipelines, mini Gantt preview, and customizable card layout
 - **Document Integration** -- Browse, search, and link documents from a connected [Paperless-ngx](https://docs.paperless-ngx.com/) instance to work items and invoices
 - **Dark Mode** -- Light, Dark, or System theme with instant switching


### PR DESCRIPTION
## Summary

Refreshes user-facing documentation to reflect features that shipped to `beta` since the v2.5.0 release (#1396) and are about to promote to `main` as v2.6.0. Covers the photo annotator, invoice deposits, and the diary drafts overhaul -- the three biggest behavioural changes since the last docs refresh.

## Changes

- **New guide: Photo Annotation** (`docs/src/guides/diary/photo-annotation.md`) -- nine tools, six colours, stroke/font dropdowns, undo/redo, save/reset flow, signed-entry behaviour
- **New guide: Invoice Deposits** (`docs/src/guides/budget/invoice-deposits.md`) -- staged-payment deposits, status transitions, deposit-aware budget rollup math, quotation interaction, cascade behaviour
- **Diary draft flow** documented across `index.md` and `manual-entries.md` -- auto-draft on type-card click, auto-save status, Drafts filter chip, `DIARY_DRAFT_RETENTION_DAYS` cleanup
- **Invoices & vendors** page cross-links to the new deposits guide and mentions the Deposits section on invoice detail
- **README.md** and **intro.md** feature lists updated -- photo annotation and staged-payment deposits added (protected `> [!NOTE]` block untouched)
- **Configuration reference** documents `DIARY_DRAFT_RETENTION_DAYS`
- **`.env.example`** adds the `DIARY_DRAFT_RETENTION_DAYS` placeholder, keeps the comment style consistent with surrounding optional vars
- **`RELEASE_SUMMARY.md`** rewritten for v2.6.0 (photo annotation, invoice deposits, diary drafts, photo viewer improvements)
- **`docs/sidebars.js`** updated to surface both new guides in their categories

## Test plan

- [x] `npm run docs:build` succeeds locally (only the expected pre-existing screenshot warnings — those resolve when the stable release captures screenshots)
- [x] All internal doc links resolve (Docusaurus `onBrokenLinks: 'throw'`)
- [x] New pages have proper frontmatter (`title:` + `sidebar_position:`)
- [x] Both new pages appear in their respective sidebar categories
- [x] Protected `> [!NOTE]` block at the top of `README.md` is untouched
- [x] `.env.example`, `configuration.md`, and `CLAUDE.md` are consistent on env vars