### PR TITLE
fix(invoices): restore eagerLinkInvoice=true in InvoiceBudgetLinesSection (#1611)

### DIFF
--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
@@ -882,9 +882,17 @@ describe('InvoiceBudgetLinesSection', () => {
       expect(screen.getByTestId('budget-line-form')).toBeInTheDocument();
     });
 
-    it('submit happy path — direct mode VAT included: calls createWorkItemBudget (not createInvoiceBudgetLine), then closes', async () => {
+    it('submit happy path — creates work item budget line AND eagerly links to invoice (#1611 fix)', async () => {
       const newBudgetLineStub = makeBudgetLineStub('wib-new-001', 500);
       mockCreateWorkItemBudget.mockResolvedValue(newBudgetLineStub);
+
+      // #1611 fix: eagerLinkInvoice is now true so createInvoiceBudgetLine MUST be called
+      const linkedLine = makeDetailLine('ibl-eager-001', {
+        workItemBudgetId: 'wib-new-001',
+        itemizedAmount: 500,
+        plannedAmount: 500,
+      });
+      mockCreateInvoiceBudgetLine.mockResolvedValue(makeCreateResponse(linkedLine, 1000.0));
 
       await openCreateFormWorkItemEmpty();
 
@@ -906,8 +914,16 @@ describe('InvoiceBudgetLinesSection', () => {
         );
       });
 
-      // createInvoiceBudgetLine is NOT called from the create flow (non-eager mode)
-      expect(mockCreateInvoiceBudgetLine).not.toHaveBeenCalled();
+      // createInvoiceBudgetLine IS called immediately after creation (eagerLinkInvoice = true)
+      await waitFor(() => {
+        expect(mockCreateInvoiceBudgetLine).toHaveBeenCalledWith(
+          INVOICE_ID,
+          expect.objectContaining({
+            workItemBudgetId: 'wib-new-001',
+            itemizedAmount: 500,
+          }),
+        );
+      });
 
       // Picker closes after success
       await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
@@ -92,15 +92,7 @@ export function InvoiceBudgetLinesSection({
   const [selectedLineIds, setSelectedLineIds] = useState<Set<string>>(() => new Set());
   const [itemizedAmounts, setItemizedAmounts] = useState<Record<string, number>>({});
 
-  // Use the picker hook with a no-op callback (InvoiceBudgetLinesSection uses multi-select, not eager link)
-  const picker = useBudgetLinePicker({
-    invoiceId,
-    invoiceAmount: invoiceTotal,
-    onLineCreated: () => {}, // No-op: InvoiceBudgetLinesSection handles linking via handleAddSelectedLines
-    eagerLinkInvoice: false, // Don't auto-link in the create flow
-  });
-
-  // Load budget lines on mount
+  // Load budget lines on mount (defined before picker so onLineCreated can reference it)
   const loadBudgetLines = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -118,6 +110,17 @@ export function InvoiceBudgetLinesSection({
       setIsLoading(false);
     }
   }, [invoiceId, t]);
+
+  // Use the picker hook — eagerLinkInvoice defaults to true so the create-new flow
+  // calls createInvoiceBudgetLine automatically before invoking onLineCreated.
+  const picker = useBudgetLinePicker({
+    invoiceId,
+    invoiceAmount: invoiceTotal,
+    onLineCreated: () => {
+      // Reload budget lines after a new line is created and eagerly linked to the invoice
+      void loadBudgetLines();
+    },
+  });
 
   useEffect(() => {
     void loadBudgetLines();


### PR DESCRIPTION
## Summary

Fixes a regression where creating a new budget line through the invoice picker's "Create Budget Line" form no longer linked the line to the invoice.

## Root Cause

`InvoiceBudgetLinesSection` called `useBudgetLinePicker` with `eagerLinkInvoice: false`, which causes `handleCreateBudgetLine` inside the hook to skip the `createInvoiceBudgetLine` call. The `onLineCreated` callback was also a no-op, meaning the newly created budget line simply disappeared after the picker closed — never linked to the invoice.

The confusion arose because `handleAddSelectedLines` (the checkbox multi-select path for *existing* lines) handles linking itself. But the create-new form path depends entirely on the hook's internal eager-link logic.

## Changes

### `InvoiceBudgetLinesSection.tsx`
- Move `loadBudgetLines` `useCallback` **before** the `useBudgetLinePicker` call so `onLineCreated` can reference it cleanly
- Remove `eagerLinkInvoice: false` — the default (`true`) is now used
- Replace no-op `onLineCreated: () => {}` with `() => { void loadBudgetLines(); }` to refresh the section after create+link

### `InvoiceBudgetLinesSection.test.tsx`
- Update the "happy path" unit test (previously asserted `createInvoiceBudgetLine` was NOT called — documenting the broken behaviour) to verify it IS called with the correct `workItemBudgetId` and `itemizedAmount`

## Testing

- Unit test updated to reflect correct eager-link behaviour
- E2E tests `invoice-budget-line-create-and-link.spec.ts` Scenarios 1/2/3 are unchanged (they encoded correct expected behaviour throughout)

Closes #1611
