### PR TITLE
chore(eslint): wrap non-trivial useState initializers in arrow functions (#1465)

### DIFF
--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -689,7 +689,7 @@ export function CostBreakdownTable({
 }: CostBreakdownTableProps) {
   const { t } = useTranslation('budget');
   const { formatCurrency } = useFormatters();
-  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() => new Set());
   const [perspective, setPerspective] = useState<CostPerspective>('avg');
   const budgetSources: BudgetSourceSummaryBreakdown[] = breakdown.budgetSources ?? [];
 

--- a/client/src/components/DataTable/DataTable.tsx
+++ b/client/src/components/DataTable/DataTable.tsx
@@ -164,7 +164,7 @@ export function DataTable<T>({
   const { t } = useTranslation('common');
 
   // Client-side filter state for columns without server-side support
-  const [clientFilters, setClientFilters] = useState<Map<string, { value: string }>>(new Map());
+  const [clientFilters, setClientFilters] = useState<Map<string, { value: string }>>(() => new Map());
 
   // Load column visibility and ordering preferences
   const { visibleColumns, columnOrder, toggleColumn, moveColumn, resetToDefaults } =

--- a/client/src/components/DataTable/filters/EnumFilter.tsx
+++ b/client/src/components/DataTable/filters/EnumFilter.tsx
@@ -36,7 +36,7 @@ export function EnumFilter({
   const { t } = useTranslation('common');
 
   const parseValue = (v: string) => new Set(v ? v.split(',') : []);
-  const [selected, setSelected] = useState(parseValue(value));
+  const [selected, setSelected] = useState(() => parseValue(value));
 
   // Build childrenOf map from hierarchy for arbitrary depth support
   const childrenOf = new Map<string | null, string[]>();

--- a/client/src/components/milestones/MilestoneForm.tsx
+++ b/client/src/components/milestones/MilestoneForm.tsx
@@ -51,7 +51,7 @@ export function MilestoneForm({
   const [targetDate, setTargetDate] = useState(milestone?.targetDate ?? '');
   const [isCompleted, setIsCompleted] = useState(milestone?.isCompleted ?? false);
   const [completedAt, setCompletedAt] = useState<string>(
-    milestone?.completedAt ? toDateInputValue(milestone.completedAt) : '',
+    () => (milestone?.completedAt ? toDateInputValue(milestone.completedAt) : ''),
   );
 
   // Work items to link — only used in create mode

--- a/client/src/hooks/usePaperless.ts
+++ b/client/src/hooks/usePaperless.ts
@@ -46,7 +46,7 @@ export function usePaperless(): UsePaperlessResult {
   const [selectedTags, setSelectedTagsState] = useState<number[]>([]);
   const [page, setPageState] = useState(1);
   const [fetchCount, setFetchCount] = useState(0);
-  const [tagCountMap, setTagCountMap] = useState<Map<number, number>>(new Map());
+  const [tagCountMap, setTagCountMap] = useState<Map<number, number>>(() => new Map());
 
   // Phase 1: fetch status on mount
   useEffect(() => {

--- a/client/src/hooks/usePhotos.ts
+++ b/client/src/hooks/usePhotos.ts
@@ -29,7 +29,7 @@ export function usePhotos(entityType: string, entityId: string): UsePhotosResult
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fetchCount, setFetchCount] = useState(0);
-  const [uploadProgress, setUploadProgress] = useState<Map<string, number>>(new Map());
+  const [uploadProgress, setUploadProgress] = useState<Map<string, number>>(() => new Map());
 
   // Fetch photos on mount and when refresh is called
   useEffect(() => {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -299,15 +299,15 @@ export function BudgetSourcesPage() {
   const [deleteError, setDeleteError] = useState<string>('');
 
   // Budget lines expansion state
-  const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
+  const [expandedSources, setExpandedSources] = useState<Set<string>>(() => new Set());
   const [linesCache, setLinesCache] = useState<Map<string, BudgetSourceBudgetLinesResponse>>(
-    new Map(),
+    () => new Map(),
   );
-  const [linesLoading, setLinesLoading] = useState<Set<string>>(new Set());
-  const [linesError, setLinesError] = useState<Map<string, string>>(new Map());
+  const [linesLoading, setLinesLoading] = useState<Set<string>>(() => new Set());
+  const [linesError, setLinesError] = useState<Map<string, string>>(() => new Map());
 
   // Selection state for mass-move
-  const [sourceSelections, setSourceSelections] = useState<Map<string, Set<string>>>(new Map());
+  const [sourceSelections, setSourceSelections] = useState<Map<string, Set<string>>>(() => new Map());
   const [moveModalSourceId, setMoveModalSourceId] = useState<string | null>(null);
 
   // Translation-dependent label maps

--- a/client/src/pages/MilestonesPage/MilestonesPage.tsx
+++ b/client/src/pages/MilestonesPage/MilestonesPage.tsx
@@ -45,14 +45,14 @@ export function MilestonesPage() {
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
 
   // Table state
-  const [tableState, setTableState] = useState<TableState>({
+  const [tableState, setTableState] = useState<TableState>(() => ({
     search: '',
     filters: new Map(),
     sortBy: null,
     sortDir: null,
     page: 1,
     pageSize: 100,
-  });
+  }));
 
   // Load milestones on mount
   useEffect(() => {

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
@@ -99,7 +99,7 @@ export function SubsidyProgramsPage() {
   const { t: tSettings } = useTranslation('settings');
   const { formatCurrency, formatDate } = useFormatters();
   const [programs, setPrograms] = useState<SubsidyProgram[]>([]);
-  const [oversubscribedIds, setOversubscribedIds] = useState<Set<string>>(new Set());
+  const [oversubscribedIds, setOversubscribedIds] = useState<Set<string>>(() => new Set());
   const [allCategories, setAllCategories] = useState<BudgetCategory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>('');

--- a/client/src/pages/UserManagementPage/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage/UserManagementPage.tsx
@@ -83,14 +83,14 @@ export function UserManagementPage() {
   const [activeMenuId, setActiveMenuId] = useState<string | null>(null);
 
   // Table state
-  const [tableState, setTableState] = useState<TableState>({
+  const [tableState, setTableState] = useState<TableState>(() => ({
     search: '',
     filters: new Map(),
     sortBy: null,
     sortDir: null,
     page: 1,
     pageSize: 100,
-  });
+  }));
 
   // Load users on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Wraps non-trivial `useState` initial values in lazy initializer arrow functions. This prevents unnecessary re-computation on every render — the initialization function is only called once (on mount).

## Pattern applied

```tsx
// Before — computed on every render
const [items, setItems] = useState(someFunction());

// After — computed once on mount
const [items, setItems] = useState(() => someFunction());
```

## Files changed (10 pages)
- `BudgetSourcesPage.tsx` (2 changes)
- `MilestonesPage.tsx` (2 changes)
- `SubsidyProgramsPage.tsx` (1 change)
- `UserManagementPage.tsx` (2 changes)
- Additional pages (6 more files, 1-2 changes each)

## Related
- Parent: #1455
- Closes #1465