### PR TITLE
fix(auto-itemize): provider-aware LLM request shaping (#1547)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,18 @@ BACKUP_DIR=/backups                                     # Backup destination dir
 # PAPERLESS_API_TOKEN=your-paperless-api-token
 # PAPERLESS_EXTERNAL_URL=https://paperless.example.com  # Optional: browser-accessible URL for "View in Paperless-ngx" links
 # PAPERLESS_FILTER_TAG=cornerstone                      # Optional: only show documents with this Paperless-ngx tag
+
+# ─── Auto-itemize (LLM) ────────────────────────────────
+# Optional. Set all three core vars to enable extracting line items from
+# Paperless OCR text. Works with any OpenAI-compatible /v1/chat/completions
+# endpoint (Anthropic, OpenAI, Gemini, OpenRouter, Ollama, LiteLLM, …).
+# When unset, GET /api/config returns autoItemizeEnabled: false and the UI hides the button.
+# LLM_BASE_URL=https://api.anthropic.com/v1
+# LLM_API_KEY=your-llm-api-key
+# LLM_MODEL=claude-haiku-4-5                            # e.g. gemini-2.5-flash, gpt-4o-mini, llama3
+# LLM_REQUEST_TIMEOUT_MS=30000                          # Default: 30000
+# LLM_PROVIDER=                                         # Optional: openai|anthropic|gemini|ollama|generic
+#                                                       # Auto-detected from LLM_BASE_URL when unset.
+#                                                       # Different providers require different request
+#                                                       # shapes (Anthropic needs json_schema, not json_object).
+#                                                       # Override only if auto-detect misses your provider.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,7 @@ Hand-written SQL files in `server/src/db/migrations/` with a numeric prefix (e.g
 | `LLM_API_KEY`                | (none)                     | API key for LLM provider authentication                                                                       |
 | `LLM_MODEL`                  | (none)                     | LLM model identifier (e.g., `gpt-4-turbo`, `claude-3-opus-20240229`)                                          |
 | `LLM_REQUEST_TIMEOUT_MS`     | `30000`                    | Timeout in milliseconds for LLM requests (must be positive integer)                                           |
+| `LLM_PROVIDER`               | auto-detect                | Optional: `openai`, `anthropic`, `gemini`, `ollama`, or `generic`. Auto-detected from `LLM_BASE_URL` if unset |
 
 Production images use Docker Hardened Images (DHI). See `Dockerfile` and `docker-compose.yml` for build/deploy details.
 

--- a/e2e/pages/InvoiceDetailPage.ts
+++ b/e2e/pages/InvoiceDetailPage.ts
@@ -567,8 +567,12 @@ export class InvoiceDetailPage {
     // ─── Budget Line Picker locators (Issue #1401) ────────────────────────
     this.budgetLinePickerModal = page.locator('[role="dialog"][aria-labelledby="picker-title"]');
 
+    // The visible text is `+ Add Budget Line` but the `+` is a literal text node and
+    // `Add Budget Line` comes from i18n; accessible-name normalization can collapse
+    // whitespace inconsistently across React renders. Match the i18n text only so
+    // the locator is resilient to the optional `+` prefix.
     this.pickerAddBudgetLineButton = this.budgetLinesSection.getByRole('button', {
-      name: /\+ Add Budget Line/i,
+      name: /Add Budget Line/i,
     });
 
     this.pickerCreateBudgetLineButton = this.budgetLinePickerModal.getByRole('button', {

--- a/e2e/tests/budget/budget-line-assign.spec.ts
+++ b/e2e/tests/budget/budget-line-assign.spec.ts
@@ -607,8 +607,10 @@ test.describe('Edit modal for assigned budget line — collapsed parent picker (
       const pickerBody = parentPickerFieldset.locator('#parent-picker-body');
       await expect(pickerBody).toBeHidden();
 
-      // The amount input is still shown (full edit form for assigned lines)
-      const amountInput = page.locator('#budget-line-amount');
+      // The itemized amount input is still shown (full edit form for assigned lines)
+      // The field id changed from #budget-line-amount to #budget-itemized-amount in PR #1553
+      // when the simple amount-only modal was replaced by the unified BudgetLineForm.
+      const amountInput = page.locator('#budget-itemized-amount');
       await expect(amountInput).toBeVisible();
 
       // Close the modal

--- a/e2e/tests/budget/budget-line-assign.spec.ts
+++ b/e2e/tests/budget/budget-line-assign.spec.ts
@@ -523,8 +523,13 @@ test.describe('Assign unassigned budget line to household item (Scenario 3)', ()
 // Scenario 4: Edit modal on already-assigned line — no parent picker
 // ─────────────────────────────────────────────────────────────────────────────
 
-test.describe('Edit modal for assigned budget line — no parent picker (Scenario 4)', () => {
-  test('Opening Edit modal on an already-assigned line does NOT show the parent picker fieldset', async ({
+test.describe('Edit modal for assigned budget line — collapsed parent picker (Scenario 4)', () => {
+  // Behavior updated by PR #1553 ("full edit + linked-item move"): assigned
+  // budget lines now render the parent picker in a COLLAPSED state inside
+  // the edit modal — the current parent is shown as a pill + label with a
+  // "Change" affordance, and the expandable picker body is hidden by default.
+  // The picker only expands when the user clicks "Change".
+  test('Opening Edit modal on an already-assigned line shows the collapsed parent row with the current parent and a Change button (picker body hidden)', async ({
     page,
     testPrefix,
   }) => {
@@ -541,12 +546,14 @@ test.describe('Edit modal for assigned budget line — no parent picker (Scenari
     let workItemId = '';
 
     try {
-      vendorId = await createVendorViaApi(page, `${testPrefix} NoPicker Vendor`);
+      vendorId = await createVendorViaApi(page, `${testPrefix} CollapsedPicker Vendor`);
       invoiceId = await createInvoiceViaApi(page, vendorId, {
         amount: 500,
         date: '2026-06-01',
       });
-      workItemId = await createWorkItemViaApi(page, { title: `${testPrefix} NoPicker WI` });
+      workItemId = await createWorkItemViaApi(page, {
+        title: `${testPrefix} CollapsedPicker WI`,
+      });
 
       // Create and link a NORMAL (assigned) budget line via REST API
       const budgetResp = await page.request.post(`${API.workItems}/${workItemId}/budgets`, {
@@ -581,11 +588,26 @@ test.describe('Edit modal for assigned budget line — no parent picker (Scenari
       const editModal = page.getByRole('dialog', { name: 'Edit Budget Line' });
       await expect(editModal).toBeVisible();
 
-      // For assigned lines, the parent picker fieldset MUST NOT be present
+      // The parent picker fieldset IS present (collapsed state)
       const parentPickerFieldset = editModal.locator('fieldset[class*="parentPickerSection"]');
-      await expect(parentPickerFieldset).not.toBeVisible();
+      await expect(parentPickerFieldset).toBeVisible();
 
-      // The amount input IS shown (normal edit form for assigned lines)
+      // The collapsed current-parent row shows the current parent name
+      const currentParentRow = parentPickerFieldset.locator('[class*="currentParentRow"]');
+      await expect(currentParentRow).toBeVisible();
+      await expect(currentParentRow).toContainText(`${testPrefix} CollapsedPicker WI`);
+
+      // A "Change" button is available to expand the picker
+      const changeButton = currentParentRow.getByRole('button');
+      await expect(changeButton).toBeVisible();
+      // The button starts collapsed (aria-expanded="false")
+      await expect(changeButton).toHaveAttribute('aria-expanded', 'false');
+
+      // The expanded picker body is hidden by default
+      const pickerBody = parentPickerFieldset.locator('#parent-picker-body');
+      await expect(pickerBody).toBeHidden();
+
+      // The amount input is still shown (full edit form for assigned lines)
       const amountInput = page.locator('#budget-line-amount');
       await expect(amountInput).toBeVisible();
 

--- a/e2e/tests/i18n/i18n.spec.ts
+++ b/e2e/tests/i18n/i18n.spec.ts
@@ -135,10 +135,15 @@ test.describe('i18n: Language Switching', () => {
     await setLanguage(page, 'de');
 
     // Then: Dashboard/project overview renders with German heading
-    // Reload after setLanguage to ensure the app re-reads locale from localStorage
+    // Reload after setLanguage to ensure the app re-reads locale from localStorage.
+    // Wait for the network to be idle so the dashboard's data + translations are
+    // both resolved before asserting on the localized heading.
     await page.goto(ROUTES.home);
     await page.reload();
-    await expect(page.getByRole('heading', { level: 1, name: 'Projekt' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { level: 1, name: 'Projekt' })).toBeVisible({
+      timeout: 15000,
+    });
 
     // And: Budget page renders in German
     await page.goto(ROUTES.budget);

--- a/e2e/tests/invoices/invoice-budget-line-full-edit.spec.ts
+++ b/e2e/tests/invoices/invoice-budget-line-full-edit.spec.ts
@@ -580,8 +580,11 @@ test.describe('Move budget line to WI that already has a line on this invoice (S
       await expect(detailPage.budgetLinesSection).not.toContainText('MultiLine WI-A');
 
       // Remaining amount = 3000 − 500 − 400 = 2100 (unchanged; amounts weren't modified)
+      // Locale-agnostic match: en-US renders €2,100.00 (comma thousands separator);
+      // de-DE renders €2.100,00 (period thousands separator). Plain '2100' substring
+      // fails both because of the inserted separator.
       const remainingCell = detailPage.budgetLinesSection.locator('[aria-live="polite"]');
-      await expect(remainingCell).toContainText('2100');
+      await expect(remainingCell).toContainText(/2[.,]?100/);
     } finally {
       if (invoiceId && vendorId) await deleteInvoiceViaApi(page, vendorId, invoiceId);
       if (vendorId) await deleteVendorViaApi(page, vendorId);

--- a/scripts/diagnose-llm.mjs
+++ b/scripts/diagnose-llm.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Standalone diagnostic for the Cornerstone auto-itemize LLM gateway.
+// Uses only Node built-ins (node:dns, native fetch). Safe to run in a no-shell
+// hardened container via:
+//   docker cp diagnose-llm.mjs <container>:/tmp/diagnose-llm.mjs
+//   docker exec <container> node /tmp/diagnose-llm.mjs
+//
+// Reads the same env vars the server reads. Masks the API key in output.
+
+import { lookup } from 'node:dns/promises';
+
+const BASE_URL = process.env.LLM_BASE_URL;
+const API_KEY = process.env.LLM_API_KEY;
+const MODEL = process.env.LLM_MODEL;
+const TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30000);
+
+const mask = (s) => (s ? `${s.slice(0, 6)}...${s.slice(-4)} (length ${s.length})` : '(unset)');
+
+function section(label) {
+  console.log(`\n=== ${label} ===`);
+}
+
+function dumpError(err, indent = '  ') {
+  if (!err) {
+    console.log(`${indent}(no error object)`);
+    return;
+  }
+  console.log(`${indent}name:    ${err.name ?? '(none)'}`);
+  console.log(`${indent}message: ${err.message ?? '(none)'}`);
+  if (err.code) console.log(`${indent}code:    ${err.code}`);
+  if (err.errno) console.log(`${indent}errno:   ${err.errno}`);
+  if (err.syscall) console.log(`${indent}syscall: ${err.syscall}`);
+  if (err.hostname) console.log(`${indent}hostname:${err.hostname}`);
+  if (err.cause) {
+    console.log(`${indent}cause:`);
+    dumpError(err.cause, indent + '  ');
+  }
+}
+
+async function main() {
+  section('Config');
+  console.log(`LLM_BASE_URL:           ${BASE_URL ?? '(unset)'}`);
+  console.log(`LLM_API_KEY:            ${mask(API_KEY)}`);
+  console.log(`LLM_MODEL:              ${MODEL ?? '(unset)'}`);
+  console.log(`LLM_REQUEST_TIMEOUT_MS: ${TIMEOUT_MS}`);
+  console.log(`Node version:           ${process.version}`);
+  console.log(`Platform:               ${process.platform} ${process.arch}`);
+  console.log(`HTTP_PROXY:             ${process.env.HTTP_PROXY ?? '(unset)'}`);
+  console.log(`HTTPS_PROXY:            ${process.env.HTTPS_PROXY ?? '(unset)'}`);
+  console.log(`NO_PROXY:               ${process.env.NO_PROXY ?? '(unset)'}`);
+
+  if (!BASE_URL || !API_KEY || !MODEL) {
+    console.error('\nFATAL: one or more required env vars are unset.');
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(BASE_URL);
+  } catch (err) {
+    console.error('\nFATAL: LLM_BASE_URL is not a valid URL.');
+    dumpError(err);
+    process.exit(1);
+  }
+  const hostname = parsed.hostname;
+
+  // -------------------------------------------------------------------------
+  section(`Step 1: DNS lookup for ${hostname}`);
+  try {
+    const t0 = Date.now();
+    const v4 = await lookup(hostname, { family: 4 }).catch((err) => ({ error: err }));
+    const v6 = await lookup(hostname, { family: 6 }).catch((err) => ({ error: err }));
+    const ms = Date.now() - t0;
+    if (v4.error && v6.error) {
+      console.log(`FAIL in ${ms}ms — no A or AAAA records resolvable.`);
+      console.log('  IPv4 error:');
+      dumpError(v4.error, '    ');
+      console.log('  IPv6 error:');
+      dumpError(v6.error, '    ');
+      console.log('\nMost likely: container has no DNS resolver, or your network blocks DNS for this host.');
+      process.exit(2);
+    }
+    console.log(`OK in ${ms}ms`);
+    if (!v4.error) console.log(`  IPv4: ${v4.address}`);
+    if (!v6.error) console.log(`  IPv6: ${v6.address}`);
+  } catch (err) {
+    console.log('FAIL:');
+    dumpError(err);
+    process.exit(2);
+  }
+
+  // -------------------------------------------------------------------------
+  section(`Step 2: HTTPS reachability — GET ${parsed.origin}/`);
+  // Anonymous GET to the root. Most APIs return 401/403/404 — we don't care,
+  // we only want to confirm TCP + TLS work.
+  try {
+    const t0 = Date.now();
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    const res = await fetch(`${parsed.origin}/`, { method: 'GET', signal: ctrl.signal });
+    clearTimeout(to);
+    const ms = Date.now() - t0;
+    console.log(`OK in ${ms}ms — HTTP ${res.status} ${res.statusText}`);
+    console.log('  (Any HTTP response confirms TCP + TLS work. Status code does not matter here.)');
+  } catch (err) {
+    console.log('FAIL:');
+    dumpError(err);
+    console.log('\nMost likely: egress firewall blocks outbound HTTPS to this host, or TLS handshake failed.');
+    console.log('Tip: HTTPS_PROXY env var? Corporate MITM proxy with its own CA?');
+    process.exit(3);
+  }
+
+  // -------------------------------------------------------------------------
+  const fullUrl = `${BASE_URL.replace(/\/$/, '')}/chat/completions`;
+  section(`Step 3: POST ${fullUrl} (minimal echo prompt)`);
+  try {
+    const t0 = Date.now();
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    const res = await fetch(fullUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: 'user', content: 'Reply with the single word: pong' }],
+        max_tokens: 16,
+        temperature: 0,
+      }),
+      signal: ctrl.signal,
+    });
+    clearTimeout(to);
+    const ms = Date.now() - t0;
+    const text = await res.text();
+    console.log(`HTTP ${res.status} ${res.statusText} in ${ms}ms`);
+    console.log(`Response body (first 1500 chars):`);
+    console.log(text.slice(0, 1500));
+    if (!res.ok) {
+      console.log('\nInterpretation:');
+      if (res.status === 401 || res.status === 403) {
+        console.log('  Auth failed. Check LLM_API_KEY value, header name (we use Authorization: Bearer), and that the key is allowed for this model.');
+      } else if (res.status === 404) {
+        console.log('  Endpoint not found. Either LLM_BASE_URL is wrong, or this provider does not expose /chat/completions at that path.');
+      } else if (res.status === 400) {
+        console.log('  Provider rejected the request. Check LLM_MODEL value matches an available model.');
+      } else if (res.status >= 500) {
+        console.log('  Upstream server-side error. Try again in a minute; if persistent, check the provider status page.');
+      }
+      process.exit(4);
+    }
+    console.log('\nOK — provider answered. Auto-itemize should work.');
+  } catch (err) {
+    console.log('FAIL during POST:');
+    dumpError(err);
+    if (err?.name === 'AbortError') {
+      console.log(`\nTimed out after ${TIMEOUT_MS}ms. Try setting LLM_REQUEST_TIMEOUT_MS=60000 in env and restarting the server.`);
+    }
+    process.exit(4);
+  }
+
+  // -------------------------------------------------------------------------
+  section(`Step 4: POST ${fullUrl} (production-shaped payload)`);
+  // Mirrors what server/src/services/budgetExtraction/openAICompatibleProvider.ts
+  // actually sends. The previous step proved connectivity; this step proves
+  // whether the provider accepts our exact production body. Common failure mode:
+  // - Anthropic requires `max_tokens`; OpenAI/Gemini make it optional.
+  // - Anthropic OpenAI-compat layer historically did not support
+  //   `response_format: { type: 'json_object' }`.
+  // The full response body is printed verbatim so you can see the provider's
+  // exact complaint.
+  const SYSTEM_PROMPT_SHORT = 'You are an expert at extracting structured line items from German construction-trade invoices. Return a JSON object: { "lines": [{ "description": string, "totalAmount": number, "confidence": number }] }. Output ONLY valid JSON.';
+  const USER_PROMPT_SHORT = 'Extract line items from:\n\nRechnung Nr. 123\nMaterial Kies, 2 m³, 50 EUR/m³, gesamt 100 EUR\n\nReturn { "lines": ExtractedLine[] }.';
+  const productionBody = {
+    model: MODEL,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT_SHORT },
+      { role: 'user', content: USER_PROMPT_SHORT },
+    ],
+    response_format: { type: 'json_object' },
+    temperature: 0,
+  };
+  console.log('Request body (matches production, minus the full system prompt):');
+  console.log(JSON.stringify(productionBody, null, 2));
+  try {
+    const t0 = Date.now();
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    const res = await fetch(fullUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify(productionBody),
+      signal: ctrl.signal,
+    });
+    clearTimeout(to);
+    const ms = Date.now() - t0;
+    const text = await res.text();
+    console.log(`\nHTTP ${res.status} ${res.statusText} in ${ms}ms`);
+    console.log(`Response body (FULL — copy this back to debug):`);
+    console.log(text);
+    if (!res.ok) {
+      console.log('\nInterpretation:');
+      console.log('  The provider responded but rejected the production-shaped body.');
+      console.log('  Look at the error message above for the exact missing/invalid field.');
+      console.log('  Common causes for 400 on Anthropic OpenAI-compat:');
+      console.log('    - missing "max_tokens"');
+      console.log('    - "response_format" not supported');
+      console.log('    - model name typo (must include vendor prefix? exact version?)');
+      process.exit(5);
+    }
+    console.log('\nOK — production-shaped payload also works. The bug is elsewhere.');
+  } catch (err) {
+    console.log('FAIL during production-shaped POST:');
+    dumpError(err);
+    process.exit(5);
+  }
+}
+
+main().catch((err) => {
+  console.error('\nUnexpected error in diagnostic script:');
+  dumpError(err);
+  process.exit(99);
+});

--- a/server/src/errors/AppError.ts
+++ b/server/src/errors/AppError.ts
@@ -326,23 +326,27 @@ export class PayloadTooLargeError extends AppError {
   }
 }
 
+// LLM errors carry diagnostic context (underlying fetch error, response body,
+// parse error) in `details` for the server log. `suppressDetails: true` keeps
+// `details` out of the API response — the response body can echo prompts
+// (vendor names, amounts from OCR) so we never want it leaving the host.
 export class LlmUnreachableError extends AppError {
   constructor(message = 'LLM provider is unreachable', details?: Record<string, unknown>) {
-    super('LLM_UNREACHABLE', 502, message, details);
+    super('LLM_UNREACHABLE', 502, message, details, true);
     this.name = 'LlmUnreachableError';
   }
 }
 
 export class LlmInvalidResponseError extends AppError {
   constructor(message = 'LLM returned an invalid response', details?: Record<string, unknown>) {
-    super('LLM_INVALID_RESPONSE', 502, message, details);
+    super('LLM_INVALID_RESPONSE', 502, message, details, true);
     this.name = 'LlmInvalidResponseError';
   }
 }
 
 export class LlmUpstreamError extends AppError {
   constructor(message = 'LLM upstream error', details?: Record<string, unknown>) {
-    super('LLM_UPSTREAM_ERROR', 502, message, details);
+    super('LLM_UPSTREAM_ERROR', 502, message, details, true);
     this.name = 'LlmUpstreamError';
   }
 }

--- a/server/src/plugins/config.test.ts
+++ b/server/src/plugins/config.test.ts
@@ -44,6 +44,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         llmApiKey: undefined,
         llmModel: undefined,
         llmRequestTimeoutMs: 30000,
+        llmProvider: 'generic',
         autoItemizeEnabled: false,
       });
     });
@@ -90,6 +91,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         llmApiKey: undefined,
         llmModel: undefined,
         llmRequestTimeoutMs: 30000,
+        llmProvider: 'generic',
         autoItemizeEnabled: false,
       });
     });
@@ -138,6 +140,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         llmApiKey: undefined,
         llmModel: undefined,
         llmRequestTimeoutMs: 30000,
+        llmProvider: 'generic',
         autoItemizeEnabled: false,
       });
     });
@@ -181,6 +184,7 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
         llmApiKey: undefined,
         llmModel: undefined,
         llmRequestTimeoutMs: 30000,
+        llmProvider: 'generic',
         autoItemizeEnabled: false,
       });
     });

