### PR TITLE
fix(e2e): make multi-deselection refetchB predicate specific to SOURCE_B_ID

### DIFF
--- a/e2e/tests/budget/budget-source-filter.spec.ts
+++ b/e2e/tests/budget/budget-source-filter.spec.ts
@@ -1020,10 +1020,15 @@ test.describe('Deselect triggers server refetch', { tag: '@responsive' }, () => 
       await expect(overviewPage.sourceRow('Bank Loan')).toHaveAttribute('aria-pressed', 'false');
       await refetchA;
 
-      // Deselect Equity — new refetch should include both IDs
+      // Deselect Equity — new refetch must include BOTH source IDs.
+      // The predicate requires SOURCE_B_ID to prevent refetchB from accidentally
+      // resolving on a spurious SOURCE_A_ID-only re-request that the component might
+      // emit between refetchA resolving and the Equity click being processed.
       const refetchB = page.waitForResponse(
         (resp) =>
-          resp.url().includes('/api/budget/breakdown') && resp.url().includes('deselectedSources='),
+          resp.url().includes('/api/budget/breakdown') &&
+          resp.url().includes('deselectedSources=') &&
+          resp.url().includes(SOURCE_B_ID),
       );
       await overviewPage.sourceRow('Equity').click();
       // aria-pressed for Equity updates from URL state before server response


### PR DESCRIPTION
## Summary

- Tightens the `refetchB` predicate in the 'Multi-deselection: both IDs appear in URL' test to also require `SOURCE_B_ID` in the URL
- Prevents `refetchB` from accidentally resolving on a spurious SOURCE_A_ID-only request that the component might emit between `refetchA` resolving and the Equity click being processed
- This is a follow-up to PR #1666 (Perspective toggle stale-read fix)

## Root Cause

After `refetchA` resolves (Bank Loan deselect response received), the component begins re-rendering. During this brief window before the Equity click, `refetchB` was registered with a predicate that only checked for `deselectedSources=`. If the component emitted a spurious second request with only SOURCE_A_ID during the re-render cycle, `refetchB` would resolve on that spurious request, and the assertion `expect(responseB.url()).toContain(SOURCE_B_ID)` would fail intermittently.

## Test plan

- [x] Fix applied to multi-deselection test to require `SOURCE_B_ID` in `refetchB` predicate
- [x] Verify CI Quality Gates pass on this PR
- [x] After merge to beta, verify shard 3 passes on promotion PR #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)