### PR TITLE
chore(lint): resolve @typescript-eslint/consistent-type-imports errors (#1458)

### DIFF
--- a/client/src/components/MassMoveModal/MassMoveModal.test.tsx
+++ b/client/src/components/MassMoveModal/MassMoveModal.test.tsx
@@ -7,6 +7,7 @@ import type React from 'react';
 import type { BudgetSource, BudgetSourceListResponse } from '@cornerstone/shared';
 import { ApiClientError } from '../../lib/apiClient.js';
 import type { MassMoveModalProps } from './MassMoveModal.js';
+import type * as MassMoveModalModule from './MassMoveModal.js';
 
 // ─── Module-scope mock functions ─────────────────────────────────────────────
 
@@ -159,7 +160,7 @@ function buildProps(overrides: Partial<MassMoveModalProps> = {}): MassMoveModalP
 
 // ─── Component import (after mocks) ──────────────────────────────────────────
 
-let MassMoveModal: (typeof import('./MassMoveModal.js'))['MassMoveModal'];
+let MassMoveModal: (typeof MassMoveModalModule)['MassMoveModal'];
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 

--- a/client/src/components/TriStateCheckbox/TriStateCheckbox.test.tsx
+++ b/client/src/components/TriStateCheckbox/TriStateCheckbox.test.tsx
@@ -4,10 +4,11 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import type React from 'react';
+import type * as TriStateCheckboxModule from './TriStateCheckbox.js';
 
 // ─── Component import (after any mocks) ──────────────────────────────────────
 
-let TriStateCheckbox: (typeof import('./TriStateCheckbox.js'))['TriStateCheckbox'];
+let TriStateCheckbox: (typeof TriStateCheckboxModule)['TriStateCheckbox'];
 
 describe('TriStateCheckbox', () => {
   beforeEach(async () => {

--- a/client/src/components/budget/BudgetLineCard.test.tsx
+++ b/client/src/components/budget/BudgetLineCard.test.tsx
@@ -85,7 +85,9 @@ jest.unstable_mockModule('../../lib/preferencesApi.js', () => ({
 
 // ─── Dynamic import after mocks ────────────────────────────────────────────────
 
-let BudgetLineCard: (typeof import('./BudgetLineCard.js'))['BudgetLineCard'];
+import type * as BudgetLineCardModule from './BudgetLineCard.js';
+
+let BudgetLineCard: (typeof BudgetLineCardModule)['BudgetLineCard'];
 let LocaleProvider: ({ children }: { children: React.ReactNode }) => React.ReactNode;
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────

--- a/client/src/components/budget/BudgetLineForm.move.test.tsx
+++ b/client/src/components/budget/BudgetLineForm.move.test.tsx
@@ -49,7 +49,9 @@ jest.unstable_mockModule('../HouseholdItemPicker/HouseholdItemPicker.js', () => 
 
 // ─── Dynamic import ───────────────────────────────────────────────────────────
 
-let BudgetLineForm: (typeof import('./BudgetLineForm.js'))['BudgetLineForm'];
+import type * as BudgetLineFormModule from './BudgetLineForm.js';
+
+let BudgetLineForm: (typeof BudgetLineFormModule)['BudgetLineForm'];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/client/src/components/budget/BudgetLineForm.test.tsx
+++ b/client/src/components/budget/BudgetLineForm.test.tsx
@@ -5,10 +5,11 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { BudgetLineFormProps } from './BudgetLineForm.js';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+import type * as BudgetLineFormModule from './BudgetLineForm.js';
 
 // ─── Dynamic import (required for jest.unstable_mockModule pattern) ───────────
 
-let BudgetLineForm: (typeof import('./BudgetLineForm.js'))['BudgetLineForm'];
+let BudgetLineForm: (typeof BudgetLineFormModule)['BudgetLineForm'];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/client/src/components/budget/BudgetLineForm.unitPricing.test.tsx
+++ b/client/src/components/budget/BudgetLineForm.unitPricing.test.tsx
@@ -5,10 +5,11 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { BudgetLineFormProps } from './BudgetLineForm.js';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+import type * as BudgetLineFormModule from './BudgetLineForm.js';
 
 // ─── Dynamic import (required for jest.unstable_mockModule pattern) ───────────
 
-let BudgetLineForm: (typeof import('./BudgetLineForm.js'))['BudgetLineForm'];
+let BudgetLineForm: (typeof BudgetLineFormModule)['BudgetLineForm'];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/client/src/components/budget/BudgetSection.invoice-edit.test.tsx
+++ b/client/src/components/budget/BudgetSection.invoice-edit.test.tsx
@@ -172,7 +172,9 @@ jest.unstable_mockModule('./InvoiceGroup.js', () => ({
 
 // ─── Import component under test after mocks ──────────────────────────────────
 
-let BudgetSection: (typeof import('./BudgetSection.js'))['BudgetSection'];
+import type * as BudgetSectionModule from './BudgetSection.js';
+
+let BudgetSection: (typeof BudgetSectionModule)['BudgetSection'];
 let LocaleProvider: ({ children }: { children: React.ReactNode }) => React.ReactNode;
 
 // ─── Type factory helpers ──────────────────────────────────────────────────────

--- a/client/src/components/budget/BudgetSection.test.tsx
+++ b/client/src/components/budget/BudgetSection.test.tsx
@@ -71,7 +71,9 @@ jest.unstable_mockModule('./InvoiceGroup.js', () => ({
 
 // ─── Import component under test after mocks ──────────────────────────────────
 
-let BudgetSection: (typeof import('./BudgetSection.js'))['BudgetSection'];
+import type * as BudgetSectionModule from './BudgetSection.js';
+
+let BudgetSection: (typeof BudgetSectionModule)['BudgetSection'];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/client/src/components/budget/EditBudgetLineModal.test.tsx
+++ b/client/src/components/budget/EditBudgetLineModal.test.tsx
@@ -14,10 +14,11 @@ import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import type { BudgetSource, Vendor, BudgetCategory, ConfidenceLevel } from '@cornerstone/shared';
 import type { EditBudgetLineModalProps, EditableBudgetLine } from './EditBudgetLineModal.js';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+import type * as EditBudgetLineModalModule from './EditBudgetLineModal.js';
 
 // ─── Import component under test ──────────────────────────────────────────────
 
-let EditBudgetLineModal: (typeof import('./EditBudgetLineModal.js'))['EditBudgetLineModal'];
+let EditBudgetLineModal: (typeof EditBudgetLineModalModule)['EditBudgetLineModal'];
 
 // ─── Type factory helpers ──────────────────────────────────────────────────────
 

--- a/client/src/components/budget/InvoiceGroup.test.tsx
+++ b/client/src/components/budget/InvoiceGroup.test.tsx
@@ -90,7 +90,9 @@ jest.unstable_mockModule('./BudgetLineCard.js', () => ({
 }));
 
 // ─── Import component under test after mocks ────────────────────────────────
-let InvoiceGroup: (typeof import('./InvoiceGroup.js'))['InvoiceGroup'];
+import type * as InvoiceGroupModule from './InvoiceGroup.js';
+
+let InvoiceGroup: (typeof InvoiceGroupModule)['InvoiceGroup'];
 let LocaleProvider: ({ children }: { children: React.ReactNode }) => React.ReactNode;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/client/src/components/budget/InvoiceLinkModal.test.tsx
+++ b/client/src/components/budget/InvoiceLinkModal.test.tsx
@@ -88,7 +88,9 @@ jest.unstable_mockModule('../Toast/ToastContext.js', () => ({
 
 // ─── Import component after mocks ─────────────────────────────────────────────
 
-let InvoiceLinkModal: (typeof import('./InvoiceLinkModal.js'))['InvoiceLinkModal'];
+import type * as InvoiceLinkModalModule from './InvoiceLinkModal.js';
+
+let InvoiceLinkModal: (typeof InvoiceLinkModalModule)['InvoiceLinkModal'];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -288,7 +288,9 @@ jest.unstable_mockModule('./geometry.js', () => ({
 
 // ─── Dynamic imports ──────────────────────────────────────────────────────────
 
-let PhotoAnnotator: typeof import('./PhotoAnnotator.js').PhotoAnnotator;
+import type * as PhotoAnnotatorModule from './PhotoAnnotator.js';
+
+let PhotoAnnotator: (typeof PhotoAnnotatorModule)['PhotoAnnotator'];
 
 // ─── Image stub: make imageLoaded=true synchronously ─────────────────────────
 //

--- a/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
+++ b/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
@@ -86,7 +86,9 @@ jest.unstable_mockModule('../../lib/preferencesApi.js', () => ({
 
 // ─── Dynamic imports (after mocks) ────────────────────────────────────────────
 
-let PhotoMetadataSidepanel: typeof import('./PhotoMetadataSidepanel.js').PhotoMetadataSidepanel;
+import type * as PhotoMetadataSidepanelModule from './PhotoMetadataSidepanel.js';
+
+let PhotoMetadataSidepanel: (typeof PhotoMetadataSidepanelModule)['PhotoMetadataSidepanel'];
 let LocaleProvider: (props: { children: React.ReactNode }) => React.ReactElement;
 
 // ─── Test fixtures ────────────────────────────────────────────────────────────

--- a/client/src/components/photos/PhotoViewer.test.tsx
+++ b/client/src/components/photos/PhotoViewer.test.tsx
@@ -132,7 +132,9 @@ jest.unstable_mockModule('./PhotoMetadataSidepanel.js', () => ({
 
 // ─── Dynamic imports ──────────────────────────────────────────────────────────
 
-let PhotoViewer: typeof import('./PhotoViewer.js').PhotoViewer;
+import type * as PhotoViewerModule from './PhotoViewer.js';
+
+let PhotoViewer: (typeof PhotoViewerModule)['PhotoViewer'];
 
 // ─── Test fixtures ────────────────────────────────────────────────────────────
 

--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -328,7 +328,7 @@ export class BudgetSourcesPage {
    * The row must be visible and not in edit mode.
    * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
    */
-  getSourceRowByName(name: string): import('@playwright/test').Locator {
+  getSourceRowByName(name: string): Locator {
     return this.page.locator('[class*="sourceRow_"]').filter({ hasText: name });
   }
 
@@ -336,14 +336,14 @@ export class BudgetSourcesPage {
    * Get the "System" badge within the named source row.
    * Returns null if the source is not found or has no system badge.
    */
-  getSystemBadge(sourceName: string): import('@playwright/test').Locator {
+  getSystemBadge(sourceName: string): Locator {
     return this.getSourceRowByName(sourceName).locator('[class*="systemBadge"]');
   }
 
   /**
    * Get the inline edit type select for the source currently being edited (by source id).
    */
-  getEditTypeSelect(sourceId: string): import('@playwright/test').Locator {
+  getEditTypeSelect(sourceId: string): Locator {
     return this.page.locator(`#edit-type-${sourceId}`);
   }
 
@@ -354,7 +354,7 @@ export class BudgetSourcesPage {
    *
    * @deprecated `barLegendLabel` no longer exists after PR #1319. Use `getSummaryLabels()` instead.
    */
-  getAmountLabelsInRow(sourceName: string): import('@playwright/test').Locator {
+  getAmountLabelsInRow(sourceName: string): Locator {
     return this.getSummaryLabels(sourceName);
   }
 
@@ -363,7 +363,7 @@ export class BudgetSourcesPage {
    * Renders as: <span class="totalBadge">Total: €100,000.00</span>
    * (class name contains "totalBadge" after CSS Modules transformation)
    */
-  getTotalBadge(sourceName: string): import('@playwright/test').Locator {
+  getTotalBadge(sourceName: string): Locator {
     return this.getSourceRowByName(sourceName).locator('[class*="totalBadge"]');
   }
 
@@ -372,7 +372,7 @@ export class BudgetSourcesPage {
    * Three labels render in order: Projected, Paid, Claimed.
    * Each label is a <span class="summaryLabel"> inside the summary table.
    */
-  getSummaryLabels(sourceName: string): import('@playwright/test').Locator {
+  getSummaryLabels(sourceName: string): Locator {
     return this.getSourceRowByName(sourceName).locator(
       '[class*="summaryLabel"]:not([class*="summaryLabelDot"])',
     );
@@ -383,7 +383,7 @@ export class BudgetSourcesPage {
    * Renders as: <p class="sourceInterestRate">Rate X.X%</p>
    * Only present when the source has a non-null interestRate.
    */
-  getInterestRateSubtitle(sourceName: string): import('@playwright/test').Locator {
+  getInterestRateSubtitle(sourceName: string): Locator {
     return this.getSourceRowByName(sourceName).locator('[class*="sourceInterestRate"]');
   }
 
@@ -394,7 +394,7 @@ export class BudgetSourcesPage {
    * The button has aria-label "Expand budget lines for <name>" or
    * "Collapse budget lines for <name>".
    */
-  getExpandToggle(sourceName: string): import('@playwright/test').Locator {
+  getExpandToggle(sourceName: string): Locator {
     return this.getSourceRowByName(sourceName).getByRole('button', {
       name: new RegExp(
         `(Expand|Collapse) budget lines for ${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
@@ -407,7 +407,7 @@ export class BudgetSourcesPage {
    * Get the lines panel region for a specific source by its ID.
    * The panel renders as: <div id="source-lines-{sourceId}" role="region">
    */
-  getLinesPanelById(sourceId: string): import('@playwright/test').Locator {
+  getLinesPanelById(sourceId: string): Locator {
     return this.page.locator(`[id="source-lines-${sourceId}"]`);
   }
 
@@ -440,7 +440,7 @@ export class BudgetSourcesPage {
    * @param sourceId    The numeric source ID used to scope to the correct panel.
    * @param lineDescription  The line's description text (used in the aria-label).
    */
-  getLineCheckbox(sourceId: string, lineDescription: string): import('@playwright/test').Locator {
+  getLineCheckbox(sourceId: string, lineDescription: string): Locator {
     return this.getLinesPanelById(sourceId).getByRole('checkbox', {
       name: `Select ${lineDescription}`,
     });
@@ -456,7 +456,7 @@ export class BudgetSourcesPage {
    * @param sourceId  The numeric source ID used to scope to the correct panel.
    * @param areaName  The area name displayed in the group header.
    */
-  getAreaNameSelector(sourceId: string, areaName: string): import('@playwright/test').Locator {
+  getAreaNameSelector(sourceId: string, areaName: string): Locator {
     return this.getLinesPanelById(sourceId).getByRole('checkbox', {
       name: `Select all in ${areaName}`,
     });
@@ -466,7 +466,7 @@ export class BudgetSourcesPage {
    * @deprecated Use getAreaNameSelector instead.
    * Kept as an alias so existing callers continue to compile during the transition.
    */
-  getAreaGroupCheckbox(sourceId: string, areaName: string): import('@playwright/test').Locator {
+  getAreaGroupCheckbox(sourceId: string, areaName: string): Locator {
     return this.getAreaNameSelector(sourceId, areaName);
   }
 
@@ -477,7 +477,7 @@ export class BudgetSourcesPage {
    * @param sourceId    The numeric source ID used to scope to the correct panel.
    * @param parentName  The parent work/household item name.
    */
-  getParentItemCard(sourceId: string, parentName: string): import('@playwright/test').Locator {
+  getParentItemCard(sourceId: string, parentName: string): Locator {
     return this.getLinesPanelById(sourceId).getByRole('checkbox', {
       name: `Select all under ${parentName}`,
     });
@@ -491,7 +491,7 @@ export class BudgetSourcesPage {
    * @param sourceId    The numeric source ID used to scope to the correct panel.
    * @param parentName  The parent work/household item name.
    */
-  getParentItemNavIcon(sourceId: string, parentName: string): import('@playwright/test').Locator {
+  getParentItemNavIcon(sourceId: string, parentName: string): Locator {
     return this.getLinesPanelById(sourceId).getByRole('link', {
       name: `Open ${parentName}`,
     });
@@ -505,7 +505,7 @@ export class BudgetSourcesPage {
    * The selector excludes `.actionBarCount` and `.actionBarButton` children which also
    * contain "actionBar" in their CSS module class names, avoiding a strict-mode violation.
    */
-  getActionBar(sourceId: string): import('@playwright/test').Locator {
+  getActionBar(sourceId: string): Locator {
     return this.getLinesPanelById(sourceId).locator(
       '[class*="actionBar"]:not([class*="actionBarCount"]):not([class*="actionBarButton"])',
     );
@@ -514,7 +514,7 @@ export class BudgetSourcesPage {
   /**
    * Get the "Move to another source…" button inside the action bar.
    */
-  getMoveButton(sourceId: string): import('@playwright/test').Locator {
+  getMoveButton(sourceId: string): Locator {
     return this.getActionBar(sourceId).getByRole('button', {
       name: 'Move to another source\u2026',
     });
@@ -526,7 +526,7 @@ export class BudgetSourcesPage {
    * The mass-move modal dialog. Title: "Move lines to another source".
    * Uses Modal component which sets role="dialog" + aria-labelledby on the h2 title.
    */
-  get moveModal(): import('@playwright/test').Locator {
+  get moveModal(): Locator {
     return this.page.getByRole('dialog', { name: 'Move lines to another source' });
   }
 
@@ -534,21 +534,21 @@ export class BudgetSourcesPage {
    * The SearchPicker input inside the move modal.
    * The input has id="target-source".
    */
-  get moveModalSearchInput(): import('@playwright/test').Locator {
+  get moveModalSearchInput(): Locator {
     return this.moveModal.locator('#target-source');
   }
 
   /**
    * The "Move lines" confirm button inside the move modal footer.
    */
-  get moveModalConfirmButton(): import('@playwright/test').Locator {
+  get moveModalConfirmButton(): Locator {
     return this.moveModal.getByRole('button', { name: /Move lines|Loading/i });
   }
 
   /**
    * The Cancel button inside the move modal footer.
    */
-  get moveModalCancelButton(): import('@playwright/test').Locator {
+  get moveModalCancelButton(): Locator {
     return this.moveModal.getByRole('button', { name: 'Cancel', exact: true });
   }
 
@@ -556,14 +556,14 @@ export class BudgetSourcesPage {
    * The claimed invoice warning block inside the move modal.
    * Renders as role="alert" only when claimedCount > 0.
    */
-  get moveModalWarningBlock(): import('@playwright/test').Locator {
+  get moveModalWarningBlock(): Locator {
     return this.moveModal.locator('[role="alert"]');
   }
 
   /**
    * The "I understand" checkbox inside the claimed warning block.
    */
-  get moveModalUnderstoodCheckbox(): import('@playwright/test').Locator {
+  get moveModalUnderstoodCheckbox(): Locator {
     return this.moveModal.getByRole('checkbox', {
       name: 'I understand this will reassign lines with a claimed invoice',
     });
@@ -584,7 +584,7 @@ export class BudgetSourcesPage {
    * FormError renders a div with the CSS module class "banner" and role="alert".
    * Differentiated from the claimed-invoice warning block via the CSS class name.
    */
-  get moveModalFormError(): import('@playwright/test').Locator {
+  get moveModalFormError(): Locator {
     // FormError uses its own CSS module: styles.banner → [class*="banner"]
     // The warning block uses MassMoveModal's styles.warningBlock → [class*="warningBlock"]
     // These are distinct CSS module classes so the selector is unambiguous.

--- a/e2e/tests/diary/diary-drafts.spec.ts
+++ b/e2e/tests/diary/diary-drafts.spec.ts
@@ -26,6 +26,7 @@
  * 18. Editing a saved entry unchanged (save → no Draft badge, no discard button)
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/auth.js';
 import { DiaryPage, DIARY_ROUTE } from '../../pages/DiaryPage.js';
 import { DiaryEntryCreatePage, DIARY_CREATE_ROUTE } from '../../pages/DiaryEntryCreatePage.js';
@@ -52,7 +53,7 @@ async function waitForDiaryListLoaded(diaryPage: DiaryPage): Promise<void> {
 }
 
 /** Wait for an API response matching the diary entries endpoint. */
-function waitForDiaryListResponse(page: import('@playwright/test').Page) {
+function waitForDiaryListResponse(page: Page) {
   return page.waitForResponse(
     (resp) => resp.url().includes('/api/diary-entries') && resp.status() === 200,
   );

--- a/e2e/tests/diary/diary-source-entity-breadcrumb.spec.ts
+++ b/e2e/tests/diary/diary-source-entity-breadcrumb.spec.ts
@@ -16,6 +16,7 @@
  * event types (e.g. invoice_status) in a controlled manner.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/auth.js';
 import { DiaryEntryDetailPage } from '../../pages/DiaryEntryDetailPage.js';
 import {
@@ -31,7 +32,7 @@ import { API } from '../../fixtures/testData.js';
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function patchWorkItemStatus(
-  page: import('@playwright/test').Page,
+  page: Page,
   workItemId: string,
   status: string,
 ): Promise<void> {
@@ -46,7 +47,7 @@ async function patchWorkItemStatus(
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function findAutoDiaryEntryId(
-  page: import('@playwright/test').Page,
+  page: Page,
   workItemId: string,
 ): Promise<string> {
   // GET /api/diary-entries uses "type" query param (not "entryType") for filtering

--- a/e2e/tests/i18n/i18n.spec.ts
+++ b/e2e/tests/i18n/i18n.spec.ts
@@ -17,6 +17,7 @@
  * on WebKit tablet — and language correctness is not viewport-specific.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/auth.js';
 import { ROUTES } from '../../fixtures/testData.js';
 
@@ -36,7 +37,7 @@ import { ROUTES } from '../../fixtures/testData.js';
  * for the preferences API response.
  */
 async function setLanguage(
-  page: import('@playwright/test').Page,
+  page: Page,
   lang: 'en' | 'de' | 'system',
 ): Promise<void> {
   // Persist preference server-side
@@ -55,7 +56,7 @@ async function setLanguage(
  * Used in test teardown to prevent language state leaking between tests.
  * We reset both localStorage (client-side) and the server preference.
  */
-async function resetToEnglish(page: import('@playwright/test').Page): Promise<void> {
+async function resetToEnglish(page: Page): Promise<void> {
   // Reset server-side preference
   await page.request.patch('/api/users/me/preferences', {
     data: { key: 'locale', value: 'en' },

--- a/e2e/tests/work-items/work-item-embeds-breadcrumb.spec.ts
+++ b/e2e/tests/work-items/work-item-embeds-breadcrumb.spec.ts
@@ -18,6 +18,7 @@
  * 6. Gantt sidebar — null area "No area" in sidebar row (desktop only)
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/auth.js';
 import { MilestoneDetailPage } from '../../pages/MilestoneDetailPage.js';
 import { TimelinePage } from '../../pages/TimelinePage.js';
@@ -36,7 +37,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function linkWorkItemToMilestone(
-  page: import('@playwright/test').Page,
+  page: Page,
   milestoneId: number,
   workItemId: string,
 ): Promise<void> {

--- a/server/src/routes/photos.test.ts
+++ b/server/src/routes/photos.test.ts
@@ -26,6 +26,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type { Photo, ApiErrorResponse } from '@cornerstone/shared';
+import type * as AppModule from '../app.js';
+import type * as UserServiceModule from '../services/userService.js';
+import type * as SessionServiceModule from '../services/sessionService.js';
 import { diaryEntries } from '../db/schema.js';
 
 // ─── Mock photoService BEFORE importing app ────────────────────────────────────
@@ -66,9 +69,9 @@ jest.unstable_mockModule('../services/photoService.js', () => ({
 
 // ─── Dynamic imports (after mocks) ───────────────────────────────────────────
 
-let buildApp: typeof import('../app.js').buildApp;
-let userService: typeof import('../services/userService.js');
-let sessionService: typeof import('../services/sessionService.js');
+let buildApp: typeof AppModule.buildApp;
+let userService: typeof UserServiceModule;
+let sessionService: typeof SessionServiceModule;
 
 // ─── Test fixtures ────────────────────────────────────────────────────────────
 

--- a/server/src/services/draftCleanupService.test.ts
+++ b/server/src/services/draftCleanupService.test.ts
@@ -15,6 +15,8 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { runMigrations } from '../db/migrate.js';
 import * as schema from '../db/schema.js';
 import type { AppConfig } from '../plugins/config.js';
+import type * as NodeCron from 'node-cron';
+import type * as DraftCleanupServiceModule from './draftCleanupService.js';
 
 // ─── Mock node-cron ──────────────────────────────────────────────────────────
 
@@ -22,7 +24,7 @@ const mockCronTask = {
   stop: jest.fn(),
 };
 
-const mockCronSchedule = jest.fn<typeof import('node-cron').schedule>();
+const mockCronSchedule = jest.fn<typeof NodeCron.schedule>();
 
 jest.unstable_mockModule('node-cron', () => ({
   default: {
@@ -94,9 +96,9 @@ const mockLogger = {
 } as any;
 
 describe('draftCleanupService', () => {
-  let runOrphanCleanup: typeof import('./draftCleanupService.js').runOrphanCleanup;
-  let initScheduler: typeof import('./draftCleanupService.js').initScheduler;
-  let stopScheduler: typeof import('./draftCleanupService.js').stopScheduler;
+  let runOrphanCleanup: typeof DraftCleanupServiceModule.runOrphanCleanup;
+  let initScheduler: typeof DraftCleanupServiceModule.initScheduler;
+  let stopScheduler: typeof DraftCleanupServiceModule.stopScheduler;
 
   let db: BetterSQLite3Database<typeof schema>;
   let sqlite: ReturnType<typeof Database>;

--- a/server/src/services/photoAnnotationService.test.ts
+++ b/server/src/services/photoAnnotationService.test.ts
@@ -29,6 +29,7 @@ import { eq } from 'drizzle-orm';
 import { runMigrations } from '../db/migrate.js';
 import * as schema from '../db/schema.js';
 import type { Photo } from '@cornerstone/shared';
+import type * as PhotoAnnotationServiceModule from './photoAnnotationService.js';
 
 // ─── Mock sharp BEFORE any module import that uses it ─────────────────────────
 
@@ -81,7 +82,7 @@ jest.unstable_mockModule('./photoService.js', () => ({
 
 // ─── Dynamic imports (must come AFTER jest.unstable_mockModule) ─────────────
 
-let photoAnnotationService: typeof import('./photoAnnotationService.js');
+let photoAnnotationService: typeof PhotoAnnotationServiceModule;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/server/src/services/photoService.test.ts
+++ b/server/src/services/photoService.test.ts
@@ -30,6 +30,7 @@ import { eq } from 'drizzle-orm';
 import { runMigrations } from '../db/migrate.js';
 import * as schema from '../db/schema.js';
 import { ValidationError } from '../errors/AppError.js';
+import type * as PhotoServiceModule from './photoService.js';
 
 // ─── Mock sharp BEFORE any module import that uses it ─────────────────────────
 
@@ -72,7 +73,7 @@ jest.unstable_mockModule('sharp', () => ({
 
 // ─── Dynamic imports (must come AFTER jest.unstable_mockModule) ─────────────
 
-let photoService: typeof import('./photoService.js');
+let photoService: typeof PhotoServiceModule;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Converts 52 inline `import()` type annotations to top-of-file `import type` declarations across 23 test and page-object files
- Files affected: 14 client test files, 4 server test files, 1 e2e page object, 4 e2e spec files
- Zero runtime behavior change — purely mechanical lint compliance to satisfy the `@typescript-eslint/consistent-type-imports` ESLint rule

## Acceptance Criteria

- [x] 0 `consistent-type-imports` lint errors (verified pre-commit hook passed)
- [x] No production source files modified — changes are test/page-object files only
- [x] Typecheck validation via CI Quality Gates

Fixes #1458

## Test plan

- [ ] Quality Gates CI pass (typecheck, unit tests, build, E2E smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>