### PR TITLE
fix(e2e): avoid WebKit double-toggle on nested checkbox in budget-source-move (#1575)

### DIFF
--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -570,6 +570,16 @@ export class BudgetSourcesPage {
   }
 
   /**
+   * Click the "I understand" label text to toggle the understood checkbox.
+   * Must NOT use .check() on the input — nested checkbox inputs in labels
+   * double-fire on mobile WebKit (click input → toggle, then synthetic label
+   * click → toggle back). Clicking the label span fires only one toggle.
+   */
+  async clickMoveModalUnderstoodLabel(): Promise<void> {
+    await this.moveModal.locator('[class*="understoodLabel"]').click();
+  }
+
+  /**
    * The FormError banner inside the move modal (shown on API error).
    * FormError renders a div with the CSS module class "banner" and role="alert".
    * Differentiated from the claimed-invoice warning block via the CSS class name.

--- a/e2e/tests/budget/budget-source-move.spec.ts
+++ b/e2e/tests/budget/budget-source-move.spec.ts
@@ -553,10 +553,16 @@ test.describe('Claimed invoice warning gates confirm button', { tag: '@responsiv
       // Confirm button must be disabled (understood not checked)
       await expect(sourcesPage.moveModalConfirmButton).toBeDisabled();
 
-      // Check "I understand"
+      // Check "I understand" — click the label text (NOT .check() on the input) to
+      // avoid the mobile WebKit double-toggle bug where nested checkbox inputs fire
+      // two click events (once on input, once via synthetic label propagation).
       const understoodCheckbox = sourcesPage.moveModalUnderstoodCheckbox;
       await understoodCheckbox.waitFor({ state: 'visible' });
-      await understoodCheckbox.check();
+      await sourcesPage.clickMoveModalUnderstoodLabel();
+
+      // Verify the checkbox DOM state is checked before asserting button state
+      // (ensures React onChange has propagated before the next assertion)
+      await expect(understoodCheckbox).toBeChecked();
 
       // Confirm button must now be enabled
       await expect(sourcesPage.moveModalConfirmButton).toBeEnabled();


### PR DESCRIPTION
Fixes the mobile-only flake in Scenario 5 of budget-source-move.spec.ts that
blocks the beta→main promotion PR #1658.

Root cause: mobile WebKit fires two click events when .check() is called on a
checkbox input nested inside a <label>. This double-toggles the checkbox,
leaving it unchecked, so the confirm button stays disabled.

Fix: click the label text (not the input) to fire exactly one toggle.
Also adds an intermediate toBeChecked() assertion so the button assertion
only runs after React has re-rendered with understood=true.

Closes #1575