### PR TITLE
chore(eslint): fix jsx-no-children-prop — use JSX children syntax (#1461)

### DIFF
--- a/client/src/components/Modal/Modal.test.tsx
+++ b/client/src/components/Modal/Modal.test.tsx
@@ -11,7 +11,6 @@ describe('Modal', () => {
   const defaultProps = {
     title: 'Test Modal Title',
     onClose: jest.fn<() => void>(),
-    children: <p>Modal body content</p>,
   };
 
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('Modal', () => {
   // ── Rendering ─────────────────────────────────────────────────────────────
 
   it('renders the title text', () => {
-    render(<Modal {...defaultProps} />);
+    render(<Modal {...defaultProps}><p>Modal body content</p></Modal>);
 
     expect(screen.getByRole('heading', { name: 'Test Modal Title' })).toBeInTheDocument();
   });
@@ -47,7 +46,9 @@ describe('Modal', () => {
             <button type="button">Save</button>
           </>
         }
-      />,
+      >
+        <p>Modal body content</p>
+      </Modal>,
     );
 
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -55,7 +56,7 @@ describe('Modal', () => {
   });
 
   it('does not render footer section when footer prop is omitted', () => {
-    render(<Modal {...defaultProps} />);
+    render(<Modal {...defaultProps}><p>Modal body content</p></Modal>);
 
     // Only the close button should be present — no footer action buttons
     const buttons = screen.getAllByRole('button');
@@ -67,7 +68,7 @@ describe('Modal', () => {
 
   it('close button calls onClose when clicked', () => {
     const onClose = jest.fn<() => void>();
-    render(<Modal {...defaultProps} onClose={onClose} />);
+    render(<Modal {...defaultProps} onClose={onClose}><p>Modal body content</p></Modal>);
 
     fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
 
@@ -78,7 +79,7 @@ describe('Modal', () => {
     const onClose = jest.fn<() => void>();
     // Modal uses createPortal into document.body, so content lives in baseElement (body)
     // not in the render container. Use document.querySelector to find the backdrop.
-    render(<Modal {...defaultProps} onClose={onClose} />);
+    render(<Modal {...defaultProps} onClose={onClose}><p>Modal body content</p></Modal>);
 
     // The backdrop div uses the shared CSS module class "modalBackdrop"
     // identity-obj-proxy returns class names as-is, so the class is "modalBackdrop"
@@ -92,7 +93,7 @@ describe('Modal', () => {
 
   it('Escape key calls onClose', () => {
     const onClose = jest.fn<() => void>();
-    render(<Modal {...defaultProps} onClose={onClose} />);
+    render(<Modal {...defaultProps} onClose={onClose}><p>Modal body content</p></Modal>);
 
     fireEvent.keyDown(document, { key: 'Escape' });
 
@@ -101,7 +102,11 @@ describe('Modal', () => {
 
   it('Escape key does NOT call onClose after unmount (handler cleaned up)', () => {
     const onClose = jest.fn<() => void>();
-    const { unmount } = render(<Modal {...defaultProps} onClose={onClose} />);
+    const { unmount } = render(
+      <Modal {...defaultProps} onClose={onClose}>
+        <p>Modal body content</p>
+      </Modal>,
+    );
 
     unmount();
 
@@ -112,7 +117,7 @@ describe('Modal', () => {
 
   it('non-Escape key does not call onClose', () => {
     const onClose = jest.fn<() => void>();
-    render(<Modal {...defaultProps} onClose={onClose} />);
+    render(<Modal {...defaultProps} onClose={onClose}><p>Modal body content</p></Modal>);
 
     fireEvent.keyDown(document, { key: 'Enter' });
     fireEvent.keyDown(document, { key: 'Tab' });
@@ -124,19 +129,19 @@ describe('Modal', () => {
   // ── ARIA attributes ───────────────────────────────────────────────────────
 
   it('dialog container has role="dialog"', () => {
-    render(<Modal {...defaultProps} />);
+    render(<Modal {...defaultProps}><p>Modal body content</p></Modal>);
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('dialog has aria-modal="true"', () => {
-    render(<Modal {...defaultProps} />);
+    render(<Modal {...defaultProps}><p>Modal body content</p></Modal>);
 
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
   });
 
   it('dialog has aria-labelledby referencing the title element id', () => {
-    render(<Modal {...defaultProps} />);
+    render(<Modal {...defaultProps}><p>Modal body content</p></Modal>);
 
     const dialog = screen.getByRole('dialog');
     const labelledBy = dialog.getAttribute('aria-labelledby');
@@ -152,7 +157,7 @@ describe('Modal', () => {
 
   it('forwards className to the content panel', () => {
     // Modal uses createPortal; content lives in document.body, not the render container
-    render(<Modal {...defaultProps} className="myCustomClass" />);
+    render(<Modal {...defaultProps} className="myCustomClass"><p>Modal body content</p></Modal>);
 
     // The content div is the one that gets the extra className alongside the
     // shared modalContent and local content class names


### PR DESCRIPTION
## Summary

Fixes #1461
Part of #1455

## Problem

`@eslint-react/jsx-no-children-prop` and `@eslint-react/jsx-no-children-prop-with-children` fired 22 times in `client/src/components/Modal/Modal.test.tsx`.

The root cause: `defaultProps` included `children: <p>Modal body content</p>`, and every `<Modal {...defaultProps} />` spread caused ESLint to detect `children` being passed as a prop attribute rather than JSX children syntax. When a test also added explicit JSX children alongside the spread, the `-with-children` variant fired too.

## Fix

- Removed `children` from the `defaultProps` object  
- Every render call that relied on the spread-provided `children` now explicitly passes `<p>Modal body content</p>` as JSX children  
- No logic, assertion, or rendered output changed — only the prop-passing mechanism

## Verification

```
npx eslint client/src/components/Modal/Modal.test.tsx
# → no output (zero violations)

npx eslint client/src --ext .tsx 2>&1 | grep children-prop
# → no output (zero violations across all client source files)
```

## Files Changed

| File | Change |
|------|--------|
| `client/src/components/Modal/Modal.test.tsx` | Removed `children` from `defaultProps`; added explicit JSX children to each `render()` call |