--- a/server/src/plugins/config.test.ts
+++ b/server/src/plugins/config.test.ts
@@ -790,6 +790,76 @@ describe('Configuration Module - loadConfig() Pure Function', () => {
       expect(config.llmBaseUrl).toBe('http://localhost:11434/v1');
     });
   });
+
+  describe('LLM Provider Resolution', () => {
+    const baseEnv = {
+      LLM_API_KEY: 'sk-test',
+      LLM_MODEL: 'test-model',
+    };
+
+    it.each([
+      ['https://api.anthropic.com/v1', 'anthropic'],
+      ['https://api.openai.com/v1', 'openai'],
+      ['https://generativelanguage.googleapis.com/v1beta/openai', 'gemini'],
+      ['http://localhost:11434/v1', 'ollama'],
+      ['http://ollama:11434/v1', 'ollama'],
+    ] as const)('auto-detects %s as %s when LLM_PROVIDER unset', (url, expected) => {
+      const config = loadConfig({ ...baseEnv, LLM_BASE_URL: url });
+      expect(config.llmProvider).toBe(expected);
+    });
+
+    it('falls back to generic for unknown hosts', () => {
+      const config = loadConfig({
+        ...baseEnv,
+        LLM_BASE_URL: 'https://openrouter.ai/api/v1',
+      });
+      expect(config.llmProvider).toBe('generic');
+    });
+
+    it('explicit LLM_PROVIDER overrides auto-detection', () => {
+      const config = loadConfig({
+        ...baseEnv,
+        LLM_BASE_URL: 'https://api.anthropic.com/v1',
+        LLM_PROVIDER: 'openai',
+      });
+      expect(config.llmProvider).toBe('openai');
+    });
+
+    it('LLM_PROVIDER is case-insensitive and trims whitespace', () => {
+      const config = loadConfig({
+        ...baseEnv,
+        LLM_BASE_URL: 'https://example.com',
+        LLM_PROVIDER: '  ANTHROPIC  ',
+      });
+      expect(config.llmProvider).toBe('anthropic');
+    });
+
+    it('rejects unknown LLM_PROVIDER values', () => {
+      expect(() =>
+        loadConfig({
+          ...baseEnv,
+          LLM_BASE_URL: 'https://example.com',
+          LLM_PROVIDER: 'bedrock',
+        }),
+      ).toThrow(/LLM_PROVIDER must be one of/);
+    });
+
+    it('defaults to generic when LLM is not configured at all', () => {
+      const config = loadConfig({});
+      expect(config.llmProvider).toBe('generic');
+      expect(config.autoItemizeEnabled).toBe(false);
+    });
+
+    it('llmProvider is in the /api/config-loaded log (no secrets)', () => {
+      // The config object exposes llmProvider — covered by the route-level test
+      // that asserts secrets are NOT in the response. We only verify the shape here.
+      const config = loadConfig({
+        ...baseEnv,
+        LLM_BASE_URL: 'https://api.anthropic.com/v1',
+      });
+      expect(config).toHaveProperty('llmProvider', 'anthropic');
+    });
+  });
 });
 
 describe('Configuration Module - Fastify Plugin Integration', () => {

--- a/server/src/plugins/config.ts
+++ b/server/src/plugins/config.ts
@@ -34,6 +34,12 @@ export interface AppConfig {
   llmApiKey?: string;
   llmModel?: string;
   llmRequestTimeoutMs: number;
+  /**
+   * Provider profile that shapes the outbound request body. Set explicitly
+   * via `LLM_PROVIDER`, otherwise auto-detected from `LLM_BASE_URL`, with
+   * fallback to `'generic'`. See `services/budgetExtraction/providerProfiles.ts`.
+   */
+  llmProvider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'generic';
   autoItemizeEnabled: boolean;
 }
 
@@ -288,6 +294,30 @@ export function loadConfig(env: Record<string, string | undefined>): AppConfig {
   // Auto-itemization is enabled when all three LLM env vars are set
   const autoItemizeEnabled = !!(llmBaseUrl && llmApiKey && llmModel);
 
+  // Resolve LLM provider: explicit env var wins, otherwise auto-detect from URL,
+  // fall back to 'generic' when both are unavailable.
+  const llmProviderEnv = getValue('LLM_PROVIDER');
+  const validProviders = ['openai', 'anthropic', 'gemini', 'ollama', 'generic'] as const;
+  type ProviderTuple = typeof validProviders;
+  let llmProvider: ProviderTuple[number] = 'generic';
+  if (llmProviderEnv) {
+    const normalized = llmProviderEnv.trim().toLowerCase();
+    if ((validProviders as readonly string[]).includes(normalized)) {
+      llmProvider = normalized as ProviderTuple[number];
+    } else {
+      errors.push(
+        `LLM_PROVIDER must be one of ${validProviders.join(', ')}, got: ${llmProviderEnv}`,
+      );
+    }
+  } else if (llmBaseUrl) {
+    // Inline auto-detect — keep config plugin free of service imports.
+    const url = llmBaseUrl.toLowerCase();
+    if (url.includes('api.anthropic.com')) llmProvider = 'anthropic';
+    else if (url.includes('api.openai.com')) llmProvider = 'openai';
+    else if (url.includes('generativelanguage.googleapis.com')) llmProvider = 'gemini';
+    else if (url.includes(':11434') || /\bollama\b/.test(url)) llmProvider = 'ollama';
+  }
+
   // If there are any validation errors, throw a single error listing all of them
   if (errors.length > 0) {
     throw new Error(`Configuration validation failed:\n  - ${errors.join('\n  - ')}`);
@@ -325,6 +355,7 @@ export function loadConfig(env: Record<string, string | undefined>): AppConfig {
     llmApiKey,
     llmModel,
     llmRequestTimeoutMs,
+    llmProvider,
     autoItemizeEnabled,
   };
 }
@@ -359,6 +390,7 @@ export default fp(
         backupEnabled: config.backupEnabled,
         backupDir: config.backupDir,
         autoItemizeEnabled: config.autoItemizeEnabled,
+        llmProvider: config.llmProvider,
       },
       'Configuration loaded',
     );

--- a/server/src/services/backupService.test.ts
+++ b/server/src/services/backupService.test.ts
@@ -58,6 +58,7 @@ const makeConfig = (overrides: Partial<AppConfig> = {}): AppConfig => ({
   llmApiKey: undefined,
   llmModel: undefined,
   llmRequestTimeoutMs: 30000,
+    llmProvider: 'generic',
   autoItemizeEnabled: false,
   ...overrides,
 });

--- a/server/src/services/budgetExtraction/index.test.ts
+++ b/server/src/services/budgetExtraction/index.test.ts
@@ -39,6 +39,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     llmApiKey: undefined,
     llmModel: undefined,
     llmRequestTimeoutMs: 30000,
+    llmProvider: 'generic',
     autoItemizeEnabled: false,
     ...overrides,
   };
@@ -50,6 +51,7 @@ function makeLlmConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     llmApiKey: 'test-key',
     llmModel: 'gpt-4o',
     llmRequestTimeoutMs: 5000,
+    llmProvider: 'generic',
     autoItemizeEnabled: true,
     ...overrides,
   });

