### PR TITLE
chore(eslint): replace array index keys with stable identifiers (#1466)

### DIFF
--- a/client/src/components/GanttChart/GanttChart.tsx
+++ b/client/src/components/GanttChart/GanttChart.tsx
@@ -1599,6 +1599,7 @@ export function GanttChartSkeleton() {
       <div className={styles.sidebarSkeleton}>
         <div className={styles.sidebarSkeletonHeader} style={{ height: HEADER_HEIGHT }} />
         {Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- static skeleton rows, never reorder
           <div key={i} className={styles.sidebarSkeletonRow} style={{ height: ROW_HEIGHT }}>
             <div
               className={`${styles.skeleton} ${styles.skeletonSidebarRow}`}
@@ -1613,6 +1614,7 @@ export function GanttChartSkeleton() {
         <div className={styles.skeletonHeader} style={{ height: HEADER_HEIGHT }} />
         <div className={styles.skeletonCanvas}>
           {Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- static skeleton rows, never reorder
             <div
               key={i}
               className={i % 2 === 0 ? styles.skeletonRowEven : styles.skeletonRowOdd}

--- a/client/src/components/GanttChart/GanttHeader.tsx
+++ b/client/src/components/GanttChart/GanttHeader.tsx
@@ -37,12 +37,12 @@ export const GanttHeader = memo(function GanttHeader({
       aria-hidden="true"
       data-testid="gantt-header"
     >
-      {cells.map((cell, idx) => {
+      {cells.map((cell) => {
         if (zoom === 'day') {
           // Two-row sub-header: weekday above, day number below
           return (
             <div
-              key={idx}
+              key={cell.date.toISOString()}
               className={`${styles.headerCell} ${cell.isToday ? styles.headerCellToday : ''}`}
               style={{ left: cell.x, width: cell.width }}
               aria-label={cell.date.toLocaleDateString(localeString, {
@@ -59,7 +59,7 @@ export const GanttHeader = memo(function GanttHeader({
 
         return (
           <div
-            key={idx}
+            key={cell.date.toISOString()}
             className={`${styles.headerCell} ${cell.isToday ? styles.headerCellToday : ''}`}
             style={{ left: cell.x, width: cell.width }}
           >

--- a/client/src/components/Skeleton/Skeleton.tsx
+++ b/client/src/components/Skeleton/Skeleton.tsx
@@ -33,6 +33,7 @@ export function Skeleton({ lines = 3, widths, loadingLabel, className }: Skeleto
       aria-label={resolvedLabel}
     >
       {lineArray.map((width, i) => (
+        // eslint-disable-next-line @eslint-react/no-array-index-key -- static skeleton lines derived from fixed `lines` prop, never reorder
         <div key={i} className={styles.line} style={{ width }} aria-hidden="true" />
       ))}
     </div>

--- a/client/src/components/calendar/MonthGrid.tsx
+++ b/client/src/components/calendar/MonthGrid.tsx
@@ -113,6 +113,7 @@ export function MonthGrid({
           const fullName = getDayName(i, localeString);
           const narrowName = getDayNameNarrow(i, localeString);
           return (
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- static 7-element weekday header, never reorders
             <div key={i} className={styles.headerCell} role="columnheader" aria-label={fullName}>
               {/* Full name on tablet+, narrow initial on mobile */}
               <span className={styles.dayNameFull}>{fullName}</span>

--- a/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
+++ b/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
@@ -482,7 +482,7 @@ export function DiaryEntryForm({
             {(deliveryMaterials?.length ?? 0) > 0 && (
               <div className={styles.materialsList}>
                 {deliveryMaterials!.map((material, index) => (
-                  <div key={index} className={styles.materialChip}>
+                  <div key={`${material}-${index}`} className={styles.materialChip}>
                     <span>{material}</span>
                     <button
                       type="button"

--- a/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.tsx
+++ b/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.tsx
@@ -94,7 +94,7 @@ export function DiaryMetadataSummary({ entryType, metadata }: DiaryMetadataSumma
             <span className={styles.deliveryLabel}>{t('entryForm.materialsLabel')}</span>
             <div className={styles.materialsList}>
               {m.materials.map((material, idx) => (
-                <span key={idx} className={styles.materialTag}>
+                <span key={`${material}-${idx}`} className={styles.materialTag}>
                   {material}
                 </span>
               ))}

--- a/client/src/components/diary/SignatureSection/SignatureSection.tsx
+++ b/client/src/components/diary/SignatureSection/SignatureSection.tsx
@@ -58,7 +58,7 @@ export function SignatureSection({
       {(signatures?.length ?? 0) > 0 && (
         <div className={styles.signaturesList}>
           {signatures!.map((sig, index) => (
-            <div key={index} className={styles.signatureItem}>
+            <div key={`${sig.signerType}-${sig.signerName}-${index}`} className={styles.signatureItem}>
               <SignatureCapture
                 signature={sig.signatureDataUrl ? sig : null}
                 onSignatureChange={(updated) => {

--- a/client/src/components/documents/DocumentSkeleton.tsx
+++ b/client/src/components/documents/DocumentSkeleton.tsx
@@ -8,6 +8,7 @@ export function DocumentSkeleton({ count = 6 }: DocumentSkeletonProps) {
   return (
     <>
       {Array.from({ length: count }, (_, i) => (
+        // eslint-disable-next-line @eslint-react/no-array-index-key -- static skeleton placeholders, never reorder
         <div key={i} className={styles.skeletonCard} aria-hidden="true">
           <div className={styles.skeletonThumb} />
           <div className={styles.skeletonBody}>

--- a/client/src/components/photos/PhotoGrid.tsx
+++ b/client/src/components/photos/PhotoGrid.tsx
@@ -23,6 +23,7 @@ export function PhotoGrid({
     return (
       <div className={styles.grid} role="list" aria-label="Loading photos">
         {Array.from({ length: 6 }).map((_, i) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- static skeleton placeholders, never reorder
           <div key={i} className={`${styles.card} ${styles.skeleton}`} role="listitem" />
         ))}
       </div>

--- a/client/src/components/photos/PhotoUpload.tsx
+++ b/client/src/components/photos/PhotoUpload.tsx
@@ -219,8 +219,8 @@ export function PhotoUpload({
       {/* Photo queue with per-photo state */}
       {photoQueue.length > 0 && (
         <div className={styles.queueContainer} aria-label={t('photoUpload.queueAriaLabel')}>
-          {photoQueue.map((entry, index) => (
-            <div key={index} className={`${styles.queueItem} ${styles[`state-${entry.state}`]}`}>
+          {photoQueue.map((entry) => (
+            <div key={`${entry.file.name}-${entry.file.size}-${entry.file.lastModified}`} className={`${styles.queueItem} ${styles[`state-${entry.state}`]}`}>
               <div className={styles.queueItemHeader}>
                 <span className={styles.queueItemName}>{entry.file.name}</span>
                 <span className={styles.queueItemState}>

--- a/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
+++ b/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
@@ -238,7 +238,7 @@ export default function DiaryEntryDetailPage() {
             entry.entryType === 'issue') &&
           Array.isArray((entry.metadata as { signatures?: DiarySignatureEntry[] }).signatures) &&
           (entry.metadata as { signatures: DiarySignatureEntry[] }).signatures.map((sig, i) => (
-            <div key={i} className={styles.signatureSection}>
+            <div key={`${sig.signerType}-${sig.signerName}-${i}`} className={styles.signatureSection}>
               <SignatureDisplay
                 signatureDataUrl={sig.signatureDataUrl}
                 signerName={sig.signerName}


### PR DESCRIPTION
## Summary

Fixes #1466 | Part of #1455

Resolves all `@eslint-react/no-array-index-key` warnings (~13 occurrences across 11 files) by replacing `key={index}`/`key={i}`/`key={idx}` with stable, semantically meaningful identifiers.

## Fix Strategy

### Stable ID from data
| File | Old Key | New Key |
|------|---------|---------|
| `GanttHeader.tsx` | `idx` | `cell.date.toISOString()` — each cell represents a unique date period |
| `PhotoUpload.tsx` | `index` | `${entry.file.name}-${entry.file.size}-${entry.file.lastModified}` — uniquely identifies the queued file |
| `DiaryMetadataSummary.tsx` | `idx` | `${material}-${idx}` — compound (allows duplicate material names) |
| `DiaryEntryForm.tsx` | `index` | `${material}-${index}` — compound (allows duplicate material names) |
| `SignatureSection.tsx` | `index` | `${sig.signerType}-${sig.signerName}-${index}` — compound (signer identity + positional tiebreak) |
| `DiaryEntryDetailPage.tsx` | `i` | `${sig.signerType}-${sig.signerName}-${i}` — same pattern as above |

### Acceptable exception (eslint-disable with comment)
These are truly static lists that are never reordered, inserted into, or deleted from at runtime:
| File | Reason |
|------|--------|
| `MonthGrid.tsx` | Fixed 7-element weekday header `[0,1,2,3,4,5,6]`, never changes |
| `PhotoGrid.tsx` | 6 fixed skeleton placeholder divs (loading shimmer) |
| `DocumentSkeleton.tsx` | Fixed skeleton placeholders, count is a constant prop |
| `Skeleton.tsx` | Line widths derived from the static `lines` prop — array never mutates |
| `GanttChart.tsx` (×2) | `SKELETON_ROW_COUNT` constant skeleton rows in `GanttChartSkeleton` |

Each suppression includes an inline explanatory comment.

## Files Changed
- `client/src/components/calendar/MonthGrid.tsx`
- `client/src/components/photos/PhotoUpload.tsx`
- `client/src/components/photos/PhotoGrid.tsx`
- `client/src/components/documents/DocumentSkeleton.tsx`
- `client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.tsx`
- `client/src/components/diary/SignatureSection/SignatureSection.tsx`
- `client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx`
- `client/src/components/Skeleton/Skeleton.tsx`
- `client/src/components/GanttChart/GanttChart.tsx`
- `client/src/components/GanttChart/GanttHeader.tsx`
- `client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx`