### PR TITLE
chore(deps): ical-generator v11 compatibility verified (#1656)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,19 +11,19 @@
   },
   "dependencies": {
     "@cornerstone/shared": "*",
-    "i18next": "26.2.0",
+    "i18next": "26.3.1",
     "konva": "10.3.0",
-    "react": "19.2.6",
-    "react-dom": "19.2.6",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
     "react-konva": "19.2.4",
-    "react-router-dom": "7.15.1"
+    "react-router-dom": "7.17.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@babel/preset-react": "7.29.7",
     "@babel/preset-typescript": "7.29.7",
-    "@types/react": "19.2.14",
+    "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "babel-loader": "10.1.1",
     "copy-webpack-plugin": "14.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "3.1.1",
     "prism-react-renderer": "2.4.1",
-    "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,19 +45,19 @@
       "version": "0.1.0",
       "dependencies": {
         "@cornerstone/shared": "*",
-        "i18next": "26.2.0",
+        "i18next": "26.3.1",
         "konva": "10.3.0",
-        "react": "19.2.6",
-        "react-dom": "19.2.6",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
         "react-i18next": "17.0.8",
         "react-konva": "19.2.4",
-        "react-router-dom": "7.15.1"
+        "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/preset-react": "7.29.7",
         "@babel/preset-typescript": "7.29.7",
-        "@types/react": "19.2.14",
+        "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "babel-loader": "10.1.1",
         "copy-webpack-plugin": "14.0.0",
@@ -261,6 +261,37 @@
         "node": ">=6.9.0"
       }
     },
+    "client/node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "client/node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "client/node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
     "client/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -279,8 +310,32 @@
         "@docusaurus/preset-classic": "3.10.1",
         "@mdx-js/react": "3.1.1",
         "prism-react-renderer": "2.4.1",
-        "react": "19.2.6",
-        "react-dom": "19.2.6"
+        "react": "19.2.7",
+        "react-dom": "19.2.7"
+      }
+    },
+    "docs/node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "docs/node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "e2e": {
@@ -289,7 +344,7 @@
       "devDependencies": {
         "@playwright/test": "1.60.0",
         "@types/node": "25.9.1",
-        "testcontainers": "^12.0.1"
+        "testcontainers": "12.0.1"
       }
     },
     "e2e/node_modules/@types/node": {
@@ -19483,9 +19538,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
-      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
       "funding": [
         {
           "type": "individual",
@@ -19511,12 +19566,12 @@
       }
     },
     "node_modules/ical-generator": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-10.2.0.tgz",
-      "integrity": "sha512-XR5FsiDWCsz5MwBwMA/sQqR3A9H240xkXIeXOabV7uNAiieP+TA9rleVvlwPLRXMz+CXME8cGuDd7cdnE5At6w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-11.0.0.tgz",
+      "integrity": "sha512-OScZbXduIbjqtJzq0WLyPpAuKnc106+l28wszD+Wi2O9jXn76NVBfr4Ksv2XFyQn4JNZ9vWr5xAac0uT/FhVag==",
       "license": "MIT",
       "engines": {
-        "node": "20 || 22 || >=24"
+        "node": "22 || >=24.0.0"
       },
       "peerDependencies": {
         "@touch4it/ical-timezones": ">=1.6.0",
@@ -30081,6 +30136,8 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30089,6 +30146,8 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -30297,12 +30356,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -30313,9 +30372,9 @@
       }
     },
     "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -33690,9 +33749,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -36311,11 +36370,11 @@
         "drizzle-orm": "0.45.2",
         "fastify": "5.8.5",
         "fastify-plugin": "5.1.0",
-        "ical-generator": "10.2.0",
+        "ical-generator": "11.0.0",
         "node-cron": "4.2.1",
         "openid-client": "6.8.4",
         "sharp": "0.34.5",
-        "tar": "^7.5.15",
+        "tar": "^7.5.16",
         "vcard-creator": "1.0.0"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,11 +23,11 @@
     "drizzle-orm": "0.45.2",
     "fastify": "5.8.5",
     "fastify-plugin": "5.1.0",
-    "ical-generator": "10.2.0",
+    "ical-generator": "11.0.0",
     "node-cron": "4.2.1",
     "openid-client": "6.8.4",
     "sharp": "0.34.5",
-    "tar": "^7.5.15",
+    "tar": "^7.5.16",
     "vcard-creator": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Verified compatibility with ical-generator v11 from Dependabot PR #1656.

## Summary

- Tested ical-generator v11 API against calendarIcal.ts implementation
- Confirmed 'id' property still works in ICalEventData constructor
- Confirmed createEvent() and toString() methods are compatible
- All other dependency updates (tar, i18next, react, react-router-dom) are compatible

## Test Coverage

Manual testing confirms:
- Event creation with id, summary, start, end, allDay, description, url all work correctly
- Calendar toString() generates valid iCalendar output
- No breaking API changes affect the current usage pattern

No code changes required — the Dependabot PR #1656 is ready as-is.