### PR TITLE
chore(deps): align root and client konva versions to prevent type collision (#1646)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check single Konva version
+        run: bash scripts/check-konva-single-version.sh package-lock.json
+
       - name: Verify dependency signatures
         run: npm audit signatures
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "picomatch@>=4.0.0 <4.0.4": "4.0.4",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "konva": "10.3.0"
   }
 }

--- a/scripts/check-konva-single-version.sh
+++ b/scripts/check-konva-single-version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-konva-single-version.sh
+#
+# Verifies that exactly one version of konva is resolved across the entire
+# npm workspace tree by inspecting package-lock.json.
+#
+# A duplicate konva installation causes mutually incompatible Shape<ShapeConfig>
+# interfaces between 9.x and 10.x, leading to TS2322 type errors.
+#
+# Usage: check-konva-single-version.sh <path-to-package-lock.json>
+#
+# Exits non-zero with a clear error message if more than one distinct konva
+# version is found.
+
+set -euo pipefail
+
+LOCKFILE="${1:-package-lock.json}"
+
+if [[ ! -f "$LOCKFILE" ]]; then
+  echo "check-konva-single-version: lockfile not found: $LOCKFILE" >&2
+  exit 1
+fi
+
+RESULT=$(LOCKFILE="$LOCKFILE" node --input-type=module <<'EOF'
+import { readFileSync } from 'fs';
+
+const lock = JSON.parse(readFileSync(process.env.LOCKFILE, 'utf8'));
+const packages = lock.packages ?? {};
+
+// Collect every resolved konva entry: hoisted (node_modules/konva) and
+// any nested installation (*/node_modules/konva).
+const entries = Object.entries(packages)
+  .filter(([k]) => k === 'node_modules/konva' || k.endsWith('/node_modules/konva'));
+
+const versions = [...new Set(entries.map(([, v]) => v.version))];
+
+if (versions.length === 0) {
+  // konva not installed at all — not this script's concern
+  process.exit(0);
+}
+
+if (versions.length > 1) {
+  process.stdout.write('MULTIPLE:' + versions.join(',') + '\n');
+} else {
+  process.stdout.write('OK:' + versions[0] + '\n');
+}
+EOF
+)
+
+if [[ "$RESULT" == MULTIPLE:* ]]; then
+  VERSIONS="${RESULT#MULTIPLE:}"
+  echo "" >&2
+  echo "ERROR: Multiple konva versions found in ${LOCKFILE}:" >&2
+  echo "  ${VERSIONS//,/  }" >&2
+  echo "" >&2
+  echo "  Incompatible konva versions cause TS2322 type-collision errors" >&2
+  echo "  (Shape<ShapeConfig> interfaces are mutually incompatible between" >&2
+  echo "  the 9.x and 10.x series)." >&2
+  echo "" >&2
+  echo "  Fix: ensure the root package.json 'overrides' block pins konva to" >&2
+  echo "  exactly one version, then run 'npm install' to regenerate the lockfile." >&2
+  echo "" >&2
+  exit 1
+fi
+
+if [[ "$RESULT" == OK:* ]]; then
+  echo "check-konva-single-version: OK (konva ${RESULT#OK:})"
+fi


### PR DESCRIPTION
## Summary

- Add a root `package.json` `overrides` entry pinning `konva` to `10.3.0` (matching the client workspace pin) so npm hoists a single konva version across the workspace tree
- Prevents a latent 9.x/10.x version split that produces `TS2322 Shape<ShapeConfig>` type-collision errors on lockfile regeneration
- Add `scripts/check-konva-single-version.sh`: a CI guardrail that fails when more than one konva version is resolved in `package-lock.json`, wired into the `static-analysis` job after `npm ci`

Fixes #1646

## Test plan

- [ ] `scripts/check-konva-single-version.sh package-lock.json` exits 0 (single version `10.3.0` resolved)
- [ ] CI static-analysis job runs the new konva check step without error
- [ ] `Quality Gates` CI gate passes

Co-Authored-By: Claude backend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>