### PR TITLE
docs: update documentation for photo enhancement release

### DIFF
--- a/RELEASE_SUMMARY.md
+++ b/RELEASE_SUMMARY.md
@@ -1,33 +1,25 @@
-# v2.8.0 Release Summary
+# v2.9.0 Release Summary
 
 ## What's New
 
-This release makes capturing the real-world record of your build faster and more mobile-friendly. You can now create an entire invoice straight from a scanned Paperless document, snap and tag photos one-handed from your phone, and log who worked on site and for how long -- all without leaving the screen you are on. No manual migration steps are required.
+This release polishes the mobile photo workflow introduced in 2.8.0. The "Add photo details" modal now shows a preview of the photo you just picked, and choosing where a photo was taken is far clearer when your home has rooms with the same name on different floors. No manual migration steps are required.
 
 ### Highlights
 
-- **Create invoices from a Paperless document** -- When Paperless-ngx and Auto-itemize are both configured, **New Invoice** opens a document picker. Pick the PDF the vendor sent you and Cornerstone reads the invoice for you: it pre-fills the invoice number, amount, date, due date, and notes, suggests the matching vendor, and extracts the line items -- grossing up net lines by VAT so the totals match. Review, assign each line to a work item or household item, and click **Create Invoice & Itemize** to create the invoice and all its budget lines in one step. The new-invoice review screen now shares the exact same interface as the existing Auto-itemize page.
+- **Photo preview while tagging** -- The "Add photo details" modal now shows a preview of the photo you just selected, right above the description field. You can confirm you picked the right shot before adding its caption, area, and orientation -- handy when you are snapping several photos in a row on site.
 
-- **Mobile-first photo capture** -- Capturing site photos is built for the phone. Snap a photo with your camera, and a photo-details modal lets you add a caption, the area it was taken in, and the compass orientation it faces before it uploads. A new **Orientations** tab on the Manage page lets you maintain your own list of directions (e.g. "South – Street-facing") to tag photos with. The photo annotator now scales to fit any screen and is fully touch- and stylus-enabled, so you can mark up a photo on a tablet as easily as on a desktop.
+- **Clearer area picker** -- When tagging a photo (or a work item or household item) with its location, the area picker now indents each option to show its place in your hierarchy and prints the full path (e.g. *Ground Floor › Kitchen*) beneath the name. Telling apart a "Bathroom" on the ground floor from one upstairs is now obvious. Once you pick an area, the field collapses to just the short room name to stay tidy.
 
-- **Diary daily-log vendor and work hours** -- Daily Log entries gained optional **Vendor**, **Work start**, and **Work end** fields, with the total work duration computed automatically. The entry's information panel shows who worked and for how long at a glance, turning a daily log into a simple labour record.
+- **Smarter orientation search** -- The orientation picker now searches your descriptions as well as the names. Typing *street* finds an orientation named *South* whose description reads *Street-facing side of house*, so you do not have to remember the exact label you gave it.
 
-- **Discoverable document unlink** -- The action to unlink a document from a work item, household item, or invoice now lives as a clear **✕** overlay in the top-right corner of each linked-document card, so it is easy to find without cluttering the card.
+### Behind the Scenes
 
-### Notable Fixes
-
-- Search-as-you-type pickers now position their dropdown correctly and stay anchored while scrolling on mobile.
-- Mobile browsers no longer zoom in when you focus a text field or pinch, keeping forms steady on small screens.
-- Hardened the construction-diary daily-log experience and the mobile diary filter panel.
+- Hardened the photo-capture and internationalization browser tests, and tightened the continuous-integration pipeline so releases stay reliable.
 
 ## Upgrade
 
