### PR TITLE
chore(test): adopt Jest 30.4 workerGracefulExitTimeout + --collectTests scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,7 @@ npm run dev                   # Start server (port 3000) + client dev server (po
 | `npm run dev:client`       | Start only the Webpack dev server                           |
 | `npm run build`            | Build all packages (shared -> client -> server)             |
 | `npm test`                 | Run all tests                                               |
+| `npm run test:collect`     | List all tests (suites + names) without executing them      |
 | `npm run lint`             | Lint all code                                               |
 | `npm run format`           | Format all code                                             |
 | `npm run typecheck`        | Type-check all packages                                     |

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -40,6 +40,12 @@ const config: Config = {
   // Locally, use up to 2 workers and recycle when heap exceeds 512 MB.
   // CI auto-detects workers (GitHub Actions sets CI=true).
   ...(isCI ? {} : { maxWorkers: 2, workerIdleMemoryLimit: '512M' }),
+  // Give workers 2 s to release file-watchers and jsdom handles after tests
+  // complete before force-killing. The 500 ms default is too tight in the
+  // resource-constrained sandbox and produces spurious "worker failed to exit
+  // gracefully" warnings; 2000 ms lets legitimate cleanup finish while still
+  // bounding true hangs.
+  workerGracefulExitTimeout: 2000,
   projects: [
     {
       ...baseConfig,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "test:collect": "node --experimental-vm-modules node_modules/.bin/jest --collectTests",
+    "test:collect:json": "node --experimental-vm-modules node_modules/.bin/jest --collectTests --json",
     "test:e2e": "npm test -w e2e",
     "test:e2e:shard": "npm run test:shard -w e2e",
     "test:e2e:smoke": "npm run test:smoke -w e2e",


### PR DESCRIPTION
## Summary

- **`workerGracefulExitTimeout: 2000`** added to the top-level Jest config object (alongside the existing `maxWorkers`/`workerIdleMemoryLimit` spread). The 500 ms default causes spurious "worker failed to exit gracefully" warnings in the resource-constrained sandbox when jsdom and file-watcher handles take slightly longer to release; 2000 ms lets legitimate cleanup finish while still bounding true hangs.
- **`test:collect` / `test:collect:json` scripts** added to root `package.json`, using Jest 30.4.0's new `--collectTests` flag. These enumerate all test suites and test names in a hierarchical tree without executing any tests — useful for auditing coverage and generating machine-readable test inventories.
- **CLAUDE.md** Common Commands table updated with a single `test:collect` row.

## Validation

- Ran `node --experimental-vm-modules node_modules/.bin/jest shared/src/types/user.test.ts --maxWorkers=1`: **no "Unknown option" warning** for `workerGracefulExitTimeout`; 16 tests passed.
- Full shared suite (10 suites, 259 tests): zero config-validation warnings.
- `--collectTests` flag accepted by installed 30.4.2; prints hierarchical tree, exits 0, does not execute tests.
- `--collectTests --json` emits valid JSON with `numPendingTests: 16`, `numPassedTests: 0`, exits 0.

## Notes

- No production code changed (nothing under `server/`, `client/`, `shared/`, `e2e/`). No new unit tests required — this is a test-tooling-only change.
- `workerGracefulExitTimeout` is a root/global config option per Jest 30.4 docs; it is placed on the top-level `config` object, not inside `baseConfig`.
- The flag form `--collectTests` (camelCase) was used; it is accepted by 30.4.2.

## Test plan

- [ ] CI Quality Gates pass (typecheck + test + build)
- [ ] No "Unknown option" warnings in CI Jest output

Fixes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)