### PR TITLE
refactor(invoice): align handleAddSelectedLines to use loadBudgetLines() (#1627)

### DIFF
--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.test.tsx
@@ -1112,6 +1112,12 @@ describe('InvoiceBudgetLinesSection', () => {
       });
       mockCreateInvoiceBudgetLine.mockResolvedValue(makeCreateResponse(linkedLine, 1100.0));
 
+      // Override with two sequential returns: one for mount, one for post-add refresh.
+      // This makes toHaveBeenCalledTimes(2) deterministic regardless of beforeEach default.
+      mockFetchInvoiceBudgetLines
+        .mockResolvedValueOnce(makeListResponse([], INVOICE_TOTAL))
+        .mockResolvedValueOnce(makeListResponse([linkedLine], 1100.0));
+
       renderSection(INVOICE_ID, INVOICE_TOTAL);
 
       await waitFor(() =>
@@ -1144,6 +1150,7 @@ describe('InvoiceBudgetLinesSection', () => {
         fireEvent.click(screen.getByRole('button', { name: /Add Selected Lines/i }));
       });
 
+      // createInvoiceBudgetLine called with the correct payload
       await waitFor(() =>
         expect(mockCreateInvoiceBudgetLine).toHaveBeenCalledWith(
           INVOICE_ID,
@@ -1156,6 +1163,79 @@ describe('InvoiceBudgetLinesSection', () => {
 
       // createWorkItemBudget was NOT called (existing line path)
       expect(mockCreateWorkItemBudget).not.toHaveBeenCalled();
+
+      // fetchInvoiceBudgetLines called twice: once on mount, once after the add operation
+      await waitFor(() =>
+        expect(mockFetchInvoiceBudgetLines).toHaveBeenCalledTimes(2),
+      );
+
+      // Picker is closed after a successful add (dialog no longer in DOM)
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    it('error path — createInvoiceBudgetLine BUDGET_LINE_ALREADY_LINKED: refreshes list and keeps picker open with error', async () => {
+      const existingLine = makeBudgetLineStub('wib-already-linked-001', 300);
+      mockFetchWorkItemBudgets.mockResolvedValue([existingLine]);
+
+      // Override fetchInvoiceBudgetLines: mount call + post-error refresh call
+      mockFetchInvoiceBudgetLines
+        .mockResolvedValueOnce(makeListResponse([], INVOICE_TOTAL))
+        .mockResolvedValueOnce(makeListResponse([], INVOICE_TOTAL));
+
+      // Configure the create call to fail with BUDGET_LINE_ALREADY_LINKED
+      mockCreateInvoiceBudgetLine.mockRejectedValue(
+        new MockApiClientError(409, { code: 'BUDGET_LINE_ALREADY_LINKED' }),
+      );
+
+      renderSection(INVOICE_ID, INVOICE_TOTAL);
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /\+ Add Budget Line/i })).not.toBeDisabled(),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /\+ Add Budget Line/i }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('work-item-picker'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Add Selected Lines/i })).toBeInTheDocument(),
+      );
+
+      // Select the checkbox and set an itemized amount
+      const checkbox = screen.getByRole('checkbox');
+      await act(async () => {
+        fireEvent.click(checkbox);
+      });
+
+      const amountInput = screen.getByRole('spinbutton', {
+        name: /Itemized amount for/i,
+      });
+      fireEvent.change(amountInput, { target: { value: '300' } });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Add Selected Lines/i }));
+      });
+
+      // fetchInvoiceBudgetLines called twice: once on mount, once after the error
+      await waitFor(() =>
+        expect(mockFetchInvoiceBudgetLines).toHaveBeenCalledTimes(2),
+      );
+
+      // Picker stays open (dialog remains in the DOM)
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      // Picker error shows the localized alreadyLinked message
+      await waitFor(() =>
+        expect(
+          screen.getByText('This budget line is already linked to another invoice.'),
+        ).toBeInTheDocument(),
+      );
+
+      // Focus was NOT moved to the new line row (setTimeout block only runs on success path)
+      // Verified implicitly: the dialog is still open so closePicker was never called
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
@@ -222,11 +222,7 @@ export function InvoiceBudgetLinesSection({
           itemizedAmount: amount,
         };
 
-        const response = await createInvoiceBudgetLine(invoiceId, createData);
-
-        // Update state with new line and remaining amount
-        setBudgetLines((prev) => [...prev, response.budgetLine]);
-        setRemainingAmount(response.remainingAmount);
+        await createInvoiceBudgetLine(invoiceId, createData);
       } catch (err) {
         let errorMsg = t('invoiceDetail.budgetLines.picker.error.linkFailed');
 
@@ -244,6 +240,7 @@ export function InvoiceBudgetLinesSection({
           ...picker.pickerState,
           error: errorMsg,
         });
+        await loadBudgetLines();
         return;
       }
     }
@@ -251,6 +248,7 @@ export function InvoiceBudgetLinesSection({
     // Clear selection and close picker on success
     setSelectedLineIds(new Set());
     setItemizedAmounts({});
+    await loadBudgetLines();
     picker.closePicker();
 
     // Focus the newly added row after a short delay


### PR DESCRIPTION
## Summary

Refactors `handleAddSelectedLines` to replace per-iteration optimistic state mutations with a server-authoritative `loadBudgetLines()` call on both the success and error paths, aligning the select-existing-line flow with the create-new-line pattern introduced in PR #1617; tests updated to assert server-refresh call count and error/success UX behaviour.

## Scope Clarification

The issue title references `handleSelectBudgetLine`, which was the function name at the time of filing. This function was renamed to `handleAddSelectedLines` during the PR #1617 / #1610-era restructure. This PR addresses the correct current function — see [the orchestrator scope clarification comment](https://github.com/steilerDev/cornerstone/issues/1627#issuecomment-4582237440) for details.

## Test Results

- **InvoiceBudgetLinesSection.test.tsx**: 55/55 tests pass ✅

## Contributors

- `frontend-developer` — commit `dba2c62`: production refactor of `handleAddSelectedLines`
- `qa-integration-tester` — commit `223766d`: test updates asserting `loadBudgetLines` call count and UX behaviour

## Review Notes

- VERDICT: APPROVED by dev-team-lead
- Q3 error-path ordering: implementation reversed spec's order (error UX shown before reload) — functionally equivalent and slightly better UX; acceptable deviation
- Full spec compliance on all other paths

Closes #1627

---
Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>