### PR TITLE
chore(test-infra): add afterEach(jest.clearAllMocks) hygiene to unit tests

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest, describe, it, expect, beforeAll, afterEach } from '@jest/globals';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { CostBreakdownTable as CostBreakdownTableType } from './CostBreakdownTable.js';
 import type { BudgetBreakdown, BudgetOverview } from '@cornerstone/shared';

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { jest, describe, it, expect, beforeAll } from '@jest/globals';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { jest, describe, it, expect, beforeAll, afterEach } from '@jest/globals';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { CostBreakdownTable as CostBreakdownTableType } from './CostBreakdownTable.js';
 import type { BudgetBreakdown, BudgetOverview } from '@cornerstone/shared';
@@ -78,6 +78,10 @@ let CostBreakdownTable: typeof CostBreakdownTableType;
 beforeAll(async () => {
   const module = await import('./CostBreakdownTable.js');
   CostBreakdownTable = module.CostBreakdownTable;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
 });
 
 /**

--- a/client/src/components/GanttChart/GanttSidebar.test.tsx
+++ b/client/src/components/GanttChart/GanttSidebar.test.tsx
@@ -5,7 +5,7 @@
  * Tests item rendering, muted state for undated items, click/keyboard interactions,
  * and accessibility attributes. Issue #449: Household item rows.
  */
-import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { jest, describe, it, expect, beforeAll, afterAll, afterEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GanttSidebar } from './GanttSidebar.js';
 import type { UnifiedRow } from './GanttSidebar.js';
@@ -55,6 +55,10 @@ function makeHI(overrides: Partial<TimelineHouseholdItem> = {}): TimelineHouseho
 function makeHIRow(hi: TimelineHouseholdItem): UnifiedRow {
   return { kind: 'householdItem', item: hi };
 }
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('GanttSidebar', () => {
   // ── Rendering ──────────────────────────────────────────────────────────────

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.inline-edit.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.inline-edit.test.tsx
@@ -4,7 +4,7 @@
  * Tests for inline date editing and section structure on HouseholdItemDetailPage.
  * Story #467: Inline date and dependency editing on Household Item Detail Page.
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import type * as HouseholdItemsApiTypes from '../../lib/householdItemsApi.js';
@@ -390,6 +390,10 @@ describe('HouseholdItemDetailPage — inline date editing (Story #467)', () => {
   }
 
   // ─── Schedule row display ──────────────────────────────────────────────────
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
 
   describe('Schedule row — target vs actual date display', () => {
     it('shows "Target Date" label when actualDeliveryDate is null', async () => {

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.inline-edit.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.inline-edit.test.tsx
@@ -389,11 +389,11 @@ describe('HouseholdItemDetailPage — inline date editing (Story #467)', () => {
     });
   }
 
-  // ─── Schedule row display ──────────────────────────────────────────────────
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  // ─── Schedule row display ──────────────────────────────────────────────────
 
   describe('Schedule row — target vs actual date display', () => {
     it('shows "Target Date" label when actualDeliveryDate is null', async () => {

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
@@ -380,6 +380,10 @@ describe('HouseholdItemDetailPage', () => {
       </MemoryRouter>,
     );
   }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('loading state', () => {
     it('shows loading state initially', async () => {

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
@@ -429,6 +429,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  jest.clearAllMocks();
   jest.restoreAllMocks();
 });
 

--- a/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.test.tsx
+++ b/client/src/pages/MilestoneDetailPage/MilestoneDetailPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
@@ -215,6 +215,10 @@ describe('MilestoneDetailPage', () => {
       </MemoryRouter>,
     );
   }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   // ─── Loading state ──────────────────────────────────────────────────────────
 

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.harmonization.test.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.harmonization.test.tsx
@@ -13,7 +13,7 @@
  * - Empty notes: "No notes yet. Use the form above to add one."
  * - Empty subtasks: "No subtasks yet. Add one above."
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { WorkItemDetail } from '@cornerstone/shared';
@@ -362,6 +362,10 @@ describe('WorkItemDetailPage — UI Harmonization (Story #501)', () => {
       </MemoryRouter>,
     );
   }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   // ── Scenario 1: Loading state ──────────────────────────────────────────────
 

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { WorkItemDetail, WorkItemSummary } from '@cornerstone/shared';
@@ -349,6 +349,10 @@ describe('WorkItemDetailPage', () => {
       </MemoryRouter>,
     );
   }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('initial render', () => {
     it('shows loading state initially', async () => {


### PR DESCRIPTION
## Summary

Scope-narrowed from the original memory-audit PR. This PR contains **only test-file changes** — adding `afterEach(jest.clearAllMocks)` hygiene to 8 unit test files to prevent mock state accumulation across tests within a worker lifetime.

## Changes

- `CostBreakdownTable.test.tsx`: add `afterEach`/`within` imports + `afterEach(() => jest.clearAllMocks())`
- `GanttSidebar.test.tsx`: add `afterEach` import + `afterEach(() => jest.clearAllMocks())`
- `WorkItemDetailPage.test.tsx`: same pattern
- `WorkItemDetailPage.harmonization.test.tsx`: same pattern
- `HouseholdItemDetailPage.test.tsx`: same pattern
- `HouseholdItemDetailPage.inline-edit.test.tsx`: same pattern
- `InvoiceBudgetLinesSection.test.tsx`: add `jest.clearAllMocks()` to existing `afterEach` alongside `jest.restoreAllMocks()`
- `MilestoneDetailPage.test.tsx`: same pattern

## What was deferred

The `jest.config.ts` change (adding `clearMocks: true` globally) and dependency upgrades originally in this PR have been deferred:

- **#1620** (jest.config.ts + dep upgrades) was closed — it triggered a root/client Konva type collision (`miterLimit` / `RefObject<Stage>`) on lockfile regeneration.
- **#1646** tracks the Konva collision for future resolution.

**No `jest.config.ts`, `package.json`, or `package-lock.json` changes in this PR.** Only explicit per-file `afterEach(jest.clearAllMocks)` additions.