### PR TITLE
chore(eslint): add test-files override to relax React Compiler rules (#1456)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,21 @@ export default tseslint.config(
     },
   },
 
+  // Test files (unit + integration) — relax React-Compiler-focused rules
+  // that don't apply to mocks and test scaffolding. These rules optimize
+  // production rendering; test code never ships.
+  {
+    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}', '**/__mocks__/**/*.{ts,tsx}'],
+    rules: {
+      '@eslint-react/component-hook-factories': 'off',
+      '@eslint-react/no-unnecessary-use-prefix': 'off',
+      '@eslint-react/no-array-index-key': 'off',
+      '@eslint-react/use-state': 'off',
+      '@eslint-react/exhaustive-deps': 'off',
+      '@eslint-react/set-state-in-effect': 'off',
+    },
+  },
+
   // Disable formatting rules that conflict with Prettier
   prettierConfig,
 );


### PR DESCRIPTION
## Summary

Adds a test-files override block to `eslint.config.js` that relaxes React Compiler-focused rules for test files (`*.test.{ts,tsx}`, `*.spec.{ts,tsx}`, `**/__mocks__/**/*.{ts,tsx}`).

These rules are designed to enforce production rendering constraints and generate high-volume, non-actionable noise when applied to test mocks and scaffolding code.

## Rules relaxed for test files only

| Rule | Violations suppressed |
|---|---|
| `@eslint-react/component-hook-factories` | 119 errors |
| `@eslint-react/no-unnecessary-use-prefix` | 146 warnings |
| `@eslint-react/no-array-index-key` | ~34 warnings |
| `@eslint-react/use-state` | ~36 warnings |
| `@eslint-react/exhaustive-deps` | ~74 warnings |
| `@eslint-react/set-state-in-effect` | ~76 warnings |

**Net reduction: ~280 lint problems. Zero production code changes.**

## Files changed
- `eslint.config.js` — one new override block added (15 lines)

## Related
- Parent tracking issue: #1455
- Closes #1456