### PR TITLE
chore(eslint): add cleanup for setTimeout/setInterval/addEventListener in useEffect (#1468)

### DIFF
--- a/client/src/components/documents/LinkedDocumentsSection.tsx
+++ b/client/src/components/documents/LinkedDocumentsSection.tsx
@@ -123,18 +123,20 @@ export function LinkedDocumentsSection({ entityType, entityId }: LinkedDocuments
   useEffect(() => {
     if (showPicker) {
       void systemLinkedIds.fetch();
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         pickerModalRef.current?.focus();
       }, 0);
+      return () => clearTimeout(timer);
     }
   }, [showPicker, systemLinkedIds.fetch]);
 
   // Focus Cancel button when unlink confirmation opens
   useEffect(() => {
     if (unlinkTarget && cancelButtonRef.current) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         cancelButtonRef.current?.focus();
       }, 0);
+      return () => clearTimeout(timer);
     }
   }, [unlinkTarget]);
 


### PR DESCRIPTION
## Summary

Fixes `@eslint-react/web-api-no-leaked-timeout` warnings by adding proper cleanup in all `useEffect` hooks that create `setTimeout` calls without returning a cleanup function.

## Changes

### `client/src/components/documents/LinkedDocumentsSection.tsx`
- **Focus picker modal on open** (`showPicker` effect): Capture the `setTimeout` return value and `clearTimeout` it in the cleanup
- **Focus Cancel button on unlink dialog open** (`unlinkTarget` effect): Same pattern

### `client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx`
- **Focus picker modal on open** (`showPicker` effect): Same pattern as above
- **Focus description field when create form opens** (`pickerState.showCreateForm` effect): Same pattern

## Investigation Notes

I audited every `setTimeout`, `setInterval`, `addEventListener` call in the codebase that appeared inside a `useEffect`. The vast majority were already correctly cleaned up:

- **`setTimeout` in event handlers / callbacks** (not in `useEffect`) — not flagged by the rule, already safe
- **Debounce refs** (`SearchPicker`, `WorkItemSelector`, `BudgetOverviewPage`, etc.) — all have a dedicated unmount `useEffect` that calls `clearTimeout`
- **`addEventListener` calls** — all 20+ instances already return a corresponding `removeEventListener` cleanup

The 4 genuine violations were all zero-delay focus management `setTimeout`s (`delay: 0`) used to defer focus into newly-rendered modal/picker elements. These are a well-known React pattern but need the cleanup return to avoid the rule warning and to be technically correct (the timer would fire even if the component unmounts before the next microtask tick).

Fixes #1468
Part of #1455