### PR TITLE
feat(photos): show photo preview in "Add photo details" modal (#1722)

### DIFF
--- a/client/src/components/photos/PhotoMetadataModal.module.css
+++ b/client/src/components/photos/PhotoMetadataModal.module.css
@@ -32,3 +32,34 @@
 @media (prefers-reduced-motion: reduce) {
   /* No transitions on modal content — inherited from shared.module.css which already handles this */
 }
+
+.photoPreview {
+  width: 100%;
+  max-height: 14rem;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photoPreviewImage {
+  max-width: 100%;
+  max-height: 14rem;
+  object-fit: contain;
+  object-position: center;
+  display: block;
+  border-radius: var(--radius-md);
+}
+
+@media (max-width: 767px) {
+  .photoPreview {
+    max-height: 10rem;
+  }
+
+  .photoPreviewImage {
+    max-height: 10rem;
+  }
+}

--- a/client/src/components/photos/PhotoMetadataModal.test.tsx
+++ b/client/src/components/photos/PhotoMetadataModal.test.tsx
@@ -40,6 +40,12 @@ import '../../i18n/index.js';
 // from throwing and keeps the test environment clean.
 let savedFetch: typeof globalThis.fetch;
 
+// ─── Stub URL.createObjectURL / revokeObjectURL ────────────────────────────────
+// jsdom does not implement these APIs.  We save/restore them per test so that
+// individual tests can override the mock return value as needed.
+let savedCreateObjectURL: typeof URL.createObjectURL;
+let savedRevokeObjectURL: typeof URL.revokeObjectURL;
+
 beforeEach(() => {
   savedFetch = globalThis.fetch;
   globalThis.fetch = jest.fn<typeof globalThis.fetch>().mockResolvedValue({
@@ -49,10 +55,17 @@ beforeEach(() => {
     text: async () => '{"orientations":[],"areas":[]}',
     headers: new Headers(),
   } as Response);
+
+  savedCreateObjectURL = URL.createObjectURL;
+  savedRevokeObjectURL = URL.revokeObjectURL;
+  URL.createObjectURL = jest.fn<typeof URL.createObjectURL>().mockReturnValue('blob:mock-url');
+  URL.revokeObjectURL = jest.fn<typeof URL.revokeObjectURL>();
 });
 
 afterEach(() => {
   globalThis.fetch = savedFetch;
+  URL.createObjectURL = savedCreateObjectURL;
+  URL.revokeObjectURL = savedRevokeObjectURL;
 });
 
 // ─── Captured onChange handlers from mocked pickers ──────────────────────────
@@ -338,6 +351,138 @@ describe('PhotoMetadataModal', () => {
       fireEvent.click(getSaveButton());
       expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ caption: 'Panoramic shot' }));
     }
+  });
+
+  // ─── Photo preview tests ───────────────────────────────────────────────────
+
+  describe('photo preview (objectUrl effect)', () => {
+    it('URL.createObjectURL is called once with the file instance on mount', async () => {
+      const file = makeFile('test-photo.jpg');
+      renderModal({ file });
+
+      await waitFor(() => {
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+      });
+    });
+
+    it('renders a preview img with src=blob:mock-url and alt=file.name', async () => {
+      const file = makeFile('my-photo.jpg');
+      renderModal({ file });
+
+      // Wait for the effect to run and the img to appear in the DOM.
+      const img = await screen.findByRole('img');
+      expect(img).toHaveAttribute('src', 'blob:mock-url');
+      expect(img).toHaveAttribute('alt', 'my-photo.jpg');
+    });
+
+    it('preview img is the first element child of formBody', async () => {
+      const file = makeFile('first-child.jpg');
+      renderModal({ file });
+
+      await screen.findByRole('img');
+
+      // The formBody div contains the preview as its first child element.
+      // We locate it by finding the img and walking up to its grandparent (the
+      // photoPreview div) and then to the formBody.
+      const img = screen.getByRole('img');
+      const photoPreviewDiv = img.parentElement!;
+      const formBody = photoPreviewDiv.parentElement!;
+      expect(formBody.firstElementChild).toBe(photoPreviewDiv);
+    });
+
+    it('no preview img when createObjectURL returns an empty string (falsy objectUrl)', async () => {
+      // Override the mock to return an empty string so the conditional `{objectUrl && ...}`
+      // evaluates to falsy and the img is not rendered.
+      (URL.createObjectURL as ReturnType<typeof jest.fn>).mockReturnValue('');
+
+      renderModal();
+
+      // Give the effect a chance to run then assert no img is present.
+      await waitFor(() => {
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.queryByRole('img')).toBeNull();
+    });
+
+    it('URL.revokeObjectURL is called with blob:mock-url on unmount', async () => {
+      const { unmount } = renderModal();
+
+      // Wait for effect to run and URL to be created.
+      await waitFor(() => {
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        unmount();
+      });
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    });
+
+    it('revokes old URL and creates new one when file prop changes', async () => {
+      (URL.createObjectURL as ReturnType<typeof jest.fn>)
+        .mockReturnValueOnce('blob:url-file1')
+        .mockReturnValueOnce('blob:url-file2');
+
+      const file1 = makeFile('file1.jpg');
+      const file2 = makeFile('file2.jpg');
+
+      const { rerender } = renderModal({ file: file1 });
+
+      // Wait for the first effect to run.
+      await waitFor(() => {
+        expect(URL.createObjectURL).toHaveBeenCalledWith(file1);
+      });
+      // First img should show file1 url.
+      expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:url-file1');
+
+      // Rerender with file2.
+      act(() => {
+        rerender(
+          <PhotoMetadataModal
+            file={file2}
+            entityType="work_item"
+            areas={makeAreas()}
+            onSave={jest.fn()}
+            onCancel={jest.fn()}
+          />,
+        );
+      });
+
+      // Cleanup for file1's effect should revoke the first URL.
+      await waitFor(() => {
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:url-file1');
+      });
+      // New effect should have created a URL for file2.
+      expect(URL.createObjectURL).toHaveBeenCalledWith(file2);
+      // The img should now show file2's url and alt.
+      const img = screen.getByRole('img');
+      expect(img).toHaveAttribute('src', 'blob:url-file2');
+      expect(img).toHaveAttribute('alt', 'file2.jpg');
+    });
+
+    it('Save behavior unchanged when preview is present — onSave called with correct payload', async () => {
+      const onSave = jest.fn<PhotoMetadataModalProps['onSave']>();
+      renderModal({ onSave });
+
+      // Wait for preview to appear.
+      await screen.findByRole('img');
+
+      // Fill in description.
+      const textarea = document.getElementById('modal-photo-caption') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: 'Preview caption' } });
+
+      fireEvent.click(getSaveButton());
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith({
+        caption: 'Preview caption',
+        areaId: null,
+        orientationId: null,
+      });
+    });
   });
 
   describe('focus trap (useEffect keyboard handler)', () => {

--- a/client/src/components/photos/PhotoMetadataModal.tsx
+++ b/client/src/components/photos/PhotoMetadataModal.tsx
@@ -30,6 +30,13 @@ export function PhotoMetadataModal({
   const [caption, setCaption] = useState('');
   const [areaId, setAreaId] = useState('');
   const [orientationId, setOrientationId] = useState('');
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
 
   // Focus trap: cycle Tab/Shift+Tab within the modal (form + footer buttons)
   useEffect(() => {
@@ -93,6 +100,15 @@ export function PhotoMetadataModal({
       }
     >
       <div className={styles.formBody}>
+        {objectUrl && (
+          <div className={styles.photoPreview}>
+            <img
+              src={objectUrl}
+              alt={file.name}
+              className={styles.photoPreviewImage}
+            />
+          </div>
+        )}
         {/* Description textarea */}
         <div>
           <label htmlFor="modal-photo-caption" className={styles.fieldLabel}>

--- a/e2e/tests/photo-capture-flow.spec.ts
+++ b/e2e/tests/photo-capture-flow.spec.ts
@@ -1056,3 +1056,86 @@ test.describe(
     });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 12: PhotoMetadataModal — photo preview (Story #1722)
+//
+// The modal now renders a preview <img> of the selected file before upload.
+// The img's src is a blob: object URL created from the File object, and its alt
+// is set to the selected file's name.
+//
+// Scenario 12 (@smoke): default viewport — preview img is visible, alt equals
+//   the filename, src starts with "blob:".
+// Scenario 12b (@responsive): mobile viewport (375×667) — same assertions,
+//   confirming the mobile CSS (max-height: 10rem) does not hide the element.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('PhotoMetadataModal — photo preview (Scenario 12)', () => {
+  test(
+    'Photo preview visible in modal after file selection (Scenario 12)',
+    { tag: '@smoke' },
+    async ({ page }) => {
+      let draftId: string | null = null;
+      try {
+        draftId = await createDraftDiaryEntryViaApi(page, { entryType: 'general_note' });
+        await page.goto(`/diary/${draftId}/edit`);
+        await page
+          .getByRole('heading', { level: 1, name: 'Edit Diary Entry' })
+          .waitFor({ state: 'visible' });
+
+        const libraryInput = page.getByTestId('photo-library-input');
+        await libraryInput.setInputFiles([MINIMAL_JPEG]);
+
+        const modal = page.getByRole('dialog', { name: 'Add photo details' });
+        await modal.waitFor({ state: 'visible' });
+
+        // The modal should contain a preview image of the selected file.
+        const previewImg = modal.getByRole('img');
+        await expect(previewImg).toBeVisible();
+
+        // alt equals the selected file's name
+        await expect(previewImg).toHaveAttribute('alt', MINIMAL_JPEG.name);
+
+        // src is a blob: object URL (created from the File object pre-upload)
+        await expect(previewImg).toHaveAttribute('src', /^blob:/);
+      } finally {
+        if (draftId) await deleteDiaryEntryViaApi(page, draftId);
+      }
+    },
+  );
+
+  test(
+    'Preview present on mobile viewport (Scenario 12b)',
+    { tag: '@responsive' },
+    async ({ page }) => {
+      // Force mobile viewport to verify the preview is not hidden by
+      // max-height: 10rem CSS applied at small screen sizes.
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      let draftId: string | null = null;
+      try {
+        draftId = await createDraftDiaryEntryViaApi(page, { entryType: 'general_note' });
+        await page.goto(`/diary/${draftId}/edit`);
+        await page
+          .getByRole('heading', { level: 1, name: 'Edit Diary Entry' })
+          .waitFor({ state: 'visible' });
+
+        const libraryInput = page.getByTestId('photo-library-input');
+        await libraryInput.setInputFiles([MINIMAL_JPEG]);
+
+        const modal = page.getByRole('dialog', { name: 'Add photo details' });
+        await modal.waitFor({ state: 'visible' });
+
+        // Preview must remain visible even at 375px where max-height: 10rem is applied.
+        const previewImg = modal.getByRole('img');
+        await expect(previewImg).toBeVisible();
+
+        // alt and src sanity-check on mobile too
+        await expect(previewImg).toHaveAttribute('alt', MINIMAL_JPEG.name);
+        await expect(previewImg).toHaveAttribute('src', /^blob:/);
+      } finally {
+        if (draftId) await deleteDiaryEntryViaApi(page, draftId);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Renders a preview image of the selected photo inside the `PhotoMetadataModal`, displayed above the description field
- Object URL is created from the selected `File` on file change and revoked on unmount/file change to prevent memory leaks
- `PhotoMetadataSidepanel` is intentionally out of scope for this story

Fixes #1722

## Test plan

- [ ] Unit tests pass — `PhotoMetadataModal.test.tsx` covers preview rendering, object URL lifecycle (create/revoke), and absence when no file is selected
- [ ] E2E tests pass — `photo-capture-flow.spec.ts` verifies the preview image appears in the modal after file selection
- [ ] Pre-commit hook quality gates pass (lint, typecheck, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)