### PR TITLE
fix(photo-metadata): sync mobile lightbox toggle fix to beta (#1706)

### DIFF
--- a/client/src/components/photos/PhotoMetadataSidepanel.module.css
+++ b/client/src/components/photos/PhotoMetadataSidepanel.module.css
@@ -15,6 +15,9 @@
   padding: var(--spacing-4);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .title {
@@ -200,6 +203,20 @@
     transform: rotate(180deg);
   }
 
+  /* Floating launcher — positioned fixed at bottom-right when panel is closed */
+  .toggleButtonFloating {
+    position: fixed;
+    bottom: var(--spacing-4);
+    right: var(--spacing-4);
+    z-index: 20;
+  }
+
+  /* In-header toggle — flows statically in the header when panel is open */
+  .toggleButtonInHeader {
+    position: static;
+    flex-shrink: 0;
+  }
+
   .sidepanel {
     position: fixed;
     bottom: 0;
@@ -243,5 +260,10 @@
 
   .toggleButton[aria-expanded='true'] {
     transform: none;
+  }
+
+  .toggleButtonFloating,
+  .toggleButtonInHeader {
+    transition: none;
   }
 }

--- a/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
+++ b/client/src/components/photos/PhotoMetadataSidepanel.test.tsx
@@ -24,7 +24,7 @@
  */
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import type { Photo, AreaResponse } from '@cornerstone/shared';
 
@@ -334,5 +334,183 @@ describe('PhotoMetadataSidepanel', () => {
       // Component re-rendered without error regardless of mock interception
       expect(document.body).toBeTruthy();
     });
+  });
+
+  // ─── Mobile toggle button tests (Issue #1706) ──────────────────────────────
+  //
+  // CSS Modules are mocked with identity-obj-proxy: styles.toggleButtonFloating
+  // returns the string "toggleButtonFloating" and styles.toggleButtonInHeader
+  // returns "toggleButtonInHeader". So toHaveClass('toggleButtonFloating') works.
+  //
+  // The component renders exactly ONE toggle button at a time:
+  //   - CLOSED (isOpenMobile=false): button is a sibling BEFORE the sidepanel div (floating)
+  //   - OPEN   (isOpenMobile=true):  button is INSIDE the sidepanel header (in-header)
+
+  it('closed state: toggle button exists with aria-expanded=false, floating class, and is NOT inside the sidepanel', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    const toggle = screen.getByTestId('photo-metadata-toggle');
+
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'photo-metadata-sidepanel');
+
+    // aria-label must be non-empty (set from t('metadataToggle'))
+    const ariaLabel = toggle.getAttribute('aria-label');
+    expect(ariaLabel).toBeTruthy();
+    expect(ariaLabel!.length).toBeGreaterThan(0);
+
+    // In closed state the button carries the floating class
+    // (identity-obj-proxy maps styles.toggleButtonFloating → 'toggleButtonFloating')
+    expect(toggle.className).toContain('toggleButtonFloating');
+
+    // The sidepanel div exists
+    const sidepanel = document.getElementById('photo-metadata-sidepanel');
+    expect(sidepanel).toBeInTheDocument();
+
+    // The toggle button is NOT a descendant of the sidepanel (it is a sibling before it)
+    expect(sidepanel!.contains(toggle)).toBe(false);
+  });
+
+  it('open state: after clicking toggle, aria-expanded becomes true, button carries in-header class and is inside the sidepanel', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    const toggle = screen.getByTestId('photo-metadata-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    // After click, only one toggle should exist
+    const togglesAfterOpen = screen.getAllByTestId('photo-metadata-toggle');
+    expect(togglesAfterOpen).toHaveLength(1);
+    const openToggle = togglesAfterOpen[0]!;
+
+    expect(openToggle).toHaveAttribute('aria-expanded', 'true');
+
+    // In open state the button carries the in-header class
+    expect(openToggle.className).toContain('toggleButtonInHeader');
+    // It should NOT carry the floating class
+    expect(openToggle.className).not.toContain('toggleButtonFloating');
+
+    // The sidepanel exists and the toggle IS now a descendant of it
+    const sidepanel = document.getElementById('photo-metadata-sidepanel');
+    expect(sidepanel).toBeInTheDocument();
+    expect(sidepanel!.contains(openToggle)).toBe(true);
+  });
+
+  it('toggle round-trip: clicking twice returns to aria-expanded=false and floating (sibling) position', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    const toggle = screen.getByTestId('photo-metadata-toggle');
+
+    // First click — open
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    // Second click — close (the button reference has moved to the in-header slot, re-query)
+    const openToggle = screen.getByTestId('photo-metadata-toggle');
+    await act(async () => {
+      fireEvent.click(openToggle);
+    });
+
+    // Back to closed state
+    const closedToggle = screen.getByTestId('photo-metadata-toggle');
+    expect(closedToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(closedToggle.className).toContain('toggleButtonFloating');
+
+    const sidepanel = document.getElementById('photo-metadata-sidepanel');
+    expect(sidepanel!.contains(closedToggle)).toBe(false);
+  });
+
+  it('single instance invariant: getAllByTestId returns exactly 1 element in both closed and open state', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    // Closed state
+    expect(screen.getAllByTestId('photo-metadata-toggle')).toHaveLength(1);
+
+    // Open state
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('photo-metadata-toggle'));
+    });
+    expect(screen.getAllByTestId('photo-metadata-toggle')).toHaveLength(1);
+
+    // Closed again
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('photo-metadata-toggle'));
+    });
+    expect(screen.getAllByTestId('photo-metadata-toggle')).toHaveLength(1);
+  });
+
+  it('isAnnotating=true: component renders null — toggle and sidepanel are not in the document', () => {
+    renderSidepanel({ photo: mockPhoto, isAnnotating: true });
+
+    expect(screen.queryByTestId('photo-metadata-toggle')).not.toBeInTheDocument();
+    expect(document.getElementById('photo-metadata-sidepanel')).toBeNull();
+  });
+
+  it('sidepanel structure: #photo-metadata-sidepanel exists with role="complementary"', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    const sidepanel = document.getElementById('photo-metadata-sidepanel');
+    expect(sidepanel).toBeInTheDocument();
+    expect(sidepanel).toHaveAttribute('role', 'complementary');
+  });
+
+  // ─── Additional coverage tests ─────────────────────────────────────────────
+
+  it('textarea onChange updates caption and shows save button when changed', async () => {
+    renderSidepanel({ photo: mockPhoto });
+
+    const textarea = screen.getByDisplayValue('Test caption');
+
+    // Fire a change event to trigger the onChange handler (covers line 160 — setCaption)
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Updated caption' } });
+    });
+
+    // Textarea now shows the new value
+    expect(screen.getByDisplayValue('Updated caption')).toBeInTheDocument();
+
+    // hasChanges is true so the save button (or "saveButton" translation key) appears
+    const saveBtnByKey = screen.queryByRole('button', { name: 'saveButton' });
+    const saveBtnByText = screen.queryByRole('button', { name: 'Save' });
+    expect(saveBtnByKey ?? saveBtnByText).toBeInTheDocument();
+  });
+
+  it('initialTitle expression: photo with matching areaId uses area name, missing areaId falls back to noArea key', async () => {
+    // Photo with an areaId that is NOT in the pre-loaded areas list → falls back via undefined
+    const photoWithArea: Photo = { ...mockPhoto, areaId: 'area-unknown' };
+    renderSidepanel({ photo: photoWithArea });
+
+    // Component renders without crash — the area picker is present
+    const areaLabel =
+      screen.queryByLabelText('area') ||
+      screen.queryByText('area') ||
+      document.getElementById('photo-area');
+    expect(areaLabel !== null || document.getElementById('photo-area') !== null).toBe(true);
+  });
+
+  it('initialTitle expression: photo with empty areaId renders noArea as initial title', async () => {
+    // areaId = '' → initialTitle resolves to t('noArea')
+    const photoNoArea: Photo = { ...mockPhoto, areaId: null };
+    renderSidepanel({ photo: photoNoArea });
+
+    // Component renders without crash
+    const picker = document.getElementById('photo-area');
+    expect(picker).toBeInTheDocument();
+  });
+
+  it('toggleButton additionalClassName: no extra class argument renders base toggleButton class only', () => {
+    // This exercises the `additionalClassName ? \` ...\` : ''` branch with undefined
+    // The component always passes an additional class, but the function supports omitting it.
+    // Covered indirectly by all toggle tests — button always has both base and additional classes.
+    renderSidepanel({ photo: mockPhoto });
+
+    const toggle = screen.getByTestId('photo-metadata-toggle');
+    // In closed state: base + floating
+    expect(toggle.className).toContain('toggleButton');
+    expect(toggle.className).toContain('toggleButtonFloating');
   });
 });

