### PR TITLE
fix(auto-itemize): bump max_tokens to 16384 + surface truncation explicitly (#1547)

### DIFF
--- a/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.test.ts
@@ -408,6 +408,42 @@ describe('createOpenAICompatibleProvider — failure modes', () => {
     expect((thrown as LlmInvalidResponseError).code).toBe('LLM_INVALID_RESPONSE');
   });
 
+  it('finish_reason: "length" → throws LlmInvalidResponseError with truncation message', async () => {
+    // Simulate Anthropic/OpenAI hitting max_tokens mid-stream: the JSON content
+    // would be cut off, but rather than producing a confusing "Unterminated
+    // string in JSON" we surface a distinct truncation error.
+    const truncatedResponse = {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          choices: [
+            {
+              message: { content: '{"lines":[{"description":"item' },
+              finish_reason: 'length',
+            },
+          ],
+        }),
+    } as unknown as Response;
+    fetchSpy.mockResolvedValueOnce(truncatedResponse);
+
+    const provider = createOpenAICompatibleProvider(BASE_CONFIG);
+
+    let thrown: unknown;
+    try {
+      await provider.extract('ocr text', {});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(LlmInvalidResponseError);
+    const err = thrown as LlmInvalidResponseError;
+    expect(err.code).toBe('LLM_INVALID_RESPONSE');
+    // Message must reference max_tokens for ops debugging.
+    expect(err.message.toLowerCase()).toContain('max_tokens');
+    // Details must carry finishReason for log diagnostics.
+    expect(err.details?.finishReason).toBe('length');
+  });
+
   it('response body { choices: [] } (no message) → throws LlmInvalidResponseError', async () => {
     const emptyChoices = {
       ok: true,

--- a/server/src/services/budgetExtraction/openAICompatibleProvider.ts
+++ b/server/src/services/budgetExtraction/openAICompatibleProvider.ts
@@ -224,15 +224,32 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
       let body: unknown;
       try {
         const json = (await response.json()) as {
-          choices?: Array<{ message?: { content?: string } }>;
+          choices?: Array<{ message?: { content?: string }; finish_reason?: string }>;
         };
-        const content = json.choices?.[0]?.message?.content;
+        const choice = json.choices?.[0];
+        const content = choice?.message?.content;
+        const finishReason = choice?.finish_reason;
         if (typeof content !== 'string') {
           throw new LlmInvalidResponseError('LLM response missing choices[0].message.content', {
             provider: config.provider,
             url,
             envelope: json,
           });
+        }
+        // Detect upstream truncation explicitly. `finish_reason: 'length'` means
+        // the LLM hit our `max_tokens` cap mid-stream and the JSON will be
+        // unterminated. Surface a distinct, actionable error instead of a
+        // confusing "Unterminated string in JSON" parse failure.
+        if (finishReason === 'length') {
+          throw new LlmInvalidResponseError(
+            'LLM response was truncated (hit max_tokens). Increase LLM max_tokens or shorten the invoice OCR.',
+            {
+              provider: config.provider,
+              url,
+              finishReason,
+              contentLength: content.length,
+            },
+          );
         }
         try {
           body = JSON.parse(content);
@@ -241,6 +258,7 @@ export function createOpenAICompatibleProvider(config: LlmConfig): BudgetExtract
             provider: config.provider,
             url,
             parseError: (parseErr as Error).message,
+            finishReason,
             content: content.length > 8000 ? `${content.slice(0, 8000)}…[truncated]` : content,
           });
         }

--- a/server/src/services/budgetExtraction/providerProfiles.test.ts
+++ b/server/src/services/budgetExtraction/providerProfiles.test.ts
@@ -66,7 +66,7 @@ describe('buildRequestBody', () => {
       { role: 'user', content: 'user' },
     ]);
     expect(body.temperature).toBe(0);
-    expect(body.max_tokens).toBe(4096);
+    expect(body.max_tokens).toBe(16384);
   }
 
   it('openai → response_format: json_object', () => {

--- a/server/src/services/budgetExtraction/providerProfiles.ts
+++ b/server/src/services/budgetExtraction/providerProfiles.ts
@@ -82,7 +82,18 @@ const EXTRACTED_LINES_SCHEMA = {
   },
 } as const;
 
-const DEFAULT_MAX_TOKENS = 4096;
+// Output cap. A typical German construction invoice has 20–60 line items,
+// each ~200–400 chars of JSON, so ~10–25K output chars ≈ 3–8K tokens. Many
+// real-world invoices exceed this (one Göbel Farbwerk invoice was 40+ lines
+// with verbose descriptions and truncated at 4096). 16384 handles 100+ lines
+// comfortably and stays under every supported provider's max output:
+//   - Anthropic Haiku: 64K output
+//   - OpenAI gpt-4o-mini: 16K output (this is the binding constraint)
+//   - Gemini 2.5 Flash: 65K output
+//   - Ollama: model-dependent, typically 4–32K
+// Truncation surfaces as LLM_INVALID_RESPONSE with a JSON parse error in
+// details — we also check `finish_reason: 'length'` for a clearer signal.
+const DEFAULT_MAX_TOKENS = 16384;
 
 /**
  * Infer the provider from a base URL. Returns 'generic' when the URL doesn't


### PR DESCRIPTION
## Summary

Real-world invoice triggered \`LLM_INVALID_RESPONSE\` with parseError \`Unterminated string in JSON at position 10483\`. Anthropic hit our 4096 \`max_tokens\` cap mid-stream extracting 40+ verbose German construction line items, returning a truncated JSON that failed parsing.

- **Bump DEFAULT_MAX_TOKENS from 4096 → 16384.** Stays under every supported provider's output max (OpenAI gpt-4o-mini = 16K is the binding cap; Anthropic Haiku = 64K, Gemini = 65K).
- **Detect \`finish_reason: 'length'\`** in the chat-completions envelope and surface a distinct \`LLM_INVALID_RESPONSE\` with message *"LLM response was truncated (hit max_tokens). Increase LLM max_tokens or shorten the invoice OCR."* — instead of the confusing "Unterminated string in JSON" parse failure.
- Include \`finishReason\` in error details on parse failures too, so ops can spot the pattern even if the explicit check misses.

Fixes the parse-failure surface the diagnostic logging from #1558 exposed against a real invoice.

## Test plan

- [x] New test asserts \`finish_reason: 'length'\` → distinct error with truncation message + \`details.finishReason\`
- [x] Existing \`max_tokens: 4096\` assertion bumped to 16384
- [x] Server typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)