### PR TITLE
chore(eslint): extract IIFEs from JSX to const variables (#1460)

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -820,6 +820,81 @@ export function CostBreakdownTable({
   const hiSectionExpanded = expandedKeys.has(hiSectionKey);
   const availFundsExpanded = expandedKeys.has(availFundsKey);
 
+  // Subsidy adjustments section state (extracted from JSX)
+  const adjSectionKey = 'adj-section';
+  const adjSectionExpanded = expandedKeys.has(adjSectionKey);
+
+  // Source detail rows for expanded available-funds section
+  const sourceDetailRows: React.ReactNode[] = availFundsExpanded
+    ? budgetSources.map((source: BudgetSourceSummaryBreakdown) => {
+        const colorIndex = getSourceColorIndex(source.id);
+        const isSelected = !deselectedSourceIds.has(source.id);
+        const allocatedCost = resolveProjected(source.projectedMin, source.projectedMax, perspective);
+        const payback = resolveProjected(
+          source.subsidyPaybackMin,
+          source.subsidyPaybackMax,
+          perspective,
+        );
+        const net = source.totalAmount + payback - allocatedCost;
+        const rowStyle = {
+          '--chip-dot': `var(--color-source-${colorIndex}-dot)`,
+        } as React.CSSProperties;
+        const displayName =
+          source.id === 'unassigned'
+            ? t('overview.costBreakdown.sourceFilter.unassigned')
+            : source.name;
+        return (
+          <tr
+            key={source.id}
+            role="button"
+            tabIndex={0}
+            aria-pressed={isSelected}
+            aria-label={
+              isSelected
+                ? t('overview.costBreakdown.sourceRow.selectedAriaLabel', { name: displayName })
+                : t('overview.costBreakdown.sourceRow.deselectedAriaLabel', { name: displayName })
+            }
+            className={`${styles.rowSourceDetail} ${styles.rowSourceDetailToggle}`}
+            style={rowStyle}
+            onClick={() => onSourceToggle(source.id === 'unassigned' ? null : source.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSourceToggle(source.id === 'unassigned' ? null : source.id);
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                onSelectAllSources();
+              }
+            }}
+          >
+            <td className={styles.colName}>
+              <div className={`${styles.nameContent} ${styles.nameIndented}`}>
+                <span
+                  className={styles.sourceDot}
+                  style={{ backgroundColor: 'var(--chip-dot)' }}
+                  aria-hidden="true"
+                />
+                <span>{displayName}</span>
+              </div>
+            </td>
+            <td className={styles.colBudget}>
+              <span className={styles.valueNegative}>
+                {formatCost(allocatedCost, formatCurrency)}
+              </span>
+            </td>
+            <td className={styles.colPayback}>
+              <span className={styles.valuePositive}>{formatCurrency(payback)}</span>
+            </td>
+            <td className={styles.colRemaining}>
+              <span className={net >= 0 ? styles.valuePositive : styles.valueNegative}>
+                {formatCurrency(net)}
+              </span>
+            </td>
+          </tr>
+        );
+      })
+    : [];
+
   return (
     <FormatterContext.Provider value={formatCurrency}>
       <BreakdownContext.Provider
@@ -1016,67 +1091,62 @@ export function CostBreakdownTable({
               </tbody>
 
               {/* ===== SUBSIDY ADJUSTMENTS SECTION ===== */}
-              {subsidyAdjustments.length > 0 &&
-                (() => {
-                  const adjSectionKey = 'adj-section';
-                  const adjSectionExpanded = expandedKeys.has(adjSectionKey);
-                  return (
-                    <tbody>
-                      <tr className={styles.rowLevel0}>
-                        <td className={styles.colName}>
-                          <div className={styles.nameContent}>
-                            <button
-                              type="button"
-                              className={styles.expandBtn}
-                              aria-expanded={adjSectionExpanded}
-                              aria-label="Expand subsidy adjustments"
-                              onClick={() => toggle(adjSectionKey)}
-                            >
-                              <ChevronSvg
-                                className={`${styles.chevron} ${adjSectionExpanded ? styles.chevronOpen : ''}`}
-                              />
-                            </button>
-                            <span>{t('overview.costBreakdown.subsidyAdjustments')}</span>
-                          </div>
-                        </td>
-                        <td className={styles.colBudget} />
-                        <td className={styles.colPayback} colSpan={2}>
-                          <span className={styles.adjustmentValue}>
-                            {formatCost(resolvedTotalExcess, formatCurrency)}
-                          </span>
-                        </td>
-                      </tr>
-                      {adjSectionExpanded &&
-                        subsidyAdjustments.map((adj: SubsidyAdjustment) => {
-                          const adjExcess = resolveProjected(
-                            adj.minExcess,
-                            adj.maxExcess,
-                            perspective,
-                          );
-                          return (
-                            <tr key={adj.subsidyProgramId} className={styles.rowLevel1}>
-                              <td className={`${styles.colName} ${styles.cellLevel1Name}`}>
-                                <div className={styles.adjustmentName}>
-                                  <span>{adj.name}</span>
-                                  <span className={styles.adjustmentHint}>
-                                    {t('overview.costBreakdown.oversubscribed', {
-                                      amount: formatCurrency(adj.maximumAmount),
-                                    })}
-                                  </span>
-                                </div>
-                              </td>
-                              <td className={styles.colBudget} />
-                              <td className={styles.colPayback} colSpan={2}>
-                                <span className={styles.adjustmentValue}>
-                                  {formatCost(adjExcess, formatCurrency)}
-                                </span>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                    </tbody>
-                  );
-                })()}
+              {subsidyAdjustments.length > 0 && (
+                <tbody>
+                  <tr className={styles.rowLevel0}>
+                    <td className={styles.colName}>
+                      <div className={styles.nameContent}>
+                        <button
+                          type="button"
+                          className={styles.expandBtn}
+                          aria-expanded={adjSectionExpanded}
+                          aria-label="Expand subsidy adjustments"
+                          onClick={() => toggle(adjSectionKey)}
+                        >
+                          <ChevronSvg
+                            className={`${styles.chevron} ${adjSectionExpanded ? styles.chevronOpen : ''}`}
+                          />
+                        </button>
+                        <span>{t('overview.costBreakdown.subsidyAdjustments')}</span>
+                      </div>
+                    </td>
+                    <td className={styles.colBudget} />
+                    <td className={styles.colPayback} colSpan={2}>
+                      <span className={styles.adjustmentValue}>
+                        {formatCost(resolvedTotalExcess, formatCurrency)}
+                      </span>
+                    </td>
+                  </tr>
+                  {adjSectionExpanded &&
+                    subsidyAdjustments.map((adj: SubsidyAdjustment) => {
+                      const adjExcess = resolveProjected(
+                        adj.minExcess,
+                        adj.maxExcess,
+                        perspective,
+                      );
+                      return (
+                        <tr key={adj.subsidyProgramId} className={styles.rowLevel1}>
+                          <td className={`${styles.colName} ${styles.cellLevel1Name}`}>
+                            <div className={styles.adjustmentName}>
+                              <span>{adj.name}</span>
+                              <span className={styles.adjustmentHint}>
+                                {t('overview.costBreakdown.oversubscribed', {
+                                  amount: formatCurrency(adj.maximumAmount),
+                                })}
+                              </span>
+                            </div>
+                          </td>
+                          <td className={styles.colBudget} />
+                          <td className={styles.colPayback} colSpan={2}>
+                            <span className={styles.adjustmentValue}>
+                              {formatCost(adjExcess, formatCurrency)}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              )}
 
               {/* ===== SUMMARY SECTION (no column tints) ===== */}
               <tbody>
@@ -1142,93 +1212,7 @@ export function CostBreakdownTable({
                 </tr>
 
                 {/* Source detail rows as toggle buttons */}
-                {availFundsExpanded &&
-                  (() => {
-                    const sourceRows: React.ReactNode[] = [];
-
-                    budgetSources.forEach((source: BudgetSourceSummaryBreakdown) => {
-                      const colorIndex = getSourceColorIndex(source.id);
-                      const isSelected = !deselectedSourceIds.has(source.id);
-                      const allocatedCost = resolveProjected(
-                        source.projectedMin,
-                        source.projectedMax,
-                        perspective,
-                      );
-                      const payback = resolveProjected(
-                        source.subsidyPaybackMin,
-                        source.subsidyPaybackMax,
-                        perspective,
-                      );
-                      const net = source.totalAmount + payback - allocatedCost;
-                      const rowStyle = {
-                        '--chip-dot': `var(--color-source-${colorIndex}-dot)`,
-                      } as React.CSSProperties;
-                      const displayName =
-                        source.id === 'unassigned'
-                          ? t('overview.costBreakdown.sourceFilter.unassigned')
-                          : source.name;
-
-                      sourceRows.push(
-                        <tr
-                          key={source.id}
-                          role="button"
-                          tabIndex={0}
-                          aria-pressed={isSelected}
-                          aria-label={
-                            isSelected
-                              ? t('overview.costBreakdown.sourceRow.selectedAriaLabel', {
-                                  name: displayName,
-                                })
-                              : t('overview.costBreakdown.sourceRow.deselectedAriaLabel', {
-                                  name: displayName,
-                                })
-                          }
-                          className={`${styles.rowSourceDetail} ${styles.rowSourceDetailToggle}`}
-                          style={rowStyle}
-                          onClick={() =>
-                            onSourceToggle(source.id === 'unassigned' ? null : source.id)
-                          }
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              onSourceToggle(source.id === 'unassigned' ? null : source.id);
-                            } else if (e.key === 'Escape') {
-                              e.preventDefault();
-                              onSelectAllSources();
-                            }
-                          }}
-                        >
-                          <td className={styles.colName}>
-                            <div className={`${styles.nameContent} ${styles.nameIndented}`}>
-                              <span
-                                className={styles.sourceDot}
-                                style={{ backgroundColor: 'var(--chip-dot)' }}
-                                aria-hidden="true"
-                              />
-                              <span>{displayName}</span>
-                            </div>
-                          </td>
-                          <td className={styles.colBudget}>
-                            <span className={styles.valueNegative}>
-                              {formatCost(allocatedCost, formatCurrency)}
-                            </span>
-                          </td>
-                          <td className={styles.colPayback}>
-                            <span className={styles.valuePositive}>{formatCurrency(payback)}</span>
-                          </td>
-                          <td className={styles.colRemaining}>
-                            <span
-                              className={net >= 0 ? styles.valuePositive : styles.valueNegative}
-                            >
-                              {formatCurrency(net)}
-                            </span>
-                          </td>
-                        </tr>,
-                      );
-                    });
-
-                    return sourceRows;
-                  })()}
+                {availFundsExpanded && sourceDetailRows}
 
                 {/* Remaining Budget row */}
                 <tr className={`${styles.rowLevel0} ${styles.rowSummary}`}>

--- a/client/src/components/GanttChart/GanttTooltip.tsx
+++ b/client/src/components/GanttChart/GanttTooltip.tsx
@@ -209,6 +209,38 @@ function WorkItemTooltipContent({
   // the dependencies block and removing the trailing separator from the variance branch.
   const hasOwner = data.assignedUserName !== null;
 
+  const durationVariance =
+    hasBothDurations ? data.actualDurationDays! - data.plannedDurationDays! : null;
+  const absDurationVariance = durationVariance !== null ? Math.abs(durationVariance) : 0;
+  const varianceLabel =
+    durationVariance !== null && durationVariance !== 0
+      ? durationVariance > 0
+        ? `+${absDurationVariance}`
+        : `-${absDurationVariance}`
+      : null;
+  const varianceDayWord =
+    absDurationVariance === 1
+      ? t('gantt.tooltip.duration.day')
+      : t('gantt.tooltip.duration.days');
+  const varianceClass =
+    durationVariance !== null && durationVariance > 0
+      ? styles.detailValueOverPlan
+      : styles.detailValueUnderPlan;
+  const durationVarianceRow =
+    durationVariance === null ? null : durationVariance === 0 ? (
+      <div className={styles.detailRow}>
+        <span className={styles.detailLabel}>{t('gantt.tooltip.duration.variance')}</span>
+        <span className={styles.detailValue}>{t('gantt.tooltip.duration.onPlan')}</span>
+      </div>
+    ) : (
+      <div className={styles.detailRow}>
+        <span className={styles.detailLabel}>{t('gantt.tooltip.duration.variance')}</span>
+        <span className={`${styles.detailValue} ${varianceClass}`}>
+          {varianceLabel} {varianceDayWord}
+        </span>
+      </div>
+    );
+
   return (
     <>
       {/* Header: title + status badge */}
@@ -247,33 +279,7 @@ function WorkItemTooltipContent({
               {formatDuration(data.actualDurationDays ?? null)}
             </span>
           </div>
-          {(() => {
-            const variance = data.actualDurationDays! - data.plannedDurationDays!;
-            if (variance === 0) {
-              return (
-                <div className={styles.detailRow}>
-                  <span className={styles.detailLabel}>{t('gantt.tooltip.duration.variance')}</span>
-                  <span className={styles.detailValue}>{t('gantt.tooltip.duration.onPlan')}</span>
-                </div>
-              );
-            }
-            const absVariance = Math.abs(variance);
-            const label = variance > 0 ? `+${absVariance}` : `-${absVariance}`;
-            const dayWord =
-              absVariance === 1
-                ? t('gantt.tooltip.duration.day')
-                : t('gantt.tooltip.duration.days');
-            const varianceClass =
-              variance > 0 ? styles.detailValueOverPlan : styles.detailValueUnderPlan;
-            return (
-              <div className={styles.detailRow}>
-                <span className={styles.detailLabel}>{t('gantt.tooltip.duration.variance')}</span>
-                <span className={`${styles.detailValue} ${varianceClass}`}>
-                  {label} {dayWord}
-                </span>
-              </div>
-            );
-          })()}
+          {durationVarianceRow}
         </>
       ) : data.plannedDurationDays != null ? (
         <div className={styles.detailRow}>

--- a/client/src/components/MiniGanttCard/MiniGanttCard.tsx
+++ b/client/src/components/MiniGanttCard/MiniGanttCard.tsx
@@ -154,6 +154,31 @@ export function MiniGanttCard({ timeline }: MiniGanttCardProps) {
     );
   }
 
+  const todayLocal = new Date();
+  const todayNoon = new Date(
+    todayLocal.getFullYear(),
+    todayLocal.getMonth(),
+    todayLocal.getDate(),
+    12,
+    0,
+    0,
+    0,
+  );
+  const todayX = dateToX(todayNoon, windowStart);
+  const todayMarker =
+    todayX >= 0 && todayX <= CHART_WIDTH ? (
+      <line
+        key="today-marker"
+        x1={todayX}
+        y1={HEADER_HEIGHT}
+        x2={todayX}
+        y2={svgHeight}
+        stroke={colors.todayMarker}
+        strokeWidth="2"
+        opacity="0.8"
+      />
+    ) : null;
+
   return (
     <div
       className={styles.container}
@@ -225,32 +250,7 @@ export function MiniGanttCard({ timeline }: MiniGanttCardProps) {
         })}
 
         {/* Today marker line */}
-        {(() => {
-          const todayLocal = new Date();
-          const todayNoon = new Date(
-            todayLocal.getFullYear(),
-            todayLocal.getMonth(),
-            todayLocal.getDate(),
-            12,
-            0,
-            0,
-            0,
-          );
-          const x = dateToX(todayNoon, windowStart);
-          if (x < 0 || x > CHART_WIDTH) return null;
-          return (
-            <line
-              key="today-marker"
-              x1={x}
-              y1={HEADER_HEIGHT}
-              x2={x}
-              y2={svgHeight}
-              stroke={colors.todayMarker}
-              strokeWidth="2"
-              opacity="0.8"
-            />
-          );
-        })()}
+        {todayMarker}
 
         {/* Work item bars rendered by row */}
         {filteredWorkItems.map((item, rowIndex) => {

--- a/client/src/components/budget/BudgetLineForm.tsx
+++ b/client/src/components/budget/BudgetLineForm.tsx
@@ -40,6 +40,13 @@ export function BudgetLineForm({
   const { t } = useTranslation('budget');
   const { t: tSettings } = useTranslation('settings');
 
+  const qty = parseFloat(form.quantity);
+  const price = parseFloat(form.unitPrice);
+  const computedTotal =
+    form.quantity && form.unitPrice && !isNaN(qty) && !isNaN(price)
+      ? (Math.round(qty * price * (form.includesVat ? 1 : 1.19) * 100) / 100).toFixed(2)
+      : '0.00';
+
   return (
     <div className={styles.container}>
       <form onSubmit={onSubmit} className={styles.form}>
@@ -177,18 +184,7 @@ export function BudgetLineForm({
                 <label className={styles.label}>{t('budgetLineForm.totalLabel')}</label>
                 <div className={styles.computedValue}>
                   €
-                  {form.quantity && form.unitPrice
-                    ? (() => {
-                        const qty = parseFloat(form.quantity);
-                        const price = parseFloat(form.unitPrice);
-                        if (!isNaN(qty) && !isNaN(price)) {
-                          const multiplier = form.includesVat ? 1 : 1.19;
-                          const total = Math.round(qty * price * multiplier * 100) / 100;
-                          return total.toFixed(2);
-                        }
-                        return '0.00';
-                      })()
-                    : '0.00'}
+                  {computedTotal}
                 </div>
               </div>
             </div>

--- a/client/src/components/budget/InvoiceLinkModal.tsx
+++ b/client/src/components/budget/InvoiceLinkModal.tsx
@@ -201,6 +201,18 @@ export function InvoiceLinkModal({
     }
   };
 
+  const parsedAmount = parseFloat(itemizedAmount);
+  const amountAvailable = remainingAmount - parsedAmount;
+  const amountIndicator = selectedInvoice && !isNaN(parsedAmount) ? (
+    <div
+      className={`${styles.amountIndicator} ${amountAvailable < 0 ? styles.amountIndicatorWarning : ''}`}
+    >
+      {amountAvailable < 0
+        ? `${formatCurrency(Math.abs(amountAvailable))} over available`
+        : `${formatCurrency(amountAvailable)} will remain`}
+    </div>
+  ) : null;
+
   return (
     <Modal
       title="Link to Invoice"
@@ -327,23 +339,7 @@ export function InvoiceLinkModal({
                 required
                 onWheel={(e) => e.currentTarget.blur()}
               />
-              {(() => {
-                const amount = parseFloat(itemizedAmount);
-                if (isNaN(amount)) {
-                  return null;
-                }
-                const available = remainingAmount - amount;
-                const isOverLimit = available < 0;
-                return (
-                  <div
-                    className={`${styles.amountIndicator} ${isOverLimit ? styles.amountIndicatorWarning : ''}`}
-                  >
-                    {isOverLimit
-                      ? `${formatCurrency(Math.abs(available))} over available`
-                      : `${formatCurrency(available)} will remain`}
-                  </div>
-                );
-              })()}
+              {amountIndicator}
             </div>
           )}
           {!selectedInvoice && (

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -385,76 +385,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    // Endpoint handles for selected line-family shapes
-  const selectedShape = state.selectedShapeId
-    ? state.shapes.find((s) => s.id === state.selectedShapeId) ?? null
-    : null;
-  const selectedLineShape =
-    selectedShape &&
-    (selectedShape.type === 'arrow' ||
-      selectedShape.type === 'line' ||
-      selectedShape.type === 'measurement')
-      ? selectedShape
-      : null;
-  const endpointRadius = selectedLineShape
-    ? Math.max(8, selectedLineShape.strokeWidth * 1.5)
-    : 0;
-  const endpointHandles = selectedLineShape ? (
-    <>
-      <Circle
-        id={`endpoint-${selectedLineShape.id}-start`}
-        x={selectedLineShape.x1}
-        y={selectedLineShape.y1}
-        radius={endpointRadius}
-        fill="#ffffff"
-        stroke={selectedLineShape.stroke}
-        strokeWidth={2}
-        draggable
-        onDragMove={(e) => {
-          const pos = e.target.position();
-          dispatch({
-            type: 'UPDATE_SHAPE',
-            shape: { ...selectedLineShape, x1: pos.x, y1: pos.y },
-          });
-        }}
-        onDragEnd={(e) => {
-          const newX1 = e.target.x();
-          const newY1 = e.target.y();
-          const updated = { ...selectedLineShape, x1: newX1, y1: newY1 };
-          undoStack.commit(
-            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
-          );
-        }}
-      />
-      <Circle
-        id={`endpoint-${selectedLineShape.id}-end`}
-        x={selectedLineShape.x2}
-        y={selectedLineShape.y2}
-        radius={endpointRadius}
-        fill="#ffffff"
-        stroke={selectedLineShape.stroke}
-        strokeWidth={2}
-        draggable
-        onDragMove={(e) => {
-          const pos = e.target.position();
-          dispatch({
-            type: 'UPDATE_SHAPE',
-            shape: { ...selectedLineShape, x2: pos.x, y2: pos.y },
-          });
-        }}
-        onDragEnd={(e) => {
-          const newX2 = e.target.x();
-          const newY2 = e.target.y();
-          const updated = { ...selectedLineShape, x2: newX2, y2: newY2 };
-          undoStack.commit(
-            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
-          );
-        }}
-      />
-    </>
-  ) : null;
-
-  return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
     inlineInput.isOpen,
     state.selectedShapeId,
@@ -853,6 +784,72 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
       </section>
     );
   }
+
+  // Endpoint handles for selected line-family shapes
+  const selectedLineShapeForHandles = state.selectedShapeId
+    ? (state.shapes.find((s) => s.id === state.selectedShapeId) ?? null)
+    : null;
+  const isLineShape =
+    selectedLineShapeForHandles !== null &&
+    (selectedLineShapeForHandles.type === 'arrow' ||
+      selectedLineShapeForHandles.type === 'line' ||
+      selectedLineShapeForHandles.type === 'measurement');
+  const selectedLineShape = isLineShape ? selectedLineShapeForHandles! : null;
+  const endpointRadius = selectedLineShape ? Math.max(8, selectedLineShape.strokeWidth * 1.5) : 0;
+  const endpointHandles = selectedLineShape ? (
+    <>
+      <Circle
+        id={`endpoint-${selectedLineShape.id}-start`}
+        x={selectedLineShape.x1}
+        y={selectedLineShape.y1}
+        radius={endpointRadius}
+        fill="#ffffff"
+        stroke={selectedLineShape.stroke}
+        strokeWidth={2}
+        draggable
+        onDragMove={(e) => {
+          const pos = e.target.position();
+          dispatch({
+            type: 'UPDATE_SHAPE',
+            shape: { ...selectedLineShape, x1: pos.x, y1: pos.y },
+          });
+        }}
+        onDragEnd={(e) => {
+          const newX1 = e.target.x();
+          const newY1 = e.target.y();
+          const updated = { ...selectedLineShape, x1: newX1, y1: newY1 };
+          undoStack.commit(
+            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
+          );
+        }}
+      />
+      <Circle
+        id={`endpoint-${selectedLineShape.id}-end`}
+        x={selectedLineShape.x2}
+        y={selectedLineShape.y2}
+        radius={endpointRadius}
+        fill="#ffffff"
+        stroke={selectedLineShape.stroke}
+        strokeWidth={2}
+        draggable
+        onDragMove={(e) => {
+          const pos = e.target.position();
+          dispatch({
+            type: 'UPDATE_SHAPE',
+            shape: { ...selectedLineShape, x2: pos.x, y2: pos.y },
+          });
+        }}
+        onDragEnd={(e) => {
+          const newX2 = e.target.x();
+          const newY2 = e.target.y();
+          const updated = { ...selectedLineShape, x2: newX2, y2: newY2 };
+          undoStack.commit(
+            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
+          );
+        }}
+      />
+    </>
+  ) : null;
 
   return (
     <section aria-label={t('region')} className={styles.annotator}>

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -385,7 +385,76 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    // Endpoint handles for selected line-family shapes
+  const selectedShape = state.selectedShapeId
+    ? state.shapes.find((s) => s.id === state.selectedShapeId) ?? null
+    : null;
+  const selectedLineShape =
+    selectedShape &&
+    (selectedShape.type === 'arrow' ||
+      selectedShape.type === 'line' ||
+      selectedShape.type === 'measurement')
+      ? selectedShape
+      : null;
+  const endpointRadius = selectedLineShape
+    ? Math.max(8, selectedLineShape.strokeWidth * 1.5)
+    : 0;
+  const endpointHandles = selectedLineShape ? (
+    <>
+      <Circle
+        id={`endpoint-${selectedLineShape.id}-start`}
+        x={selectedLineShape.x1}
+        y={selectedLineShape.y1}
+        radius={endpointRadius}
+        fill="#ffffff"
+        stroke={selectedLineShape.stroke}
+        strokeWidth={2}
+        draggable
+        onDragMove={(e) => {
+          const pos = e.target.position();
+          dispatch({
+            type: 'UPDATE_SHAPE',
+            shape: { ...selectedLineShape, x1: pos.x, y1: pos.y },
+          });
+        }}
+        onDragEnd={(e) => {
+          const newX1 = e.target.x();
+          const newY1 = e.target.y();
+          const updated = { ...selectedLineShape, x1: newX1, y1: newY1 };
+          undoStack.commit(
+            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
+          );
+        }}
+      />
+      <Circle
+        id={`endpoint-${selectedLineShape.id}-end`}
+        x={selectedLineShape.x2}
+        y={selectedLineShape.y2}
+        radius={endpointRadius}
+        fill="#ffffff"
+        stroke={selectedLineShape.stroke}
+        strokeWidth={2}
+        draggable
+        onDragMove={(e) => {
+          const pos = e.target.position();
+          dispatch({
+            type: 'UPDATE_SHAPE',
+            shape: { ...selectedLineShape, x2: pos.x, y2: pos.y },
+          });
+        }}
+        onDragEnd={(e) => {
+          const newX2 = e.target.x();
+          const newY2 = e.target.y();
+          const updated = { ...selectedLineShape, x2: newX2, y2: newY2 };
+          undoStack.commit(
+            undoStack.shapes.map((s) => (s.id === selectedLineShape.id ? updated : s)),
+          );
+        }}
+      />
+    </>
+  ) : null;
+
+  return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
     inlineInput.isOpen,
     state.selectedShapeId,
@@ -874,73 +943,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
             {state.selectedShapeId && <Transformer ref={transformerRef} />}
 
             {/* Endpoint handles for line-family shapes */}
-            {state.selectedShapeId &&
-              (() => {
-                const sel = state.shapes.find((s) => s.id === state.selectedShapeId);
-                if (
-                  !sel ||
-                  (sel.type !== 'arrow' && sel.type !== 'line' && sel.type !== 'measurement')
-                ) {
-                  return null;
-                }
-
-                const endpointRadius = Math.max(8, sel.strokeWidth * 1.5);
-
-                return (
-                  <>
-                    <Circle
-                      id={`endpoint-${sel.id}-start`}
-                      x={sel.x1}
-                      y={sel.y1}
-                      radius={endpointRadius}
-                      fill="#ffffff"
-                      stroke={sel.stroke}
-                      strokeWidth={2}
-                      draggable
-                      onDragMove={(e) => {
-                        const pos = e.target.position();
-                        dispatch({
-                          type: 'UPDATE_SHAPE',
-                          shape: { ...sel, x1: pos.x, y1: pos.y },
-                        });
-                      }}
-                      onDragEnd={(e) => {
-                        const newX1 = e.target.x();
-                        const newY1 = e.target.y();
-                        const updated = { ...sel, x1: newX1, y1: newY1 };
-                        undoStack.commit(
-                          undoStack.shapes.map((s) => (s.id === sel.id ? updated : s)),
-                        );
-                      }}
-                    />
-                    <Circle
-                      id={`endpoint-${sel.id}-end`}
-                      x={sel.x2}
-                      y={sel.y2}
-                      radius={endpointRadius}
-                      fill="#ffffff"
-                      stroke={sel.stroke}
-                      strokeWidth={2}
-                      draggable
-                      onDragMove={(e) => {
-                        const pos = e.target.position();
-                        dispatch({
-                          type: 'UPDATE_SHAPE',
-                          shape: { ...sel, x2: pos.x, y2: pos.y },
-                        });
-                      }}
-                      onDragEnd={(e) => {
-                        const newX2 = e.target.x();
-                        const newY2 = e.target.y();
-                        const updated = { ...sel, x2: newX2, y2: newY2 };
-                        undoStack.commit(
-                          undoStack.shapes.map((s) => (s.id === sel.id ? updated : s)),
-                        );
-                      }}
-                    />
-                  </>
-                );
-              })()}
+            {endpointHandles}
           </Layer>
         </Stage>
 

--- a/client/src/pages/BackupsPage/BackupsPage.tsx
+++ b/client/src/pages/BackupsPage/BackupsPage.tsx
@@ -159,7 +159,11 @@ export function BackupsPage() {
 
   // If restore has been initiated, show the restarting message
   if (restoreInitiated) {
-    return (
+    const deleteModalMessageParts = deleteTarget
+    ? t('backups.deleteModal.message', { filename: '\u0000' }).split('\u0000')
+    : null;
+
+  return (
       <PageLayout
         maxWidth="narrow"
         title={t('backups.pageTitle')}
@@ -309,18 +313,13 @@ export function BackupsPage() {
             </div>
           )}
           <p>
-            {(() => {
-              const parts = t('backups.deleteModal.message', {
-                filename: '\u0000',
-              }).split('\u0000');
-              return (
-                <>
-                  {parts[0]}
-                  <strong>{deleteTarget.filename}</strong>
-                  {parts[1]}
-                </>
-              );
-            })()}
+            {deleteModalMessageParts && (
+              <>
+                {deleteModalMessageParts[0]}
+                <strong>{deleteTarget!.filename}</strong>
+                {deleteModalMessageParts[1]}
+              </>
+            )}
           </p>
           <p className={styles.warningText}>{t('backups.deleteModal.warning')}</p>
         </Modal>

--- a/client/src/pages/BackupsPage/BackupsPage.tsx
+++ b/client/src/pages/BackupsPage/BackupsPage.tsx
@@ -159,11 +159,7 @@ export function BackupsPage() {
 
   // If restore has been initiated, show the restarting message
   if (restoreInitiated) {
-    const deleteModalMessageParts = deleteTarget
-    ? t('backups.deleteModal.message', { filename: '\u0000' }).split('\u0000')
-    : null;
-
-  return (
+    return (
       <PageLayout
         maxWidth="narrow"
         title={t('backups.pageTitle')}
@@ -190,6 +186,10 @@ export function BackupsPage() {
       </PageLayout>
     );
   }
+
+  const deleteModalMessageParts = deleteTarget
+    ? t('backups.deleteModal.message', { filename: '\u0000' }).split('\u0000')
+    : null;
 
   return (
     <PageLayout

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -273,7 +273,12 @@ export function HouseholdItemDetailPage() {
       }
     }
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    const itemCategory = categories.find((c) => c.id === item.category);
+  const categoryDisplayName = itemCategory
+    ? getCategoryDisplayName(tSettings, itemCategory.name, itemCategory.translationKey)
+    : item.category;
+
+  return () => document.removeEventListener('keydown', handleKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showDeleteModal, isDeleting, deleteError]);
 
@@ -765,11 +770,7 @@ export function HouseholdItemDetailPage() {
             <h1 className={styles.pageTitle}>{item.name}</h1>
             <div className={styles.headerBadges}>
               <span className={styles.categoryBadge}>
-                {(() => {
-                  const category = categories.find((c) => c.id === item.category);
-                  if (!category) return item.category;
-                  return getCategoryDisplayName(tSettings, category.name, category.translationKey);
-                })()}
+                {categoryDisplayName}
               </span>
               <Badge variants={HI_STATUS_VARIANTS} value={item.status} />
             </div>

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -273,12 +273,7 @@ export function HouseholdItemDetailPage() {
       }
     }
     document.addEventListener('keydown', handleKeyDown);
-    const itemCategory = categories.find((c) => c.id === item.category);
-  const categoryDisplayName = itemCategory
-    ? getCategoryDisplayName(tSettings, itemCategory.name, itemCategory.translationKey)
-    : item.category;
-
-  return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showDeleteModal, isDeleting, deleteError]);
 
@@ -721,6 +716,11 @@ export function HouseholdItemDetailPage() {
   const availableSubsidies = allSubsidyPrograms.filter(
     (prog) => !linkedSubsidies.some((linked) => linked.id === prog.id),
   );
+
+  const itemCategory = categories.find((c) => c.id === item.category);
+  const categoryDisplayName = itemCategory
+    ? getCategoryDisplayName(tSettings, itemCategory.name, itemCategory.translationKey)
+    : item.category;
 
   return (
     <div className={styles.container}>

--- a/client/src/pages/UserManagementPage/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage/UserManagementPage.tsx
@@ -420,11 +420,7 @@ export function UserManagementPage() {
     };
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-    const deactivateModalMessageParts = deactivatingUser
-    ? t('userManagement.deactivateModal.message', { name: '\u0000' }).split('\u0000')
-    : null;
-
-  return () => {
+    return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
     };
@@ -470,6 +466,10 @@ export function UserManagementPage() {
       </div>
     );
   };
+
+  const deactivateModalMessageParts = deactivatingUser
+    ? t('userManagement.deactivateModal.message', { name: '\u0000' }).split('\u0000')
+    : null;
 
   return (
     <PageLayout

--- a/client/src/pages/UserManagementPage/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage/UserManagementPage.tsx
@@ -420,7 +420,11 @@ export function UserManagementPage() {
     };
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-    return () => {
+    const deactivateModalMessageParts = deactivatingUser
+    ? t('userManagement.deactivateModal.message', { name: '\u0000' }).split('\u0000')
+    : null;
+
+  return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
     };
@@ -616,18 +620,13 @@ export function UserManagementPage() {
             </div>
           )}
           <p>
-            {(() => {
-              const parts = t('userManagement.deactivateModal.message', {
-                name: '\u0000',
-              }).split('\u0000');
-              return (
-                <>
-                  {parts[0]}
-                  <strong>{deactivatingUser.displayName}</strong>
-                  {parts[1]}
-                </>
-              );
-            })()}
+            {deactivateModalMessageParts && (
+              <>
+                {deactivateModalMessageParts[0]}
+                <strong>{deactivatingUser!.displayName}</strong>
+                {deactivateModalMessageParts[1]}
+              </>
+            )}
           </p>
         </Modal>
       )}

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -1148,6 +1148,90 @@ export default function WorkItemDetailPage() {
   const linkedSubsidyIds = new Set(linkedSubsidies.map((s) => s.id));
   const availableSubsidies = allSubsidyPrograms.filter((s) => !linkedSubsidyIds.has(s.id));
 
+  // Delay indicator: shown when not_started and scheduled start is in the past
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  const isDelayed =
+    workItem.status === 'not_started' && !!workItem.startDate && workItem.startDate < todayStr;
+  const delayDays = isDelayed
+    ? Math.floor(
+        (new Date(todayStr).getTime() - new Date(workItem.startDate!).getTime()) /
+          (1000 * 60 * 60 * 24),
+      )
+    : 0;
+  const delayIndicator = isDelayed ? (
+    <div className={styles.delayIndicator} role="status" aria-live="polite">
+      <span aria-hidden="true">⚠</span>
+      {t('detail.schedule.delayed', {
+        count: delayDays,
+        unit: delayDays === 1 ? t('detail.schedule.day') : t('detail.schedule.days')!,
+      })}
+    </div>
+  ) : null;
+
+  // Available milestones for 'required' and 'linked' milestone pickers
+  const requiredMilestoneIds = new Set(workItemMilestones.required.map((m) => m.id));
+  const availableRequiredMilestones = allMilestones.filter((m) => !requiredMilestoneIds.has(m.id));
+  const requiredMilestonePicker =
+    availableRequiredMilestones.length > 0 ? (
+      <div className={styles.linkPickerRow}>
+        <select
+          className={styles.linkPickerSelect}
+          value={selectedRequiredMilestoneId}
+          onChange={(e) => setSelectedRequiredMilestoneId(e.target.value)}
+          aria-label="Select required milestone to add"
+        >
+          <option value="">{t('detail.constraints.selectMilestonePlaceholder')}</option>
+          {availableRequiredMilestones.map((m) => (
+            <option key={m.id} value={String(m.id)}>
+              {m.title} — {formatDate(m.targetDate)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className={styles.addButton}
+          onClick={handleAddRequiredMilestone}
+          disabled={!selectedRequiredMilestoneId || isAddingRequiredMilestone}
+        >
+          {isAddingRequiredMilestone
+            ? t('detail.constraints.adding')
+            : t('detail.constraints.addMilestone')}
+        </button>
+      </div>
+    ) : null;
+
+  const linkedMilestoneIds = new Set(workItemMilestones.linked.map((m) => m.id));
+  const availableLinkedMilestones = allMilestones.filter((m) => !linkedMilestoneIds.has(m.id));
+  const linkedMilestonePicker =
+    availableLinkedMilestones.length > 0 ? (
+      <div className={styles.linkPickerRow}>
+        <select
+          className={styles.linkPickerSelect}
+          value={selectedLinkedMilestoneId}
+          onChange={(e) => setSelectedLinkedMilestoneId(e.target.value)}
+          aria-label="Select milestone to link"
+        >
+          <option value="">{t('detail.constraints.selectMilestonePlaceholder')}</option>
+          {availableLinkedMilestones.map((m) => (
+            <option key={m.id} value={String(m.id)}>
+              {m.title} — {formatDate(m.targetDate)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className={styles.addButton}
+          onClick={handleAddLinkedMilestone}
+          disabled={!selectedLinkedMilestoneId || isAddingLinkedMilestone}
+        >
+          {isAddingLinkedMilestone
+            ? t('detail.constraints.linking')
+            : t('detail.constraints.linkMilestone')}
+        </button>
+      </div>
+    ) : null;
+
   return (
     <div className={styles.container}>
       {/* Inline error banner */}
@@ -1315,24 +1399,7 @@ export default function WorkItemDetailPage() {
               </div>
             </div>
             {/* Delay indicator: shown when not_started and scheduled start is in the past */}
-            {(() => {
-              if (workItem.status !== 'not_started' || !workItem.startDate) return null;
-              const today = new Date();
-              const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-              if (workItem.startDate >= todayStr) return null;
-              const startMs = new Date(workItem.startDate).getTime();
-              const todayMs = new Date(todayStr).getTime();
-              const delayDays = Math.floor((todayMs - startMs) / (1000 * 60 * 60 * 24));
-              return (
-                <div className={styles.delayIndicator} role="status" aria-live="polite">
-                  <span aria-hidden="true">⚠</span>
-                  {t('detail.schedule.delayed', {
-                    count: delayDays,
-                    unit: delayDays === 1 ? t('detail.schedule.day') : t('detail.schedule.days')!,
-                  })}
-                </div>
-              );
-            })()}
+            {delayIndicator}
           </section>
 
           {/* Area */}
@@ -1835,37 +1902,7 @@ export default function WorkItemDetailPage() {
                 ))}
               </div>
 
-              {(() => {
-                const requiredIds = new Set(workItemMilestones.required.map((m) => m.id));
-                const available = allMilestones.filter((m) => !requiredIds.has(m.id));
-                return available.length > 0 ? (
-                  <div className={styles.linkPickerRow}>
-                    <select
-                      className={styles.linkPickerSelect}
-                      value={selectedRequiredMilestoneId}
-                      onChange={(e) => setSelectedRequiredMilestoneId(e.target.value)}
-                      aria-label="Select required milestone to add"
-                    >
-                      <option value="">{t('detail.constraints.selectMilestonePlaceholder')}</option>
-                      {available.map((m) => (
-                        <option key={m.id} value={String(m.id)}>
-                          {m.title} — {formatDate(m.targetDate)}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      className={styles.addButton}
-                      onClick={handleAddRequiredMilestone}
-                      disabled={!selectedRequiredMilestoneId || isAddingRequiredMilestone}
-                    >
-                      {isAddingRequiredMilestone
-                        ? t('detail.constraints.adding')
-                        : t('detail.constraints.addMilestone')}
-                    </button>
-                  </div>
-                ) : null;
-              })()}
+              {requiredMilestonePicker}
             </div>
 
             {/* Linked Milestones subsection */}
@@ -1902,37 +1939,7 @@ export default function WorkItemDetailPage() {
                 ))}
               </div>
 
-              {(() => {
-                const linkedIds = new Set(workItemMilestones.linked.map((m) => m.id));
-                const available = allMilestones.filter((m) => !linkedIds.has(m.id));
-                return available.length > 0 ? (
-                  <div className={styles.linkPickerRow}>
-                    <select
-                      className={styles.linkPickerSelect}
-                      value={selectedLinkedMilestoneId}
-                      onChange={(e) => setSelectedLinkedMilestoneId(e.target.value)}
-                      aria-label="Select milestone to link"
-                    >
-                      <option value="">{t('detail.constraints.selectMilestonePlaceholder')}</option>
-                      {available.map((m) => (
-                        <option key={m.id} value={String(m.id)}>
-                          {m.title} — {formatDate(m.targetDate)}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      className={styles.addButton}
-                      onClick={handleAddLinkedMilestone}
-                      disabled={!selectedLinkedMilestoneId || isAddingLinkedMilestone}
-                    >
-                      {isAddingLinkedMilestone
-                        ? t('detail.constraints.linking')
-                        : t('detail.constraints.linkMilestone')}
-                    </button>
-                  </div>
-                ) : null;
-              })()}
+              {linkedMilestonePicker}
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary

Fixes #1460 | Part of #1455

Extracted all immediately-invoked function expressions (IIFEs) used directly inside JSX into `const` variables declared before the `return` statement. This resolves 12 `@eslint-react/unsupported-syntax` violations across 10 production component files, allowing the React Compiler to properly optimize these components.

No behavioral changes — the rendered output is identical in all cases.

## Files Changed

| File | IIFE removed | Extracted to |
|------|-------------|--------------|
| `components/budget/InvoiceLinkModal.tsx` | Amount indicator computation | `amountIndicator` const |
| `components/budget/BudgetLineForm.tsx` | Computed total (qty × price × VAT) | `computedTotal` const |
| `components/MiniGanttCard/MiniGanttCard.tsx` | Today marker line | `todayMarker` const |
| `components/GanttChart/GanttTooltip.tsx` | Duration variance row | `durationVarianceRow` const |
| `components/photos/PhotoAnnotator/PhotoAnnotator.tsx` | Endpoint drag handles for line shapes | `endpointHandles` const |
| `components/CostBreakdownTable/CostBreakdownTable.tsx` | Subsidy adjustments section (2 IIFEs) | `adjSectionExpanded` + `sourceDetailRows` |
| `pages/WorkItemDetailPage/WorkItemDetailPage.tsx` | Delay indicator + 2 milestone pickers | `delayIndicator`, `requiredMilestonePicker`, `linkedMilestonePicker` |
| `pages/BackupsPage/BackupsPage.tsx` | Delete modal message i18n split | `deleteModalMessageParts` const |
| `pages/UserManagementPage/UserManagementPage.tsx` | Deactivate modal message i18n split | `deactivateModalMessageParts` const |
| `pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx` | Category display name lookup | `categoryDisplayName` const |

## Fix Pattern Applied

Before (flagged by @eslint-react/unsupported-syntax):
```tsx
return (
  <div>
    {(() => {
      const x = someValue > 0;
      return x ? <ComponentA /> : <ComponentB />;
    })()}
  </div>
);
```

After (correct):
```tsx
const content = someValue > 0 ? <ComponentA /> : <ComponentB />;
return (
  <div>
    {content}
  </div>
);
```

## Verification

- All 12 JSX IIFE patterns removed from production TSX files
- No useMemo was added (none of the computations are expensive)
- Test files untouched (already excluded by ESLint override)
- Remaining IIFEs in non-JSX contexts (assigned to const, inside callbacks) are correct and not flagged by the rule