--- a/server/src/services/budgetExtraction/index.ts
+++ b/server/src/services/budgetExtraction/index.ts
@@ -24,12 +24,14 @@ export function getProvider(config: AppConfig): BudgetExtractionProvider {
     apiKey: config.llmApiKey!,
     model: config.llmModel!,
     requestTimeoutMs: config.llmRequestTimeoutMs,
+    provider: config.llmProvider,
   });
 }
 
 // Re-export public types
-export type { ExtractedLine, ExtractionHints, BudgetExtractionProvider } from './types.js';
+export type { ExtractedLine, ExtractionHints, BudgetExtractionProvider, LlmProvider } from './types.js';
 export {
   validateExtractedLines,
   createOpenAICompatibleProvider,
 } from './openAICompatibleProvider.js';
+export { detectProvider, parseProviderEnv, buildRequestBody, LLM_PROVIDERS } from './providerProfiles.js';

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
@@ -37,6 +37,7 @@ const BASE_CONFIG: LlmConfig = {
   apiKey: 'test-api-key',
   model: 'gpt-4o',
   requestTimeoutMs: 5000,
+  provider: 'openai',
 };
 
 /**

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
@@ -47,9 +47,11 @@ function makeOkResponse(content: string, status = 200): Response {
   const body = {
     choices: [{ message: { content } }],
   };
+  const bodyText = JSON.stringify(body);
   return {
     ok: status >= 200 && status < 300,
     status,
+    text: () => Promise.resolve(bodyText),
     json: () => Promise.resolve(body),
   } as unknown as Response;
 }

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.ts
@@ -6,6 +6,7 @@
  */
 
 import { SYSTEM_PROMPT, buildUserPrompt } from './prompts.js';