-```bash
+\`\`\`bash
 docker pull steilerdev/cornerstone:latest
-```
+\`\`\`
 
-Restart your container. Schema migrations run automatically on first boot. Creating invoices from Paperless documents reuses your existing [Auto-itemize](https://steilerDev.github.io/cornerstone/guides/budget/auto-itemize) configuration -- if you have already set the `LLM_*` and `PAPERLESS_*` environment variables, the document-first flow appears automatically.
-
-<!-- CI retrigger: promotion #1700 (post-docs auto-fix skip-ci) -->
-<!-- retrigger sync be8350 -->
-<!-- promotion CI nudge (synchronize) -->
+Restart your container. Schema migrations run automatically on first boot.

--- a/docs/src/guides/diary/photo-capture.md
+++ b/docs/src/guides/diary/photo-capture.md
@@ -15,13 +15,17 @@ You can add one photo or several at once. Each file uploads as soon as it is que
 
 ## The photo details modal
 
-When you pick a photo, Cornerstone opens a **photo details** modal before the upload completes so you can tag the shot while the context is fresh:
+When you pick a photo, Cornerstone opens a **photo details** modal before the upload completes so you can tag the shot while the context is fresh. A **preview of the selected photo** appears at the top of the modal so you can confirm you picked the right shot before filling in the details below:
 
 | Field | Description |
 |-------|-------------|
 | **Description** | An optional caption (up to 500 characters). The placeholder reads *Add a description… (optional)*. |
 | **Area** | The [area](/guides/work-items/areas-and-trades) the photo was taken in -- pick from your area hierarchy. Optional. |
 | **Orientation** | The compass direction the photo faces, chosen from your managed list of [orientations](#orientations). Optional. |
+
+### Picking the area
+
+The area picker is hierarchy-aware. Each option is indented to show its depth in your area tree, and the **full ancestor path** (e.g. *Ground Floor › Kitchen*) appears beneath the area name. This makes it easy to tell apart rooms that share the same name on different floors -- for example a "Bathroom" on the ground floor and another upstairs. Once you select an area, the picker collapses to show just the concise area name.
 
 Tap **Save & upload** to store the photo with its metadata, or **Cancel** to skip the file. You can always edit a photo's description and area later from the photo viewer.
 
@@ -45,7 +49,7 @@ Navigate to **Manage** in the sidebar and open the **Orientations** tab (🧭). 
 
 Click **Create orientation** to add it. The list below shows every orientation with its sort-order label; each row has **Edit** and **Delete** actions. Deleting an orientation asks for confirmation first.
 
-Once you have created orientations they appear in the **Orientation** picker in the photo details modal.
+Once you have created orientations they appear in the **Orientation** picker in the photo details modal. The picker searches as you type, matching your query against both the orientation **name** and its **description** -- so typing *street* finds *South – Street-facing* even when "street" only appears in the description.
 
 ## Working with photos after upload
 

--- a/docs/src/guides/work-items/areas-and-trades.md
+++ b/docs/src/guides/work-items/areas-and-trades.md
@@ -32,7 +32,7 @@ Areas can be nested to any depth. A parent area implicitly includes all its chil
 
 ### Assigning Areas
 
-When creating or editing a work item or household item, select an area from the area picker. The picker displays the full hierarchy so you can quickly find the right location.
+When creating or editing a work item or household item, select an area from the area picker. The picker is hierarchy-aware: each option is indented to reflect its depth in the tree, and the **full ancestor path** (e.g. *Ground Floor › Kitchen*) is shown beneath the area name. This makes it easy to disambiguate rooms that share a name on different floors. Once you pick an area, the picker collapses to show just the concise area name.
 
 ### Area Breadcrumbs Everywhere
 


### PR DESCRIPTION
**[docs-writer]** Documents the two photo enhancement features shipped in the v2.9.0 release.

## Features documented

1. **Photo preview in "Add photo details" modal** (#1724, #1722) -- the modal now shows a preview of the selected photo above the description field.
2. **Hierarchy-aware area picker + description-aware orientation search** (#1725, #1723) -- area options render with depth indentation and the full ancestor path beneath the name (collapsing to the concise name once selected); the orientation picker now matches search queries against the description field as well as the name.

## Changes

- `docs/src/guides/diary/photo-capture.md` -- added the photo-preview note, a new "Picking the area" subsection (indentation + ancestor path), and the description-aware orientation search behavior.
- `docs/src/guides/work-items/areas-and-trades.md` -- updated "Assigning Areas" to describe the hierarchy-aware picker.
- `RELEASE_SUMMARY.md` -- rewritten for v2.9.0 (photo preview, clearer area picker, smarter orientation search, plus E2E/CI hardening).

## Notes

- **README**: no change needed -- the feature list already covers "mobile-first photo capture tagged with area and compass orientation"; these are refinements, not new top-level capabilities.
- **.env.example**: verified fully in sync with `server/src/plugins/config.ts` -- no new env vars in this release.
- `npm run docs:build` succeeds (only expected screenshot image warnings, no broken links/anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)