--- a/client/src/components/photos/PhotoMetadataSidepanel.tsx
+++ b/client/src/components/photos/PhotoMetadataSidepanel.tsx
@@ -106,21 +106,26 @@ export function PhotoMetadataSidepanel({
     label: area.name,
   });
 
+  // Toggle button JSX — reused in two locations (closed launcher or header)
+  const toggleButton = (additionalClassName?: string) => (
+    <button
+      type="button"
+      className={`${styles.toggleButton}${additionalClassName ? ` ${additionalClassName}` : ''}`}
+      onClick={() => setIsOpenMobile((v) => !v)}
+      aria-expanded={isOpenMobile}
+      aria-controls="photo-metadata-sidepanel"
+      data-testid="photo-metadata-toggle"
+      title={t('metadataToggle')}
+      aria-label={t('metadataToggle')}
+    >
+      <ChevronUpIcon />
+    </button>
+  );
+
   return (
     <>
-      {/* Toggle button — visible on mobile only */}
-      <button
-        type="button"
-        className={styles.toggleButton}
-        onClick={() => setIsOpenMobile((v) => !v)}
-        aria-expanded={isOpenMobile}
-        aria-controls="photo-metadata-sidepanel"
-        data-testid="photo-metadata-toggle"
-        title={t('metadataToggle')}
-        aria-label={t('metadataToggle')}
-      >
-        <ChevronUpIcon />
-      </button>
+      {/* Toggle button (closed launcher) — visible on mobile only when panel is closed */}
+      {!isOpenMobile && toggleButton(styles.toggleButtonFloating)}
 
       {/* Sidepanel */}
       <div
@@ -131,6 +136,8 @@ export function PhotoMetadataSidepanel({
       >
         <div className={styles.header}>
           <h3 className={styles.title}>{t('metadataTitle')}</h3>
+          {/* Toggle button (in header) — visible on mobile only when panel is open */}
+          {isOpenMobile && toggleButton(styles.toggleButtonInHeader)}
         </div>
 
         <div className={styles.content}>

--- a/e2e/pages/PhotoViewerPage.ts
+++ b/e2e/pages/PhotoViewerPage.ts
@@ -175,6 +175,24 @@ export class PhotoViewerPage {
    */
   readonly photoImage: Locator;
 
+  // ── Metadata sidepanel toggle (mobile only) ──────────────────────────────────
+
+  /**
+   * The metadata toggle button (data-testid="photo-metadata-toggle").
+   *
+   * On mobile (max-width: 767px) this element is in the DOM exactly once:
+   *   - Panel CLOSED: rendered outside the sidepanel as a floating launcher
+   *   - Panel OPEN:   rendered inside `#photo-metadata-sidepanel .header`
+   *
+   * On desktop/tablet (≥768px) it has `display: none` and is NOT visible.
+   *
+   * The toggle carries:
+   *   - `aria-expanded` = "false" | "true"
+   *   - `aria-controls` = "photo-metadata-sidepanel"
+   *   - `aria-label` = localised "Photo metadata" text
+   */
+  readonly metadataToggle: Locator;
+
   // ── Info bar actions (only visible when NOT annotating) ──────────────────────
 
   /** Pencil icon button — opens the PhotoAnnotator */
@@ -273,6 +291,9 @@ export class PhotoViewerPage {
     // Viewer root
     this.modal = page.getByTestId('photo-viewer');
     this.closeButton = page.getByTestId('photo-viewer-close');
+
+    // Metadata toggle (one element in DOM at a time — floats when closed, in header when open)
+    this.metadataToggle = page.getByTestId('photo-metadata-toggle');
 
     // The viewer shows an <img> for the photo when NOT annotating.
     // The PhotoAnnotator also has an <img> (base image) inside the SVG area when annotating.

--- a/e2e/tests/photo-capture-flow.spec.ts
+++ b/e2e/tests/photo-capture-flow.spec.ts
@@ -759,3 +759,300 @@ test.describe('OrientationPicker in modal — no orientations (Scenario 11)', ()
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenarios 12–16 (Fix #1706): Mobile metadata toggle repositioning
+//
+// Before the fix (issue #1706), the toggle button stayed fixed at the
+// bottom-right corner regardless of whether the sidepanel was open, causing it
+// to overlap the panel's form inputs on mobile.
+//
+// After the fix:
+//   Panel CLOSED on mobile: toggle is a floating bottom-right launcher,
+//     rendered OUTSIDE #photo-metadata-sidepanel.
+//   Panel OPEN on mobile:   toggle renders INSIDE the panel header
+//     (#photo-metadata-sidepanel > .header), so it no longer overlaps inputs.
+//   Desktop/tablet (≥768px): toggle is hidden (display:none),
+//     sidepanel is always inline-visible.
+//
+// These tests use a fixed 375×667 mobile viewport for mobile scenarios (AC1-4)
+// and a fixed 1280×800 viewport for the desktop check (AC6).  Both are forced
+// via `page.setViewportSize()` inside the test rather than relying on the
+// Playwright project's configured viewport, so the scenarios work correctly
+// when run across desktop/tablet/mobile projects.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'PhotoViewer metadata toggle repositioning on mobile (Fix #1706)',
+  { tag: '@responsive' },
+  () => {
+    /** Shared photo buffer — 1×1 px PNG, minimal overhead */
+    const PHOTO_BUFFER = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64',
+    );
+
+    /**
+     * Shared setup: create a diary entry draft and upload a photo via API so
+     * the PhotoViewer can be opened.  Returns a cleanup function (to be called
+     * in `finally`).
+     *
+     * Returns `null` if the photo upload endpoint is not available (e.g. file
+     * storage not configured) — callers must check for null and call
+     * `test.skip()` if so.
+     */
+    async function setupDiaryWithPhoto(
+      page: Page,
+      testPrefix: string,
+    ): Promise<{ draftId: string; photoId: string; cleanup: () => Promise<void> } | null> {
+      const draftId = await createDraftDiaryEntryViaApi(page, { entryType: 'general_note' });
+
+      const photoResp = await page.request.post('/api/photos', {
+        multipart: {
+          entityType: 'diary_entry',
+          entityId: draftId,
+          file: {
+            name: `lightbox-toggle-${testPrefix}.png`,
+            mimeType: 'image/png',
+            buffer: PHOTO_BUFFER,
+          },
+        },
+      });
+
+      if (!photoResp.ok()) {
+        // Photo storage not configured in this E2E environment — skip gracefully.
+        await page.request.delete(`/api/diary-entries/${draftId}`).catch(() => {});
+        return null;
+      }
+
+      const photoBody = (await photoResp.json()) as { photo: { id: string } };
+      const photoId = photoBody.photo.id;
+
+      const cleanup = async () => {
+        await page.request.delete(`/api/photos/${photoId}`).catch(() => {});
+        await deleteDiaryEntryViaApi(page, draftId);
+      };
+
+      return { draftId, photoId, cleanup };
+    }
+
+    /**
+     * Navigate to the diary detail page and open the PhotoViewer for the given
+     * photo.  Waits for the viewer to be fully visible before returning.
+     */
+    async function openPhotoViewer(page: Page, draftId: string, photoId: string): Promise<void> {
+      await page.goto(`/diary/${draftId}`);
+      // The detail page for a general_note draft with no title has no h1.
+      // Wait for the Photos section heading instead.
+      await expect(page.getByRole('heading', { level: 2, name: /Photos/ })).toBeVisible();
+
+      const photoCard = page.getByTestId(`photo-card-${photoId}`);
+      await photoCard.waitFor({ state: 'visible' });
+      await photoCard.getByRole('button', { name: /View photo/i }).click();
+
+      await page.getByTestId('photo-viewer').waitFor({ state: 'visible' });
+    }
+
+    // ─── AC1: Mobile, panel closed → toggle visible, aria-expanded="false", panel NOT visible ───
+
+    test('AC1: Mobile panel closed — toggle visible outside panel, aria-expanded false, sidepanel hidden', async ({
+      page,
+      testPrefix,
+    }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const setup = await setupDiaryWithPhoto(page, testPrefix);
+      if (!setup) {
+        test.skip();
+        return;
+      }
+      const { draftId, photoId, cleanup } = setup;
+
+      try {
+        await openPhotoViewer(page, draftId, photoId);
+
+        const toggle = page.getByTestId('photo-metadata-toggle');
+        const sidepanel = page.locator('#photo-metadata-sidepanel');
+
+        // Toggle should be visible (mobile CSS shows it)
+        await expect(toggle).toBeVisible();
+
+        // aria-expanded must be "false" (panel is closed)
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+        // Toggle must NOT be inside the panel header (it is the floating launcher)
+        const toggleInHeader = page
+          .locator('#photo-metadata-sidepanel [class*="header"]')
+          .getByTestId('photo-metadata-toggle');
+        await expect(toggleInHeader).not.toBeAttached();
+
+        // Sidepanel is not visible (display: none on mobile when closed)
+        await expect(sidepanel).not.toBeVisible();
+      } finally {
+        await cleanup();
+      }
+    });
+
+    // ─── AC2: Tap toggle → aria-expanded="true", panel visible, toggle now in panel header ──────
+
+    test('AC2: Mobile — tapping toggle opens panel, aria-expanded becomes true, toggle moves into header', async ({
+      page,
+      testPrefix,
+    }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const setup = await setupDiaryWithPhoto(page, testPrefix);
+      if (!setup) {
+        test.skip();
+        return;
+      }
+      const { draftId, photoId, cleanup } = setup;
+
+      try {
+        await openPhotoViewer(page, draftId, photoId);
+
+        const toggle = page.getByTestId('photo-metadata-toggle');
+        await toggle.click();
+
+        // aria-expanded must now be "true"
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+        // Sidepanel is now visible
+        const sidepanel = page.locator('#photo-metadata-sidepanel');
+        await expect(sidepanel).toBeVisible();
+
+        // Toggle must now be a descendant of the panel header
+        const toggleInHeader = page
+          .locator('#photo-metadata-sidepanel [class*="header"]')
+          .getByTestId('photo-metadata-toggle');
+        await expect(toggleInHeader).toBeVisible();
+      } finally {
+        await cleanup();
+      }
+    });
+
+    // ─── AC3: Panel open → form inputs visible / not overlapped ──────────────────────────────────
+
+    test('AC3: Mobile panel open — caption textarea is visible and its bounding box does not overlap the toggle', async ({
+      page,
+      testPrefix,
+    }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const setup = await setupDiaryWithPhoto(page, testPrefix);
+      if (!setup) {
+        test.skip();
+        return;
+      }
+      const { draftId, photoId, cleanup } = setup;
+
+      try {
+        await openPhotoViewer(page, draftId, photoId);
+
+        // Open panel
+        const toggle = page.getByTestId('photo-metadata-toggle');
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+        // Caption textarea must be visible and interactable
+        const captionTextarea = page.locator('#photo-caption');
+        await expect(captionTextarea).toBeVisible();
+
+        // The in-header toggle must not overlap the textarea (regression check).
+        // We verify that the toggle's bounding box does NOT intersect the textarea's.
+        const toggleBox = await toggle.boundingBox();
+        const textareaBox = await captionTextarea.boundingBox();
+        expect(toggleBox).not.toBeNull();
+        expect(textareaBox).not.toBeNull();
+
+        // Intersection check: two boxes overlap when they share area on both axes.
+        const overlapsX =
+          toggleBox!.x < textareaBox!.x + textareaBox!.width &&
+          toggleBox!.x + toggleBox!.width > textareaBox!.x;
+        const overlapsY =
+          toggleBox!.y < textareaBox!.y + textareaBox!.height &&
+          toggleBox!.y + toggleBox!.height > textareaBox!.y;
+        expect(
+          overlapsX && overlapsY,
+          'Toggle button must not overlap the caption textarea when panel is open',
+        ).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    // ─── AC4: Tap in-header toggle → panel closes, toggle back to floating launcher ─────────────
+
+    test('AC4: Mobile — tapping in-header toggle closes panel, aria-expanded becomes false, toggle back to floating launcher', async ({
+      page,
+      testPrefix,
+    }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const setup = await setupDiaryWithPhoto(page, testPrefix);
+      if (!setup) {
+        test.skip();
+        return;
+      }
+      const { draftId, photoId, cleanup } = setup;
+
+      try {
+        await openPhotoViewer(page, draftId, photoId);
+
+        // Open panel first
+        const toggle = page.getByTestId('photo-metadata-toggle');
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+        // Tap the in-header toggle to close
+        const toggleInHeader = page
+          .locator('#photo-metadata-sidepanel [class*="header"]')
+          .getByTestId('photo-metadata-toggle');
+        await expect(toggleInHeader).toBeVisible();
+        await toggleInHeader.click();
+
+        // aria-expanded must be "false" again
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+        // Sidepanel no longer visible
+        const sidepanel = page.locator('#photo-metadata-sidepanel');
+        await expect(sidepanel).not.toBeVisible();
+
+        // Toggle is back to being the floating launcher (not in header)
+        await expect(toggleInHeader).not.toBeAttached();
+      } finally {
+        await cleanup();
+      }
+    });
+
+    // ─── AC6: Desktop viewport → toggle NOT visible, sidepanel always visible ────────────────────
+
+    test('AC6: Desktop — toggle hidden (display:none), sidepanel always visible', async ({
+      page,
+      testPrefix,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+
+      const setup = await setupDiaryWithPhoto(page, testPrefix);
+      if (!setup) {
+        test.skip();
+        return;
+      }
+      const { draftId, photoId, cleanup } = setup;
+
+      try {
+        await openPhotoViewer(page, draftId, photoId);
+
+        // On desktop the toggle button has CSS display:none — not visible
+        const toggle = page.getByTestId('photo-metadata-toggle');
+        await expect(toggle).not.toBeVisible();
+
+        // Sidepanel is always visible on desktop (no hide/show mechanism)
+        const sidepanel = page.locator('#photo-metadata-sidepanel');
+        await expect(sidepanel).toBeVisible();
+      } finally {
+        await cleanup();
+      }
+    });
+  },
+);


### PR DESCRIPTION
Syncs the #1706 mobile lightbox metadata-toggle fix onto `beta`.

Context: the original PR #1710 was inadvertently merged to `main` (published as v2.7.1), so `beta` was missing this fix. This cherry-picks the two original #1706 commits (authored on top of `beta`) so `beta` is reconciled with `main`. Net change: 5 files (the #1706 fix only).

Fixes #1706

Co-Authored-By: Claude frontend-developer (Haiku 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude qa-integration-tester (Sonnet 4.5) <noreply@anthropic.com>
Co-Authored-By: Claude e2e-test-engineer (Sonnet 4.5) <noreply@anthropic.com>