+import { buildRequestBody } from './providerProfiles.js';
 import type {
   BudgetExtractionProvider,
   ExtractedLine,
@@ -166,15 +167,14 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
             'Content-Type': 'application/json',
             Authorization: `Bearer ${config.apiKey}`,
           },
-          body: JSON.stringify({
-            model: config.model,
-            messages: [
-              { role: 'system', content: SYSTEM_PROMPT },
-              { role: 'user', content: buildUserPrompt(ocrText, hints) },
-            ],
-            response_format: { type: 'json_object' },
-            temperature: 0,
-          }),
+          body: JSON.stringify(
+            buildRequestBody({
+              provider: config.provider,
+              model: config.model,
+              systemPrompt: SYSTEM_PROMPT,
+              userPrompt: buildUserPrompt(ocrText, hints),
+            }),
+          ),
           signal: controller.signal,
         });
       } catch (err) {

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.ts
@@ -222,11 +222,8 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
       }
 
       let body: unknown;
-      // Capture the raw response text once so we can include it in error
-      // details if JSON parsing or schema validation fails.
-      const rawResponseText = await response.text();
       try {
-        const json = JSON.parse(rawResponseText) as {
+        const json = (await response.json()) as {
           choices?: Array<{ message?: { content?: string } }>;
         };
         const content = json.choices?.[0]?.message?.content;
@@ -236,10 +233,7 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
             {
               provider: config.provider,
               url,
-              rawResponse:
-                rawResponseText.length > 8000
-                  ? `${rawResponseText.slice(0, 8000)}…[truncated]`
-                  : rawResponseText,
+              envelope: json,
             },
           );
         }
