### PR TITLE
chore(eslint): rename useRef variables to *Ref naming convention (#1467)

### DIFF
--- a/client/src/components/DataTable/DataTableHeader.tsx
+++ b/client/src/components/DataTable/DataTableHeader.tsx
@@ -29,7 +29,7 @@ export function DataTableHeader<T>({
 }: DataTableHeaderProps<T>) {
   const { t } = useTranslation('common');
   const [activeFilterColumn, setActiveFilterColumn] = useState<string | null>(null);
-  const filterTriggerRefs = useRef<Record<string, HTMLButtonElement>>({});
+  const filterTriggerRef = useRef<Record<string, HTMLButtonElement>>({});
 
   // Close filter popover on outside click or Escape
   useEffect(() => {
@@ -92,7 +92,7 @@ export function DataTableHeader<T>({
               {col.filterable && col.filterType && (col.filterParamKey || col.getValue) && (
                 <button
                   ref={(el) => {
-                    if (el) filterTriggerRefs.current[col.key] = el;
+                    if (el) filterTriggerRef.current[col.key] = el;
                   }}
                   type="button"
                   className={`${styles.tableHeaderFilterButton} ${
@@ -125,7 +125,7 @@ export function DataTableHeader<T>({
               col.filterable &&
               col.filterType &&
               (col.filterParamKey || col.getValue) &&
-              filterTriggerRefs.current[col.key] && (
+              filterTriggerRef.current[col.key] && (
                 <DataTableFilterPopover
                   column={col}
                   value={tableState.filters.get(col.filterParamKey || col.key)?.value || ''}
@@ -133,8 +133,8 @@ export function DataTableHeader<T>({
                   onApply={(value) => {
                     onFilter(col.filterParamKey || col.key, value || null);
                   }}
-                  // filterTriggerRefs.current[col.key] is guarded by the && condition above
-                  triggerRect={filterTriggerRefs.current[col.key]!.getBoundingClientRect()}
+                  // filterTriggerRef.current[col.key] is guarded by the && condition above
+                  triggerRect={filterTriggerRef.current[col.key]!.getBoundingClientRect()}
                 />
               )}
           </th>

--- a/client/src/components/DataTable/filters/EnumFilter.tsx
+++ b/client/src/components/DataTable/filters/EnumFilter.tsx
@@ -151,7 +151,7 @@ export function EnumFilter({
   };
 
   // Set indeterminate state on parent checkboxes
-  const parentCheckboxRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const parentCheckboxRef = useRef<Map<string, HTMLInputElement>>(new Map());
 
   return (
     <div className={styles.filterContent}>
@@ -192,10 +192,10 @@ export function EnumFilter({
               <input
                 ref={(el) => {
                   if (el && isParent) {
-                    parentCheckboxRefs.current.set(option.value, el);
+                    parentCheckboxRef.current.set(option.value, el);
                     el.indeterminate = isIndeterminate(option.value);
                   } else if (isParent) {
-                    parentCheckboxRefs.current.delete(option.value);
+                    parentCheckboxRef.current.delete(option.value);
                   }
                 }}
                 type="checkbox"

--- a/client/src/components/GanttChart/GanttChart.tsx
+++ b/client/src/components/GanttChart/GanttChart.tsx
@@ -162,7 +162,7 @@ export function GanttChart({
   const chartScrollRef = useRef<HTMLDivElement>(null);
   const sidebarScrollRef = useRef<HTMLDivElement>(null);
   const headerScrollRef = useRef<HTMLDivElement>(null);
-  const isScrollSyncing = useRef(false);
+  const isScrollSyncingRef = useRef(false);
   const svgRef = useRef<SVGSVGElement>(null);
 
   // CSS color values read from computed styles (updated on theme change)
@@ -1100,13 +1100,13 @@ export function GanttChart({
    * Uses requestAnimationFrame to prevent jank on large datasets.
    */
   const handleChartScroll = useCallback(() => {
-    if (isScrollSyncing.current) return;
+    if (isScrollSyncingRef.current) return;
 
     const chartEl = chartScrollRef.current;
     if (!chartEl) return;
 
     requestAnimationFrame(() => {
-      isScrollSyncing.current = true;
+      isScrollSyncingRef.current = true;
 
       if (sidebarScrollRef.current) {
         sidebarScrollRef.current.scrollTop = chartEl.scrollTop;
@@ -1116,7 +1116,7 @@ export function GanttChart({
         headerScrollRef.current.scrollLeft = chartEl.scrollLeft;
       }
 
-      isScrollSyncing.current = false;
+      isScrollSyncingRef.current = false;
     });
   }, []);
 
@@ -1125,19 +1125,19 @@ export function GanttChart({
    * This is called when the user scrolls the sidebar independently.
    */
   const handleSidebarScroll = useCallback(() => {
-    if (isScrollSyncing.current) return;
+    if (isScrollSyncingRef.current) return;
 
     const sidebarEl = sidebarScrollRef.current;
     if (!sidebarEl) return;
 
     requestAnimationFrame(() => {
-      isScrollSyncing.current = true;
+      isScrollSyncingRef.current = true;
 
       if (chartScrollRef.current) {
         chartScrollRef.current.scrollTop = sidebarEl.scrollTop;
       }
 
-      isScrollSyncing.current = false;
+      isScrollSyncingRef.current = false;
     });
   }, []);
 

--- a/client/src/components/Toast/ToastContext.tsx
+++ b/client/src/components/Toast/ToastContext.tsx
@@ -43,21 +43,21 @@ interface ToastProviderProps {
 
 export function ToastProvider({ children }: ToastProviderProps) {
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const nextId = useRef(0);
-  const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const nextIdRef = useRef(0);
+  const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
 
   const dismissToast = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
-    const timer = timers.current.get(id);
+    const timer = timersRef.current.get(id);
     if (timer !== undefined) {
       clearTimeout(timer);
-      timers.current.delete(id);
+      timersRef.current.delete(id);
     }
   }, []);
 
   const showToast = useCallback(
     (variant: ToastVariant, message: string) => {
-      const id = nextId.current++;
+      const id = nextIdRef.current++;
       const toast: Toast = { id, variant, message };
 
       setToasts((prev) => {
@@ -70,7 +70,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
         dismissToast(id);
       }, DISMISS_DURATION[variant]);
 
-      timers.current.set(id, timer);
+      timersRef.current.set(id, timer);
     },
     [dismissToast],
   );

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.tsx
@@ -85,7 +85,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
   const transformerRef = useRef<Konva.Transformer>(null);
   const inlineInputRef = useRef<HTMLInputElement>(null);
   const liveRegionRef = useRef<HTMLDivElement>(null);
-  const fontSizePerTool = useRef<Partial<Record<ToolName, FontSizeKey>>>({});
+  const fontSizePerToolRef = useRef<Partial<Record<ToolName, FontSizeKey>>>({});
   const shapesNodesRef = useRef<Map<string, Konva.Node>>(new Map());
 
   // Konva image object
@@ -96,7 +96,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
     : `${getBaseUrl()}/photos/${photo.id}/file`;
 
   function getActiveFontSizeKey(): FontSizeKey {
-    return fontSizePerTool.current[state.selectedTool] ?? state.activeFontSizeKey;
+    return fontSizePerToolRef.current[state.selectedTool] ?? state.activeFontSizeKey;
   }
 
   function getActiveFontSizePx(): number {
@@ -818,7 +818,7 @@ export function PhotoAnnotator({ photo, onSave, onCancel }: PhotoAnnotatorProps)
           }
         }}
         onSelectFontSize={(key) => {
-          fontSizePerTool.current[state.selectedTool] = key as FontSizeKey;
+          fontSizePerToolRef.current[state.selectedTool] = key as FontSizeKey;
           dispatch({ type: 'SET_FONT_SIZE', key: key as FontSizeKey });
           if (state.selectedShapeId) {
             const shape = state.shapes.find((s) => s.id === state.selectedShapeId);

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -156,7 +156,7 @@ export function HouseholdItemDetailPage() {
   const [autosaveActualDelivery, setAutosaveActualDelivery] = useState<AutosaveState>('idle');
   const [autosaveEarliestDelivery, setAutosaveEarliestDelivery] = useState<AutosaveState>('idle');
   const [autosaveLatestDelivery, setAutosaveLatestDelivery] = useState<AutosaveState>('idle');
-  const autosaveResetRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const autosaveResetRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   // Shared reload functions for budget-related data
   const reloadBudgetLines = async () => {
@@ -514,8 +514,8 @@ export function HouseholdItemDetailPage() {
   };
 
   function triggerAutosaveReset(setter: (v: AutosaveState) => void, key: string) {
-    if (autosaveResetRefs.current[key]) clearTimeout(autosaveResetRefs.current[key]);
-    autosaveResetRefs.current[key] = setTimeout(() => setter('idle'), 2000);
+    if (autosaveResetRef.current[key]) clearTimeout(autosaveResetRef.current[key]);
+    autosaveResetRef.current[key] = setTimeout(() => setter('idle'), 2000);
   }
 
   const handleOrderDateBlur = async () => {

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -296,13 +296,13 @@ export default function WorkItemDetailPage() {
   const [autosaveActualStart, setAutosaveActualStart] = useState<AutosaveState>('idle');
   const [autosaveActualEnd, setAutosaveActualEnd] = useState<AutosaveState>('idle');
   // Timeouts to auto-reset indicator back to idle after success/error
-  const autosaveResetRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const autosaveResetRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   function triggerAutosaveReset(setter: (v: AutosaveState) => void, key: string) {
-    if (autosaveResetRefs.current[key]) {
-      clearTimeout(autosaveResetRefs.current[key]);
+    if (autosaveResetRef.current[key]) {
+      clearTimeout(autosaveResetRef.current[key]);
     }
-    autosaveResetRefs.current[key] = setTimeout(() => {
+    autosaveResetRef.current[key] = setTimeout(() => {
       setter('idle');
     }, 2000);
   }


### PR DESCRIPTION
## Summary

Fixes all 8 `useRef` variable naming convention violations flagged by `@eslint-react/naming-convention-ref-name`. The rule requires ref variables to end in `Ref`.

Fixes #1467
Part of #1455

## Changes

Pure variable renames — no logic changes whatsoever.

| File | Old name | New name |
|------|----------|----------|
| `PhotoAnnotator.tsx` | `fontSizePerTool` | `fontSizePerToolRef` |
| `GanttChart.tsx` | `isScrollSyncing` | `isScrollSyncingRef` |
| `EnumFilter.tsx` | `parentCheckboxRefs` | `parentCheckboxRef` |
| `DataTableHeader.tsx` | `filterTriggerRefs` | `filterTriggerRef` |
| `ToastContext.tsx` | `nextId` | `nextIdRef` |
| `ToastContext.tsx` | `timers` | `timersRef` |
| `WorkItemDetailPage.tsx` | `autosaveResetRefs` | `autosaveResetRef` |
| `HouseholdItemDetailPage.tsx` | `autosaveResetRefs` | `autosaveResetRef` |

All usages of each renamed variable (e.g. `.current` accesses) were updated in the same file. Local `const timer` variables inside callbacks in `ToastContext.tsx` were correctly left untouched.

## Verification

After renaming, `grep -rn '= useRef' client/src --include='*.tsx' --include='*.ts' | grep -v '.test.' | grep -v 'Ref = useRef'` returns zero results — all refs now conform.