### PR TITLE
docs(server/services): document better-sqlite3 12.10.0 percentile adoption opportunity (#1571)

### DIFF
--- a/server/src/services/budgetBreakdownService.ts
+++ b/server/src/services/budgetBreakdownService.ts
@@ -60,10 +60,12 @@ export function getBudgetBreakdown(
   //     GROUP BY wi.area_id
   //
   //   P90 invoice amount per budget category (flagging unusually large invoices):
-  //     SELECT budget_category_id,
-  //            percentile_disc(0.9) WITHIN GROUP (ORDER BY itemized_amount) AS p90_amount
-  //     FROM invoice_budget_lines
-  //     GROUP BY budget_category_id
+  //     SELECT wib.budget_category_id,
+  //            percentile_disc(0.9) WITHIN GROUP (ORDER BY ibl.itemized_amount) AS p90_amount
+  //     FROM invoice_budget_lines ibl
+  //     JOIN work_item_budgets wib ON wib.id = ibl.work_item_budget_id
+  //     WHERE ibl.work_item_budget_id IS NOT NULL
+  //     GROUP BY wib.budget_category_id
   //
   // These are NOT currently implemented (no caller exists). Filed for visibility
   // per issue #1571 (better-sqlite3 12.10.0 library adoption).

--- a/server/src/services/budgetBreakdownService.ts
+++ b/server/src/services/budgetBreakdownService.ts
@@ -47,6 +47,27 @@ export function getBudgetBreakdown(
   db: DbType,
   deselectedSources: Set<string> = new Set(),
 ): BudgetBreakdown {
+  // ─── Library Adoption Opportunity: SQLite percentile functions ────────────
+  //
+  // See budgetOverviewService.ts for full details. In the breakdown context,
+  // percentile functions could power:
+  //
+  //   Median cost per area (for heatmap or outlier badges):
+  //     SELECT area_id,
+  //            percentile_cont(0.5) WITHIN GROUP (ORDER BY planned_amount) AS median_planned
+  //     FROM work_item_budgets wib
+  //     JOIN work_items wi ON wi.id = wib.work_item_id
+  //     GROUP BY wi.area_id
+  //
+  //   P90 invoice amount per budget category (flagging unusually large invoices):
+  //     SELECT budget_category_id,
+  //            percentile_disc(0.9) WITHIN GROUP (ORDER BY itemized_amount) AS p90_amount
+  //     FROM invoice_budget_lines
+  //     GROUP BY budget_category_id
+  //
+  // These are NOT currently implemented (no caller exists). Filed for visibility
+  // per issue #1571 (better-sqlite3 12.10.0 library adoption).
+  // ─────────────────────────────────────────────────────────────────────────
   // ── 1. Query A: Work item budget lines with area assignment ──────────────
   const workItemLineRows = db.all<{
     workItemId: string;

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -36,6 +36,44 @@ type DbType = BetterSQLite3Database<typeof schemaTypes>;
  *   Actual Paid     = SUM(invoice_budget_lines.itemized_amount WHERE work_item_budget_id IS NOT NULL AND invoices.status IN ('paid', 'claimed'))
  */
 export function getBudgetOverview(db: DbType): BudgetOverview {
+  // ─── Library Adoption Opportunity: SQLite percentile functions ────────────
+  //
+  // better-sqlite3 12.10.0 (PR #1527) ships SQLite 3.53.1, which exposes
+  // native aggregate functions:
+  //
+  //   percentile_cont(0.5) WITHIN GROUP (ORDER BY column)  -- interpolated median
+  //   percentile_disc(0.75) WITHIN GROUP (ORDER BY column) -- discrete P75 (actual sample)
+  //
+  // No extension loading is required; these are builtins in SQLite ≥ 3.53.
+  //
+  // Future analytics that would benefit from these:
+  //
+  //   Median planned_amount across all budget lines:
+  //     SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY planned_amount)
+  //     FROM work_item_budgets WHERE work_item_id IS NOT NULL
+  //
+  //   75th-percentile invoice amount (useful for outlier detection):
+  //     SELECT percentile_disc(0.75) WITHIN GROUP (ORDER BY amount)
+  //     FROM invoices WHERE status != 'cancelled'
+  //
+  //   Median work-item duration (days) for project timeline insights:
+  //     SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_days)
+  //     FROM work_items WHERE duration_days IS NOT NULL
+  //
+  // Edge cases to remember when implementing:
+  //   - Both functions return NULL for an empty (or all-NULL) input set.
+  //     Always COALESCE(percentile_cont(...), 0) or handle NULL in the caller.
+  //   - percentile_cont interpolates between values (may produce non-integer
+  //     results for integer columns). percentile_disc always returns an actual
+  //     value from the dataset.
+  //   - The WITHIN GROUP clause is required; the argument N must be a literal
+  //     float constant in [0, 1].
+  //
+  // When implementing: use db.get<{ value: number | null }>(sql`SELECT
+  //   COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY planned_amount), 0)
+  //   AS value FROM work_item_budgets WHERE work_item_id IS NOT NULL`)
+  // and surface the result as a new field on the BudgetOverview type.
+  // ─────────────────────────────────────────────────────────────────────────
   // ── 1. Available funds from active budget sources ──────────────────────────
   const sourcesRow = db.get<{ availableFunds: number | null; sourceCount: number }>(
     sql`SELECT

--- a/server/src/services/budgetOverviewService.ts
+++ b/server/src/services/budgetOverviewService.ts
@@ -54,7 +54,7 @@ export function getBudgetOverview(db: DbType): BudgetOverview {
   //
   //   75th-percentile invoice amount (useful for outlier detection):
   //     SELECT percentile_disc(0.75) WITHIN GROUP (ORDER BY amount)
-  //     FROM invoices WHERE status != 'cancelled'
+  //     FROM invoices WHERE status IN ('pending', 'paid', 'claimed')
   //
   //   Median work-item duration (days) for project timeline insights:
   //     SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_days)


### PR DESCRIPTION
## Summary

Documents the `percentile_cont` / `percentile_disc` SQLite window functions enabled by the better-sqlite3 12.10.0 bump (#1527), so future engineers know these functions are available without a re-upgrade.

Closes #1571

## Outcome

Pure documentation — **no behaviour change**. An audit of the JS/TS codebase found zero existing percentile/median/quartile callsites. Comment blocks were added to the two most-likely future homes for such logic, per acceptance criterion 3 of the issue.

## Files Changed

- `server/src/services/budgetOverviewService.ts` — added documentation comment block explaining `percentile_cont` / `percentile_disc` usage, concrete SQL examples, and NULL-handling guidance
- `server/src/services/budgetBreakdownService.ts` — same documentation comment block

## Related

- Closes #1571
- References merged bump PR #1527

## Contributing Agents

- **backend-developer** — commits `b8b88ee` (initial docs), `7a5b3b9` (review fixup: SQL example corrections)
- **dev-team-lead** — spec generation and code review

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>