### PR TITLE
fix(e2e): replace fragile waitForResponse with networkidle for i18n locale reset test

### DIFF
--- a/e2e/tests/i18n/i18n.spec.ts
+++ b/e2e/tests/i18n/i18n.spec.ts
@@ -319,19 +319,18 @@ test.describe('i18n: Language Persistence via API', () => {
     // which re-initialises LocaleContext: localStorage is empty → server has no
     // preference → fallback to system locale (English in CI).
     //
-    // Register waitForResponse AFTER goto (so the goto's preferences response does not
-    // prematurely resolve the promise) but BEFORE reload (so we don't miss the reload's
-    // preferences GET). If the promise is registered before goto, the goto itself triggers
-    // a preferences fetch (200) that resolves the promise. Then await page.reload() starts
-    // a new full-page load whose async React locale update may not finish within the 7s
-    // expect.timeout — the heading stays "Profil" (German) until that async fetch resolves.
+    // waitForResponse is NOT used here because it creates a timing race: both the
+    // goto() navigation and React's post-load async mounting can trigger a preferences
+    // GET, meaning the promise can resolve prematurely (capturing the goto's fetch
+    // instead of the reload's fetch). Instead, we navigate, reload, then wait for
+    // network idle — ensuring all async preferences fetches AND React locale state
+    // updates have settled before asserting the heading text.
     await page.goto(ROUTES.profile);
-    const resetPrefsPromise = page.waitForResponse(
-      (resp) => resp.url().includes('/api/users/me/preferences') && resp.status() === 200,
-    );
     await page.reload();
-    await resetPrefsPromise;
+    await page.waitForLoadState('networkidle');
     // After no locale preference, system default (English) applies
-    await expect(page.getByRole('heading', { level: 1, name: 'Profile' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Profile' })).toBeVisible({
+      timeout: 15000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Removes the `waitForResponse` race condition in the `DELETE preference resets to system locale` E2E test (shard 4, `i18n.spec.ts:305`)
- Replaces it with `page.waitForLoadState('networkidle')` after `page.reload()` to ensure all async preferences fetches and React locale state updates have settled before asserting
- Adds an explicit `timeout: 15000` on the heading assertion as a belt-and-suspenders measure

## Root Cause

The previous fix (PR #1729) moved `waitForResponse` to after `goto` but before `reload`. However, the race still existed: both the `goto()` navigation and React's async post-load component mounting can independently trigger a `GET /api/users/me/preferences` response. The `waitForResponse` promise could resolve on the **goto's** response rather than the **reload's** response, causing the heading assertion to run before the locale state had been updated from the reload's preferences fetch. Result: intermittent `'Profil'` (German) instead of `'Profile'` (English).

## Fix Approach (Option A)

`waitForResponse` is eliminated entirely. After `reload()`, `page.waitForLoadState('networkidle')` waits for all network activity to settle. Only then do we assert the heading. This is timing-race-free because we don't care *which* request triggers the locale update — we just wait until all async activity is done.

## Test plan

- [ ] CI E2E smoke tests pass (Quality Gates)
- [ ] Shard 4 of the full E2E run passes (the previously failing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)