### PR TITLE
ci: enforce that PRs into main originate from beta

### DIFF
--- a/.github/workflows/enforce-promotion-source.yml
+++ b/.github/workflows/enforce-promotion-source.yml
@@ -1,0 +1,31 @@
+name: Enforce Promotion Source
+
+# Guards the beta -> main promotion model: PRs targeting `main` must originate
+# from `beta`. This prevents a feature/fix branch (typically based on beta) from
+# being merged directly into main, which would drag in-flight beta work onto a
+# stable release out-of-band (see the #1710 incident).
+#
+# Enforcement: mark the `guard` job as a required status check on the `main`
+# ruleset. It only blocks at merge time; a non-beta PR into main stays blocked.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: enforce-promotion-source-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Require head branch == beta
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR originates from beta
+        if: github.head_ref != 'beta'
+        run: |
+          echo "::error::PRs into 'main' must originate from 'beta' (got '${{ github.head_ref }}'). Promote via a beta -> main PR instead."
+          exit 1
+      - name: Promotion source OK
+        if: github.head_ref == 'beta'
+        run: echo "Head branch is 'beta' — promotion source is valid."


### PR DESCRIPTION
## Why

PR #1710 was squash-merged into `main` from a beta-based fix branch, dragging in-flight beta work onto the stable release out-of-band and tagging a spurious `v2.7.1`. GitHub branch protection / rulesets cannot restrict a PR's **source** branch — only the target. This adds the missing guard.

## What

New workflow `.github/workflows/enforce-promotion-source.yml`:
- Runs on `pull_request` targeting `main`.
- The `guard` job **fails** unless `github.head_ref == 'beta'`.

## Activation (manual, after merge)

Mark **`Require head branch == beta`** (job `guard`) as a required status check on the `main` ruleset. Then any PR into `main` from a non-`beta` branch cannot be merged.

## Notes
- Blocks at **merge** time, not PR-open time (strongest head-branch restriction GitHub offers).
- Fails safe: if the workflow is skipped, the required check is simply unmet → PR stays blocked.
- Recommend pairing with disabling squash/rebase merges repo-wide so promotions land as merge commits (preserves individual commits for semantic-release).