@@ -259,10 +253,6 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
           provider: config.provider,
           url,
           parseError: (err as Error).message,
-          rawResponse:
-            rawResponseText.length > 8000
-              ? `${rawResponseText.slice(0, 8000)}…[truncated]`
-              : rawResponseText,
         });
       }
 

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.ts
@@ -178,34 +178,92 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
           signal: controller.signal,
         });
       } catch (err) {
-        // AbortError (timeout) or network error → treat as unreachable
+        // AbortError (timeout) or network error → treat as unreachable.
+        // Include the underlying error so the server log shows DNS / TLS /
+        // refused / AbortError context. `LlmUnreachableError` suppresses
+        // details from the API response.
         clearTimeout(timeoutId);
-        throw new LlmUnreachableError('LLM provider is unreachable');
+        const e = err as { name?: string; message?: string; code?: string; cause?: unknown };
+        throw new LlmUnreachableError('LLM provider is unreachable', {
+          provider: config.provider,
+          url,
+          cause: {
+            name: e?.name,
+            message: e?.message,
+            code: e?.code,
+            // Node's fetch nests the underlying ECONNREFUSED/ENOTFOUND in cause
+            innerCause:
+              e?.cause && typeof e.cause === 'object'
+                ? {
+                    name: (e.cause as { name?: string }).name,
+                    message: (e.cause as { message?: string }).message,
+                    code: (e.cause as { code?: string }).code,
+                  }
+                : undefined,
+          },
+        });
       }
 
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        // Do NOT include response body — it may echo the prompt (vendor names, amounts, etc.)
-        // Only include status code and method for diagnostic purposes.
+        // Read the body so ops can debug from the server log. `LlmUpstreamError`
+        // suppresses `details` from the API response so the body (which may
+        // echo prompt content) never leaves the host.
+        const bodyText = await response.text().catch(() => '<failed to read response body>');
         throw new LlmUpstreamError(`LLM upstream returned ${response.status}`, {
+          provider: config.provider,
+          url,
           status: response.status,
+          statusText: response.statusText,
+          // Cap body at 8KB so a runaway response doesn't flood the log.
+          body: bodyText.length > 8000 ? `${bodyText.slice(0, 8000)}…[truncated]` : bodyText,
         });
       }
 
       let body: unknown;
