### PR TITLE
fix(e2e): correct Scenario 25 invoice amount to account for VAT gross-up (#1591)

### DIFF
--- a/e2e/tests/invoices/invoice-auto-itemize-page.spec.ts
+++ b/e2e/tests/invoices/invoice-auto-itemize-page.spec.ts
@@ -2005,10 +2005,12 @@ test.describe('Scenario 25 — Variance indicator recomputes on totalAmount edit
     let invoiceId = '';
 
     try {
-      // Invoice amount = 1700, extracted total = 900+680+120 = 1700 → 0% variance → match state
+      // All THREE_LINES are includesVat:false (net), so effectiveLineAmount grosses up by 1.19:
+      //   900x1.19=1071.00 + 680x1.19=809.20 + 120x1.19=142.80 = 2023.00 gross total
+      // Invoice amount = 2023 to match gross total -> 0% variance -> match state
       vendorId = await createVendorViaApi(page, `${testPrefix} AI-Variance Vendor`);
       invoiceId = await createInvoiceViaApi(page, vendorId, {
-        amount: 1700,
+        amount: 2023,
         date: '2026-06-01',
       });
 
@@ -2019,14 +2021,15 @@ test.describe('Scenario 25 — Variance indicator recomputes on totalAmount edit
       await autoItemizePage.goto(invoiceId, docId);
       await autoItemizePage.waitForAnalyzingDone();
 
-      // ── Initial state: invoice=1700, lines total=1700 → varianceMatch ────────
+      // Initial state: invoice=2023, gross total=2023 -> 0% variance -> varianceMatch
       const indicator = autoItemizePage.getVarianceIndicator();
       await expect(indicator).toBeVisible();
-      // Initial: ≤1% → varianceMatch CSS class
+      // Initial: 0% variance -> varianceMatch CSS class
       await expect(indicator).toHaveClass(/varianceMatch/);
 
-      // ── Edit first line totalAmount to 500 (total becomes 500+680+120=1300) ──
-      // Variance = |1300-1700|/1700 ≈ 23.5% → > 5% → varianceDanger
+      // Edit first line totalAmount to 500 (net -> grossed to 500x1.19=595.00)
+      // New gross total = 595.00+809.20+142.80 = 1547.00
+      // Variance = |1547-2023|/2023 = 476/2023 ~23.5% -> > 5% -> varianceDanger
       const totalInput = autoItemizePage.getLineCardTotalAmountInput(0);
       await totalInput.fill('500');
       // Trigger change event by tabbing away


### PR DESCRIPTION
## Summary

- Fixes deterministic failure in Scenario 25 of `invoice-auto-itemize-page.spec.ts`: the variance indicator initial state assertion `toHaveClass(/varianceMatch/)` was failing because the invoice amount of 1700 was the raw **net** sum, but the production `AutoItemizePage` computes variance using `effectiveLineAmount()` which grosses up `includesVat:false` lines by ×1.19
- `THREE_LINES` fixture: 900 + 680 + 120 (all net) → 1071 + 809.20 + 142.80 = **2023.00 gross**
- Set `amount: 2023` in the `createInvoiceViaApi` call so the initial state is a genuine 0% variance → `varianceMatch`
- Post-edit math (line 0 → 500 net = 595 gross): new total 1547 vs 2023 = 23.5% > 5% → `varianceDanger` (unchanged)
- Updated all inline comments to reflect gross-up math; assertions are unchanged

## Root Cause

The `effectiveLineAmount()` gross-up was introduced in Stories #1677/#1678 after Scenario 25 was written. The test was written when `AutoItemizePage` summed raw `totalAmount`, so `amount: 1700` was correct then. After the gross-up change, the production code computes 2023 as the effective total but the test still used 1700, causing an immediate 19% deviation on load.

## Test plan

- [ ] CI E2E run: Scenario 25 in `invoice-auto-itemize-page.spec.ts` passes on all viewports (desktop/tablet/mobile)
- [ ] Other scenarios that use `THREE_LINES` are unaffected (they don't assert `varianceMatch`)
- [ ] `amount: 1700` in all other scenarios is correct (they don't depend on gross-total matching invoice amount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)