### PR TITLE
fix(auto-itemize): drop ineffective position:sticky on previewColumn

### DIFF
--- a/client/src/pages/AutoItemizePage/AutoItemizePage.module.css
+++ b/client/src/pages/AutoItemizePage/AutoItemizePage.module.css
@@ -73,20 +73,13 @@
   }
 }
 
+/* Grid item; default align-items: stretch fills the row height naturally.
+   No position: sticky is needed: the form column has its own internal overflow,
+   so siblings in the grid don't move when it scrolls. */
 .previewColumn {
   display: flex;
   flex-direction: column;
-  position: sticky;
-  top: var(--auto-itemize-header-height);
-  height: calc(100vh - var(--auto-itemize-header-height));
-}
-
-@media (max-width: 860px) {
-  .previewColumn {
-    position: static;
-    height: auto;
-    top: auto;
-  }
+  min-height: 0;
 }
 
 .metadataCard {


### PR DESCRIPTION
## Summary

The `previewColumn` carried `position: sticky; top: 72px; height: calc(100vh - 72px)` from the original #1590 attempt. After the AppShell `:has()` opt-in disabled `.mainContent { overflow-y: auto }`, **no ancestor of `.previewColumn` scrolls anymore** — only its sibling `.formColumn` does, via its own internal `overflow-y: auto`. `position: sticky` requires a scrolling ancestor, not a scrolling sibling, so the sticky/top/calc rules were **inert no-ops** masquerading as a fix.

The column appeared to "stick" only because CSS Grid defaults to `align-items: stretch`, making the column naturally fill the row height. The user correctly observed something was off.

## Change

`.previewColumn` is now a plain flex column:

```css
.previewColumn {
  display: flex;
  flex-direction: column;
  min-height: 0;
}
```

The parent `.pageBody` (`flex: 1; min-height: 0` inside `.pageContainer { height: 100vh }`) is height-constrained; grid stretch fills the column; the iframe inside already has `flex: 1; min-height: 0`.

The mobile media query that was *undoing* the desktop sticky rules is now redundant and removed.

## Test plan

- [ ] Visually verify PDF preview fills the full available height at desktop
- [ ] Verify form column still scrolls independently (PDF stays visible)
- [ ] Verify mobile layout (≤860px) still stacks form above preview

Existing E2E scenarios 19, 28 (assert preview column y-stable on scroll) and 29 (assert position:static on mobile) all pass with the new CSS — they were measuring what grid layout produces, not what sticky positioning produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)