### PR TITLE
chore: retrigger promotion CI

### DIFF
--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -27,3 +27,5 @@ docker pull steilerdev/cornerstone:latest
 ```
 
 Restart your container. Schema migrations run automatically on first boot. Creating invoices from Paperless documents reuses your existing [Auto-itemize](https://steilerDev.github.io/cornerstone/guides/budget/auto-itemize) configuration -- if you have already set the `LLM_*` and `PAPERLESS_*` environment variables, the document-first flow appears automatically.
+
+<!-- CI retrigger: promotion #1700 (post-docs auto-fix skip-ci) -->

--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -29,3 +29,4 @@ docker pull steilerdev/cornerstone:latest
 Restart your container. Schema migrations run automatically on first boot. Creating invoices from Paperless documents reuses your existing [Auto-itemize](https://steilerDev.github.io/cornerstone/guides/budget/auto-itemize) configuration -- if you have already set the `LLM_*` and `PAPERLESS_*` environment variables, the document-first flow appears automatically.
 
 <!-- CI retrigger: promotion #1700 (post-docs auto-fix skip-ci) -->
+<!-- retrigger sync be8350 -->


### PR DESCRIPTION
Empty commit to advance beta HEAD with a clean (non-skip-ci) message, re-firing CI on the stuck v2.8.0 promotion PR #1700 (Mode A skip-ci recovery per CLAUDE.md).