### PR TITLE
chore(eslint): fix miscellaneous @eslint-react structural errors (#1462)

### DIFF
--- a/client/src/components/calendar/CalendarView.tsx
+++ b/client/src/components/calendar/CalendarView.tsx
@@ -131,14 +131,21 @@ const TOOLTIP_HIDE_DELAY = 80;
 const TOOLTIP_ID = 'calendar-view-tooltip';
 
 // ---------------------------------------------------------------------------
+// Stable empty-array defaults (avoids unstable reference on every render)
+// ---------------------------------------------------------------------------
+
+const EMPTY_HOUSEHOLD_ITEMS: TimelineHouseholdItem[] = [];
+const EMPTY_DEPENDENCIES: TimelineDependency[] = [];
+
+// ---------------------------------------------------------------------------
 // CalendarView component
 // ---------------------------------------------------------------------------
 
 export function CalendarView({
   workItems,
   milestones,
-  householdItems = [],
-  dependencies = [],
+  householdItems = EMPTY_HOUSEHOLD_ITEMS,
+  dependencies = EMPTY_DEPENDENCIES,
   onMilestoneClick,
 }: CalendarViewProps) {
   const { t } = useTranslation('schedule');

--- a/client/src/components/calendar/MonthGrid.tsx
+++ b/client/src/components/calendar/MonthGrid.tsx
@@ -63,6 +63,12 @@ export interface MonthGridProps {
 }
 
 // ---------------------------------------------------------------------------
+// Stable empty-array default (avoids unstable reference on every render)
+// ---------------------------------------------------------------------------
+
+const EMPTY_HOUSEHOLD_ITEMS: TimelineHouseholdItem[] = [];
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -71,7 +77,7 @@ export function MonthGrid({
   month,
   workItems,
   milestones,
-  householdItems = [],
+  householdItems = EMPTY_HOUSEHOLD_ITEMS,
   onMilestoneClick,
   hoveredItemId = null,
   onItemMouseEnter,

--- a/client/src/components/calendar/WeekGrid.tsx
+++ b/client/src/components/calendar/WeekGrid.tsx
@@ -63,6 +63,12 @@ export interface WeekGridProps {
 }
 
 // ---------------------------------------------------------------------------
+// Stable empty-array default (avoids unstable reference on every render)
+// ---------------------------------------------------------------------------
+
+const EMPTY_HOUSEHOLD_ITEMS: TimelineHouseholdItem[] = [];
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -70,7 +76,7 @@ export function WeekGrid({
   weekDate,
   workItems,
   milestones,
-  householdItems = [],
+  householdItems = EMPTY_HOUSEHOLD_ITEMS,
   onMilestoneClick,
   hoveredItemId = null,
   onItemMouseEnter,

--- a/client/src/components/documents/DocumentBrowser.tsx
+++ b/client/src/components/documents/DocumentBrowser.tsx
@@ -17,10 +17,13 @@ interface DocumentBrowserProps {
 
 const GRID_ID = 'document-grid';
 
+// Stable empty-array default (avoids unstable reference on every render)
+const EMPTY_LINKED_DOCUMENT_IDS: number[] = [];
+
 export function DocumentBrowser({
   mode = 'page',
   onSelect,
-  linkedDocumentIds = [],
+  linkedDocumentIds = EMPTY_LINKED_DOCUMENT_IDS,
 }: DocumentBrowserProps) {
   const { t } = useTranslation('documents');
   const hook = usePaperless();

--- a/client/src/components/milestones/MilestoneWorkItemLinker.tsx
+++ b/client/src/components/milestones/MilestoneWorkItemLinker.tsx
@@ -25,6 +25,12 @@ interface MilestoneWorkItemLinkerProps {
 }
 
 // ---------------------------------------------------------------------------
+// Stable empty-array default (avoids unstable reference on every render)
+// ---------------------------------------------------------------------------
+
+const EMPTY_DEPENDENT_WORK_ITEMS: WorkItemDependentSummary[] = [];
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -40,7 +46,7 @@ interface MilestoneWorkItemLinkerProps {
 export function MilestoneWorkItemLinker({
   milestoneId: _milestoneId,
   linkedWorkItems,
-  dependentWorkItems = [],
+  dependentWorkItems = EMPTY_DEPENDENT_WORK_ITEMS,
   isLinking,
   onLink,
   onUnlink,

--- a/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
+++ b/client/src/pages/HouseholdItemDetailPage/HouseholdItemDetailPage.tsx
@@ -62,6 +62,20 @@ import { AreaPicker } from '../../components/AreaPicker/AreaPicker.js';
 import { AreaBreadcrumb } from '../../components/AreaBreadcrumb/index.js';
 import styles from './HouseholdItemDetailPage.module.css';
 
+function MilestoneIconSvg() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 10 10"
+      width="10"
+      height="10"
+      aria-hidden="true"
+    >
+      <polygon points="5,0 10,5 5,10 0,5" fill="currentColor" />
+    </svg>
+  );
+}
+
 const HI_STATUS_VARIANTS = {
   planned: { label: 'Planned', className: badgeStyles.planned! },
   purchased: { label: 'Purchased', className: badgeStyles.purchased! },
@@ -735,20 +749,6 @@ export function HouseholdItemDetailPage() {
       setIsDeleting(false);
     }
   };
-
-  function MilestoneIconSvg() {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 10 10"
-        width="10"
-        height="10"
-        aria-hidden="true"
-      >
-        <polygon points="5,0 10,5 5,10 0,5" fill="currentColor" />
-      </svg>
-    );
-  }
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

Fixes #1462 | Part of #1455

Resolves ~7 @eslint-react violations across 6 production components.

## Changes

### `@eslint-react/no-nested-components`
- **`HouseholdItemDetailPage.tsx`**: Lifted `MilestoneIconSvg` from inside the render scope of `HouseholdItemDetailPage` to module scope. It requires no props, so the lift is clean and zero-risk.

### `@eslint-react/no-unstable-default-props`
Replaced all `= []` inline array literal default props with stable module-level `const` arrays. Each creates a single reference shared across all renders:

| File | Prop | Constant |
|------|------|----------|
| `CalendarView.tsx` | `householdItems` | `EMPTY_HOUSEHOLD_ITEMS` |
| `CalendarView.tsx` | `dependencies` | `EMPTY_DEPENDENCIES` |
| `MonthGrid.tsx` | `householdItems` | `EMPTY_HOUSEHOLD_ITEMS` |
| `WeekGrid.tsx` | `householdItems` | `EMPTY_HOUSEHOLD_ITEMS` |
| `DocumentBrowser.tsx` | `linkedDocumentIds` | `EMPTY_LINKED_DOCUMENT_IDS` |
| `MilestoneWorkItemLinker.tsx` | `dependentWorkItems` | `EMPTY_DEPENDENT_WORK_ITEMS` |

### `@eslint-react/no-direct-mutation-state` / `@eslint-react/no-access-state-in-setstate`
Not applicable — the codebase uses functional components with hooks throughout. No class components found.

## No Behavioral Changes
These are purely structural refactors. The runtime behavior is identical — stable references actually improve memoization performance (e.g., `useMemo` dependencies that include these arrays won't fire unnecessarily).