### PR TITLE
fix(client): disable mobile viewport zoom on input focus and pinch (#1707)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
     <meta name="description" content="Cornerstone - Home Building Project Management" />
     <title>Cornerstone</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## Summary

- Added `maximum-scale=1, user-scalable=no` to the viewport meta tag in `client/index.html`
- Prevents iOS Safari from auto-zooming when a form input is focused
- Disables pinch/double-tap zoom to preserve the native-app feel on mobile

Fixes #1707

## Test plan

- [ ] Unit tests pass (95%+ coverage)
- [ ] Integration tests pass
- [ ] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>