### PR TITLE
chore(test-infra): audit Jest unit test memory + fix useNavigate anti-pattern (#1568)

### DIFF
--- a/.claude/agent-memory/qa-integration-tester/MEMORY.md
+++ b/.claude/agent-memory/qa-integration-tester/MEMORY.md
@@ -3,6 +3,12 @@
 > Detailed notes live in topic files. This index links to them.
 > See: `budget-categories-story-142.md`, `e2e-pom-patterns.md`, `e2e-parallel-isolation.md`, `story-358-document-linking.md`, `story-360-document-a11y.md`, `story-epic08-e2e.md`, `story-509-manage-page.md`, `story-471-dashboard.md`
 
+## Issue #1568 — Jest ESM mock static-import constraint (2026-06-15)
+
+**jest.unstable_mockModule + static import before it = mock fails in CI**: In Jest 30 with `--experimental-vm-modules`, adding a static `import` statement BEFORE `jest.unstable_mockModule()` in a test file breaks mock registration for components that call the mocked module's code directly (e.g., `useFormatters()` → `useLocale()`). Components tested by files in shards 3/4 that also mock `LocaleContext` (or don't call `useFormatters()` directly) appear to pass — but that's because they have a safety net, not because the mock works. The inline factory pattern (all code inside the `jest.unstable_mockModule()` factory body, no imports before it) is REQUIRED for reliable mock registration in Jest ESM. Attempted shared-factory approach across 46 files was reverted.
+
+**Stable useNavigate mock pattern**: `useNavigate: () => jest.fn()` in a jest.unstable_mockModule factory allocates a new function on every component render/re-render. Replace with a module-scope `const mockNavigate = jest.fn()` + `useNavigate: () => mockNavigate` + `mockNavigate.mockClear()` in beforeEach. This is a genuine memory improvement (fewer short-lived allocations). Applied to `LinkedDocumentsSection.test.tsx` in PR #1686.
+
 ## Story #1677 — effectiveLineAmount VAT gross-up tests (2026-06-15)
 
 **Coverage: budget.ts needs effectivePlannedAmount tested too**: When adding tests for `effectiveLineAmount`, the coverage tool also measures `effectivePlannedAmount` (same file). Add tests for it to reach 100% on `shared/src/types/budget.ts`. Import via `import { CONFIDENCE_MARGINS, effectivePlannedAmount, effectiveLineAmount } from './budget.js'`.

--- a/client/src/components/documents/LinkedDocumentsSection.test.tsx
+++ b/client/src/components/documents/LinkedDocumentsSection.test.tsx
@@ -70,9 +70,14 @@ jest.unstable_mockModule('../../lib/configApi.js', () => ({
 // module via `await import` retains the whole library per-test and causes Jest
 // workers to OOM. This file does not render <Routes>/<Link>/etc., so the real
 // module is not needed.
+//
+// Stable mock: declare at module scope so each test render re-uses the same function
+// object instead of allocating a new jest.fn() on every component render.
+
+const mockNavigate = jest.fn();
 
 jest.unstable_mockModule('react-router-dom', () => ({
-  useNavigate: () => jest.fn(),
+  useNavigate: () => mockNavigate,
 }));
 
 // ─── Mock: child components (to avoid transitive dependency issues) ───────────
@@ -227,6 +232,7 @@ beforeEach(async () => {
   mockGetPaperlessStatus.mockReset();
   mockFetchConfig.mockReset();
   capturedLinkedDocumentIds = undefined;
+  mockNavigate.mockClear();
 
   // Default: configured paperless, no links, auto-itemize disabled
   mockUseDocumentLinks.mockReturnValue(makeHook());


### PR DESCRIPTION
## Summary

Audit of Jest unit-test memory growth (issue #1568). The >4 GB OOM in #1564 was a single pathological file (a `react-router-dom` `{...actual}` mock spread), already fixed in #1566. This PR completes the broader audit, applies a safe per-render fix, and records the CI-defense decision.

### Acceptance criteria

**1. Top-3 most memory-hungry test files** (measured with `jest --logHeapUsage --maxWorkers=1`, Node 22):

| Rank | File | Peak heap |
| ---- | ---- | --------- |
| 1 | `HouseholdItemDetailPage.test.tsx` | **1071 MB** |
| 2 | `LinkedDocumentsSection.test.tsx` | **1041 MB** |
| 3 | `CostBreakdownTable.test.tsx` | **623 MB** |

(Also measured: BudgetSourcesPage 615 MB, SubsidyProgramsPage 609 MB, AutoItemizePage 578 MB.)

**2. Reduce peak worker heap < 2 GB per test** — already satisfied: the worst single-file peak is **1071 MB**, far below 2 GB. No individual file is pathological after the #1566 fix. Applied an additional safe reduction: replaced the per-render `useNavigate: () => jest.fn()` allocation in `LinkedDocumentsSection.test.tsx` with a stable module-scope mock cleared in `beforeEach`.

**3. CI defenses — kept (orchestrator's call).** The flags (`--max-old-space-size=6144`, `--maxWorkers=2`, `--workerIdleMemoryLimit=2048MB`) guard the *cumulative per-worker* heap as a shard processes dozens of files sequentially — a scenario single-file profiling doesn't exercise. They remain a cheap, conservatively-set safety net (idle limit is approx 2x the worst observed single-file peak; worst-case 2-worker concurrent approx 2.1 GB, inside Node's 4144 MB default). They are kept because the cumulative-retention refactor that would justify dropping them could not be landed (below).

### Deferred: shared formatters-mock dedup (Phases 2-3)

The dominant remaining pattern is a ~60-line inline `jest.unstable_mockModule('...formatters.js', ...)` block duplicated across 46 test files. Deduplicating it into a shared factory imported per file was attempted but reverted: under Jest 30 ESM (`--experimental-vm-modules`), a static `import` before `jest.unstable_mockModule()` failed to intercept in CI shards 1/2. Not required to meet the per-file <2 GB criterion; documented in qa-integration-tester memory for a future, more careful attempt.

## Changes

- `client/src/components/documents/LinkedDocumentsSection.test.tsx` — stable `useNavigate` mock (no per-render `jest.fn()` allocation).
- `.claude/agent-memory/qa-integration-tester/MEMORY.md` — record the Jest ESM mock-interception finding and the stable-mock pattern.

Fixes #1568

## Test plan
- [x] Heap profiled for the 6 largest test files; top-3 identified; all < 2 GB.
- [x] `LinkedDocumentsSection.test.tsx` passes in CI (Node 24) after the mock change.
- [x] No production code changed (test-infra only).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>