### PR TITLE
chore(client): clear residual eslint warnings (#1455 follow-up)

### DIFF
--- a/client/src/components/documents/LinkedDocumentsSection.tsx
+++ b/client/src/components/documents/LinkedDocumentsSection.tsx
@@ -122,6 +122,7 @@ export function LinkedDocumentsSection({ entityType, entityId }: LinkedDocuments
   // Focus into picker modal when it opens
   useEffect(() => {
     if (showPicker) {
+      // eslint-disable-next-line @eslint-react/web-api-no-leaked-fetch -- systemLinkedIds.fetch is a custom hook method (useAllLinkedDocumentIds), not the Web Fetch API; no AbortController applies
       void systemLinkedIds.fetch();
       const timer = setTimeout(() => {
         pickerModalRef.current?.focus();

--- a/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
+++ b/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
@@ -166,9 +166,11 @@ describe('PhotoMetadataSidepanel', () => {
     isAnnotating?: boolean;
   }) {
     return render(
-      React.createElement(LocaleProvider, {
-        children: React.createElement(PhotoMetadataSidepanel, props),
-      }),
+      React.createElement(
+        LocaleProvider,
+        null,
+        React.createElement(PhotoMetadataSidepanel, props),
+      ),
     );
   }
 
@@ -233,11 +235,13 @@ describe('PhotoMetadataSidepanel', () => {
     const newPhoto: Photo = { ...mockPhoto, caption: 'Different caption' };
 
     rerender(
-      React.createElement(LocaleProvider, {
-        children: React.createElement(PhotoMetadataSidepanel, {
+      React.createElement(
+        LocaleProvider,
+        null,
+        React.createElement(PhotoMetadataSidepanel, {
           photo: newPhoto,
         }),
-      }),
+      ),
     );
 
     await waitFor(() => {

--- a/client/src/hooks/useTimeline.ts
+++ b/client/src/hooks/useTimeline.ts
@@ -23,7 +23,7 @@ export function useTimeline(): UseTimelineResult {
   useEffect(() => {
     let cancelled = false;
 
-    async function fetch() {
+    async function loadTimeline() {
       setIsLoading(true);
       setError(null);
 
@@ -51,7 +51,7 @@ export function useTimeline(): UseTimelineResult {
       }
     }
 
-    void fetch();
+    void loadTimeline();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary

- Rename `async function fetch()` to `loadTimeline` in `useTimeline.ts` — eliminates false-positive `@eslint-react/web-api-no-leaked-fetch` warning (the function is not the Web Fetch API)
- Add justified `// eslint-disable-next-line @eslint-react/web-api-no-leaked-fetch` in `LinkedDocumentsSection.tsx` — `systemLinkedIds.fetch()` is a custom hook method, not the Web Fetch API; the rule cannot distinguish by type
- Move `children` from the `React.createElement` props object to the 3rd positional argument at two call sites in `PhotoMetadataSidepanel.test.tsx` — fixes `jsx-no-children-prop`; behavior-identical

All changes are behavior-preserving. `eslint .` now reports **0 errors + 0 warnings** across the client workspace, completing the clean-lint baseline established by #1455.

Ref #1455

## Test plan

- [ ] Pre-commit hook / Quality Gates (typecheck + tests + build) pass
- [ ] `eslint .` produces 0 problems on a full install
- [ ] All 3 changes are behavior-preserving (no logic altered)

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>