+      // Capture the raw response text once so we can include it in error
+      // details if JSON parsing or schema validation fails.
+      const rawResponseText = await response.text();
       try {
-        const json = (await response.json()) as {
+        const json = JSON.parse(rawResponseText) as {
           choices?: Array<{ message?: { content?: string } }>;
         };
         const content = json.choices?.[0]?.message?.content;
         if (typeof content !== 'string') {
-          throw new LlmInvalidResponseError('LLM response missing choices[0].message.content');
+          throw new LlmInvalidResponseError(
+            'LLM response missing choices[0].message.content',
+            {
+              provider: config.provider,
+              url,
+              rawResponse:
+                rawResponseText.length > 8000
+                  ? `${rawResponseText.slice(0, 8000)}…[truncated]`
+                  : rawResponseText,
+            },
+          );
         }
-        body = JSON.parse(content);
+        try {
+          body = JSON.parse(content);
+        } catch (parseErr) {
+          throw new LlmInvalidResponseError('LLM content is not valid JSON', {
+            provider: config.provider,
+            url,
+            parseError: (parseErr as Error).message,
+            content: content.length > 8000 ? `${content.slice(0, 8000)}…[truncated]` : content,
+          });
+        }
       } catch (err) {
         if (err instanceof LlmInvalidResponseError) throw err;
-        throw new LlmInvalidResponseError('LLM response is not valid JSON');
+        throw new LlmInvalidResponseError('LLM response envelope is not valid JSON', {
+          provider: config.provider,
+          url,
+          parseError: (err as Error).message,
+          rawResponse:
+            rawResponseText.length > 8000
+              ? `${rawResponseText.slice(0, 8000)}…[truncated]`
+              : rawResponseText,
+        });
       }
 
       return validateExtractedLines(body);

--- a/server/src/services/budgetExtraction/providerProfiles.test.ts
+++ b/server/src/services/budgetExtraction/providerProfiles.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for providerProfiles.ts — provider detection, env parsing,
+ * and per-provider request body shaping.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  detectProvider,
+  parseProviderEnv,
+  buildRequestBody,
+  LLM_PROVIDERS,
+} from './providerProfiles.js';
+
+describe('detectProvider', () => {
+  it.each([
+    ['https://api.anthropic.com/v1', 'anthropic'],
+    ['https://api.anthropic.com/v1/', 'anthropic'],
+    ['https://api.openai.com/v1', 'openai'],
+    ['https://api.openai.com/v1/', 'openai'],
+    [
+      'https://generativelanguage.googleapis.com/v1beta/openai',
+      'gemini',
+    ],
+    ['http://ollama:11434/v1', 'ollama'],
+    ['http://localhost:11434/v1', 'ollama'],
+    ['http://my-host:11434', 'ollama'],
+    ['https://openrouter.ai/api/v1', 'generic'],
+    ['https://my-litellm.example.com', 'generic'],
+  ] as const)('detects %s -> %s', (url, expected) => {
+    expect(detectProvider(url)).toBe(expected);
+  });
+
+  it('is case-insensitive', () => {
+    expect(detectProvider('https://API.ANTHROPIC.com/v1')).toBe('anthropic');
+  });
+});
+
+describe('parseProviderEnv', () => {
+  it('returns undefined for unset/empty', () => {
+    expect(parseProviderEnv(undefined)).toBeUndefined();
+    expect(parseProviderEnv('')).toBeUndefined();
+    expect(parseProviderEnv('   ')).toBeUndefined();
+  });
+
+  it.each(LLM_PROVIDERS)('accepts known provider %s', (p) => {
+    expect(parseProviderEnv(p)).toBe(p);
+    expect(parseProviderEnv(p.toUpperCase())).toBe(p);
+    expect(parseProviderEnv(`  ${p}  `)).toBe(p);
+  });
+
+  it('returns undefined for unknown value (caller falls back to auto-detect)', () => {
+    expect(parseProviderEnv('claude')).toBeUndefined();
+    expect(parseProviderEnv('gpt')).toBeUndefined();
+    expect(parseProviderEnv('bedrock')).toBeUndefined();
+  });
+});
+
+describe('buildRequestBody', () => {
+  const common = {
+    model: 'test-model',
+    systemPrompt: 'sys',
+    userPrompt: 'user',
+  };
+
+  function assertBaseFields(body: Record<string, unknown>) {
+    expect(body.model).toBe('test-model');
+    expect(body.messages).toEqual([
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'user' },
+    ]);
+    expect(body.temperature).toBe(0);
+    expect(body.max_tokens).toBe(4096);
+  }
+
+  it('openai → response_format: json_object', () => {
+    const body = buildRequestBody({ ...common, provider: 'openai' });
+    assertBaseFields(body);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('gemini → response_format: json_object', () => {
+    const body = buildRequestBody({ ...common, provider: 'gemini' });
+    assertBaseFields(body);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('ollama → response_format: json_object', () => {
+    const body = buildRequestBody({ ...common, provider: 'ollama' });
+    assertBaseFields(body);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('anthropic → response_format: json_schema with full ExtractedLine schema', () => {
+    const body = buildRequestBody({ ...common, provider: 'anthropic' });
+    assertBaseFields(body);
+    const rf = body.response_format as { type: string; json_schema: { name: string; schema: { properties: { lines: unknown } } } };
+    expect(rf.type).toBe('json_schema');
+    expect(rf.json_schema.name).toBe('extracted_lines');
+    // Schema must allow our optional fields with type unions; we don't snapshot the full
+    // shape (brittle) but verify the top-level lines array is declared.
+    expect(rf.json_schema.schema.properties.lines).toBeDefined();
+  });
+
+  it('generic → no response_format hint', () => {
+    const body = buildRequestBody({ ...common, provider: 'generic' });
+    assertBaseFields(body);
+    expect(body.response_format).toBeUndefined();
+  });
+
+  it('all profiles produce JSON-serializable bodies', () => {
+    for (const provider of LLM_PROVIDERS) {
+      const body = buildRequestBody({ ...common, provider });
+      expect(() => JSON.stringify(body)).not.toThrow();
+    }
+  });
+});

--- a/server/src/services/budgetExtraction/providerProfiles.ts
+++ b/server/src/services/budgetExtraction/providerProfiles.ts
@@ -1,0 +1,132 @@
+/**
+ * Provider-specific request shaping for the OpenAI-compatible LLM gateway.
+ *
+ * Different providers diverge in subtle ways on the otherwise-canonical
+ * `/v1/chat/completions` schema:
+ *
+ *  - OpenAI:    accepts `response_format: { type: 'json_object' }`. `max_tokens` optional.
+ *  - Anthropic: rejects `json_object`; requires `json_schema` with a real schema.
+ *               `max_tokens` always required on the native API; the OpenAI-compat
+ *               layer is more lenient but we send it for consistency.
+ *  - Gemini:    accepts `json_object` and `json_schema`. `max_tokens` honored as a hint.
+ *  - Ollama:    accepts `json_object` for models that support structured output;
+ *               older models silently ignore it.
+ *  - Generic:   unknown provider — send the minimum body and rely on the system
+ *               prompt's "Output ONLY valid JSON" rule plus runtime validation.
+ *
+ * `detectProvider()` sniffs the base URL and is overridden by `LLM_PROVIDER` env var.
+ */
+
+export type LlmProvider = 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'generic';
+
+export const LLM_PROVIDERS: readonly LlmProvider[] = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'ollama',
+  'generic',
+] as const;
+
+/**
+ * JSON schema for the response Anthropic must conform to. Mirrors the
+ * `ExtractedLine[]` shape validated at parse time by `validateExtractedLines`.
+ * Anthropic's OpenAI-compat layer requires this when `response_format.type`
+ * is `'json_schema'`.
+ */
+const EXTRACTED_LINES_SCHEMA = {
+  name: 'extracted_lines',
+  strict: false,
+  schema: {
+    type: 'object',
+    properties: {
+      lines: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            description: { type: 'string' },
+            quantity: { type: ['number', 'null'] },
+            unit: { type: ['string', 'null'] },
+            unitPrice: { type: ['number', 'null'] },
+            totalAmount: { type: 'number' },
+            includesVat: { type: ['boolean', 'null'] },
+            vatRate: { type: ['number', 'null'] },
+            vendorName: { type: ['string', 'null'] },
+            confidence: { type: 'number' },
+          },
+          required: ['description', 'totalAmount', 'confidence'],
+        },
+      },
+    },
+    required: ['lines'],
+  },
+} as const;
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Infer the provider from a base URL. Returns 'generic' when the URL doesn't
+ * match a known provider — caller is expected to fall back to env override.
+ */
+export function detectProvider(baseUrl: string): LlmProvider {
+  const url = baseUrl.toLowerCase();
+  if (url.includes('api.anthropic.com')) return 'anthropic';
+  if (url.includes('api.openai.com')) return 'openai';
+  if (url.includes('generativelanguage.googleapis.com')) return 'gemini';
+  // Ollama default port and common service names
+  if (url.includes(':11434') || /\bollama\b/.test(url)) return 'ollama';
+  return 'generic';
+}
+
+/**
+ * Normalize an env-var value into a known provider, or return undefined when
+ * unset/empty so the caller can fall back to auto-detection.
+ */
+export function parseProviderEnv(value: string | undefined): LlmProvider | undefined {
+  if (!value || value.trim() === '') return undefined;
+  const v = value.trim().toLowerCase();
+  if ((LLM_PROVIDERS as readonly string[]).includes(v)) return v as LlmProvider;
+  return undefined;
+}
+
+export interface RequestBodyInput {
+  provider: LlmProvider;
+  model: string;
+  systemPrompt: string;
+  userPrompt: string;
+}
+
+/**
+ * Build the request body for the configured provider.
+ *
+ * All providers receive `model`, `messages`, `temperature: 0`, and `max_tokens`.
+ * Only the structured-output hint (`response_format`) varies.
+ */
+export function buildRequestBody(input: RequestBodyInput): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    model: input.model,
+    messages: [
+      { role: 'system', content: input.systemPrompt },
+      { role: 'user', content: input.userPrompt },
+    ],
+    temperature: 0,
+    max_tokens: DEFAULT_MAX_TOKENS,
+  };
+
+  switch (input.provider) {
+    case 'openai':
+    case 'gemini':
+    case 'ollama':
+      return { ...base, response_format: { type: 'json_object' } };
+    case 'anthropic':
+      return {
+        ...base,
+        response_format: { type: 'json_schema', json_schema: EXTRACTED_LINES_SCHEMA },
+      };
+    case 'generic':
+    default:
+      // No structured-output hint. The system prompt mandates strict JSON and
+      // `validateExtractedLines` rejects anything malformed at parse time.
+      return base;
+  }
+}

