### PR TITLE
docs: update documentation for release

### DIFF
--- a/.claude/agent-memory/docs-writer/MEMORY.md
+++ b/.claude/agent-memory/docs-writer/MEMORY.md
@@ -61,3 +61,21 @@ Note: EPIC-11 and EPIC-12 each have two issues -- original (#12/#115) and new (#
 ## EPIC-15 Invoice-Budget-Line Rework
 
 Key docs changes: vendors-and-invoices.md was substantially rewritten to document the many-to-many model, two-step picker, invoice groups, and bidirectional linking. Subsidy page updated with cost basis section. Budget overview updated to reference itemized amounts. No new pages added -- no sidebar changes needed.
+
+## v2.7.0 Release (Auto-itemize + Photo Annotator + inline budget editing)
+
+Docs site already had `guides/budget/auto-itemize.md` and `guides/diary/photo-annotation.md` from prior PRs (#1547/#1552, photo-annotator epic). Both needed accuracy fixes for the final shipped state. No NEW pages added; no sidebar changes.
+
+Key shipped-state corrections made (watch for these drifting again):
+- **Auto-itemize is a DEDICATED PAGE, not a modal.** Route: `/budget/invoices/:id/auto-itemize/:documentId` (`client/src/pages/AutoItemizePage`). Triggered from the **Auto-itemize action on each linked-document card** in the invoice Documents section (`LinkedDocumentsSection.tsx`, gated on `config.autoItemizeEnabled`), NOT a button next to "+ Add Itemization". Two-column layout: form left, PDF iframe preview right. Per-row category + funding-source pickers + Assign button (two-step picker: item then budget line, or create-new). Editable invoice metadata with LLM suggestion badges. The old "Auto-itemize Preview modal" + "Unassigned pills added after Apply" flow is GONE.
+- **The "Auto-itemized" badge on Budget Overview was REMOVED** (#1655/#1615 - product feedback, no user value). Do not document it. `origin` field still exists in DB/backend but is not exposed in UI.
+- **Invoice-linked budget lines can now be EDITED and MOVED to a different parent item** (#1607/#1554) via shared `EditBudgetLineModal` (`onMove` prop). The old "assignment is one-shot / locked in" rule is GONE. Available from work item Budget tab, household item Budget tab, and invoice detail. Documented in `work-item-budgets.md#editing-invoice-linked-budget-lines` (anchor used as cross-ref target from auto-itemize.md and vendors-and-invoices.md).
+- **Photo annotator: 9 tools, NO "callout" tool.** Select, Rectangle, Highlight, Arrow, Line, Ellipse, Text, Measurement, Freehand. Saves as **WebP quality 0.92** (NOT PNG). `client/src/components/photos/PhotoAnnotator/`. The annotator dir is under `components/photos/` not `components/diary/`.
+- **Document hide-linked toggle is SYSTEM-WIDE** (#1559): uses `useAllLinkedDocumentIds()`, hides docs linked to ANY entity. Lives in the `DocumentBrowser` picker (linking flow), documented in `guides/documents/linking-documents.md` -- NOT the standalone `browsing-documents.md` Documents page.
+
+Task briefs may mislabel features: the brief called the photo annotator "EPIC-16" but **EPIC-16 (#752) is actually "Floor Plans & Utility Tracking (2.5D)" and is still OPEN/planned**. The photo annotator was tracked under issue #1472 (CLOSED). Do not relabel the floor-plans roadmap entry. README roadmap: added "Photo Annotation Editor" as a standalone completed item; kept EPIC-16 unchecked.
+
+`.env.example` was already fully in sync with `server/src/plugins/config.ts` (all 6 LLM vars present, OIDC/Paperless/LLM/Backup commented out with placeholders). config.ts env-var extraction: `grep -oE "[A-Z][A-Z_]+"` picks up `EUR` (a default value) as a false positive -- ignore it.
+
+## Build Note (still true)
+`npm run docs:build` fails in worktrees with webpack `ProgressPlugin` ValidationError (node_modules corruption, NOT content). Build reaches the webpack bundling stage, so MDX/content/link loading succeeded. Validate internal links/anchors statically with grep instead; CI does the real build.

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ A self-hosted home building project management tool for homeowners. Track work i
 
 - **Work Items** -- Manage construction tasks with statuses, dates, area assignments, notes, subtasks, dependencies, and keyboard shortcuts -- every work item shows its full area ancestor path (e.g. `House / Ground Floor / Kitchen`) as a breadcrumb across lists, detail pages, pickers, and every place it is referenced
 - **Areas & Trades** -- Organize your project with hierarchical areas (rooms, floors, zones) and trade specialties (Electrical, Plumbing, etc.) for vendors; a dedicated "No Area" filter surfaces items that have not been classified yet
-- **Budget Management** -- Budget categories, financing sources with inline expansion and mass-move of attached lines, multi-budget-line invoice linking with itemized amounts, staged-payment deposits for invoices paid in instalments (deposit-aware paid/claimed rollups), subsidies with caps, quotation tracking, and an area-grouped overview dashboard with source attribution badges on every line, a per-source filter (URL-persisted, server-side) that updates totals and subsidy math, clickable summary tiles, and print-friendly export
-- **Auto-itemize Invoices** -- Read line items off invoice PDFs (via Paperless OCR) using any OpenAI-compatible LLM provider (Gemini, Anthropic, OpenAI, Ollama) -- opt-in, no vendor lock-in, costs pennies per invoice
+- **Budget Management** -- Budget categories, financing sources with inline expansion and mass-move of attached lines, multi-budget-line invoice linking with itemized amounts, inline editing of invoice-linked budget lines (including moving a line to a different work item or household item), staged-payment deposits for invoices paid in instalments (deposit-aware paid/claimed rollups), subsidies with caps, quotation tracking, and an area-grouped overview dashboard with source attribution badges on every line, a per-source filter (URL-persisted, server-side) that updates totals and subsidy math, clickable summary tiles, and print-friendly export
+- **Auto-itemize Invoices** -- Read line items off invoice PDFs (via Paperless OCR) using any OpenAI-compatible LLM provider (Gemini, Anthropic, OpenAI, Ollama) on a dedicated review page with side-by-side PDF preview, per-row category/funding/assignment pickers -- opt-in, no vendor lock-in, costs pennies per invoice
 - **Timeline & Gantt Chart** -- Interactive Gantt chart with dependency arrows, critical path, zoom controls, milestones, and CPM-based auto-scheduling
 - **Calendar View** -- Monthly and weekly calendar grids with work items and milestones
 - **Household Items** -- Track furniture, appliances, and fixtures with categories, area assignment, delivery scheduling, budget integration, and work item linking
 - **Project Dashboard** -- At-a-glance project health with budget, timeline, invoice, and subsidy cards, mini Gantt preview, and customizable layout
 - **Construction Diary** -- Daily logs, site visits, delivery records, automatic system events, photo attachments with in-browser annotation (rectangles, arrows, text, measurements, freehand), auto-saved drafts, and digital signature capture
-- **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices
+- **Document Integration** -- Browse and link documents from Paperless-ngx to work items, household items, and invoices, with a system-wide "hide already-linked" filter to surface unfiled documents
 - **Advanced List Views** -- Filter, sort, paginate, and customize columns across all list pages with the shared DataTable system
 - **Backup & Restore** -- Manual and scheduled backups with configurable retention, restore from the settings UI
 - **Internationalization** -- English and German language support with automatic locale detection, including translated category names
@@ -90,6 +90,7 @@ Open `http://localhost:3000` -- the setup wizard will guide you through creating
 - [x] DataTable & List View Overhaul
 - [x] Backup & Restore
 - [x] Auto-itemize Invoices (LLM)
+- [x] Photo Annotation Editor (Shottr-style markup on diary photos)
 - [ ] **EPIC-16**: Floor Plans & Utility Tracking
 
 Track live progress on the [GitHub Projects board](https://github.com/users/steilerDev/projects/4).

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,70 +1,30 @@
-# v2.6.0 Release Summary
-
-A feature-packed release that brings **in-browser photo annotation**, **staged-payment deposits** for invoices, and a much smoother **diary draft flow**. Migration 0032 (invoice deposits) runs automatically on first start -- no manual steps required.
+# v2.7.0 Release Summary
 
 ## What's New
 
-### Photo Annotation
+This release turns invoice itemization into a one-click, AI-assisted workflow and makes budget bookkeeping far more forgiving. Cornerstone can now read the line items off a vendor's PDF invoice for you, you can edit and re-home invoice-linked budget lines without deleting them, and a brand-new in-app editor lets you mark up diary photos directly in the browser. No manual migration steps are required.
 
-Mark up diary photos directly in the browser. Open any diary photo in the viewer, click **Annotate**, and you get a full drawing canvas with nine tools:
+### Highlights
 
-- **Select**, **Rectangle**, **Highlight**, **Arrow**, **Line**, **Ellipse**, **Text**, **Measurement** (dimension line with end ticks and a movable label), and **Freehand**
-- Six colours, four stroke widths, five font sizes -- pick before you draw, or change them on a selected shape to update it live
-- Drag to move, endpoint handles to reshape, undo/redo for everything including live edits
-- Annotated copies are saved as separate WebP files (quality 0.92); the original is preserved, and you can switch between **View original** and **View annotated** at any time
-- A **Reset to original** button discards your current annotations and starts over
-- Photo grids and viewers expose a quick-action **Edit** button that opens the viewer directly in annotation mode
+- **Auto-itemize Invoices (LLM-powered)** -- Open a linked invoice PDF and let Cornerstone extract its line items for you. A dedicated review page shows the original document side-by-side with the extracted lines, each on its own card with editable amounts, a confidence indicator, and inline category, funding-source, and item-assignment pickers. Works with any OpenAI-compatible provider -- Google Gemini, Anthropic, OpenAI, or a self-hosted Ollama model -- auto-detected from the endpoint you configure. The feature is **opt-in and off by default**: nothing leaves your server until you set the LLM environment variables, and even then only the document's OCR text and a few invoice details are sent -- never the PDF itself or your API key.
 
-Signed diary entries cannot be annotated -- finish your markup before collecting signatures.
+- **Photo Annotation Editor** -- A Shottr-style markup editor for diary photos, right in the browser. Open any diary photo and annotate it with arrows, rectangles, ellipses, lines, text labels, dimension measurements, freehand strokes, and translucent highlights. It is optimized for touch and Apple Pencil, fully non-destructive (the original is always preserved, with a **View original** toggle and **Reset to original** action), and the annotated copy is saved alongside the original.
 
-See the [Photo Annotation guide](https://steilerDev.github.io/cornerstone/guides/diary/photo-annotation) for the full walkthrough.
+- **Inline budget line editing & move** -- Edit invoice-linked budget lines directly from the Work Item and Household Item detail pages -- no need to unlink first. You can now also **move a line to a different work item or household item**, so a line that landed on the wrong item (a common case with auto-itemized lines) can be re-homed instead of deleted and re-created.
 
-### Invoice Deposits (Staged Payments)
+- **Document viewer "hide already-linked" toggle** -- The document picker gains a system-wide filter that hides any document already linked anywhere in Cornerstone, making it easy to find documents you have not filed yet.
 
-Track invoices that are paid in stages -- a deposit on signing, a milestone payment, and a final balance.
+### Notable Fixes
 
-- Add any number of deposits to an invoice from the **Deposits** section on the invoice detail page
-- Each deposit has its own amount, due date, status (Pending / Paid / Claimed), paid/claimed dates, and optional description
-- The form refuses to save if deposits would exceed the invoice total
-- Quick actions to **mark paid** and **mark claimed** -- with revert support to fix mistakes
-- Budget rollups across every linked work item and household item are now **deposit-aware**: `actualCostPaid` and `actualCostClaimed` reflect deposit-level status, so paid and claimed amounts show real cash flow rather than waiting for the full invoice to settle
-- Deposits cascade-delete with the parent invoice
+- Print/export of the Budget Overview now restores your expansion state afterwards and resets dark-mode styling correctly for a clean printout.
+- The Budget Overview no longer shows a redundant "Auto-itemized" badge that provided no useful information.
+- Diary entry editing no longer triggers spurious native form-validation popups.
+- Save buttons on budget forms now meet the 44px minimum touch-target size on mobile.
 
-See the [Invoice Deposits guide](https://steilerDev.github.io/cornerstone/guides/budget/invoice-deposits).
-
-### Diary Drafts Overhaul
-
-Creating a diary entry no longer needs a separate "create" step.
-
-- Click a type card (Daily Log, Site Visit, Delivery, Issue, General Note) and Cornerstone immediately creates a **draft entry** and opens the edit page -- you start typing right away
-- Photos uploaded to a draft persist immediately, so you don't have to remember to "save" before attaching them
-- Auto-save runs continuously with a live status indicator (`Saving...`, `Saved`, or "save failed -- will retry")
-- Drafts are tagged with a **Draft** badge and **hidden from the diary list by default**; a dedicated **Drafts** filter chip toggles their visibility
-- Click **Save** to promote the draft to a full entry, or **Discard Draft** to delete it (and its photos) permanently
-- Abandoned drafts are cleaned up automatically after `DIARY_DRAFT_RETENTION_DAYS` days (default: 30; set to `0` to disable)
-
-### Photo Viewer Improvements
-
-- New **photo metadata sidepanel** with upload date, description, and area assignment
-- **Edit** quick-action button on the photo grid that opens the viewer directly in annotation mode
-- **Delete photo** action from the lightbox for entries that aren't signed
-- Thumbnail cache busting -- annotated thumbnails update immediately
-- Mobile-friendly: the metadata sidepanel collapses on small screens
-
-## Configuration
-
-New environment variable:
-
-| Variable                     | Default | Description                                                                   |
-| ---------------------------- | ------- | ----------------------------------------------------------------------------- |
-| `DIARY_DRAFT_RETENTION_DAYS` | `30`    | Days an untouched draft sits before automatic cleanup. Set to `0` to disable. |
-
-No other configuration changes are required. Migration 0032 adds the `invoice_deposits` table and runs automatically on container start.
-
-## What to Update
+## Upgrade
 
 ```bash
 docker pull steilerdev/cornerstone:latest
 ```
 
-Restart your container. Schema migrations run on first boot.
+Restart your container. Schema migrations run automatically on first boot. To enable Auto-itemize, set the `LLM_BASE_URL`, `LLM_API_KEY`, and `LLM_MODEL` environment variables -- see the [Auto-itemize guide](https://steilerDev.github.io/cornerstone/guides/budget/auto-itemize) for provider examples.

--- a/docs/src/guides/budget/auto-itemize.md
+++ b/docs/src/guides/budget/auto-itemize.md
@@ -5,7 +5,7 @@ title: Auto-itemize Invoices
 
 # Auto-itemize Invoices
 
-When a vendor sends you a PDF invoice, Cornerstone can read the line items off the page for you and turn them into budget lines you only need to review -- not type out. You scan or import the invoice into Paperless-ngx, link it to a Cornerstone invoice, and click **Auto-itemize**. A language model reads the OCR text and proposes one budget line per row on the invoice. You edit, accept, and assign each line to the work item or household item it belongs to.
+When a vendor sends you a PDF invoice, Cornerstone can read the line items off the page for you and turn them into budget lines you only need to review -- not type out. You scan or import the invoice into Paperless-ngx, link it to a Cornerstone invoice, and click **Auto-itemize** on the linked document. A language model reads the OCR text and proposes one budget line per row on the invoice. Cornerstone then opens a dedicated **Auto-itemize** page with the original PDF on one side and the extracted lines on the other, so you can edit, assign, and save each line against the document it came from.
 
 This feature is **opt-in** and disabled by default. You connect Cornerstone to any LLM provider that speaks the OpenAI chat-completions API -- Google Gemini, Anthropic, OpenAI, or a self-hosted model running on your own machine. Cornerstone never sends the binary PDF off your server; only the OCR text and a few invoice details (vendor name, total, date) leave your host.
 
@@ -17,7 +17,7 @@ Before you can auto-itemize, three things must be in place:
 2. **An LLM provider is configured.** Cornerstone needs an LLM endpoint to send the OCR text to (next section).
 3. **At least one Paperless document is linked to the invoice you want to itemize.** See [Linking Documents](/guides/documents/linking-documents).
 
-When all three are in place, the **Auto-itemize** button appears in the Linked Budget Lines section header on the invoice detail page, right next to **+ Add Itemization**.
+When all three are in place, an **Auto-itemize** action appears on each linked-document card in the **Documents** section of the invoice detail page. Clicking it opens the dedicated Auto-itemize page for that document.
 
 ## Configure your LLM provider
 
@@ -80,85 +80,82 @@ The numbers above are rough estimates for a typical one-page construction invoic
 
 ### Verify the configuration
 
-The easiest way to verify: open any invoice that has at least one linked Paperless document. If you see an **Auto-itemize** button in the budget-lines section header, the LLM provider is configured correctly. If not, double-check the three required variables and that the container was restarted.
+The easiest way to verify: open any invoice that has at least one linked Paperless document. If you see an **Auto-itemize** action on the linked-document card in the **Documents** section, the LLM provider is configured correctly. If not, double-check the three required variables and that the container was restarted.
 
 ## Walkthrough
 
 This walkthrough assumes you have an invoice in Cornerstone with at least one Paperless document linked to it -- typically the PDF the vendor sent you.
 
-### 1. Open the invoice
+### 1. Open the invoice and start auto-itemize
 
-Navigate to **Budget > Invoices** and open the invoice you want to itemize. Scroll to the **Linked Budget Lines** section.
+Navigate to **Budget > Invoices** and open the invoice you want to itemize. Scroll to the **Documents** section, find the linked invoice PDF, and click its **Auto-itemize** action.
 
-### 2. Click Auto-itemize
+Cornerstone opens the dedicated **Auto-itemize** page. A spinner with an elapsed-seconds counter shows while it fetches the OCR text from Paperless and sends it to your LLM provider. There is no document-picker step -- you choose which document to itemize when you click its action on the card.
 
-Click the **Auto-itemize** button in the section header (next to **+ Add Itemization**). A spinner appears while Cornerstone fetches the OCR text from Paperless and sends it to your LLM provider.
+### 2. Review the page layout
 
-### 3. Pick a document (if needed)
+When extraction finishes, the page shows two columns:
 
-If the invoice has more than one Paperless document linked, a picker modal opens listing each document with its title and date. Click the document you want to analyze. The modal closes and extraction starts.
+- **Left column -- the form.** The invoice metadata fields at the top, a mode selector, and one card per extracted line item.
+- **Right column -- the PDF preview.** The original document renders inline so you can check each extracted line against the source page without leaving the screen. If the PDF cannot be embedded, a fallback panel offers an **Open in Paperless-ngx** link instead.
 
-If the invoice has exactly one document linked, this step is skipped.
+On narrow screens the PDF preview moves below the form.
 
-### 4. Review the preview
+### 3. Review and correct the invoice metadata
 
-When extraction finishes, the **Auto-itemize Preview** modal opens. It shows:
+The top card shows the invoice's **number, amount, date, due date, notes, and status**, pre-filled with the current invoice values. Where the model read a different value off the document than what is on the invoice, a **suggestion badge** appears next to the field -- click it to apply the extracted value. Anything you change here is written back to the invoice when you save.
 
-- **One row per extracted line item**, with editable description, quantity, unit, unit price, and total amount fields. Each row has an include / exclude checkbox -- uncheck rows you do not want to save.
-- A **mode selector** (append / replace, defaults to append):
-  - **Append** -- add the extracted lines to the invoice on top of whatever is already there.
-  - **Replace** -- delete previously auto-extracted lines on this invoice and use only the new ones. Manually-added lines are always preserved.
-- A **totals row** comparing the sum of included lines against the invoice amount. If the difference is more than 1%, a warning banner appears at the top of the modal.
+### 4. Choose append or replace
 
-### 5. Edit, exclude, or correct lines
+The **mode selector** controls how the new lines combine with what is already on the invoice:
 
-Click any cell to edit it. OCR is not perfect: descriptions sometimes have stray characters, quantities may be missing, and the LLM occasionally invents a line that does not exist on the invoice. Treat the preview as a draft -- fix what is wrong, uncheck what should not be saved, and add anything that was missed manually after applying.
+- **Append** (default) -- add the extracted lines on top of whatever is already there.
+- **Replace** -- delete previously auto-extracted lines on this invoice and use only the new ones. Manually-added lines are always preserved.
 
-### 6. Click Apply
+### 5. Edit, exclude, or correct each line
 
-Click **Apply**. The modal closes, the invoice page refreshes, and your new lines appear in the Linked Budget Lines table -- each one tagged with an **Unassigned** pill in the "Linked Item" column.
+Each extracted line is a card with editable **description, quantity, unit, unit price, and total amount** fields, plus an **include** checkbox -- uncheck a card to leave that line out. A coloured confidence dot shows how sure the model was about each row.
 
-:::note What's an Unassigned line?
-Auto-extracted lines do not know which work item or household item they belong to. They land as "Unassigned" so you can record the line item the moment you see the PDF and decide where it rolls up later. Unassigned lines still count toward your financing-source totals and category aggregates, but they do **not** appear in any single work item's budget rollup until you assign them.
-:::
+OCR is not perfect: descriptions sometimes have stray characters, quantities may be missing, and the model occasionally invents a line that does not exist on the invoice. Treat every card as a draft -- fix what is wrong, uncheck what should not be saved, and use the PDF preview to confirm against the source.
 
-### 7. Assign each line to a work item or household item
+A **totals card** at the bottom sums the included lines and compares them against the invoice amount, showing a green match, an amber warning (within 5%), or a red mismatch.
 
-Each Unassigned row has an inline **Assign…** button. Click it to open the assignment picker:
+### 6. Assign each line and set its category and funding source
 
-- Switch between the **Work Item** and **Household Item** tabs at the top of the picker.
-- Use the search field to find the target item.
-- Click the item, then click **Save**.
+Each line card carries inline **Category** and **Funding source** pickers, plus an **Assign** button:
 
-The row's pill changes from "Unassigned" to the linked item's name -- and a click on that name jumps to the item's detail page. From here the line behaves like any other budget line: it shows up on the work item or household item's Budget tab, contributes to that item's totals, and feeds into the budget overview rollups.
+- **Category / Funding source.** Pick the budget category and which financing source pays for the line directly on the card. New lines default their funding source to **Discretionary Funding** (see [Funding source](#funding-source) below).
+- **Assign.** Click **Assign** to open the two-step picker. First choose the target **work item** or **household item**; then either pick an existing budget line on that item to link to, or click **Create new** to add a fresh line (pre-filled from the extracted row). A line created from the extraction is marked with a **"Created from auto-itemization"** badge so you can tell it apart. Clear an assignment with the **✕** next to it to re-assign or switch to create-new.
 
-:::caution Assignment is one-shot
-You can assign an Unassigned line to a work item or household item exactly once. After that, the parent is locked in -- there is no "reassign to a different work item" action. If you assign a line to the wrong target, delete it from the invoice and re-create it manually with the right parent.
+A line you do not assign to any item is still saved against the invoice and counts toward financing-source totals and category aggregates, but it does not roll up into a single work item's budget until you assign it.
+
+### 7. Save
+
+Click **Save**. Cornerstone writes the included lines (and any metadata changes) and returns you to the invoice. If you try to leave with unsaved edits, a confirmation dialog asks whether to discard them.
+
+:::tip You can move an assigned line later
+Unlike the old one-shot flow, an invoice-linked budget line is no longer locked to its first parent. You can later edit any invoice-linked line -- including auto-itemized ones -- and **move it to a different work item or household item** from the line's edit view. See [Inline budget line editing](work-item-budgets#editing-invoice-linked-budget-lines).
 :::
 
 ## Funding source
 
 Every budget line is funded by one of your [financing sources](financing-sources) -- your construction loan, savings, a subsidy, and so on. But when a language model reads an invoice, it has no way of knowing which pot of money you intend to draw on for each row. A line that says "Bathroom tiles -- 480 EUR" tells you nothing about whether you are paying for it out of your loan or your savings.
 
-So auto-extracted lines all start out funded by the built-in **Discretionary Funding** source. Think of it as a holding bay: the line is recorded and counted, but parked against a neutral source until you decide where the money really comes from.
+So auto-extracted lines default to the built-in **Discretionary Funding** source. Think of it as a holding bay: the line is recorded and counted, but parked against a neutral source until you decide where the money really comes from. You can override the funding source per line directly on the Auto-itemize page using each card's **Funding source** picker.
 
-You will see this called out in two places:
-
-- **In the preview.** Before you apply, an informational note in the **Auto-itemize Preview** reminds you that the new lines will be created against Discretionary Funding, and that you can reassign each line's funding source afterwards. Nothing is locked in -- it is just a sensible default to get the lines recorded quickly.
-- **On the Budget Overview.** Once applied, every auto-created line carries an **"Auto-itemized"** badge alongside its source attribution badge. The badge makes the freshly-extracted lines easy to spot, so you can sweep through and move them onto the right source instead of hunting for which lines still need attention.
+A note in the **extracted lines** section of the Auto-itemize page reminds you, before you save, that any lines still on Discretionary Funding can be moved onto a real source at any time -- nothing is locked in. It is just a sensible default to get lines recorded quickly.
 
 ### Reassign a line's funding source
 
-When you know which source should fund a line, change it on the [Budget Overview](budget-overview) or from the line's edit view:
+When you know which source should fund a line, change it from the line's edit view:
 
-1. Open **Budget > Overview** (or the work item / household item the line is assigned to).
-2. Find the line -- the **"Auto-itemized"** badge marks the ones still on Discretionary Funding.
-3. Edit the line and pick the correct financing source from the source selector, then save.
+1. Open the work item or household item the line is assigned to (or **Budget > Overview**).
+2. Edit the line and pick the correct financing source from the source selector, then save.
 
 If a whole batch of lines belongs to the same source -- for example, everything on one invoice -- the [Financing Sources](financing-sources) page lets you multi-select lines and move them in a single operation. The depletion totals on both the old and new source update immediately.
 
 :::tip Funding source is not the same as the linked item
-Reassigning the **funding source** (which pot of money pays for the line) is separate from assigning the line to a **work item or household item** (what the line is for). You can change a line's funding source as often as you like; the work item assignment, by contrast, is [one-shot](#7-assign-each-line-to-a-work-item-or-household-item).
+Reassigning the **funding source** (which pot of money pays for the line) is separate from assigning the line to a **work item or household item** (what the line is for). You can change either independently and as often as you like -- both the funding source and the parent item assignment can be edited later from the line's edit view.
 :::
 
 ## What data leaves your server

--- a/docs/src/guides/budget/vendors-and-invoices.md
+++ b/docs/src/guides/budget/vendors-and-invoices.md
@@ -99,17 +99,14 @@ The Remaining row helps you ensure the full invoice amount is allocated. If the 
 :::
 
 :::tip Skip the typing with Auto-itemize
-If the invoice has a Paperless document linked and you have configured an LLM provider, an **Auto-itemize** button appears next to **+ Add Itemization**. Cornerstone reads the OCR text from the PDF and proposes one budget line per row on the invoice -- you only review and assign them. See [Auto-itemize Invoices](auto-itemize) for the full guide.
+If the invoice has a Paperless document linked and you have configured an LLM provider, an **Auto-itemize** action appears on the linked-document card in the **Documents** section. Cornerstone reads the OCR text from the PDF and proposes one budget line per row on a dedicated review page with the PDF shown alongside -- you only review and assign them. See [Auto-itemize Invoices](auto-itemize) for the full guide.
 :::
 
 ### Unassigned Budget Lines
 
-Budget lines can exist on an invoice without yet being linked to a work item or household item -- they are called **Unassigned** and show up with a muted pill in the "Linked Item" column. Two flows create them:
+Budget lines can exist on an invoice without yet being linked to a work item or household item -- they are called **Unassigned** and show up with a muted pill in the "Linked Item" column. This happens when you add a budget line directly on the invoice and leave the parent picker empty to decide later. (Auto-itemize, by contrast, lets you assign each extracted line to its target right on the [review page](auto-itemize) before you save.)
 
-- **Auto-itemize** -- every line the LLM extracts lands as Unassigned (see [Auto-itemize Invoices](auto-itemize)).
-- **Manual** -- when adding a budget line directly on the invoice, you can leave the parent picker empty and decide later.
-
-Each Unassigned row has an inline **Assign…** button. Clicking it opens a picker with two tabs -- **Work Item** and **Household Item** -- where you choose the target and save. Assignment is one-shot: once assigned, the parent is locked in. Unassigned lines still count toward your financing-source and category totals, but they do not appear on any single work item's Budget tab until they are assigned.
+Each Unassigned row has an inline **Assign…** button. Clicking it opens a picker with two tabs -- **Work Item** and **Household Item** -- where you choose the target and save. Unassigned lines still count toward your financing-source and category totals, but they do not appear on any single work item's Budget tab until they are assigned. If you assign a line to the wrong item, you can change it later -- invoice-linked lines can be edited and [moved to a different parent item](work-item-budgets#editing-invoice-linked-budget-lines).
 
 ### How to Link from an Item Detail Page
 

--- a/docs/src/guides/budget/work-item-budgets.md
+++ b/docs/src/guides/budget/work-item-budgets.md
@@ -40,6 +40,17 @@ When multiple budget lines on the same work item share an invoice, they collapse
 
 See [Invoices & Vendors](vendors-and-invoices) for details on managing invoices and the linking workflow.
 
+## Editing Invoice-Linked Budget Lines
+
+Budget lines that are linked to an invoice -- including lines created by [auto-itemize](auto-itemize) -- can be edited in place, without unlinking them first. The same edit modal is available wherever the line appears: the work item's **Budget** tab, the household item's **Budget** tab, and the invoice detail page's **Linked Budget Lines** section.
+
+Click **Edit** on the line to open the modal. From there you can:
+
+- **Change the line details** -- description, planned amount, category, financing source, vendor, confidence level, VAT handling, and the itemized amount that ties the line to its invoice.
+- **Move the line to a different parent item.** A parent picker lets you re-home the line on another work item or household item. This replaces the old behaviour where an invoice-linked line was permanently bound to the first item it was assigned to -- if a line landed on the wrong work item (a common case with auto-itemized lines), you can now move it across instead of deleting and re-creating it.
+
+The invoice link, itemized amount, and invoice-group membership are preserved through the move; only the parent item changes.
+
 ## Multiple Budget Lines per Work Item
 
 A single work item can have multiple budget lines. For example, "Renovate bathroom" might have separate budget lines for plumbing, electrical, and tiling -- each in a different category and potentially funded by different financing sources.

--- a/docs/src/guides/diary/photo-annotation.md
+++ b/docs/src/guides/diary/photo-annotation.md
@@ -76,7 +76,7 @@ To delete a selected shape, press `Delete` or `Backspace`.
 
 ### Inline Text Input
 
-When you place text, callouts, or measurement labels, an inline editor appears anchored to the rendered shape position. The text in the editor matches what will be rendered (same font, size, and colour) so you can see your label in context as you type.
+When you place text or measurement labels, an inline editor appears anchored to the rendered shape position. The text in the editor matches what will be rendered (same font, size, and colour) so you can see your label in context as you type.
 
 ## Saving and Resetting
 

--- a/docs/src/guides/documents/linking-documents.md
+++ b/docs/src/guides/documents/linking-documents.md
@@ -31,7 +31,7 @@ Screenshots for the documents feature require a connected Paperless-ngx instance
 
 The document is immediately linked and appears in the Documents section. A screen reader announcement confirms the link was created.
 
-The picker shows **all documents** by default. If your document store is large and you only want to see documents that are not yet linked anywhere in Cornerstone, tick the **Hide already-linked documents** checkbox at the top of the picker -- it stays unchecked unless you turn it on, so you never have to clear it just to find a document you intend to re-link.
+The picker shows **all documents** by default. If your document store is large and you only want to see documents that are not yet linked anywhere in Cornerstone, tick the **Hide already-linked documents** checkbox at the top of the picker. The filter is **system-wide**: it hides any document that is already linked to *any* work item, household item, or invoice in Cornerstone -- not just the entity you are currently working on -- so you can quickly find documents that have not been filed anywhere yet. The toggle stays unchecked unless you turn it on, so you never have to clear it just to find a document you intend to re-link, and the count of hidden documents is shown while the filter is active.
 
 :::note
 Each document can only be linked once to the same entity. If you try to link a document that is already attached, Cornerstone will show a message that the document is already linked.


### PR DESCRIPTION
Updates the docs site, README, RELEASE_SUMMARY, and `.env.example` for the photo annotator + auto-itemize (v2.7.0) release.

## Docs site
- **auto-itemize.md** — rewrote the walkthrough for the **dedicated review page** (the old preview-modal flow is gone): side-by-side PDF preview, per-row category/funding/assignment pickers, in-page assignment, editable invoice metadata with LLM suggestion badges. Removed the **Budget Overview "Auto-itemized" badge** (deleted in #1655) and the obsolete **one-shot assignment** caution.
- **work-item-budgets.md** — new section documenting **inline editing of invoice-linked budget lines** and **moving a line to a different work item / household item** (#1607).
- **vendors-and-invoices.md** — corrected the Auto-itemize trigger location (now on the linked-document card) and the Unassigned-lines / permanent-assignment wording.
- **linking-documents.md** — clarified the **hide already-linked** filter is **system-wide** (#1559).
- **photo-annotation.md** — removed stray references to a non-existent "callout" tool (shipped set is 9 tools; saves WebP @ 0.92).

## README
- Enriched Budget Management (inline edit + move), Auto-itemize (dedicated page), and Document Integration (system-wide hide-linked) feature lines.
- Added **Photo Annotation Editor** to the roadmap as completed. Note: EPIC-16 (#752) is **Floor Plans & Utility Tracking**, still planned — the photo annotator was tracked under #1472, so EPIC-16 stays unchecked.
- Protected `> [!NOTE]` block left untouched.

## RELEASE_SUMMARY.md
- Rewritten for v2.7.0 (auto-itemize, photo annotator, inline budget editing, hide-linked toggle) in end-user language.

## Environment variable drift check
- Scanned `server/src/plugins/config.ts` against `.env.example` — **already in sync**. All six LLM vars present; OIDC / Paperless / LLM / Backup optional vars remain commented out with placeholder values and inline docs. No changes needed.

## Verification
- Internal links/anchors validated statically (the cross-ref `work-item-budgets#editing-invoice-linked-budget-lines` resolves). `npm run docs:build` fails in the sandbox worktree on the known webpack ProgressPlugin node_modules issue (not content) — CI runs the real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)