### PR TITLE
fix(budget-lines): remove overrestrictive guard on parent move (#1555)

### DIFF
--- a/e2e/tests/invoices/invoice-budget-line-full-edit.spec.ts
+++ b/e2e/tests/invoices/invoice-budget-line-full-edit.spec.ts
@@ -10,7 +10,7 @@
  *   1. Edit non-parent fields (description + itemized amount) on a WI budget line
  *   2. Same-table WI → WI move from invoice detail page
  *   3. Cross-table WI → HI move with move-hint banner
- *   4. BUDGET_LINE_ALREADY_LINKED guard — error shown, modal stays open
+ *   4. Move to WI that already has a line on the same invoice → succeeds (guard removed in #1555)
  *   5. WI detail page inline edit — full form visible, parent picker present (wired)
  *   6. Mobile viewport — edit modal usable at 375px touch targets
  *
@@ -458,18 +458,25 @@ test.describe('Cross-table WI → HI move (Scenario 3)', { tag: '@responsive' },
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 4: BUDGET_LINE_ALREADY_LINKED guard
+// Scenario 4: Move to WI that already has a line on the same invoice → succeeds
+//
+// The BUDGET_LINE_ALREADY_LINKED guard was removed in issue #1555 because it was
+// over-restrictive: there is no business reason to block a work item from holding
+// multiple budget lines on the same invoice. This test is an inverted regression
+// guard: same setup as before (WI-A and WI-B each have a budget line linked to
+// the same invoice), but now asserts the move SUCCEEDS and WI-B ends up owning
+// BOTH lines (its original one plus the moved one from WI-A).
 // ─────────────────────────────────────────────────────────────────────────────
 
-test.describe('BUDGET_LINE_ALREADY_LINKED guard (Scenario 4)', () => {
-  test('Attempting to move budget line to WI that already has a line on this invoice → error in modal', async ({
+test.describe('Move budget line to WI that already has a line on this invoice (Scenario 4)', () => {
+  test('Move WI-A line to WI-B (WI-B already has a line on this invoice) → both lines now under WI-B', async ({
     page,
     testPrefix,
   }) => {
-    // Desktop only — error behaviour test
+    // Desktop only — functional move test
     const viewportWidth = page.viewportSize()?.width ?? 1440;
     if (viewportWidth < 1024) {
-      test.skip(true, 'Error guard test — desktop only');
+      test.skip(true, 'Multi-line WI move test — desktop only');
       return;
     }
 
@@ -481,23 +488,23 @@ test.describe('BUDGET_LINE_ALREADY_LINKED guard (Scenario 4)', () => {
     let budgetSourceId = '';
 
     try {
-      vendorId = await createVendorViaApi(page, `${testPrefix} AlreadyLinked Vendor`);
+      vendorId = await createVendorViaApi(page, `${testPrefix} MultiLine Vendor`);
       invoiceId = await createInvoiceViaApi(page, vendorId, {
         amount: 3000,
         date: '2026-06-01',
       });
       workItemAId = await createWorkItemViaApi(page, {
-        title: `${testPrefix} AlreadyLinked WI-A`,
+        title: `${testPrefix} MultiLine WI-A`,
       });
       workItemBId = await createWorkItemViaApi(page, {
-        title: `${testPrefix} AlreadyLinked WI-B`,
+        title: `${testPrefix} MultiLine WI-B`,
       });
       budgetSourceId = await createBudgetSourceViaApi(page, {
-        name: `${testPrefix} AlreadyLinked Source`,
+        name: `${testPrefix} MultiLine Source`,
         totalAmount: 50000,
       });
 
-      // Link WI-A budget line to invoice
+      // WI-A: one budget line linked to the invoice (itemized 500)
       await createAndLinkWIBudgetLine(page, {
         workItemId: workItemAId,
         budgetSourceId,
@@ -507,7 +514,7 @@ test.describe('BUDGET_LINE_ALREADY_LINKED guard (Scenario 4)', () => {
         description: `${testPrefix} Line A`,
       });
 
-      // Link WI-B budget line to the SAME invoice (creating the conflict)
+      // WI-B: a DIFFERENT budget line also linked to the SAME invoice (itemized 400)
       await createAndLinkWIBudgetLine(page, {
         workItemId: workItemBId,
         budgetSourceId,
@@ -520,12 +527,11 @@ test.describe('BUDGET_LINE_ALREADY_LINKED guard (Scenario 4)', () => {
       await detailPage.goto(invoiceId);
       await expect(detailPage.heading).toBeVisible();
 
-      // Both lines should be visible
+      // Both lines visible on the invoice
       await expect(detailPage.budgetLinesSection).toContainText('Line A');
       await expect(detailPage.budgetLinesSection).toContainText('Line B');
 
-      // Open Edit modal for WI-A's line (the one with "Line A" description)
-      // Use the description-scoped menu trigger
+      // Open Edit modal for WI-A's line
       await detailPage.openBudgetLineMenu('Line A');
       await detailPage.clickBudgetLineMenuItem('Edit');
 
@@ -537,45 +543,45 @@ test.describe('BUDGET_LINE_ALREADY_LINKED guard (Scenario 4)', () => {
       const changeButton = parentPickerSection.getByRole('button', { name: 'Change' });
       await changeButton.click();
 
-      // Work Item tab already active — search for WI-B (which already has a line on this invoice)
+      // Work Item tab already active — search for WI-B
       const wiPickerInput = parentPickerSection.getByRole('textbox');
-      await wiPickerInput.fill(`${testPrefix} AlreadyLinked WI-B`);
+      await wiPickerInput.fill(`${testPrefix} MultiLine WI-B`);
 
       const option = page.getByRole('option', {
-        name: new RegExp(`AlreadyLinked WI-B`, 'i'),
+        name: new RegExp(`MultiLine WI-B`, 'i'),
       });
       await expect(option).toBeVisible();
       await option.click();
 
-      // Click "Move to selected item" — expect 409 from the backend guard
+      // Click "Move to selected item" — guard is gone, expect 200
       const moveButton = parentPickerSection.getByRole('button', {
         name: /Move to selected item|Moving/i,
       });
 
-      const patchErrorPromise = page.waitForResponse(
+      const patchPromise = page.waitForResponse(
         (resp) =>
           resp.url().includes('/budget-lines/') &&
           resp.request().method() === 'PATCH' &&
-          (resp.status() === 409 || resp.status() === 400),
+          resp.status() === 200,
       );
       await moveButton.click();
-      await patchErrorPromise;
+      await patchPromise;
 
-      // Error banner appears inside the modal (from movePickerError state)
-      const errorParagraph = parentPickerSection.locator('[class*="parentPickerError"]');
-      await expect(errorParagraph).toBeVisible();
+      // Modal closes — the move succeeded
+      await expect(editModal).not.toBeVisible();
 
-      // Modal stays open — user can correct their choice
-      await expect(editModal).toBeVisible();
-
-      // Both budget lines remain unchanged
+      // Both lines are still visible on the invoice, now both linked via WI-B
       await expect(detailPage.budgetLinesSection).toContainText('Line A');
       await expect(detailPage.budgetLinesSection).toContainText('Line B');
 
-      // Cancel to close modal cleanly
-      const cancelButton = editModal.getByRole('button', { name: 'Cancel' });
-      await cancelButton.click();
-      await expect(editModal).not.toBeVisible();
+      // The moved line now shows WI-B as its linked item
+      // (Line A row should reference WI-B title, not WI-A)
+      await expect(detailPage.budgetLinesSection).toContainText('MultiLine WI-B');
+      await expect(detailPage.budgetLinesSection).not.toContainText('MultiLine WI-A');
+
+      // Remaining amount = 3000 − 500 − 400 = 2100 (unchanged; amounts weren't modified)
+      const remainingCell = detailPage.budgetLinesSection.locator('[aria-live="polite"]');
+      await expect(remainingCell).toContainText('2100');
     } finally {
       if (invoiceId && vendorId) await deleteInvoiceViaApi(page, vendorId, invoiceId);
       if (vendorId) await deleteVendorViaApi(page, vendorId);

--- a/server/src/routes/invoiceBudgetLines.editAndMove.test.ts
+++ b/server/src/routes/invoiceBudgetLines.editAndMove.test.ts
@@ -300,16 +300,19 @@ describe('PATCH /api/invoices/:invoiceId/budget-lines/:id — editAndMove', () =
     expect(response.statusCode).toBe(400);
   });
 
-  // ─── Scenario 6: WI already linked to same invoice → 409 ────────────────────
+  // ─── Scenario 6: move to WI that already has another IBL on same invoice → 200 ──
 
-  it('PATCH with newWorkItemId already linked → 409 BUDGET_LINE_ALREADY_LINKED', async () => {
+  // Issue #1555: the BUDGET_LINE_ALREADY_LINKED guard was overly restrictive and
+  // has been removed. Moving to a target work item that already has another budget
+  // line on the same invoice is valid (e.g. two itemized lines for "Kitchen" WI).
+  it('PATCH with newWorkItemId that already has another IBL on same invoice → 200', async () => {
     const { cookie } = await createUserWithSession();
     const vendorId = createVendor();
     const invoiceId = createInvoice(vendorId, 2000);
     const wi1 = createWorkItem('Painting');
     const wi2 = createWorkItem('Plumbing');
     const { iblId } = createIblOnWorkItem(invoiceId, wi1, 300);
-    // wi2 already linked to the same invoice
+    // wi2 already has another IBL on the same invoice — move must succeed
     createIblOnWorkItem(invoiceId, wi2, 300);
 
     const response = await app.inject({
@@ -319,9 +322,10 @@ describe('PATCH /api/invoices/:invoiceId/budget-lines/:id — editAndMove', () =
       payload: { newWorkItemId: wi2 },
     });
 
-    expect(response.statusCode).toBe(409);
-    const body = response.json<ApiErrorResponse>();
-    expect(body.error.code).toBe('BUDGET_LINE_ALREADY_LINKED');
+    expect(response.statusCode).toBe(200);
+    const body = response.json<InvoiceBudgetLineCreateResponse>();
+    expect(body.budgetLine.parentItemId).toBe(wi2);
+    expect(body.budgetLine.parentItemType).toBe('work_item');
   });
 
   // ─── Scenario 7: Both move fields provided → 400 ────────────────────────────

--- a/server/src/services/householdItemBudgetService.move.test.ts
+++ b/server/src/services/householdItemBudgetService.move.test.ts
@@ -6,11 +6,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { runMigrations } from '../db/migrate.js';
 import * as schema from '../db/schema.js';
 import { updateHouseholdItemBudget } from './householdItemBudgetService.js';
-import {
-  NotFoundError,
-  ValidationError,
-  BudgetLineAlreadyLinkedError,
-} from '../errors/AppError.js';
+import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 /**
  * Tests for updateHouseholdItemBudget() move functionality (same-table HI→HI moves
@@ -250,11 +246,15 @@ describe('updateHouseholdItemBudget() — move scenarios', () => {
     }).toThrow(NotFoundError);
   });
 
-  it('same-table move: throws BudgetLineAlreadyLinkedError when target HI already has linked IBL', () => {
+  // Issue #1555: the BUDGET_LINE_ALREADY_LINKED guard was overly restrictive and
+  // has been removed from the same-table move path. The unique constraint is per-HIB-row,
+  // not per-(invoice, household-item) pair. Moving a HIB to a target that already has a
+  // different HIB linked to the same invoice is allowed.
+  it('same-table move: succeeds even when target HI already has a linked IBL on the same invoice', () => {
     const hi1 = createHouseholdItem('Sofa');
     const hi2 = createHouseholdItem('Table');
     const hibId = createHouseholdItemBudget(hi1);
-    // Link hi2 to an invoice
+    // Link hi2 to an invoice via a different HIB — move must still succeed
     const hib2Id = createHouseholdItemBudget(hi2);
     const vendorId = createVendor();
     const invoiceId = createInvoice(vendorId);
@@ -272,9 +272,18 @@ describe('updateHouseholdItemBudget() — move scenarios', () => {
       })
       .run();
 
-    expect(() => {
-      updateHouseholdItemBudget(db, hi1, hibId, { newHouseholdItemId: hi2 });
-    }).toThrow(BudgetLineAlreadyLinkedError);
+    const result = updateHouseholdItemBudget(db, hi1, hibId, { newHouseholdItemId: hi2 });
+
+    expect(result.id).toBe(hibId);
+    expect(result.householdItemId).toBe(hi2);
+
+    // Verify DB: HIB now belongs to hi2
+    const updatedHib = db
+      .select()
+      .from(schema.householdItemBudgets)
+      .where(eq(schema.householdItemBudgets.id, hibId))
+      .get()!;
+    expect(updatedHib.householdItemId).toBe(hi2);
   });
 
   // ─── Cross-table rejection ───────────────────────────────────────────────────

--- a/server/src/services/householdItemBudgetService.ts
+++ b/server/src/services/householdItemBudgetService.ts
@@ -19,7 +19,6 @@ import type {
 import {
   NotFoundError,
   ValidationError,
-  BudgetLineAlreadyLinkedError,
 } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
@@ -215,25 +214,6 @@ function updateAndMoveHouseholdItemBudget(
     if ('unit' in data) updates.unit = data.unit;
     if ('unitPrice' in data) updates.unitPrice = data.unitPrice;
     if ('includesVat' in data) updates.includesVat = data.includesVat;
-
-    // Check BUDGET_LINE_ALREADY_LINKED guard: does target HI have any IBLs linking to it?
-    const existingLink = db
-      .select({ id: invoiceBudgetLines.id })
-      .from(invoiceBudgetLines)
-      .innerJoin(
-        householdItemBudgets,
-        eq(householdItemBudgets.id, invoiceBudgetLines.householdItemBudgetId),
-      )
-      .where(
-        sql`${householdItemBudgets.householdItemId} = ${targetId} AND ${invoiceBudgetLines.householdItemBudgetId} IS NOT NULL`,
-      )
-      .get();
-
-    if (existingLink) {
-      throw new BudgetLineAlreadyLinkedError(
-        'Target household item already has a linked budget line',
-      );
-    }
 
     // Update budget line with new parent and field updates
     db.update(householdItemBudgets).set(updates).where(eq(householdItemBudgets.id, budgetId)).run();

--- a/server/src/services/invoiceBudgetLineService.editAndMove.test.ts
+++ b/server/src/services/invoiceBudgetLineService.editAndMove.test.ts
@@ -9,7 +9,6 @@ import * as invoiceBudgetLineService from './invoiceBudgetLineService.js';
 import {
   NotFoundError,
   ValidationError,
-  BudgetLineAlreadyLinkedError,
   ItemizedSumExceedsInvoiceError,
 } from '../errors/AppError.js';
 
@@ -451,22 +450,38 @@ describe('editAndMoveBudgetLine()', () => {
     expect(newHib.budgetCategoryId).toBe('bc-household-items');
   });
 
-  // ─── Scenario 8: BUDGET_LINE_ALREADY_LINKED guard ───────────────────────────
+  // ─── Scenario 8: Move to target WI that already has another IBL on the same invoice ─
 
-  it('guard: throws BudgetLineAlreadyLinkedError when target WI already linked to same invoice via different IBL', () => {
+  // Issue #1555: the BUDGET_LINE_ALREADY_LINKED guard was overly restrictive.
+  // The unique constraint is per-WIB-row, not per-(invoice, work-item) pair.
+  // Moving a budget line to a target work item that already has another budget line
+  // on the same invoice is a perfectly valid operation (e.g. "Kitchen" WI with
+  // separate lines for "cabinets" and "appliances" on one vendor invoice).
+  it('same-table WI move succeeds even when target WI already has another IBL on the same invoice', () => {
     const vendorId = createVendor();
     const invoiceId = createInvoice(vendorId, 2000);
     const wi1 = createWorkItem('Painting');
     const wi2 = createWorkItem('Plumbing');
-    const { iblId } = createIblOnWorkItem(invoiceId, wi1, 300);
-    // Link wi2 to the same invoice as well
+    const { iblId, wibId } = createIblOnWorkItem(invoiceId, wi1, 300);
+    // wi2 already has a different IBL on the same invoice — move must still succeed
     createIblOnWorkItem(invoiceId, wi2, 300);
 
-    expect(() => {
-      invoiceBudgetLineService.editAndMoveBudgetLine(db, invoiceId, iblId, {
-        newWorkItemId: wi2, // wi2 already has a different IBL on this invoice
-      });
-    }).toThrow(BudgetLineAlreadyLinkedError);
+    const result = invoiceBudgetLineService.editAndMoveBudgetLine(db, invoiceId, iblId, {
+      newWorkItemId: wi2,
+    });
+
+    // IBL still exists and still points at the same WIB (FK unchanged)
+    expect(result.budgetLine.id).toBe(iblId);
+    expect(result.budgetLine.workItemBudgetId).toBe(wibId);
+    // WIB parent updated to wi2
+    expect(result.budgetLine.parentItemId).toBe(wi2);
+    expect(result.budgetLine.parentItemType).toBe('work_item');
+    const updatedWib = db
+      .select()
+      .from(schema.workItemBudgets)
+      .where(eq(schema.workItemBudgets.id, wibId))
+      .get()!;
+    expect(updatedWib.workItemId).toBe(wi2);
   });
 
   // ─── Scenario 9: ITEMIZED_SUM_EXCEEDS_INVOICE guard ─────────────────────────
@@ -533,23 +548,24 @@ describe('editAndMoveBudgetLine()', () => {
 
   // ─── Scenario 12: Transaction atomicity ─────────────────────────────────────
 
-  it('transaction atomicity: no partial changes when move fails mid-transaction', () => {
+  // Issue #1555: the prior version of this test relied on BudgetLineAlreadyLinkedError
+  // to trigger a rollback. That guard has been removed (moves to targets with existing
+  // IBLs are now allowed). Transaction atomicity is validated via a NotFoundError
+  // (non-existent target WI) which still aborts the transaction mid-flight.
+  it('transaction atomicity: no partial changes when move fails due to non-existent target', () => {
     const vendorId = createVendor();
-    const invoiceId = createInvoice(vendorId, 2000);
+    const invoiceId = createInvoice(vendorId, 1000);
     const wi1 = createWorkItem('Painting');
-    const wi2 = createWorkItem('Plumbing');
     const { iblId } = createIblOnWorkItem(invoiceId, wi1, 300);
-    // wi2 is already linked — will trigger BudgetLineAlreadyLinkedError inside transaction
-    createIblOnWorkItem(invoiceId, wi2, 300);
 
     const wibCountBefore = db.select().from(schema.workItemBudgets).all().length;
     const iblCountBefore = db.select().from(schema.invoiceBudgetLines).all().length;
 
     expect(() => {
       invoiceBudgetLineService.editAndMoveBudgetLine(db, invoiceId, iblId, {
-        newWorkItemId: wi2,
+        newWorkItemId: 'non-existent-wi', // triggers NotFoundError inside transaction
       });
-    }).toThrow(BudgetLineAlreadyLinkedError);
+    }).toThrow(NotFoundError);
 
     // No changes committed
     expect(db.select().from(schema.workItemBudgets).all().length).toBe(wibCountBefore);

--- a/server/src/services/invoiceBudgetLineService.ts
+++ b/server/src/services/invoiceBudgetLineService.ts
@@ -735,22 +735,6 @@ export function editAndMoveBudgetLine(
           throw new NotFoundError('Work item not found');
         }
 
-        // Check BUDGET_LINE_ALREADY_LINKED guard
-        const existingLink = db
-          .select({ id: invoiceBudgetLines.id })
-          .from(invoiceBudgetLines)
-          .innerJoin(workItemBudgets, eq(workItemBudgets.id, invoiceBudgetLines.workItemBudgetId))
-          .where(
-            sql`${invoiceBudgetLines.invoiceId} = ${invoiceId} AND ${workItemBudgets.workItemId} = ${targetId} AND ${invoiceBudgetLines.id} != ${lineId}`,
-          )
-          .get();
-
-        if (existingLink) {
-          throw new BudgetLineAlreadyLinkedError(
-            'Target work item already has a linked budget line for this invoice',
-          );
-        }
-
         // Apply budget-line field updates and set new parent FK
         budgetLineUpdates.workItemId = targetId;
         db.update(workItemBudgets)
@@ -762,25 +746,6 @@ export function editAndMoveBudgetLine(
         const hi = db.select().from(householdItems).where(eq(householdItems.id, targetId)).get();
         if (!hi) {
           throw new NotFoundError('Household item not found');
-        }
-
-        // Check BUDGET_LINE_ALREADY_LINKED guard
-        const existingLink = db
-          .select({ id: invoiceBudgetLines.id })
-          .from(invoiceBudgetLines)
-          .innerJoin(
-            householdItemBudgets,
-            eq(householdItemBudgets.id, invoiceBudgetLines.householdItemBudgetId),
-          )
-          .where(
-            sql`${invoiceBudgetLines.invoiceId} = ${invoiceId} AND ${householdItemBudgets.householdItemId} = ${targetId} AND ${invoiceBudgetLines.id} != ${lineId}`,
-          )
-          .get();
-
-        if (existingLink) {
-          throw new BudgetLineAlreadyLinkedError(
-            'Target household item already has a linked budget line for this invoice',
-          );
         }
 
         // Apply budget-line field updates and set new parent FK
@@ -810,25 +775,6 @@ export function editAndMoveBudgetLine(
         const hi = db.select().from(householdItems).where(eq(householdItems.id, targetId)).get();
         if (!hi) {
           throw new NotFoundError('Household item not found');
-        }
-
-        // Check BUDGET_LINE_ALREADY_LINKED guard for destination type
-        const existingLink = db
-          .select({ id: invoiceBudgetLines.id })
-          .from(invoiceBudgetLines)
-          .innerJoin(
-            householdItemBudgets,
-            eq(householdItemBudgets.id, invoiceBudgetLines.householdItemBudgetId),
-          )
-          .where(
-            sql`${invoiceBudgetLines.invoiceId} = ${invoiceId} AND ${householdItemBudgets.householdItemId} = ${targetId}`,
-          )
-          .get();
-
-        if (existingLink) {
-          throw new BudgetLineAlreadyLinkedError(
-            'Target household item already has a linked budget line for this invoice',
-          );
         }
 
         // Read the full current budget-line row (WIB)
@@ -902,22 +848,6 @@ export function editAndMoveBudgetLine(
         const wi = db.select().from(workItems).where(eq(workItems.id, targetId)).get();
         if (!wi) {
           throw new NotFoundError('Work item not found');
-        }
-
-        // Check BUDGET_LINE_ALREADY_LINKED guard for destination type
-        const existingLink = db
-          .select({ id: invoiceBudgetLines.id })
-          .from(invoiceBudgetLines)
-          .innerJoin(workItemBudgets, eq(workItemBudgets.id, invoiceBudgetLines.workItemBudgetId))
-          .where(
-            sql`${invoiceBudgetLines.invoiceId} = ${invoiceId} AND ${workItemBudgets.workItemId} = ${targetId}`,
-          )
-          .get();
-
-        if (existingLink) {
-          throw new BudgetLineAlreadyLinkedError(
-            'Target work item already has a linked budget line for this invoice',
-          );
         }
 
         // Read the full current budget-line row (HIB)

--- a/server/src/services/workItemBudgetService.move.test.ts
+++ b/server/src/services/workItemBudgetService.move.test.ts
@@ -6,11 +6,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { runMigrations } from '../db/migrate.js';
 import * as schema from '../db/schema.js';
 import { updateWorkItemBudget } from './workItemBudgetService.js';
-import {
-  NotFoundError,
-  ValidationError,
-  BudgetLineAlreadyLinkedError,
-} from '../errors/AppError.js';
+import { NotFoundError, ValidationError } from '../errors/AppError.js';
 
 /**
  * Tests for updateWorkItemBudget() move functionality (same-table WI→WI moves
@@ -250,11 +246,15 @@ describe('updateWorkItemBudget() — move scenarios', () => {
     }).toThrow(NotFoundError);
   });
 
-  it('same-table move: throws BudgetLineAlreadyLinkedError when target WI already has linked IBL', () => {
+  // Issue #1555: the BUDGET_LINE_ALREADY_LINKED guard was overly restrictive and
+  // has been removed from the same-table move path. The unique constraint is per-WIB-row,
+  // not per-(invoice, work-item) pair. Moving a WIB to a target that already has a
+  // different WIB linked to the same invoice is allowed.
+  it('same-table move: succeeds even when target WI already has a linked IBL on the same invoice', () => {
     const wi1 = createWorkItem('Painting');
     const wi2 = createWorkItem('Plumbing');
     const wibId = createWorkItemBudget(wi1);
-    // Link wi2 to an invoice
+    // Link wi2 to an invoice via a different WIB — move must still succeed
     const wib2Id = createWorkItemBudget(wi2);
     const vendorId = createVendor();
     const invoiceId = createInvoice(vendorId);
@@ -272,9 +272,18 @@ describe('updateWorkItemBudget() — move scenarios', () => {
       })
       .run();
 
-    expect(() => {
-      updateWorkItemBudget(db, wi1, wibId, { newWorkItemId: wi2 });
-    }).toThrow(BudgetLineAlreadyLinkedError);
+    const result = updateWorkItemBudget(db, wi1, wibId, { newWorkItemId: wi2 });
+
+    expect(result.id).toBe(wibId);
+    expect(result.workItemId).toBe(wi2);
+
+    // Verify DB: WIB now belongs to wi2
+    const updatedWib = db
+      .select()
+      .from(schema.workItemBudgets)
+      .where(eq(schema.workItemBudgets.id, wibId))
+      .get()!;
+    expect(updatedWib.workItemId).toBe(wi2);
   });
 
   // ─── Cross-table rejection ───────────────────────────────────────────────────

--- a/server/src/services/workItemBudgetService.ts
+++ b/server/src/services/workItemBudgetService.ts
@@ -20,7 +20,6 @@ import type {
 import {
   NotFoundError,
   ValidationError,
-  BudgetLineAlreadyLinkedError,
 } from '../errors/AppError.js';
 
 type DbType = BetterSQLite3Database<typeof schemaTypes>;
@@ -206,20 +205,6 @@ function updateAndMoveWorkItemBudget(
     if ('unit' in data) updates.unit = data.unit;
     if ('unitPrice' in data) updates.unitPrice = data.unitPrice;
     if ('includesVat' in data) updates.includesVat = data.includesVat;
-
-    // Check BUDGET_LINE_ALREADY_LINKED guard: does target WI have any IBLs linking to it?
-    const existingLink = db
-      .select({ id: invoiceBudgetLines.id })
-      .from(invoiceBudgetLines)
-      .innerJoin(workItemBudgets, eq(workItemBudgets.id, invoiceBudgetLines.workItemBudgetId))
-      .where(
-        sql`${workItemBudgets.workItemId} = ${targetId} AND ${invoiceBudgetLines.workItemBudgetId} IS NOT NULL`,
-      )
-      .get();
-
-    if (existingLink) {
-      throw new BudgetLineAlreadyLinkedError('Target work item already has a linked budget line');
-    }
 
     // Update budget line with new parent and field updates
     db.update(workItemBudgets).set(updates).where(eq(workItemBudgets.id, budgetId)).run();


### PR DESCRIPTION
## Summary

Closes #1555 — Removes the overly restrictive `BUDGET_LINE_ALREADY_LINKED` guard from the budget-line move services that was blocking legitimate moves.

The guard checked `target_parent_id`, but the actual DB unique constraint is per-budget-line-row (`work_item_budget_id` / `household_item_budget_id`). Same-table moves don't change that ID; cross-table moves create a brand-new row. The guard never prevented a real constraint violation — it only blocked valid user actions like moving a "cabinets" line to a "Kitchen" work item that already had an "appliances" line on the same invoice.

## Changes

- **Backend** — removed 6 `BudgetLineAlreadyLinkedError` blocks total:
  - 4 in `editAndMoveBudgetLine` (same-table WI, same-table HI, cross-table WI→HI, cross-table HI→WI)
  - 1 in `updateAndMoveWorkItemBudget` (same-table WI→WI)
  - 1 in `updateAndMoveHouseholdItemBudget` (same-table HI→HI)
  - Unused imports cleaned up.
- **Backend untouched** — the `BudgetLineAlreadyLinkedError` class and the `createInvoiceBudgetLine` / orphan-assignment paths that legitimately use it remain intact.
- **Tests** — inverted 4 unit tests + 1 integration test + 1 E2E scenario to assert the move now succeeds (rather than erroring).
- **Wiki** — `API-Contract.md` updated to remove `409 BUDGET_LINE_ALREADY_LINKED` from the PATCH endpoint's response codes.

Fixes #1555

## Test plan
- [ ] Unit tests pass — inverted assertions verify the move now succeeds
- [ ] Integration test pass — PATCH returns 200 in the previously-blocked scenario
- [ ] E2E scenario 4 passes — Move to WI that already has a line on this invoice → succeeds, both lines now under target WI
- [ ] Pre-existing `BUDGET_LINE_ALREADY_LINKED` tests on `createInvoiceBudgetLine` still pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>