--- a/server/src/services/budgetExtraction/types.ts
+++ b/server/src/services/budgetExtraction/types.ts
@@ -6,8 +6,10 @@
  */
 
 import type { ExtractedLine, ExtractionHints } from '@cornerstone/shared';
+import type { LlmProvider } from './providerProfiles.js';
 
 export type { ExtractedLine, ExtractionHints } from '@cornerstone/shared';
+export type { LlmProvider } from './providerProfiles.js';
 
 export interface BudgetExtractionProvider {
   extract(ocrText: string, hints: ExtractionHints): Promise<ExtractedLine[]>;
@@ -18,4 +20,9 @@ export interface LlmConfig {
   apiKey: string;
   model: string;
   requestTimeoutMs: number;
+  /**
+   * Which provider profile shapes the outbound request body.
+   * See `providerProfiles.ts` for the differences.
+   */
+  provider: LlmProvider;
 }

--- a/server/src/services/draftCleanupService.test.ts
+++ b/server/src/services/draftCleanupService.test.ts
@@ -75,6 +75,7 @@ const makeConfig = (overrides: Partial<AppConfig> = {}): AppConfig => ({
   llmApiKey: undefined,
   llmModel: undefined,
   llmRequestTimeoutMs: 30000,
+    llmProvider: 'generic',
   autoItemizeEnabled: false,
   ...overrides,
 });

--- a/server/src/services/invoiceAutoItemizeService.test.ts
+++ b/server/src/services/invoiceAutoItemizeService.test.ts
@@ -161,6 +161,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     llmApiKey: 'llm-key',
     llmModel: 'gpt-4o',
     llmRequestTimeoutMs: 5000,
+    llmProvider: 'openai',
     autoItemizeEnabled: true,
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Auto-itemize was broken on Anthropic because the OpenAI-compat layer rejects `response_format: { type: 'json_object' }` (it requires `json_schema`). The previous implementation sent the same body to every provider.

This PR introduces per-provider request shaping:

| Provider | `response_format` | `max_tokens` |
|---|---|---|
| OpenAI | `{ type: 'json_object' }` | 4096 |
| Gemini | `{ type: 'json_object' }` | 4096 |
| Ollama | `{ type: 'json_object' }` | 4096 |
| Anthropic | `{ type: 'json_schema', json_schema: {…} }` | 4096 |
| Generic (OpenRouter, LiteLLM, …) | none (rely on prompt + validator) | 4096 |

Provider is auto-detected from `LLM_BASE_URL` (`api.anthropic.com` → anthropic, etc.) and can be overridden with the new optional `LLM_PROVIDER` env var.

Includes \`scripts/diagnose-llm.mjs\` — a node-only diagnostic script that works inside no-shell DHI containers and walks 4 progressive checks (DNS → TLS → endpoint → production-shaped payload) with detailed error dumps. This is what found the original 400.

Fixes #1547 (regression introduced by the original implementation).

## Test plan

- [x] Server typecheck passes
- [x] Unit tests pass for `providerProfiles` (detection, env parsing, body shapes) and `config` (7 new LLM_PROVIDER scenarios)
- [x] No breaking changes to the public API — `LLM_PROVIDER` env var is optional with auto-detect default

🤖 Generated with [Claude Code](https://claude.com/claude-code)