### PR TITLE
chore: zero out remaining ESLint warnings + errors (#1455)

### DIFF
--- a/client/src/components/AreaBreadcrumb/AreaBreadcrumb.tsx
+++ b/client/src/components/AreaBreadcrumb/AreaBreadcrumb.tsx
@@ -28,12 +28,14 @@ export function AreaBreadcrumb({ area, variant = 'default' }: AreaBreadcrumbProp
   segments.forEach((name, index) => {
     if (index > 0) {
       listItems.push(
+        // eslint-disable-next-line @eslint-react/no-array-index-key -- static fixed-order breadcrumb segments; index is a stable key here
         <li key={`sep-${index}`} className={styles.separator} aria-hidden="true">
           {SEPARATOR}
         </li>,
       );
     }
     listItems.push(
+      // eslint-disable-next-line @eslint-react/no-array-index-key -- static fixed-order breadcrumb segments; index is a stable key here
       <li key={`seg-${index}`} className={styles.segment}>
         {name}
       </li>,

--- a/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/client/src/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, createContext, use, useMemo, useCallback } from 'react';
+import { useState, useRef, createContext, use, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type {

--- a/client/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/client/src/components/DateRangePicker/DateRangePicker.tsx
@@ -384,6 +384,7 @@ export function DateRangePicker({
         </div>
 
         {weeks.map((week, weekIndex) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- static month grid; week index is a stable key here
           <div key={weekIndex} className={styles.weekRow} role="row">
             {week.map((day) => {
               const isSelected = day.dateStr === startDate || day.dateStr === endDate;

--- a/client/src/components/GanttChart/GanttGrid.tsx
+++ b/client/src/components/GanttChart/GanttGrid.tsx
@@ -71,7 +71,7 @@ export const GanttGrid = memo(function GanttGrid({
       {/* Vertical grid lines */}
       {gridLines.map((line, idx) => (
         <line
-          key={`vline-${idx}`}
+          key={`vline-${idx}`} // eslint-disable-line @eslint-react/no-array-index-key -- static grid lines; index is a stable key here
           x1={line.x}
           y1={0}
           x2={line.x}

--- a/client/src/components/GanttChart/GanttTooltip.tsx
+++ b/client/src/components/GanttChart/GanttTooltip.tsx
@@ -331,6 +331,7 @@ function WorkItemTooltipContent({
               aria-label={t('gantt.tooltip.workItem.dependencies')}
             >
               {shownDeps.map((dep, idx) => (
+                // eslint-disable-next-line @eslint-react/no-array-index-key -- dependency list filtered at render time; composite key with title+index is stable
                 <li key={`${dep.relatedTitle}-${idx}`} className={styles.linkedItem}>
                   <span className={styles.depTypeLabel}>
                     {dependencyTypeLabels[dep.dependencyType]}

--- a/client/src/components/MiniGanttCard/MiniGanttCard.tsx
+++ b/client/src/components/MiniGanttCard/MiniGanttCard.tsx
@@ -154,6 +154,7 @@ export function MiniGanttCard({ timeline }: MiniGanttCardProps) {
     );
   }
 
+  // eslint-disable-next-line @eslint-react/purity -- intentional current-time read for today marker; value is meant to reflect render time for date calculations
   const todayLocal = new Date();
   const todayNoon = new Date(
     todayLocal.getFullYear(),
@@ -219,7 +220,7 @@ export function MiniGanttCard({ timeline }: MiniGanttCardProps) {
           const dayLabel = labelDate.toLocaleDateString('en-US', { weekday: 'short' });
           return (
             <text
-              key={`header-${i}`}
+              key={`header-${i}`} // eslint-disable-line @eslint-react/no-array-index-key -- static 5-day window header; index is a stable key here
               x={x + 4}
               y={HEADER_HEIGHT - 8}
               fontSize="14"
@@ -237,7 +238,7 @@ export function MiniGanttCard({ timeline }: MiniGanttCardProps) {
           const x = dateToX(lineDate, windowStart);
           return (
             <line
-              key={`grid-${i}`}
+              key={`grid-${i}`} // eslint-disable-line @eslint-react/no-array-index-key -- static 5-day window grid; index is a stable key here
               x1={x}
               y1={HEADER_HEIGHT}
               x2={x}

--- a/client/src/components/SearchPicker/SearchPicker.tsx
+++ b/client/src/components/SearchPicker/SearchPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -85,6 +85,7 @@ export function SearchPicker<T>({
   // Update dropdown rect for portal positioning
   const updateDropdownRect = useCallback(() => {
     if (inputRef.current) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- DOM-measurement state update invoked from effect callback
       setDropdownRect(inputRef.current.getBoundingClientRect());
     }
   }, []);
@@ -240,6 +241,18 @@ export function SearchPicker<T>({
     inputRef.current?.focus();
   };
 
+  // Compute dropdown top position (fixed vs above)
+  const dropdownTop = useMemo(() => {
+    if (!dropdownRect) return 0;
+    const VIEWPORT_PADDING = 8;
+    const DROPDOWN_HEIGHT = 300;
+    const spaceBelow = window.innerHeight - dropdownRect.bottom;
+    const flipAbove = spaceBelow < DROPDOWN_HEIGHT + VIEWPORT_PADDING;
+    return flipAbove
+      ? Math.max(4, dropdownRect.top - DROPDOWN_HEIGHT - 4)
+      : dropdownRect.bottom + 4;
+  }, [dropdownRect]);
+
   // If a special option is selected, show it in a display similar to selectedItem
   if (selectedSpecial) {
     return (
@@ -332,15 +345,7 @@ export function SearchPicker<T>({
             data-search-picker-dropdown
             style={{
               position: 'fixed',
-              top: (() => {
-                const VIEWPORT_PADDING = 8;
-                const DROPDOWN_HEIGHT = 300;
-                const spaceBelow = window.innerHeight - dropdownRect.bottom;
-                const flipAbove = spaceBelow < DROPDOWN_HEIGHT + VIEWPORT_PADDING;
-                return flipAbove
-                  ? Math.max(4, dropdownRect.top - DROPDOWN_HEIGHT - 4)
-                  : dropdownRect.bottom + 4;
-              })(),
+              top: dropdownTop,
               left: dropdownRect.left,
               width: dropdownRect.width,
             }}

--- a/client/src/components/Toast/ToastContext.test.tsx
+++ b/client/src/components/Toast/ToastContext.test.tsx
@@ -342,6 +342,7 @@ describe('ToastProvider', () => {
 describe('useToast', () => {
   it('throws an error when used outside ToastProvider', () => {
     function ComponentWithoutProvider() {
+      // eslint-disable-next-line @eslint-react/error-boundaries -- test intentionally uses try/catch to assert error behavior
       try {
         useToast();
         return <div>No error</div>;

--- a/client/src/components/budget/BudgetLineForm.tsx
+++ b/client/src/components/budget/BudgetLineForm.tsx
@@ -10,7 +10,6 @@ import type {
 } from '@cornerstone/shared';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
 import { getCategoryDisplayName } from '../../lib/categoryUtils.js';
-import { translateApiError } from '../../lib/errorTranslation.js';
 import { FormError } from '../FormError/index.js';
 import { ParentPicker } from '../ParentPicker/index.js';
 import styles from './BudgetLineForm.module.css';
@@ -70,7 +69,6 @@ export function BudgetLineForm({
 }: BudgetLineFormProps) {
   const { t } = useTranslation('budget');
   const { t: tSettings } = useTranslation('settings');
-  const { t: tErrors } = useTranslation('errors');
 
   // Parent picker state
   const [selectedParentType, setSelectedParentType] = useState<'work_item' | 'household_item'>(

--- a/client/src/components/budget/BudgetSection.tsx
+++ b/client/src/components/budget/BudgetSection.tsx
@@ -15,7 +15,7 @@ import { BudgetLineForm } from './BudgetLineForm.js';
 import { SubsidyLinkSection } from './SubsidyLinkSection.js';
 import { BudgetCostOverview, type SubsidyPaybackData } from './BudgetCostOverview.js';
 import { InvoiceGroup } from './InvoiceGroup.js';
-import { EditBudgetLineModal, type EditableBudgetLine } from './EditBudgetLineModal.js';
+import { EditBudgetLineModal } from './EditBudgetLineModal.js';
 import styles from './BudgetSection.module.css';
 
 export interface BudgetSectionProps<T extends BaseBudgetLine> {

--- a/client/src/components/budget/EditBudgetLineModal.test.tsx
+++ b/client/src/components/budget/EditBudgetLineModal.test.tsx
@@ -10,7 +10,7 @@
  */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import React from 'react';
-import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { BudgetSource, Vendor, BudgetCategory, ConfidenceLevel } from '@cornerstone/shared';
 import type { EditBudgetLineModalProps, EditableBudgetLine } from './EditBudgetLineModal.js';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';

--- a/client/src/components/budget/EditBudgetLineModal.tsx
+++ b/client/src/components/budget/EditBudgetLineModal.tsx
@@ -1,7 +1,6 @@
 import { type FormEvent } from 'react';
 import type { BudgetCategory, BudgetSource, ConfidenceLevel, Vendor } from '@cornerstone/shared';
 import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
-import { getCategoryDisplayName } from '../../lib/categoryUtils.js';
 import { BudgetLineForm } from './BudgetLineForm.js';
 import { Modal } from '../Modal/Modal.js';
 

--- a/client/src/components/calendar/MonthGrid.tsx
+++ b/client/src/components/calendar/MonthGrid.tsx
@@ -139,6 +139,7 @@ export function MonthGrid({
         const containerHeight = maxLane >= 0 ? (maxLane + 1) * LANE_HEIGHT_COMPACT : undefined;
 
         return (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- static month grid; week index is a stable key here
           <div key={weekIdx} className={styles.weekRow} role="row">
             {week.map((day) => {
               const dayItems = getItemsForDay(day.dateStr, workItems);

--- a/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
+++ b/client/src/components/diary/DiaryEntryForm/DiaryEntryForm.tsx
@@ -585,6 +585,7 @@ export function DiaryEntryForm({
             {(deliveryMaterials?.length ?? 0) > 0 && (
               <div className={styles.materialsList}>
                 {deliveryMaterials!.map((material, index) => (
+                  // eslint-disable-next-line @eslint-react/no-array-index-key -- materials list may have duplicates; composite key with material+index is stable
                   <div key={`${material}-${index}`} className={styles.materialChip}>
                     <span>{material}</span>
                     <button

--- a/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.test.tsx
+++ b/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.test.tsx
@@ -7,7 +7,7 @@
  * Covers all the new daily_log metadata fields as well as the pre-existing
  * weather/temperature/workers behaviour and the site_visit render path.
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import type React from 'react';
 import type { DiaryEntryType } from '@cornerstone/shared';

--- a/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.tsx
+++ b/client/src/components/diary/DiaryMetadataSummary/DiaryMetadataSummary.tsx
@@ -112,6 +112,7 @@ export function DiaryMetadataSummary({ entryType, metadata }: DiaryMetadataSumma
             <span className={styles.deliveryLabel}>{t('entryForm.materialsLabel')}</span>
             <div className={styles.materialsList}>
               {m.materials.map((material, idx) => (
+                // eslint-disable-next-line @eslint-react/no-array-index-key -- materials list may have duplicates; composite key with material+index is stable
                 <span key={`${material}-${idx}`} className={styles.materialTag}>
                   {material}
                 </span>

--- a/client/src/components/diary/SignatureCapture/SignatureCapture.tsx
+++ b/client/src/components/diary/SignatureCapture/SignatureCapture.tsx
@@ -103,6 +103,7 @@ export function SignatureCapture({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !signature) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- canvas initialization state update invoked from effect
       setHasStrokes(false);
 
       return;

--- a/client/src/components/diary/SignatureSection/SignatureSection.tsx
+++ b/client/src/components/diary/SignatureSection/SignatureSection.tsx
@@ -59,30 +59,30 @@ export function SignatureSection({
         <div className={styles.signaturesList}>
           {signatures!.map((sig, index) => (
             <div
-              key={`${sig.signerType}-${sig.signerName}-${index}`}
+              key={`${sig.signerType}-${sig.signerName}-${index}`} // eslint-disable-line @eslint-react/no-array-index-key -- signatures list may have duplicates; composite key with signerType+name+index is stable
               className={styles.signatureItem}
             >
-              <SignatureCapture
-                signature={sig.signatureDataUrl ? sig : null}
-                onSignatureChange={(updated) => {
-                  handleSignatureUpdate(index, updated);
-                }}
-                signerName={sig.signerName}
-                onSignerNameChange={(name) => {
-                  onSignatureChange(index, { ...sig, signerName: name });
-                }}
-                signerType={sig.signerType}
-                onSignerTypeChange={(type) => {
-                  onSignatureChange(index, {
-                    ...sig,
-                    signerType: type,
-                    signerName: type === 'self' ? currentUserName || '' : '',
-                  });
-                }}
-                disabled={disabled}
-                currentUserName={currentUserName}
-                vendors={vendors}
-              />
+                <SignatureCapture
+                  signature={sig.signatureDataUrl ? sig : null}
+                  onSignatureChange={(updated) => {
+                    handleSignatureUpdate(index, updated);
+                  }}
+                  signerName={sig.signerName}
+                  onSignerNameChange={(name) => {
+                    onSignatureChange(index, { ...sig, signerName: name });
+                  }}
+                  signerType={sig.signerType}
+                  onSignerTypeChange={(type) => {
+                    onSignatureChange(index, {
+                      ...sig,
+                      signerType: type,
+                      signerName: type === 'self' ? currentUserName || '' : '',
+                    });
+                  }}
+                  disabled={disabled}
+                  currentUserName={currentUserName}
+                  vendors={vendors}
+                />
             </div>
           ))}
         </div>

--- a/client/src/components/milestones/WorkItemSelector.tsx
+++ b/client/src/components/milestones/WorkItemSelector.tsx
@@ -79,6 +79,7 @@ export function WorkItemSelector({
   // Update anchor rect for portal positioning
   const updateAnchorRect = useCallback(() => {
     if (containerRef.current) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- DOM-measurement state update invoked from effect callback
       setAnchorRect(containerRef.current.getBoundingClientRect());
     }
   }, []);

--- a/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
+++ b/client/src/components/photos/PhotoAnnotator/PhotoAnnotator.test.tsx
@@ -98,6 +98,7 @@ jest.unstable_mockModule('./useAnnotator.js', () => {
     const initialShapes = override?.shapes ?? [];
     const initialSelectedId = override?.selectedShapeId ?? null;
 
+    // eslint-disable-next-line @eslint-react/rules-of-hooks -- mockUseAnnotator is a test mock standing in for the useAnnotator hook
     const [state, dispatchBase] = useReducer(
       (
         s: {
@@ -166,6 +167,7 @@ jest.unstable_mockModule('./useAnnotator.js', () => {
       replace: jest.fn(),
     };
 
+    // eslint-disable-next-line @eslint-react/rules-of-hooks -- mockUseAnnotator is a test mock standing in for the useAnnotator hook
     const dispatch = useCallback(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (action: any) => dispatchBase(action),

--- a/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
+++ b/client/src/components/photos/PhotoAnnotator/useAnnotator.ts
@@ -100,7 +100,7 @@ export function annotatorReducer(
     case 'SET_DRAFT':
       return { ...state, draftShape: action.shape };
 
-    case 'COMMIT_DRAFT':
+    case 'COMMIT_DRAFT': {
       if (!state.draftShape) return state;
       const liveShapesOnCommit = undoStack?.shapes ?? state.shapes;
       const newShapes = [...liveShapesOnCommit, state.draftShape];
@@ -111,6 +111,7 @@ export function annotatorReducer(
         draftShape: null,
         selectedShapeId: null,
       };
+    }
 
     case 'SELECT_SHAPE':
       return { ...state, selectedShapeId: action.id };
@@ -124,7 +125,7 @@ export function annotatorReducer(
       return { ...state, shapes: updatedShapes };
     }
 
-    case 'DELETE_SELECTED':
+    case 'DELETE_SELECTED': {
       if (!state.selectedShapeId) return state;
       const liveShapesOnDelete = undoStack?.shapes ?? state.shapes;
       const filtered = liveShapesOnDelete.filter((s) => s.id !== state.selectedShapeId);
@@ -134,6 +135,7 @@ export function annotatorReducer(
         shapes: filtered,
         selectedShapeId: null,
       };
+    }
 
     case 'REPLACE_SHAPES':
       return { ...state, shapes: action.shapes };

--- a/client/src/contexts/AuthContext.test.tsx
+++ b/client/src/contexts/AuthContext.test.tsx
@@ -186,6 +186,7 @@ describe('AuthContext', () => {
 
   it('throws error when useAuth is called outside AuthProvider', async () => {
     function TestComponentWithoutProvider() {
+      // eslint-disable-next-line @eslint-react/error-boundaries -- test intentionally uses try/catch to assert error behavior
       try {
         useAuth();
         return <div>Should not reach here</div>;

--- a/client/src/contexts/LocaleContext.tsx
+++ b/client/src/contexts/LocaleContext.tsx
@@ -60,6 +60,7 @@ interface LocaleProviderProps {
 
 export function LocaleProvider({ children }: LocaleProviderProps) {
   const initialPreference = readStoredPreference();
+  // eslint-disable-next-line @eslint-react/use-state -- setLocaleState used to avoid collision with the public setLocale callback
   const [locale, setLocaleState] = useState<LocalePreference>(initialPreference);
   const [resolvedLocale, setResolvedLocale] = useState<ResolvedLocale>(() =>
     resolveLocale(initialPreference),

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -56,6 +56,7 @@ interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   // Read localStorage once, derive both initial states from the single value.
   const initialPreference = readStoredPreference();
+  // eslint-disable-next-line @eslint-react/use-state -- setThemeState used to avoid collision with the public setTheme callback
   const [theme, setThemeState] = useState<ThemePreference>(initialPreference);
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
     resolveTheme(initialPreference),

--- a/client/src/hooks/useBudgetSection.ts
+++ b/client/src/hooks/useBudgetSection.ts
@@ -249,9 +249,9 @@ export function useBudgetSection<T extends BaseBudgetLine>(
       setDeletingBudgetId(null);
       const apiErr = err as { statusCode?: number; message?: string };
       if (apiErr.statusCode === 409) {
-        throw new Error(apiErr.message || 'Budget line cannot be deleted because it is in use');
+        throw new Error(apiErr.message || 'Budget line cannot be deleted because it is in use', { cause: err });
       } else {
-        throw new Error('Failed to delete budget line');
+        throw new Error('Failed to delete budget line', { cause: err });
       }
     }
   };

--- a/client/src/hooks/usePaperless.ts
+++ b/client/src/hooks/usePaperless.ts
@@ -43,8 +43,8 @@ export function usePaperless(): UsePaperlessResult {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
-  const [selectedTags, setSelectedTagsState] = useState<number[]>([]);
-  const [page, setPageState] = useState(1);
+  const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  const [page, setPage] = useState(1);
   const [fetchCount, setFetchCount] = useState(0);
   const [tagCountMap, setTagCountMap] = useState<Map<number, number>>(() => new Map());
 
@@ -137,18 +137,14 @@ export function usePaperless(): UsePaperlessResult {
 
   const search = useCallback((q: string) => {
     setQuery(q);
-    setPageState(1);
+    setPage(1);
   }, []);
 
   const toggleTag = useCallback((tagId: number) => {
-    setSelectedTagsState((prev) =>
+    setSelectedTags((prev) =>
       prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
     );
-    setPageState(1);
-  }, []);
-
-  const setPage = useCallback((p: number) => {
-    setPageState(p);
+    setPage(1);
   }, []);
 
   const refresh = useCallback(() => {

--- a/client/src/pages/AutoItemizePage/AutoItemizePage.tsx
+++ b/client/src/pages/AutoItemizePage/AutoItemizePage.tsx
@@ -122,7 +122,7 @@ export function AutoItemizePage() {
   // Budget line picker state
   const [activeRowId, setActiveRowId] = useState<string | null>(null);
   const [lineFieldsEdited, setLineFieldsEdited] = useState(false);
-  const wasCreatedFromExtraction = useRef(false);
+  const wasCreatedFromExtractionRef = useRef(false);
   const { t: tSettings } = useTranslation('settings');
 
   const picker = useBudgetLinePicker({
@@ -136,11 +136,11 @@ export function AutoItemizePage() {
       const lineType = 'workItemId' in line ? 'work_item' : 'household_item';
       // Snapshot the ref value NOW (before setLines) so the updater closure captures
       // the correct value regardless of when React executes the deferred updater.
-      // Reading wasCreatedFromExtraction.current INSIDE the setLines updater causes a
+      // Reading wasCreatedFromExtractionRef.current INSIDE the setLines updater causes a
       // race on WebKit: the ref is reset to false before the updater executes (React 18
       // automatic batching defers updater execution after the synchronous reset).
-      const fromExtraction = wasCreatedFromExtraction.current;
-      wasCreatedFromExtraction.current = false;
+      const fromExtraction = wasCreatedFromExtractionRef.current;
+      wasCreatedFromExtractionRef.current = false;
       // Store the assigned budget line ID, type, and description on the row
       // Note: when eagerLinkInvoice is false, invoiceBudgetLineId will be null
       // Use line.id (the work_item_budget or household_item_budget ID) instead
@@ -569,7 +569,7 @@ export function AutoItemizePage() {
       includesVat: row.includesVat !== false,
     };
 
-    wasCreatedFromExtraction.current = true;
+    wasCreatedFromExtractionRef.current = true;
     void picker.showCreateBudgetLineForm(prefill);
   }, [activeRowId, lines, picker]);
 

--- a/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
+++ b/client/src/pages/DiaryEntryDetailPage/DiaryEntryDetailPage.tsx
@@ -241,7 +241,7 @@ export default function DiaryEntryDetailPage() {
           Array.isArray((entry.metadata as { signatures?: DiarySignatureEntry[] }).signatures) &&
           (entry.metadata as { signatures: DiarySignatureEntry[] }).signatures.map((sig, i) => (
             <div
-              key={`${sig.signerType}-${sig.signerName}-${i}`}
+              key={`${sig.signerType}-${sig.signerName}-${i}`} // eslint-disable-line @eslint-react/no-array-index-key -- signatures list may have duplicates; composite key with signerType+name+index is stable
               className={styles.signatureSection}
             >
               <SignatureDisplay

--- a/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
+++ b/client/src/pages/InvoiceDetailPage/InvoiceBudgetLinesSection.tsx
@@ -1009,7 +1009,9 @@ export function InvoiceBudgetLinesSection({
                     description: '',
                     color: selectedBudgetLine.categoryColor ?? '',
                     sortOrder: 0,
+                    // eslint-disable-next-line @eslint-react/purity -- temporary BudgetCategory object with placeholder timestamps for modal display; not persisted
                     createdAt: new Date().toISOString(),
+                    // eslint-disable-next-line @eslint-react/purity -- temporary BudgetCategory object with placeholder timestamps for modal display; not persisted
                     updatedAt: new Date().toISOString(),
                   } as BudgetCategory)
                 : null,

--- a/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
+++ b/client/src/pages/WorkItemDetailPage/WorkItemDetailPage.tsx
@@ -1242,6 +1242,7 @@ export default function WorkItemDetailPage() {
   const availableSubsidies = allSubsidyPrograms.filter((s) => !linkedSubsidyIds.has(s.id));
 
   // Delay indicator: shown when not_started and scheduled start is in the past
+  // eslint-disable-next-line @eslint-react/purity -- intentional current-time read for delay calculation; value is meant to reflect render time
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
   const isDelayed =

--- a/e2e/tests/budget/budget-categories.spec.ts
+++ b/e2e/tests/budget/budget-categories.spec.ts
@@ -234,7 +234,6 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
 
   test('Create form resets after successful creation', async ({ page, testPrefix }) => {
     const categoriesPage = new BudgetCategoriesPage(page);
-    let createdId: string | null = null;
     const categoryName = `${testPrefix} Create Reset Test`;
 
     try {
@@ -259,8 +258,7 @@ test.describe('Create category — happy path (Scenario 3)', { tag: '@responsive
       const body = (await response.json()) as { categories: Array<{ id: string; name: string }> };
       const found = body.categories.find((c) => c.name === categoryName);
       if (found) {
-        createdId = found.id;
-        await deleteCategoryViaApi(page, createdId);
+        await deleteCategoryViaApi(page, found.id);
       }
     }
   });

--- a/e2e/tests/budget/budget-source-filter.spec.ts
+++ b/e2e/tests/budget/budget-source-filter.spec.ts
@@ -1342,12 +1342,10 @@ test.describe('Stale-while-revalidate during refetch', { tag: '@responsive' }, (
     });
 
     // Mount breakdown with artificial 200ms delay on filtered requests
-    let requestCount = 0;
     await page.route('**/api/budget/breakdown**', async (route) => {
       if (route.request().method() === 'GET') {
         const url = new URL(route.request().url());
         const deselected = url.searchParams.get('deselectedSources');
-        requestCount++;
         if (deselected) {
           // Delay the filtered response by 200ms to simulate slow server
           await new Promise<void>((resolve) => setTimeout(resolve, 200));

--- a/e2e/tests/diary/diary-drafts.spec.ts
+++ b/e2e/tests/diary/diary-drafts.spec.ts
@@ -243,7 +243,6 @@ test.describe('No draft created without interaction (Scenario 4)', () => {
 test.describe('Auto-save on metadata change (Scenario 5)', () => {
   test('Changing weather select on a draft triggers auto-save; value persists on reload', async ({
     page,
-    testPrefix,
   }) => {
     const editPage = new DiaryEntryEditPage(page);
     let draftId: string | null = null;
@@ -567,8 +566,7 @@ test.describe('Promote draft — happy path (Scenario 9)', { tag: '@responsive' 
         // in the badge region. The entry is now saved, so no draft indicator.
         await expect(page.getByTestId('draft-status-badge')).not.toBeVisible();
 
-        // Mark as promoted so we can clean up
-        draftId = draftId; // still use same id to delete the now-promoted entry
+        // draftId still holds the same id — use it to delete the now-promoted entry
       } finally {
         if (draftId) await deleteDiaryEntryViaApi(page, draftId);
       }

--- a/e2e/tests/diary/diary-list.spec.ts
+++ b/e2e/tests/diary/diary-list.spec.ts
@@ -20,7 +20,6 @@
 import { test, expect } from '../../fixtures/auth.js';
 import { DiaryPage, DIARY_ROUTE } from '../../pages/DiaryPage.js';
 import { AppShellPage } from '../../pages/AppShellPage.js';
-import { API } from '../../fixtures/testData.js';
 import { createDiaryEntryViaApi, deleteDiaryEntryViaApi } from '../../fixtures/apiHelpers.js';
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/e2e/tests/invoices/invoice-auto-itemize-page.spec.ts
+++ b/e2e/tests/invoices/invoice-auto-itemize-page.spec.ts
@@ -1364,7 +1364,6 @@ test.describe('Scenario 14 — Status field: change pending → paid', () => {
     }
 
     const autoItemizePage = new AutoItemizePage(page);
-    const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
     let invoiceId = '';
 
@@ -2061,7 +2060,7 @@ test.describe('Scenario 26 — assignmentMode:"assign-existing" in commit payloa
     let vendorId = '';
     let invoiceId = '';
     let workItemId = '';
-    let budgetLineId = '';
+    let budgetLineId: string;
     const budgetLineDescription = `${testPrefix} AI-AssignMode BL`;
 
     try {

--- a/e2e/tests/invoices/invoice-deposits.spec.ts
+++ b/e2e/tests/invoices/invoice-deposits.spec.ts
@@ -112,7 +112,7 @@ test.describe('Deposits — empty state (Scenario 1)', { tag: '@responsive' }, (
     async ({ page, testPrefix }) => {
       const detailPage = new InvoiceDetailPage(page);
       let vendorId = '';
-      let invoiceId = '';
+      let invoiceId: string;
 
       try {
         vendorId = await createVendorViaApi(page, `${testPrefix} Dep EmptyVendor`);
@@ -155,7 +155,7 @@ test.describe('Deposits — add deposit (Scenario 2)', { tag: '@responsive' }, (
     async ({ page, testPrefix }) => {
       const detailPage = new InvoiceDetailPage(page);
       let vendorId = '';
-      let invoiceId = '';
+      let invoiceId: string;
 
       try {
         vendorId = await createVendorViaApi(page, `${testPrefix} Dep AddVendor`);
@@ -221,7 +221,7 @@ test.describe('Deposits — add deposit (Scenario 2)', { tag: '@responsive' }, (
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep CancelVendor`);
@@ -265,7 +265,7 @@ test.describe('Deposits — full lifecycle (Scenario 3)', () => {
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep LifecycleVendor`);
@@ -542,7 +542,7 @@ test.describe('Deposits — exceed invoice total error (Scenario 5)', () => {
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep ExceedVendor`);
@@ -618,7 +618,7 @@ test.describe('Deposits — tablet layout (Scenario 6)', { tag: '@responsive' },
 
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep TabletVendor`);
@@ -668,7 +668,7 @@ test.describe('Deposits — mobile card layout (Scenario 7)', { tag: '@responsiv
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep MobileVendor`);
@@ -741,7 +741,7 @@ test.describe('Deposits — mobile card layout (Scenario 7)', { tag: '@responsiv
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep MobFormVendor`);
@@ -794,7 +794,7 @@ test.describe('Deposits — multiple deposits and sum invariant', () => {
   }) => {
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     try {
       vendorId = await createVendorViaApi(page, `${testPrefix} Dep MultiVendor`);
@@ -849,7 +849,7 @@ test.describe('Deposits — revert-to-pending API error (Scenario 8)', () => {
 
     const detailPage = new InvoiceDetailPage(page);
     let vendorId = '';
-    let invoiceId = '';
+    let invoiceId: string;
 
     // The page.route() interceptor handle — kept so we can unroute in teardown.
     const routePattern = '**/api/invoices/*/deposits/*';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,34 @@ export default tseslint.config(
     },
   },
 
+  // Node scripts (build/diagnostic tooling)
+  {
+    files: ['scripts/**/*.{mjs,js,cjs}'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        global: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        require: 'readonly',
+        module: 'readonly',
+        setImmediate: 'readonly',
+        setInterval: 'readonly',
+        setTimeout: 'readonly',
+        clearImmediate: 'readonly',
+        clearInterval: 'readonly',
+        clearTimeout: 'readonly',
+        fetch: 'readonly',
+        URL: 'readonly',
+        AbortController: 'readonly',
+        structuredClone: 'readonly',
+      },
+    },
+    rules: { 'no-console': 'off' },
+  },
+
   // Test files (unit + integration) — relax React-Compiler-focused rules
   // that don't apply to mocks and test scaffolding. These rules optimize
   // production rendering; test code never ships.

--- a/server/src/services/calendarIcal.ts
+++ b/server/src/services/calendarIcal.ts
@@ -110,18 +110,13 @@ export function buildCalendar(
 
   // Add household items as delivery events
   for (const hi of timeline.householdItems) {
-    let startDate: string | null = null;
-    let endDate: string | null = null;
-
     // Prefer actual delivery date if set
-    if (hi.actualDeliveryDate) {
-      startDate = toDateOnly(hi.actualDeliveryDate);
-      endDate = startDate;
-    } else {
-      // Use earliest/latest delivery date range, or target if those aren't set
-      startDate = hi.earliestDeliveryDate ?? hi.targetDeliveryDate;
-      endDate = hi.latestDeliveryDate ?? hi.targetDeliveryDate;
-    }
+    const startDate: string | null = hi.actualDeliveryDate
+      ? toDateOnly(hi.actualDeliveryDate)
+      : hi.earliestDeliveryDate ?? hi.targetDeliveryDate;
+    const endDate: string | null = hi.actualDeliveryDate
+      ? toDateOnly(hi.actualDeliveryDate)
+      : hi.latestDeliveryDate ?? hi.targetDeliveryDate;
 
     // Skip if no delivery dates are available
     if (!startDate || !endDate) continue;

--- a/server/src/services/diaryService.ts
+++ b/server/src/services/diaryService.ts
@@ -672,7 +672,7 @@ export function createDiaryEntry(
   const status = data.status ?? 'saved';
 
   // Validate body: required and non-empty for saved, optional/empty for drafts
-  let trimmedBody = '';
+  let trimmedBody: string;
   if (!isDraft) {
     // Saved entry requires non-empty body
     if (!data.body) {

--- a/shared/src/types/diary.ts
+++ b/shared/src/types/diary.ts
@@ -186,9 +186,7 @@ export interface DiaryEntrySummary {
 }
 
 /** Diary entry detail (used in single-item responses). */
-export interface DiaryEntryDetail extends DiaryEntrySummary {
-  // Detail includes all summary fields; extend if detail-only fields are added later.
-}
+export type DiaryEntryDetail = DiaryEntrySummary;
 
 // ─── Request Shapes ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds a Node-scripts flat-config block in `eslint.config.js` (Node globals + `no-console: off` for `scripts/**`), clearing 171 `no-undef`/`no-console` problems that were previously untouched
- Real code fixes across `server/src`, `shared/src`, `client/src`, and `e2e/tests`: `no-useless-assignment`, `no-case-declarations`, `no-unused-vars`, `no-empty-object-type`, IIFE-in-JSX extractions, and dead-variable removals in E2E tests (no behavior or assertion changes)
- 25 justified inline disables for patterns with no stable key alternatives, intentional render-time `new Date()` calls, correct DOM-measurement effects, and naming collisions in context providers

Full-project `eslint .` now reports **0 errors and 0 warnings** (down from 857 at the start of the tracking issue). All 16 child issues of #1455 were already individually closed; this PR completes the tracking issue.

Fixes #1455

## Test plan

- [ ] `eslint .` reports 0 errors and 0 warnings
- [ ] All E2E test assertions unchanged (dead-variable removals only in e2e/tests)
- [ ] Quality Gates pass (typecheck + unit tests + Docker build + E2E smoke)

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: Claude backend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude e2e-test-engineer (Sonnet 4.5) <noreply@anthropic.com>