### PR TITLE
feat(documents): attach documents to budget sources and subsidy programs (#1744)

### DIFF
--- a/client/src/components/documents/LinkedDocumentsSection.test.tsx
+++ b/client/src/components/documents/LinkedDocumentsSection.test.tsx
@@ -797,4 +797,54 @@ describe('LinkedDocumentsSection', () => {
       expect(capturedLinkedDocumentIds).toEqual([]);
     });
   });
+
+  // ─── New entity types: budget_source and subsidy_program ─────────────────
+
+  describe('budget_source entity type', () => {
+    it('renders Documents heading and budgetSourceEmpty empty copy when entity type is budget_source', async () => {
+      mockUseDocumentLinks.mockReturnValue(makeHook({ links: [] }));
+
+      render(<LinkedDocumentsSection entityType="budget_source" entityId="bs-001" />);
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /\+ Add Document/i })).toBeInTheDocument(),
+      );
+
+      // Should render the section without errors — empty state copy
+      // The t('linkedDocuments.budgetSourceEmpty') key must exist in en/documents.json
+      // We verify the section rendered by checking for the heading/add button
+      expect(screen.getByRole('button', { name: /\+ Add Document/i })).toBeInTheDocument();
+    });
+
+    it('passes entityType=budget_source to useDocumentLinks hook', async () => {
+      mockUseDocumentLinks.mockReturnValue(makeHook({ links: [] }));
+
+      render(<LinkedDocumentsSection entityType="budget_source" entityId="bs-001" />);
+
+      // Verify the hook was called with the correct entity type
+      expect(mockUseDocumentLinks).toHaveBeenCalledWith('budget_source', 'bs-001');
+    });
+  });
+
+  describe('subsidy_program entity type', () => {
+    it('renders Documents heading and subsidyProgramEmpty empty copy when entity type is subsidy_program', async () => {
+      mockUseDocumentLinks.mockReturnValue(makeHook({ links: [] }));
+
+      render(<LinkedDocumentsSection entityType="subsidy_program" entityId="sp-001" />);
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /\+ Add Document/i })).toBeInTheDocument(),
+      );
+
+      expect(screen.getByRole('button', { name: /\+ Add Document/i })).toBeInTheDocument();
+    });
+
+    it('passes entityType=subsidy_program to useDocumentLinks hook', async () => {
+      mockUseDocumentLinks.mockReturnValue(makeHook({ links: [] }));
+
+      render(<LinkedDocumentsSection entityType="subsidy_program" entityId="sp-001" />);
+
+      expect(mockUseDocumentLinks).toHaveBeenCalledWith('subsidy_program', 'sp-001');
+    });
+  });
 });

--- a/client/src/components/documents/LinkedDocumentsSection.tsx
+++ b/client/src/components/documents/LinkedDocumentsSection.tsx
@@ -61,6 +61,16 @@ export function LinkedDocumentsSection({ entityType, entityId }: LinkedDocuments
       unlinkBody: 'invoiceEntity',
       emptyBody: 'invoiceEmpty',
     },
+    budget_source: {
+      pickerSubtitle: 'selectDocumentSubtitle',
+      unlinkBody: 'budgetSourceEntity',
+      emptyBody: 'budgetSourceEmpty',
+    },
+    subsidy_program: {
+      pickerSubtitle: 'selectDocumentSubtitle',
+      unlinkBody: 'subsidyProgramEntity',
+      emptyBody: 'subsidyProgramEmpty',
+    },
   } as const satisfies Record<
     DocumentLinkEntityType,
     { pickerSubtitle: string; unlinkBody: string; emptyBody: string }
@@ -72,7 +82,11 @@ export function LinkedDocumentsSection({ entityType, entityId }: LinkedDocuments
       ? t('linkedDocuments.workItemEntity')
       : entityType === 'household_item'
         ? t('linkedDocuments.householdItemEntity')
-        : t('linkedDocuments.invoiceEntity');
+        : entityType === 'invoice'
+          ? t('linkedDocuments.invoiceEntity')
+          : entityType === 'budget_source'
+            ? t('linkedDocuments.budgetSourceEntity')
+            : t('linkedDocuments.subsidyProgramEntity');
 
   // Paperless status state
   const [paperlessStatus, setPaperlessStatus] = useState<Awaited<

--- a/client/src/i18n/de/budget.json
+++ b/client/src/i18n/de/budget.json
@@ -221,6 +221,13 @@
         "genericError": "Positionen konnten nicht verschoben werden. Bitte versuchen Sie es erneut."
       }
     },
+    "docs": {
+      "expand": "Dokumente einblenden",
+      "collapse": "Dokumente ausblenden",
+      "expandAriaLabel": "Dokumente für {{name}} einblenden",
+      "collapseAriaLabel": "Dokumente für {{name}} ausblenden",
+      "panelAriaLabel": "Dokumente für {{name}}"
+    },
     "summary": {
       "remainingLabel": "Verbleibend"
     }
@@ -725,6 +732,13 @@
       "created": "Förderprogramm \"{{name}}\" erfolgreich erstellt",
       "updated": "Förderprogramm \"{{name}}\" erfolgreich aktualisiert",
       "deleted": "Förderprogramm \"{{name}}\" erfolgreich gelöscht"
+    },
+    "docs": {
+      "expand": "Dokumente einblenden",
+      "collapse": "Dokumente ausblenden",
+      "expandAriaLabel": "Dokumente für {{name}} einblenden",
+      "collapseAriaLabel": "Dokumente für {{name}} ausblenden",
+      "panelAriaLabel": "Dokumente für {{name}}"
     }
   },
   "budgetLineForm": {

--- a/client/src/i18n/de/documents.json
+++ b/client/src/i18n/de/documents.json
@@ -54,9 +54,13 @@
     "workItemEntity": "dieses Arbeitspaket",
     "householdItemEntity": "dieses Haushaltsartikel",
     "invoiceEntity": "diese Rechnung",
+    "budgetSourceEntity": "diese Budgetquelle",
+    "subsidyProgramEntity": "dieses Förderprogramm",
     "workItemEmpty": "Verknüpfen Sie Quittungen, Verträge und Pläne aus Paperless-ngx, um alles an einem Ort zu haben.",
     "householdItemEmpty": "Verknüpfen Sie Quittungen, Garantien und Handbücher aus Paperless-ngx, um alles an einem Ort zu haben.",
-    "invoiceEmpty": "Verknüpfen Sie Rechnungs-PDFs, Quittungen und verwandte Dokumente aus Paperless-ngx, um alles an einem Ort zu haben."
+    "invoiceEmpty": "Verknüpfen Sie Rechnungs-PDFs, Quittungen und verwandte Dokumente aus Paperless-ngx, um alles an einem Ort zu haben.",
+    "budgetSourceEmpty": "Verknüpfen Sie Verträge, Garantien und verwandte Dokumente aus Paperless-ngx, um alles an einem Ort zu haben.",
+    "subsidyProgramEmpty": "Verknüpfen Sie Antragsformulare, Genehmigungsschreiben und verwandte Dokumente aus Paperless-ngx, um alles an einem Ort zu haben."
   },
   "documentCard": {
     "documentLabel": "Dokument: {{title}}{{date}}",

--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -219,6 +219,13 @@
         "successToast_other": "Moved {{count}} lines to {{targetName}}",
         "genericError": "Failed to move lines. Please try again."
       }
+    },
+    "docs": {
+      "expand": "Show documents",
+      "collapse": "Hide documents",
+      "expandAriaLabel": "Show documents for {{name}}",
+      "collapseAriaLabel": "Hide documents for {{name}}",
+      "panelAriaLabel": "Documents for {{name}}"
     }
   },
   "vendors": {
@@ -840,6 +847,13 @@
       "created": "Subsidy program \"{{name}}\" created successfully",
       "updated": "Subsidy program \"{{name}}\" updated successfully",
       "deleted": "Subsidy program \"{{name}}\" deleted successfully"
+    },
+    "docs": {
+      "expand": "Show documents",
+      "collapse": "Hide documents",
+      "expandAriaLabel": "Show documents for {{name}}",
+      "collapseAriaLabel": "Hide documents for {{name}}",
+      "panelAriaLabel": "Documents for {{name}}"
     }
   },
   "budgetLineForm": {

--- a/client/src/i18n/en/documents.json
+++ b/client/src/i18n/en/documents.json
@@ -54,9 +54,13 @@
     "workItemEntity": "this work item",
     "householdItemEntity": "this household item",
     "invoiceEntity": "this invoice",
+    "budgetSourceEntity": "this budget source",
+    "subsidyProgramEntity": "this subsidy program",
     "workItemEmpty": "Link receipts, contracts, and plans from Paperless-ngx to keep everything in one place.",
     "householdItemEmpty": "Link receipts, warranties, and manuals from Paperless-ngx to keep everything in one place.",
-    "invoiceEmpty": "Link invoice PDFs, receipts, and related documents from Paperless-ngx to keep everything in one place."
+    "invoiceEmpty": "Link invoice PDFs, receipts, and related documents from Paperless-ngx to keep everything in one place.",
+    "budgetSourceEmpty": "Link contracts, warranties, and related documents from Paperless-ngx to keep everything in one place.",
+    "subsidyProgramEmpty": "Link application forms, approval letters, and related documents from Paperless-ngx to keep everything in one place."
   },
   "documentCard": {
     "documentLabel": "Document: {{title}}{{date}}",

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.module.css
@@ -478,6 +478,66 @@
   }
 }
 
+/* ---- Documents toggle button ---- */
+
+.docsToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
+  padding: 0;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.docsToggle:hover:not(:disabled) {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong);
+}
+
+.docsToggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.docsToggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.docsToggleActive {
+  background-color: var(--color-primary-bg);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.docsIcon {
+  width: var(--spacing-4);
+  height: var(--spacing-4);
+  flex-shrink: 0;
+}
+
+.docsPanel {
+  padding: var(--spacing-4) var(--spacing-4) var(--spacing-2);
+  border-top: 1px solid var(--color-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docsToggle {
+    transition: none;
+  }
+}
+
 /* ---- Source type badge ---- */
 
 .typeBadge {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -33,6 +33,28 @@ jest.unstable_mockModule('../../lib/budgetSourcesApi.js', () => ({
   moveBudgetLinesBetweenSources: jest.fn(),
 }));
 
+// ─── Mock: LinkedDocumentsSection — avoids deep dependency chain (Paperless hooks, etc.) ───
+
+// Capture the last props passed to LinkedDocumentsSection so tests can assert them
+// (prefixed with _ because assertions use DOM data-attributes, not this variable directly)
+let _capturedLinkedDocsSectionProps: { entityType: string; entityId: string } | null = null;
+
+jest.unstable_mockModule('../../components/documents/LinkedDocumentsSection.js', () => ({
+  LinkedDocumentsSection: function MockLinkedDocumentsSection(props: {
+    entityType: string;
+    entityId: string;
+  }) {
+    _capturedLinkedDocsSectionProps = { entityType: props.entityType, entityId: props.entityId };
+    return (
+      <div
+        data-testid="linked-documents-section"
+        data-entity-type={props.entityType}
+        data-entity-id={props.entityId}
+      />
+    );
+  },
+}));
+
 // ─── Mock: ToastContext — provides useToast() hook without a real ToastProvider ───
 
 jest.unstable_mockModule('../../components/Toast/ToastContext.js', () => ({
@@ -189,6 +211,7 @@ describe('BudgetSourcesPage', () => {
     mockUpdateBudgetSource.mockReset();
     mockDeleteBudgetSource.mockReset();
     mockFetchBudgetLinesForSource.mockReset();
+    _capturedLinkedDocsSectionProps = null;
   });
 
   function renderPage() {
@@ -2203,6 +2226,172 @@ describe('BudgetSourcesPage', () => {
         el.className.includes('sourceMain'),
       );
       expect(sourceMainAsDirectChild).toBeDefined();
+    });
+  });
+
+  // ─── Docs toggle (story #1744) ──────────────────────────────────────────────
+
+  describe('docs toggle (paperclip button)', () => {
+    it('renders a paperclip/docs toggle button for each source row', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // The docs toggle button has an aria-label containing the source name
+      expect(screen.getByRole('button', { name: /home loan/i, hidden: true })).toBeInTheDocument();
+    });
+
+    it('clicking the docs toggle button renders LinkedDocumentsSection with entityType=budget_source and correct entityId', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // The aria-label includes 'Home Loan' — find the docs-expand toggle (aria-expanded=false)
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find(
+          (btn) =>
+            btn.getAttribute('aria-controls') === `source-docs-${sampleSource1.id}` &&
+            btn.getAttribute('aria-expanded') === 'false',
+        );
+      expect(docsBtn).toBeDefined();
+
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument();
+      });
+
+      const section = screen.getByTestId('linked-documents-section');
+      expect(section.getAttribute('data-entity-type')).toBe('budget_source');
+      expect(section.getAttribute('data-entity-id')).toBe(sampleSource1.id);
+    });
+
+    it('clicking the docs toggle button a second time hides LinkedDocumentsSection', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `source-docs-${sampleSource1.id}`);
+      expect(docsBtn).toBeDefined();
+
+      // First click — opens
+      fireEvent.click(docsBtn!);
+      await waitFor(() =>
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument(),
+      );
+
+      // Second click — closes
+      fireEvent.click(docsBtn!);
+      await waitFor(() =>
+        expect(screen.queryByTestId('linked-documents-section')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('docs toggle button has aria-expanded=false initially', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `source-docs-${sampleSource1.id}`);
+      expect(docsBtn).toBeDefined();
+      expect(docsBtn!.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('docs toggle button has aria-expanded=true after clicking', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `source-docs-${sampleSource1.id}`);
+      expect(docsBtn).toBeDefined();
+
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() => {
+        expect(docsBtn!.getAttribute('aria-expanded')).toBe('true');
+      });
+    });
+
+    it('docs toggle button is disabled when editingSource is active', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({
+        budgetSources: [sampleSource1, sampleSource2],
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // Start editing source1
+      const editBtn = screen.getByRole('button', { name: /edit home loan/i });
+      fireEvent.click(editBtn);
+
+      await waitFor(() => {
+        // Both docs toggles should be disabled when editing
+        const allDocsToggleBtns = screen
+          .getAllByRole('button', { hidden: true })
+          .filter((btn) => btn.getAttribute('aria-controls')?.startsWith('source-docs-'));
+        expect(allDocsToggleBtns.length).toBeGreaterThan(0);
+        for (const btn of allDocsToggleBtns) {
+          expect(btn).toBeDisabled();
+        }
+      });
+    });
+
+    it('LinkedDocumentsSection is hidden when editing the same source', async () => {
+      mockFetchBudgetSources.mockResolvedValueOnce({ budgetSources: [sampleSource1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Home Loan')).toBeInTheDocument();
+      });
+
+      // Open docs panel
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `source-docs-${sampleSource1.id}`);
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument(),
+      );
+
+      // Now start editing the same source — docs panel should disappear
+      const editBtn = screen.getByRole('button', { name: /edit home loan/i });
+      fireEvent.click(editBtn);
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('linked-documents-section')).not.toBeInTheDocument(),
+      );
     });
   });
 });

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -63,6 +63,9 @@ jest.unstable_mockModule('../../components/Toast/ToastContext.js', () => ({
 }));
 
 // ─── Mock: LocaleContext — prevents useLocale() from throwing outside LocaleProvider ───
+// In CI, jest.unstable_mockModule intercepts; the LocaleProvider wrapper in
+// renderPage is then redundant but harmless (passthrough stub).
+// Locally, when mock doesn't intercept, the real LocaleProvider handles useLocale().
 
 jest.unstable_mockModule('../../contexts/LocaleContext.js', () => ({
   useLocale: jest.fn(() => ({
@@ -73,6 +76,19 @@ jest.unstable_mockModule('../../contexts/LocaleContext.js', () => ({
     syncWithServer: jest.fn(),
   })),
   LocaleProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ─── Mock: configApi and preferencesApi (real LocaleProvider needs them) ──────
+// When jest.unstable_mockModule doesn't intercept LocaleContext locally, the real
+// LocaleProvider makes network calls. These mocks stop that.
+
+jest.unstable_mockModule('../../lib/configApi.js', () => ({
+  fetchConfig: jest.fn(() => Promise.resolve({ currency: 'EUR' })),
+}));
+
+jest.unstable_mockModule('../../lib/preferencesApi.js', () => ({
+  listPreferences: jest.fn(() => Promise.resolve([])),
+  upsertPreference: jest.fn(() => Promise.resolve()),
 }));
 
 // ─── Mock: formatters — provides useFormatters() hook ────────────────────────
@@ -139,6 +155,7 @@ jest.unstable_mockModule('../../lib/formatters.js', () => {
 
 describe('BudgetSourcesPage', () => {
   let BudgetSourcesPage: React.ComponentType;
+  let LocaleProvider: ({ children }: { children: React.ReactNode }) => React.ReactNode;
 
   // Sample data
 
@@ -203,6 +220,14 @@ describe('BudgetSourcesPage', () => {
       const module = await import('./BudgetSourcesPage.js');
       BudgetSourcesPage = module.default;
     }
+    if (!LocaleProvider) {
+      const localeMod = await import('../../contexts/LocaleContext.js');
+      LocaleProvider = localeMod.LocaleProvider as ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => React.ReactNode;
+    }
 
     // Reset all mocks
     mockFetchBudgetSources.mockReset();
@@ -216,9 +241,13 @@ describe('BudgetSourcesPage', () => {
 
   function renderPage() {
     return render(
-      <MemoryRouter initialEntries={['/budget/sources']}>
-        <BudgetSourcesPage />
-      </MemoryRouter>,
+      // Wrap in LocaleProvider so useFormatters→useLocale works in both CI (mock
+      // intercepts and this becomes a passthrough) and local (real provider used).
+      <LocaleProvider>
+        <MemoryRouter initialEntries={['/budget/sources']}>
+          <BudgetSourcesPage />
+        </MemoryRouter>
+      </LocaleProvider>,
     );
   }
 

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.test.tsx
@@ -2169,14 +2169,19 @@ describe('BudgetSourcesPage', () => {
       const actionsDiv = container.querySelector('[class*="sourceActions"]');
       expect(actionsDiv).not.toBeNull();
       const buttons = Array.from(actionsDiv!.querySelectorAll('button'));
-      expect(buttons.length).toBe(3);
-      // Order: Show lines → Edit → Delete
+      // Order: Show lines → docs toggle (paperclip) → Edit → Delete
+      expect(buttons.length).toBe(4);
       expect(buttons[0]).toHaveAttribute(
         'aria-label',
         expect.stringMatching(/expand budget lines for home loan/i),
       );
-      expect(buttons[1]).toHaveAccessibleName(/edit home loan/i);
-      expect(buttons[2]).toHaveAccessibleName(/delete home loan/i);
+      // The docs toggle sits between Show lines and Edit
+      expect(buttons[1]).toHaveAttribute(
+        'aria-controls',
+        expect.stringContaining('source-docs-'),
+      );
+      expect(buttons[2]).toHaveAccessibleName(/edit home loan/i);
+      expect(buttons[3]).toHaveAccessibleName(/delete home loan/i);
     });
 
     it('discretionary source shows Show lines and Edit in sourceActions but not Delete', async () => {
@@ -2194,12 +2199,18 @@ describe('BudgetSourcesPage', () => {
       const actionsDiv = container.querySelector('[class*="sourceActions"]');
       expect(actionsDiv).not.toBeNull();
       const buttons = Array.from(actionsDiv!.querySelectorAll('button'));
-      expect(buttons.length).toBe(2);
+      // Discretionary sources have no Delete: Show lines → docs toggle (paperclip) → Edit
+      expect(buttons.length).toBe(3);
       expect(buttons[0]).toHaveAttribute(
         'aria-label',
         expect.stringMatching(/expand budget lines for contingency reserve/i),
       );
-      expect(buttons[1]).toHaveAccessibleName(/edit contingency reserve/i);
+      // The docs toggle sits between Show lines and Edit
+      expect(buttons[1]).toHaveAttribute(
+        'aria-controls',
+        expect.stringContaining('source-docs-'),
+      );
+      expect(buttons[2]).toHaveAccessibleName(/edit contingency reserve/i);
       expect(
         screen.queryByRole('button', { name: /delete contingency reserve/i }),
       ).not.toBeInTheDocument();
@@ -2270,8 +2281,15 @@ describe('BudgetSourcesPage', () => {
         expect(screen.getByText('Home Loan')).toBeInTheDocument();
       });
 
-      // The docs toggle button has an aria-label containing the source name
-      expect(screen.getByRole('button', { name: /home loan/i, hidden: true })).toBeInTheDocument();
+      // The docs toggle button has aria-label "Show documents for <name>" — narrow to this
+      // specific label to avoid colliding with "Expand budget lines for Home Loan", "Edit Home Loan",
+      // or "Delete Home Loan", all of which also contain the source name.
+      expect(
+        screen.getByRole('button', { name: /show documents for home loan/i, hidden: true }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /show documents for savings account/i, hidden: true }),
+      ).toBeInTheDocument();
     });
 
     it('clicking the docs toggle button renders LinkedDocumentsSection with entityType=budget_source and correct entityId', async () => {

--- a/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
+++ b/client/src/pages/BudgetSourcesPage/BudgetSourcesPage.tsx
@@ -23,6 +23,7 @@ import { BudgetBar } from '../../components/BudgetBar/BudgetBar.js';
 import type { BudgetBarSegment } from '../../components/BudgetBar/BudgetBar.js';
 import { SourceBudgetLinePanel } from '../../components/SourceBudgetLinePanel/SourceBudgetLinePanel.js';
 import { MassMoveModal } from '../../components/MassMoveModal/MassMoveModal.js';
+import { LinkedDocumentsSection } from '../../components/documents/LinkedDocumentsSection.js';
 import styles from './BudgetSourcesPage.module.css';
 
 const BUDGET_TABS: SubNavTab[] = [
@@ -309,6 +310,9 @@ export function BudgetSourcesPage() {
   );
   const [linesLoading, setLinesLoading] = useState<Set<string>>(() => new Set());
   const [linesError, setLinesError] = useState<Map<string, string>>(() => new Map());
+
+  // Documents expansion state (separate from budget lines)
+  const [expandedDocsSources, setExpandedDocsSources] = useState<Set<string>>(() => new Set());
 
   // Selection state for mass-move
   const [sourceSelections, setSourceSelections] = useState<Map<string, Set<string>>>(
@@ -611,6 +615,14 @@ export function BudgetSourcesPage() {
 
   const handleOpenMoveModal = useCallback((sourceId: string) => {
     setMoveModalSourceId(sourceId);
+  }, []);
+
+  const handleToggleDocs = useCallback((sourceId: string) => {
+    setExpandedDocsSources((prev) => {
+      const next = new Set(prev);
+      next.has(sourceId) ? next.delete(sourceId) : next.add(sourceId);
+      return next;
+    });
   }, []);
 
   const activeMoveSource = moveModalSourceId
@@ -1177,6 +1189,33 @@ export function BudgetSourcesPage() {
                         </button>
                         <button
                           type="button"
+                          className={`${styles.docsToggle} ${expandedDocsSources.has(source.id) ? styles.docsToggleActive : ''}`}
+                          onClick={() => handleToggleDocs(source.id)}
+                          disabled={!!editingSource}
+                          aria-expanded={expandedDocsSources.has(source.id)}
+                          aria-controls={`source-docs-${source.id}`}
+                          aria-label={
+                            expandedDocsSources.has(source.id)
+                              ? t('sources.docs.collapseAriaLabel', { name: source.name })
+                              : t('sources.docs.expandAriaLabel', { name: source.name })
+                          }
+                        >
+                          <svg
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            aria-hidden="true"
+                            className={styles.docsIcon}
+                          >
+                            <path d="M4.5 3a2.5 2.5 0 0 1 5 0v9a1.5 1.5 0 0 1-3 0V5a.5.5 0 0 1 1 0v7a.5.5 0 0 0 1 0V3a1.5 1.5 0 1 0-3 0v9a2.5 2.5 0 0 0 5 0V5a.5.5 0 0 1 1 0v7a3.5 3.5 0 1 1-7 0z" />
+                          </svg>
+                          <span className={styles.srOnly}>
+                            {expandedDocsSources.has(source.id)
+                              ? t('sources.docs.collapse')
+                              : t('sources.docs.expand')}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
                           className={styles.editButton}
                           onClick={() => startEdit(source)}
                           disabled={!!editingSource}
@@ -1229,6 +1268,16 @@ export function BudgetSourcesPage() {
                     onSelectionChange={(newSet) => handleSelectionChange(source.id, newSet)}
                     onMoveLines={() => handleOpenMoveModal(source.id)}
                   />
+                )}
+                {editingSource?.id !== source.id && expandedDocsSources.has(source.id) && (
+                  <div
+                    id={`source-docs-${source.id}`}
+                    className={styles.docsPanel}
+                    role="region"
+                    aria-label={t('sources.docs.panelAriaLabel', { name: source.name })}
+                  >
+                    <LinkedDocumentsSection entityType="budget_source" entityId={source.id} />
+                  </div>
                 )}
               </div>
             ))}

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.module.css
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.module.css
@@ -267,8 +267,7 @@
 
 .programRow {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  flex-direction: column;
   padding: var(--spacing-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -465,6 +464,78 @@
   display: flex;
   gap: var(--spacing-2);
   flex-shrink: 0;
+}
+
+/* ---- Documents toggle button ---- */
+
+.docsToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
+  padding: 0;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.docsToggle:hover:not(:disabled) {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong);
+}
+
+.docsToggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.docsToggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.docsToggleActive {
+  background-color: var(--color-primary-bg);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.docsIcon {
+  width: var(--spacing-4);
+  height: var(--spacing-4);
+  flex-shrink: 0;
+}
+
+.docsPanel {
+  padding: var(--spacing-4) var(--spacing-4) var(--spacing-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docsToggle {
+    transition: none;
+  }
 }
 
 /* ---- Edit form inside list row ---- */

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
@@ -112,8 +112,38 @@ jest.unstable_mockModule('../../lib/formatters.js', () => {
   };
 });
 
+// ─── Mock: LocaleContext — prevents useLocale() from throwing outside LocaleProvider ───
+// In CI, jest.unstable_mockModule intercepts; the LocaleProvider wrapper in
+// renderPage is then redundant but harmless (passthrough stub).
+// Locally, when mock doesn't intercept, the real LocaleProvider handles useLocale().
+
+jest.unstable_mockModule('../../contexts/LocaleContext.js', () => ({
+  useLocale: jest.fn(() => ({
+    locale: 'en' as const,
+    resolvedLocale: 'en' as const,
+    currency: 'EUR',
+    setLocale: jest.fn(),
+    syncWithServer: jest.fn(),
+  })),
+  LocaleProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ─── Mock: configApi and preferencesApi (real LocaleProvider needs them) ──────
+// When jest.unstable_mockModule doesn't intercept LocaleContext locally, the real
+// LocaleProvider makes network calls. These mocks stop that.
+
+jest.unstable_mockModule('../../lib/configApi.js', () => ({
+  fetchConfig: jest.fn(() => Promise.resolve({ currency: 'EUR' })),
+}));
+
+jest.unstable_mockModule('../../lib/preferencesApi.js', () => ({
+  listPreferences: jest.fn(() => Promise.resolve([])),
+  upsertPreference: jest.fn(() => Promise.resolve()),
+}));
+
 describe('SubsidyProgramsPage', () => {
   let SubsidyProgramsPage: React.ComponentType;
+  let LocaleProvider: ({ children }: { children: React.ReactNode }) => React.ReactNode;
 
   // Sample budget categories
   const sampleCategory1: BudgetCategory = {
@@ -204,6 +234,14 @@ describe('SubsidyProgramsPage', () => {
       const module = await import('./SubsidyProgramsPage.js');
       SubsidyProgramsPage = module.default;
     }
+    if (!LocaleProvider) {
+      const localeMod = await import('../../contexts/LocaleContext.js');
+      LocaleProvider = localeMod.LocaleProvider as ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => React.ReactNode;
+    }
 
     // Reset all mocks
     mockFetchSubsidyPrograms.mockReset();
@@ -251,9 +289,13 @@ describe('SubsidyProgramsPage', () => {
 
   function renderPage() {
     return render(
-      <MemoryRouter initialEntries={['/budget/subsidies']}>
-        <SubsidyProgramsPage />
-      </MemoryRouter>,
+      // Wrap in LocaleProvider so useFormatters→useLocale works in both CI (mock
+      // intercepts and this becomes a passthrough) and local (real provider used).
+      <LocaleProvider>
+        <MemoryRouter initialEntries={['/budget/subsidies']}>
+          <SubsidyProgramsPage />
+        </MemoryRouter>
+      </LocaleProvider>,
     );
   }
 

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.test.tsx
@@ -5,6 +5,7 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { screen, waitFor, render, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import type React from 'react';
 import type * as SubsidyProgramsApiTypes from '../../lib/subsidyProgramsApi.js';
 import type * as BudgetCategoriesApiTypes from '../../lib/budgetCategoriesApi.js';
 import type * as BudgetOverviewApiTypes from '../../lib/budgetOverviewApi.js';
@@ -48,6 +49,28 @@ jest.unstable_mockModule('../../lib/budgetCategoriesApi.js', () => ({
 jest.unstable_mockModule('../../lib/budgetOverviewApi.js', () => ({
   fetchBudgetOverview: mockFetchBudgetOverview,
   fetchBudgetBreakdown: jest.fn(),
+}));
+
+// ─── Mock: LinkedDocumentsSection — avoids deep dependency chain (Paperless hooks, etc.) ───
+
+// Capture the last props passed to LinkedDocumentsSection so tests can assert them
+// (prefixed with _ because assertions use DOM data-attributes, not this variable directly)
+let _capturedLinkedDocsSectionProps: { entityType: string; entityId: string } | null = null;
+
+jest.unstable_mockModule('../../components/documents/LinkedDocumentsSection.js', () => ({
+  LinkedDocumentsSection: function MockLinkedDocumentsSection(props: {
+    entityType: string;
+    entityId: string;
+  }) {
+    _capturedLinkedDocsSectionProps = { entityType: props.entityType, entityId: props.entityId };
+    return (
+      <div
+        data-testid="linked-documents-section"
+        data-entity-type={props.entityType}
+        data-entity-id={props.entityId}
+      />
+    );
+  },
 }));
 
 // ─── Mock: formatters — provides useFormatters() hook ────────────────────────
@@ -197,6 +220,8 @@ describe('SubsidyProgramsPage', () => {
 
     // Default: categories return empty list unless overridden
     mockFetchBudgetCategories.mockResolvedValue(emptyCategoriesResponse);
+
+    _capturedLinkedDocsSectionProps = null;
 
     // Default: budget overview with empty oversubscribed subsidies
     mockFetchBudgetOverview.mockResolvedValue({
@@ -1697,6 +1722,172 @@ describe('SubsidyProgramsPage', () => {
         const successAlert = alerts.find((el) => el.textContent?.includes('created successfully'));
         expect(successAlert).toBeDefined();
       });
+    });
+  });
+
+  // ─── Docs toggle (story #1744) ──────────────────────────────────────────────
+
+  describe('docs toggle (paperclip button)', () => {
+    it('renders a docs toggle button for each program row', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      // The docs toggle button has aria-controls matching program-docs-{id}
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}`);
+      expect(docsBtn).toBeDefined();
+    });
+
+    it('clicking the docs toggle button renders LinkedDocumentsSection with entityType=subsidy_program and correct entityId', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find(
+          (btn) =>
+            btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}` &&
+            btn.getAttribute('aria-expanded') === 'false',
+        );
+      expect(docsBtn).toBeDefined();
+
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument();
+      });
+
+      const section = screen.getByTestId('linked-documents-section');
+      expect(section.getAttribute('data-entity-type')).toBe('subsidy_program');
+      expect(section.getAttribute('data-entity-id')).toBe(sampleProgram1.id);
+    });
+
+    it('clicking the docs toggle button a second time hides LinkedDocumentsSection', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}`);
+      expect(docsBtn).toBeDefined();
+
+      // First click — opens
+      fireEvent.click(docsBtn!);
+      await waitFor(() =>
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument(),
+      );
+
+      // Second click — closes
+      fireEvent.click(docsBtn!);
+      await waitFor(() =>
+        expect(screen.queryByTestId('linked-documents-section')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('docs toggle button has aria-expanded=false initially', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce({ subsidyPrograms: [sampleProgram1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}`);
+      expect(docsBtn).toBeDefined();
+      expect(docsBtn!.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('docs toggle button has aria-expanded=true after clicking', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce({ subsidyPrograms: [sampleProgram1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}`);
+      expect(docsBtn).toBeDefined();
+
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() => {
+        expect(docsBtn!.getAttribute('aria-expanded')).toBe('true');
+      });
+    });
+
+    it('docs toggle button is disabled when editingProgram is active', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce(listResponse);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      // Start editing program1
+      const editBtn = screen.getByRole('button', { name: /edit energy rebate/i });
+      fireEvent.click(editBtn);
+
+      await waitFor(() => {
+        // All docs toggles should be disabled when editing
+        const allDocsToggleBtns = screen
+          .getAllByRole('button', { hidden: true })
+          .filter((btn) => btn.getAttribute('aria-controls')?.startsWith('program-docs-'));
+        expect(allDocsToggleBtns.length).toBeGreaterThan(0);
+        for (const btn of allDocsToggleBtns) {
+          expect(btn).toBeDisabled();
+        }
+      });
+    });
+
+    it('LinkedDocumentsSection is hidden when editing the same program', async () => {
+      mockFetchSubsidyPrograms.mockResolvedValueOnce({ subsidyPrograms: [sampleProgram1] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Energy Rebate')).toBeInTheDocument();
+      });
+
+      // Open docs panel
+      const docsBtn = screen
+        .getAllByRole('button', { hidden: true })
+        .find((btn) => btn.getAttribute('aria-controls') === `program-docs-${sampleProgram1.id}`);
+      fireEvent.click(docsBtn!);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('linked-documents-section')).toBeInTheDocument(),
+      );
+
+      // Now start editing the same program — docs panel should disappear
+      const editBtn = screen.getByRole('button', { name: /edit energy rebate/i });
+      fireEvent.click(editBtn);
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('linked-documents-section')).not.toBeInTheDocument(),
+      );
     });
   });
 });

--- a/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
+++ b/client/src/pages/SubsidyProgramsPage/SubsidyProgramsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {
   SubsidyProgram,
@@ -20,6 +20,7 @@ import { ApiClientError } from '../../lib/apiClient.js';
 import { useFormatters } from '../../lib/formatters.js';
 import { PageLayout } from '../../components/PageLayout/PageLayout.js';
 import { SubNav, type SubNavTab } from '../../components/SubNav/SubNav.js';
+import { LinkedDocumentsSection } from '../../components/documents/LinkedDocumentsSection.js';
 import styles from './SubsidyProgramsPage.module.css';
 
 const BUDGET_TABS: SubNavTab[] = [
@@ -130,6 +131,9 @@ export function SubsidyProgramsPage() {
   const [deletingProgramId, setDeletingProgramId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string>('');
+
+  // Documents expansion state
+  const [expandedDocsPrograms, setExpandedDocsPrograms] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     void loadData();
@@ -368,6 +372,14 @@ export function SubsidyProgramsPage() {
       setIsDeleting(false);
     }
   };
+
+  const handleToggleProgramDocs = useCallback((programId: string) => {
+    setExpandedDocsPrograms((prev) => {
+      const next = new Set(prev);
+      next.has(programId) ? next.delete(programId) : next.add(programId);
+      return next;
+    });
+  }, []);
 
   if (isLoading) {
     return (
@@ -1059,6 +1071,33 @@ export function SubsidyProgramsPage() {
                     <div className={styles.programActions}>
                       <button
                         type="button"
+                        className={`${styles.docsToggle} ${expandedDocsPrograms.has(program.id) ? styles.docsToggleActive : ''}`}
+                        onClick={() => handleToggleProgramDocs(program.id)}
+                        disabled={!!editingProgram}
+                        aria-expanded={expandedDocsPrograms.has(program.id)}
+                        aria-controls={`program-docs-${program.id}`}
+                        aria-label={
+                          expandedDocsPrograms.has(program.id)
+                            ? t('subsidies.docs.collapseAriaLabel', { name: program.name })
+                            : t('subsidies.docs.expandAriaLabel', { name: program.name })
+                        }
+                      >
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          aria-hidden="true"
+                          className={styles.docsIcon}
+                        >
+                          <path d="M4.5 3a2.5 2.5 0 0 1 5 0v9a1.5 1.5 0 0 1-3 0V5a.5.5 0 0 1 1 0v7a.5.5 0 0 0 1 0V3a1.5 1.5 0 1 0-3 0v9a2.5 2.5 0 0 0 5 0V5a.5.5 0 0 1 1 0v7a3.5 3.5 0 1 1-7 0z" />
+                        </svg>
+                        <span className={styles.srOnly}>
+                          {expandedDocsPrograms.has(program.id)
+                            ? t('subsidies.docs.collapse')
+                            : t('subsidies.docs.expand')}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
                         className={styles.editButton}
                         onClick={() => startEdit(program)}
                         disabled={!!editingProgram}
@@ -1077,6 +1116,16 @@ export function SubsidyProgramsPage() {
                       </button>
                     </div>
                   </>
+                )}
+                {editingProgram?.id !== program.id && expandedDocsPrograms.has(program.id) && (
+                  <div
+                    id={`program-docs-${program.id}`}
+                    className={styles.docsPanel}
+                    role="region"
+                    aria-label={t('subsidies.docs.panelAriaLabel', { name: program.name })}
+                  >
+                    <LinkedDocumentsSection entityType="subsidy_program" entityId={program.id} />
+                  </div>
                 )}
               </div>
             ))}

--- a/e2e/pages/BudgetSourcesPage.ts
+++ b/e2e/pages/BudgetSourcesPage.ts
@@ -579,6 +579,41 @@ export class BudgetSourcesPage {
     await this.moveModal.locator('[class*="understoodLabel"]').click();
   }
 
+  // ─── Documents toggle helpers (Story #1744) ───────────────────────────────
+
+  /**
+   * Get the documents toggle button for the named source row.
+   * The button has aria-label "Show documents for <name>" (collapsed) or
+   * "Hide documents for <name>" (expanded).
+   */
+  getDocsToggle(sourceName: string): Locator {
+    return this.getSourceRowByName(sourceName).getByRole('button', {
+      name: new RegExp(
+        `(Show|Hide) documents for ${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+        'i',
+      ),
+    });
+  }
+
+  /**
+   * Get the documents panel region for a specific source by its ID.
+   * The panel renders as: <div id="source-docs-{sourceId}" role="region">
+   * Only present in the DOM when expanded (conditional render, not hidden).
+   */
+  getDocsPanelById(sourceId: string): Locator {
+    return this.page.locator(`[id="source-docs-${sourceId}"]`);
+  }
+
+  /**
+   * Click the docs toggle for the named source to reveal the documents panel.
+   * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+   */
+  async expandSourceDocs(sourceName: string): Promise<void> {
+    const toggle = this.getDocsToggle(sourceName);
+    await toggle.waitFor({ state: 'visible' });
+    await toggle.click();
+  }
+
   /**
    * The FormError banner inside the move modal (shown on API error).
    * FormError renders a div with the CSS module class "banner" and role="alert".

--- a/e2e/pages/SubsidyProgramsPage.ts
+++ b/e2e/pages/SubsidyProgramsPage.ts
@@ -392,4 +392,47 @@ export class SubsidyProgramsPage {
     }
     return names;
   }
+
+  /**
+   * Find the program row that contains the given program name (display mode, not editing).
+   * Mirrors the BudgetSourcesPage.getSourceRowByName pattern.
+   */
+  getProgramRowByName(name: string): Locator {
+    return this.page.locator('[class*="programRow"]').filter({ hasText: name });
+  }
+
+  // ─── Documents toggle helpers (Story #1744) ───────────────────────────────
+
+  /**
+   * Get the documents toggle button for the named program row.
+   * The button has aria-label "Show documents for <name>" (collapsed) or
+   * "Hide documents for <name>" (expanded).
+   */
+  getDocsToggle(programName: string): Locator {
+    return this.getProgramRowByName(programName).getByRole('button', {
+      name: new RegExp(
+        `(Show|Hide) documents for ${programName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+        'i',
+      ),
+    });
+  }
+
+  /**
+   * Get the documents panel region for a specific program by its ID.
+   * The panel renders as: <div id="program-docs-{programId}" role="region">
+   * Only present in the DOM when expanded (conditional render, not hidden).
+   */
+  getDocsPanelById(programId: string): Locator {
+    return this.page.locator(`[id="program-docs-${programId}"]`);
+  }
+
+  /**
+   * Click the docs toggle for the named program to reveal the documents panel.
+   * No explicit timeout — uses project-level actionTimeout (15s for WebKit).
+   */
+  async expandProgramDocs(programName: string): Promise<void> {
+    const toggle = this.getDocsToggle(programName);
+    await toggle.waitFor({ state: 'visible' });
+    await toggle.click();
+  }
 }

--- a/e2e/tests/budget/budget-sources.spec.ts
+++ b/e2e/tests/budget/budget-sources.spec.ts
@@ -16,6 +16,7 @@
  * - Dark mode rendering
  * - Discretionary Funding source — system source presence, no delete, type locked, zero amount edit
  * - Projected and Paid amount fields visible on source rows
+ * - Documents toggle (Story #1744) — toggle visible, expand/collapse, not-configured state
  */
 
 import { test, expect } from '../../fixtures/auth.js';
@@ -1049,6 +1050,209 @@ test.describe('Bar chart rework #1319', { tag: '@responsive' }, () => {
 
       const badge = sourcesPage.getTotalBadge(sourceName);
       await expect(badge).toBeVisible();
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Documents toggle (Story #1744)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Documents toggle (Story #1744)', { tag: '@responsive' }, () => {
+  // NOTE: @smoke tag is intentionally omitted — these tests require the Story #1744
+  // implementation (docs toggle UI) which is not yet merged to beta. Add @smoke
+  // after the implementation PR is merged to beta.
+  test('Documents toggle button is visible in source row header', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs Toggle Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 10000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // The toggle button should be visible in the source row
+      const toggle = sourcesPage.getDocsToggle(sourceName);
+      await expect(toggle).toBeVisible();
+
+      // Initial state: not expanded (aria-expanded=false)
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('Clicking docs toggle reveals documents panel with correct role and aria-label', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs Panel Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 20000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Panel should NOT be in the DOM before expanding
+      const panel = sourcesPage.getDocsPanelById(createdId);
+      await expect(panel).not.toBeAttached();
+
+      // Click the toggle to expand
+      await sourcesPage.expandSourceDocs(sourceName);
+
+      // Panel is now in the DOM and visible with correct region attributes
+      await expect(panel).toBeVisible();
+      await expect(panel).toHaveAttribute('role', 'region');
+      await expect(panel).toHaveAttribute('aria-label', `Documents for ${sourceName}`);
+
+      // Toggle button now shows aria-expanded=true
+      const toggle = sourcesPage.getDocsToggle(sourceName);
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('Documents panel contains "Documents" heading inside source docs region', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs Heading Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 30000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+      await sourcesPage.expandSourceDocs(sourceName);
+
+      const panel = sourcesPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // LinkedDocumentsSection renders an h2 "Documents" heading inside the panel
+      const docsHeading = panel.getByRole('heading', { name: 'Documents', exact: true });
+      await expect(docsHeading).toBeVisible();
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('"+ Add Document" button is visible and disabled (Paperless not configured)', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs AddBtn Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 40000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+      await sourcesPage.expandSourceDocs(sourceName);
+
+      const panel = sourcesPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // "+ Add Document" button is present but disabled because Paperless is not configured
+      const addButton = panel.getByRole('button', { name: '+ Add Document', exact: true });
+      await expect(addButton).toBeVisible();
+      await expect(addButton).toBeDisabled();
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('"Paperless-ngx is not configured" banner is shown inside documents panel', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs Banner Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 50000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+      await sourcesPage.expandSourceDocs(sourceName);
+
+      const panel = sourcesPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // Not-configured banner text is visible inside the panel
+      const banner = panel.getByText('Paperless-ngx is not configured');
+      await expect(banner).toBeVisible();
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('Clicking docs toggle again collapses the documents panel', async ({ page, testPrefix }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs Collapse Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 60000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Expand
+      await sourcesPage.expandSourceDocs(sourceName);
+      const panel = sourcesPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // Collapse by clicking the toggle again (aria-label changes to "Hide documents for <name>")
+      const toggle = sourcesPage.getDocsToggle(sourceName);
+      await toggle.click();
+
+      // Panel is removed from DOM (conditional render)
+      await expect(panel).not.toBeAttached();
+
+      // Toggle aria-expanded is false again
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      if (createdId) await deleteSourceViaApi(page, createdId);
+    }
+  });
+
+  test('Documents toggle is disabled while source is being edited', async ({
+    page,
+    testPrefix,
+  }) => {
+    const sourcesPage = new BudgetSourcesPage(page);
+    const sourceName = `${testPrefix} Docs EditDisable Source`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createSourceViaApi(page, { name: sourceName, totalAmount: 70000 });
+
+      await sourcesPage.goto();
+      await sourcesPage.waitForSourcesLoaded();
+
+      // Enter edit mode for this source
+      await sourcesPage.startEdit(sourceName);
+
+      // Docs toggle should be disabled while editing
+      // The toggle button scoped to the row is not accessible by name when in edit mode
+      // (the row no longer shows sourceName span) — use the panel button directly
+      const docsToggle = page.locator('[aria-controls^="source-docs-"]').first();
+      await expect(docsToggle).toBeDisabled();
+
+      // Cancel edit to restore state
+      await sourcesPage.cancelEdit(sourceName);
     } finally {
       if (createdId) await deleteSourceViaApi(page, createdId);
     }

--- a/e2e/tests/budget/subsidy-programs.spec.ts
+++ b/e2e/tests/budget/subsidy-programs.spec.ts
@@ -15,6 +15,7 @@
  * - Delete blocked (409) — error shown, confirm button hidden
  * - Responsive layout: no horizontal scroll
  * - Dark mode rendering
+ * - Documents toggle (Story #1744) — toggle visible, expand/collapse, not-configured state
  */
 
 import { test, expect } from '../../fixtures/auth.js';
@@ -790,6 +791,207 @@ test.describe('Dark mode rendering', { tag: '@responsive' }, () => {
       await expect(subsidyPage.deleteCancelButton).toBeVisible();
 
       await subsidyPage.cancelDelete();
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Documents toggle (Story #1744)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Documents toggle (Story #1744)', { tag: '@responsive' }, () => {
+  // NOTE: @smoke tag is intentionally omitted — these tests require the Story #1744
+  // implementation (docs toggle UI) which is not yet merged to beta. Add @smoke
+  // after the implementation PR is merged to beta.
+  test('Documents toggle button is visible in program row header', async ({ page, testPrefix }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs Toggle Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 10 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+
+      // The toggle button should be visible in the program row
+      const toggle = subsidyPage.getDocsToggle(programName);
+      await expect(toggle).toBeVisible();
+
+      // Initial state: not expanded (aria-expanded=false)
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('Clicking docs toggle reveals documents panel with correct role and aria-label', async ({
+    page,
+    testPrefix,
+  }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs Panel Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 15 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+
+      // Panel should NOT be in the DOM before expanding
+      const panel = subsidyPage.getDocsPanelById(createdId);
+      await expect(panel).not.toBeAttached();
+
+      // Click the toggle to expand
+      await subsidyPage.expandProgramDocs(programName);
+
+      // Panel is now in the DOM and visible with correct region attributes
+      await expect(panel).toBeVisible();
+      await expect(panel).toHaveAttribute('role', 'region');
+      await expect(panel).toHaveAttribute('aria-label', `Documents for ${programName}`);
+
+      // Toggle button now shows aria-expanded=true
+      const toggle = subsidyPage.getDocsToggle(programName);
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('Documents panel contains "Documents" heading inside program docs region', async ({
+    page,
+    testPrefix,
+  }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs Heading Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 20 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+      await subsidyPage.expandProgramDocs(programName);
+
+      const panel = subsidyPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // LinkedDocumentsSection renders an h2 "Documents" heading inside the panel
+      const docsHeading = panel.getByRole('heading', { name: 'Documents', exact: true });
+      await expect(docsHeading).toBeVisible();
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('"+ Add Document" button is visible and disabled (Paperless not configured)', async ({
+    page,
+    testPrefix,
+  }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs AddBtn Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 25 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+      await subsidyPage.expandProgramDocs(programName);
+
+      const panel = subsidyPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // "+ Add Document" button is present but disabled because Paperless is not configured
+      const addButton = panel.getByRole('button', { name: '+ Add Document', exact: true });
+      await expect(addButton).toBeVisible();
+      await expect(addButton).toBeDisabled();
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('"Paperless-ngx is not configured" banner is shown inside documents panel', async ({
+    page,
+    testPrefix,
+  }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs Banner Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 30 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+      await subsidyPage.expandProgramDocs(programName);
+
+      const panel = subsidyPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // Not-configured banner text is visible inside the panel
+      const banner = panel.getByText('Paperless-ngx is not configured');
+      await expect(banner).toBeVisible();
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('Clicking docs toggle again collapses the documents panel', async ({ page, testPrefix }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs Collapse Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 35 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+
+      // Expand
+      await subsidyPage.expandProgramDocs(programName);
+      const panel = subsidyPage.getDocsPanelById(createdId);
+      await expect(panel).toBeVisible();
+
+      // Collapse by clicking the toggle again (aria-label changes to "Hide documents for <name>")
+      const toggle = subsidyPage.getDocsToggle(programName);
+      await toggle.click();
+
+      // Panel is removed from DOM (conditional render)
+      await expect(panel).not.toBeAttached();
+
+      // Toggle aria-expanded is false again
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      if (createdId) await deleteProgramViaApi(page, createdId);
+    }
+  });
+
+  test('Documents toggle is disabled while program is being edited', async ({
+    page,
+    testPrefix,
+  }) => {
+    const subsidyPage = new SubsidyProgramsPage(page);
+    const programName = `${testPrefix} Docs EditDisable Program`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createProgramViaApi(page, { name: programName, reductionValue: 40 });
+
+      await subsidyPage.goto();
+      await subsidyPage.waitForProgramsLoaded();
+
+      // Enter edit mode for this program
+      await subsidyPage.startEdit(programName);
+
+      // Docs toggle should be disabled while editing
+      const docsToggle = page.locator('[aria-controls^="program-docs-"]').first();
+      await expect(docsToggle).toBeDisabled();
+
+      // Cancel edit to restore state
+      await subsidyPage.cancelEdit(programName);
     } finally {
       if (createdId) await deleteProgramViaApi(page, createdId);
     }

--- a/e2e/tests/documents/documents-linked-sections.spec.ts
+++ b/e2e/tests/documents/documents-linked-sections.spec.ts
@@ -1,12 +1,15 @@
 /**
  * E2E tests for the LinkedDocumentsSection component — EPIC-08 (Stories 8.4, 8.5, 8.7)
+ * and Story #1744 (budget sources + subsidy programs document attachment).
  *
  * The LinkedDocumentsSection is embedded on:
  *   - Work Item detail page (/project/work-items/:id) — Story 8.4
  *   - Invoice detail page (/budget/invoices/:id) — Story 8.5
+ *   - Budget Sources page (/budget/sources) — Story #1744 (via docs toggle panel)
+ *   - Subsidy Programs page (/budget/subsidies) — Story #1744 (via docs toggle panel)
  *
  * In the E2E environment, Paperless-ngx is NOT configured, so tests verify:
- * - The "Documents" section heading is present on both pages
+ * - The "Documents" section heading is present
  * - The "+ Add Document" button is DISABLED (not configured)
  * - The "not configured" banner is shown with guidance text
  * - Responsive layout: no horizontal scroll
@@ -23,12 +26,27 @@
  * 8.  Invoice detail page: "+ Add Document" button is disabled (not configured)
  * 9.  Invoice detail page: "not configured" banner shows setup guidance
  * 10. Invoice detail page: section renders without horizontal scroll (responsive)
+ * 11. Budget source: "Documents" section heading visible after toggle expand
+ * 12. Budget source: "+ Add Document" button disabled (not configured)
+ * 13. Budget source: section heading is accessible (aria-labelledby)
+ * 14. Subsidy program: "Documents" section heading visible after toggle expand
+ * 15. Subsidy program: "+ Add Document" button disabled (not configured)
+ * 16. Subsidy program: section heading is accessible (aria-labelledby)
  */
 
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/auth.js';
 import { WorkItemDetailPage } from '../../pages/WorkItemDetailPage.js';
-import { createWorkItemViaApi, deleteWorkItemViaApi } from '../../fixtures/apiHelpers.js';
+import { BudgetSourcesPage } from '../../pages/BudgetSourcesPage.js';
+import { SubsidyProgramsPage } from '../../pages/SubsidyProgramsPage.js';
+import {
+  createWorkItemViaApi,
+  deleteWorkItemViaApi,
+  createBudgetSourceViaApi,
+  deleteBudgetSourceViaApi,
+  createSubsidyProgramViaApi,
+  deleteSubsidyProgramViaApi,
+} from '../../fixtures/apiHelpers.js';
 import { API } from '../../fixtures/testData.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -387,6 +405,206 @@ test.describe(
         expect(hasHorizontalScroll).toBe(false);
       } finally {
         if (ids) await deleteVendorViaApi(page, ids.vendorId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenarios 11–13: Budget Source — LinkedDocumentsSection (Story #1744)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'LinkedDocumentsSection on Budget Source (Scenarios 11–13, Story #1744)',
+  { tag: '@responsive' },
+  () => {
+    test('"Documents" section heading is visible after expanding source docs panel', async ({
+      page,
+      testPrefix,
+    }) => {
+      const sourcesPage = new BudgetSourcesPage(page);
+      const sourceName = `${testPrefix} LinkedDocs Budget Source`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createBudgetSourceViaApi(page, {
+          name: sourceName,
+          totalAmount: 10000,
+        });
+
+        // When: Navigate to budget sources and expand the docs panel
+        await sourcesPage.goto();
+        await sourcesPage.waitForSourcesLoaded();
+        await sourcesPage.expandSourceDocs(sourceName);
+
+        // Then: The "Documents" section heading is visible inside the panel
+        const panel = sourcesPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        const docsHeading = panel.getByRole('heading', { name: 'Documents', exact: true });
+        await expect(docsHeading).toBeVisible();
+      } finally {
+        if (createdId) await deleteBudgetSourceViaApi(page, createdId);
+      }
+    });
+
+    test('"+ Add Document" button is disabled when Paperless is not configured (budget source)', async ({
+      page,
+      testPrefix,
+    }) => {
+      const sourcesPage = new BudgetSourcesPage(page);
+      const sourceName = `${testPrefix} LinkedDocs AddBtn Source`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createBudgetSourceViaApi(page, {
+          name: sourceName,
+          totalAmount: 20000,
+        });
+
+        await sourcesPage.goto();
+        await sourcesPage.waitForSourcesLoaded();
+        await sourcesPage.expandSourceDocs(sourceName);
+
+        const panel = sourcesPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        // "+ Add Document" button is present but disabled (Paperless not configured)
+        const addDocButton = panel.getByRole('button', { name: '+ Add Document', exact: true });
+        await expect(addDocButton).toBeVisible();
+        await expect(addDocButton).toBeDisabled();
+      } finally {
+        if (createdId) await deleteBudgetSourceViaApi(page, createdId);
+      }
+    });
+
+    test('Documents section heading has accessible id="documents-section-title" on budget source', async ({
+      page,
+      testPrefix,
+    }) => {
+      const sourcesPage = new BudgetSourcesPage(page);
+      const sourceName = `${testPrefix} LinkedDocs A11y Source`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createBudgetSourceViaApi(page, {
+          name: sourceName,
+          totalAmount: 30000,
+        });
+
+        await sourcesPage.goto();
+        await sourcesPage.waitForSourcesLoaded();
+        await sourcesPage.expandSourceDocs(sourceName);
+
+        const panel = sourcesPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        // The h2 inside LinkedDocumentsSection has id="documents-section-title"
+        const sectionTitle = panel.locator('#documents-section-title');
+        await expect(sectionTitle).toBeVisible();
+        await expect(sectionTitle).toHaveText(/Documents/);
+      } finally {
+        if (createdId) await deleteBudgetSourceViaApi(page, createdId);
+      }
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenarios 14–16: Subsidy Program — LinkedDocumentsSection (Story #1744)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'LinkedDocumentsSection on Subsidy Program (Scenarios 14–16, Story #1744)',
+  { tag: '@responsive' },
+  () => {
+    test('"Documents" section heading is visible after expanding program docs panel', async ({
+      page,
+      testPrefix,
+    }) => {
+      const subsidyPage = new SubsidyProgramsPage(page);
+      const programName = `${testPrefix} LinkedDocs Subsidy Program`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createSubsidyProgramViaApi(page, {
+          name: programName,
+          reductionValue: 10,
+        });
+
+        // When: Navigate to subsidy programs and expand the docs panel
+        await subsidyPage.goto();
+        await subsidyPage.waitForProgramsLoaded();
+        await subsidyPage.expandProgramDocs(programName);
+
+        // Then: The "Documents" section heading is visible inside the panel
+        const panel = subsidyPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        const docsHeading = panel.getByRole('heading', { name: 'Documents', exact: true });
+        await expect(docsHeading).toBeVisible();
+      } finally {
+        if (createdId) await deleteSubsidyProgramViaApi(page, createdId);
+      }
+    });
+
+    test('"+ Add Document" button is disabled when Paperless is not configured (subsidy program)', async ({
+      page,
+      testPrefix,
+    }) => {
+      const subsidyPage = new SubsidyProgramsPage(page);
+      const programName = `${testPrefix} LinkedDocs AddBtn Program`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createSubsidyProgramViaApi(page, {
+          name: programName,
+          reductionValue: 15,
+        });
+
+        await subsidyPage.goto();
+        await subsidyPage.waitForProgramsLoaded();
+        await subsidyPage.expandProgramDocs(programName);
+
+        const panel = subsidyPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        // "+ Add Document" button is present but disabled (Paperless not configured)
+        const addDocButton = panel.getByRole('button', { name: '+ Add Document', exact: true });
+        await expect(addDocButton).toBeVisible();
+        await expect(addDocButton).toBeDisabled();
+      } finally {
+        if (createdId) await deleteSubsidyProgramViaApi(page, createdId);
+      }
+    });
+
+    test('Documents section heading has accessible id="documents-section-title" on subsidy program', async ({
+      page,
+      testPrefix,
+    }) => {
+      const subsidyPage = new SubsidyProgramsPage(page);
+      const programName = `${testPrefix} LinkedDocs A11y Program`;
+      let createdId: string | null = null;
+
+      try {
+        createdId = await createSubsidyProgramViaApi(page, {
+          name: programName,
+          reductionValue: 20,
+        });
+
+        await subsidyPage.goto();
+        await subsidyPage.waitForProgramsLoaded();
+        await subsidyPage.expandProgramDocs(programName);
+
+        const panel = subsidyPage.getDocsPanelById(createdId);
+        await expect(panel).toBeVisible();
+
+        // The h2 inside LinkedDocumentsSection has id="documents-section-title"
+        const sectionTitle = panel.locator('#documents-section-title');
+        await expect(sectionTitle).toBeVisible();
+        await expect(sectionTitle).toHaveText(/Documents/);
+      } finally {
+        if (createdId) await deleteSubsidyProgramViaApi(page, createdId);
       }
     });
   },

--- a/server/src/db/migrations/0039_document_links_budget_entity_types.sql
+++ b/server/src/db/migrations/0039_document_links_budget_entity_types.sql
@@ -1,0 +1,36 @@
+-- Migration 0039: Widen document_links entity_type CHECK constraint
+--
+-- Story #1744: Attach documents to budget sources and subsidy programs
+--
+-- SQLite cannot ALTER a CHECK constraint in place. This migration rebuilds
+-- the document_links table with two new allowed entity_type values:
+--   'budget_source' and 'subsidy_program'
+--
+-- ROLLBACK: rebuild with original CHECK omitting the two new values, copy rows, drop, rename, recreate indexes.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE document_links_new (
+  id TEXT PRIMARY KEY,
+  entity_type TEXT NOT NULL CHECK(entity_type IN ('work_item', 'household_item', 'invoice', 'budget_source', 'subsidy_program')),
+  entity_id TEXT NOT NULL,
+  paperless_document_id INTEGER NOT NULL,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL
+);
+
+INSERT INTO document_links_new
+  SELECT id, entity_type, entity_id, paperless_document_id, created_by, created_at
+  FROM document_links;
+
+DROP TABLE document_links;
+ALTER TABLE document_links_new RENAME TO document_links;
+
+CREATE UNIQUE INDEX idx_document_links_unique
+  ON document_links (entity_type, entity_id, paperless_document_id);
+CREATE INDEX idx_document_links_entity
+  ON document_links (entity_type, entity_id);
+CREATE INDEX idx_document_links_paperless_doc
+  ON document_links (paperless_document_id);
+
+PRAGMA foreign_keys = ON;

--- a/server/src/db/migrations/0039_document_links_budget_entity_types.test.ts
+++ b/server/src/db/migrations/0039_document_links_budget_entity_types.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Migration integration tests for 0039_document_links_budget_entity_types.sql
+ *
+ * Tests that:
+ *   1. Applies on an empty document_links table without error
+ *   2. Preserves existing work_item, household_item, invoice rows inserted pre-migration
+ *   3. INSERT entity_type='budget_source' succeeds post-migration
+ *   4. INSERT entity_type='subsidy_program' succeeds post-migration
+ *   5. INSERT bogus entity_type throws CHECK constraint violation
+ *   6. All three indexes exist (idx_document_links_unique, idx_document_links_entity, idx_document_links_paperless_doc)
+ *   7. UNIQUE (entity_type, entity_id, paperless_document_id) still enforced
+ *
+ * Story: #1744 Attach documents to budget sources and subsidy programs
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import Database from 'better-sqlite3';
+import { mkdtempSync, symlinkSync, unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runMigrations } from '../migrate.js';
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// All migrations that must run before 0039
+const PRE_0039_MIGRATIONS = [
+  '0001_create_users_and_sessions.sql',
+  '0002_create_work_items.sql',
+  '0003_create_budget_tables.sql',
+  '0004_add_work_item_budget_fields.sql',
+  '0005_budget_rework.sql',
+  '0006_milestones.sql',
+  '0007_milestone_dependencies.sql',
+  '0008_actual_dates_and_status.sql',
+  '0009_document_links.sql',
+  '0010_household_items.sql',
+  '0011_household_item_invoice_link.sql',
+  '0012_household_item_deps.sql',
+  '0013_drop_hi_dep_cpm_columns.sql',
+  '0014_rename_hi_status_values.sql',
+  '0015_hi_delivery_date_redesign.sql',
+  '0016_household_item_categories.sql',
+  '0017_invoice_budget_lines.sql',
+  '0018_user_preferences.sql',
+  '0019_photos.sql',
+  '0019_unit_pricing_vat.sql',
+  '0020_subsidy_max_amount.sql',
+  '0021_discretionary_budget_source.sql',
+  '0022_security_hygiene.sql',
+  '0023_require_budget_source.sql',
+  '0024_diary_entries.sql',
+  '0025_add_invoice_created_entry_type.sql',
+  '0026_vendor_contacts_and_dav.sql',
+  '0027_vendor_contact_names.sql',
+  '0028_add_quotation_status.sql',
+  '0028_areas_trades_rework.sql',
+  '0029_fix_vendor_contacts_columns.sql',
+  '0030_translation_keys.sql',
+  '0031_fix_vat_storage_semantics.sql',
+  '0031_includes_vat_not_null.sql',
+  '0032_invoice_deposits.sql',
+  '0033_diary_entry_status.sql',
+  '0034_photo_annotations.sql',
+  '0035_add_photo_area.sql',
+  '0036_orphan_work_item_budgets.sql',
+  '0037_orientations.sql',
+  '0038_add_photo_orientation.sql',
+];
+
+/**
+ * Apply migrations 0001–0038 to a fresh in-memory DB using symlinks in a temp dir.
+ */
+function setupPreMigrationDb(db: Database.Database): void {
+  const tempDir = mkdtempSync(join(tmpdir(), 'cs-mig-0039-test-'));
+  const symlinks: string[] = [];
+
+  for (const file of PRE_0039_MIGRATIONS) {
+    const linkPath = join(tempDir, file);
+    symlinkSync(join(MIGRATIONS_DIR, file), linkPath);
+    symlinks.push(linkPath);
+  }
+
+  try {
+    runMigrations(db, tempDir);
+  } finally {
+    for (const linkPath of symlinks) {
+      if (existsSync(linkPath)) {
+        unlinkSync(linkPath);
+      }
+    }
+  }
+}
+
+/**
+ * Apply migration 0039 directly on a DB that already has 0001–0038 applied.
+ */
+function runMigration0039(db: Database.Database): void {
+  const sql = readFileSync(
+    join(MIGRATIONS_DIR, '0039_document_links_budget_entity_types.sql'),
+    'utf-8',
+  );
+  db.exec(sql);
+  db.prepare('INSERT OR IGNORE INTO _migrations (name) VALUES (?)').run(
+    '0039_document_links_budget_entity_types.sql',
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function insertUser(db: Database.Database, id: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, display_name, role, auth_provider, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, `${id}@example.com`, `User ${id}`, 'member', 'local', now, now);
+}
+
+function insertDocumentLink(
+  db: Database.Database,
+  id: string,
+  entityType: string,
+  entityId: string,
+  paperlessDocumentId: number,
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, entityType, entityId, paperlessDocumentId, now);
+}
+
+function indexExists(db: Database.Database, indexName: string): boolean {
+  const result = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+    .get(indexName) as { name: string } | undefined;
+  return result !== undefined;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Migration 0039: Widen document_links entity_type CHECK constraint', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.pragma('journal_mode = WAL');
+    sqlite.pragma('foreign_keys = ON');
+    // Suppress migration runner console output during tests
+    const originalWarn = console.warn;
+    console.warn = () => undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Custom property on better-sqlite3 instance
+    (sqlite as any).__originalWarn = originalWarn;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Custom property on better-sqlite3 instance
+    const originalWarn = (sqlite as any).__originalWarn;
+    if (originalWarn) console.warn = originalWarn;
+    sqlite.close();
+  });
+
+  // ── Scenario 1: Applies on empty table ────────────────────────────────────
+
+  it('applies without error when document_links table is empty', () => {
+    setupPreMigrationDb(sqlite);
+
+    expect(() => {
+      runMigration0039(sqlite);
+    }).not.toThrow();
+
+    const count = (
+      sqlite.prepare('SELECT COUNT(*) AS cnt FROM document_links').get() as { cnt: number }
+    ).cnt;
+    expect(count).toBe(0);
+  });
+
+  // ── Scenario 2: Preserves existing rows ───────────────────────────────────
+
+  it('preserves pre-migration work_item, household_item, and invoice rows after migration', () => {
+    setupPreMigrationDb(sqlite);
+    insertUser(sqlite, 'user-001');
+
+    // Insert pre-migration rows for each legacy entity type
+    insertDocumentLink(sqlite, 'link-wi', 'work_item', 'wi-123', 10);
+    insertDocumentLink(sqlite, 'link-hi', 'household_item', 'hi-456', 20);
+    insertDocumentLink(sqlite, 'link-inv', 'invoice', 'inv-789', 30);
+
+    runMigration0039(sqlite);
+
+    const rows = sqlite
+      .prepare(
+        'SELECT id, entity_type, entity_id, paperless_document_id FROM document_links ORDER BY id',
+      )
+      .all() as {
+      id: string;
+      entity_type: string;
+      entity_id: string;
+      paperless_document_id: number;
+    }[];
+
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === 'link-wi')).toMatchObject({
+      entity_type: 'work_item',
+      entity_id: 'wi-123',
+      paperless_document_id: 10,
+    });
+    expect(rows.find((r) => r.id === 'link-hi')).toMatchObject({
+      entity_type: 'household_item',
+      entity_id: 'hi-456',
+      paperless_document_id: 20,
+    });
+    expect(rows.find((r) => r.id === 'link-inv')).toMatchObject({
+      entity_type: 'invoice',
+      entity_id: 'inv-789',
+      paperless_document_id: 30,
+    });
+  });
+
+  // ── Scenario 3: INSERT budget_source succeeds post-migration ─────────────
+
+  it("INSERT entity_type='budget_source' succeeds after migration", () => {
+    setupPreMigrationDb(sqlite);
+    runMigration0039(sqlite);
+
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-bs', 'budget_source', 'bs-001', 100);
+    }).not.toThrow();
+
+    const row = sqlite
+      .prepare('SELECT entity_type FROM document_links WHERE id=?')
+      .get('link-bs') as { entity_type: string } | undefined;
+    expect(row?.entity_type).toBe('budget_source');
+  });
+
+  // ── Scenario 4: INSERT subsidy_program succeeds post-migration ───────────
+
+  it("INSERT entity_type='subsidy_program' succeeds after migration", () => {
+    setupPreMigrationDb(sqlite);
+    runMigration0039(sqlite);
+
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-sp', 'subsidy_program', 'sp-001', 200);
+    }).not.toThrow();
+
+    const row = sqlite
+      .prepare('SELECT entity_type FROM document_links WHERE id=?')
+      .get('link-sp') as { entity_type: string } | undefined;
+    expect(row?.entity_type).toBe('subsidy_program');
+  });
+
+  // ── Scenario 5: Bogus entity_type throws CHECK constraint ─────────────────
+
+  it('INSERT with an invalid entity_type throws a CHECK constraint violation', () => {
+    setupPreMigrationDb(sqlite);
+    runMigration0039(sqlite);
+
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-bad', 'bad_type', 'entity-001', 999);
+    }).toThrow();
+  });
+
+  // ── Scenario 6: All three indexes exist ───────────────────────────────────
+
+  it('all three indexes exist after migration', () => {
+    setupPreMigrationDb(sqlite);
+    runMigration0039(sqlite);
+
+    expect(indexExists(sqlite, 'idx_document_links_unique')).toBe(true);
+    expect(indexExists(sqlite, 'idx_document_links_entity')).toBe(true);
+    expect(indexExists(sqlite, 'idx_document_links_paperless_doc')).toBe(true);
+  });
+
+  // ── Scenario 7: UNIQUE constraint still enforced ──────────────────────────
+
+  it('UNIQUE(entity_type, entity_id, paperless_document_id) is still enforced after migration', () => {
+    setupPreMigrationDb(sqlite);
+    runMigration0039(sqlite);
+
+    insertDocumentLink(sqlite, 'link-first', 'budget_source', 'bs-001', 42);
+
+    // Same (entity_type, entity_id, paperless_document_id) → UNIQUE violation
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-dup', 'budget_source', 'bs-001', 42);
+    }).toThrow(/UNIQUE constraint failed/i);
+
+    // Different entity_id is allowed
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-diff-entity', 'budget_source', 'bs-002', 42);
+    }).not.toThrow();
+
+    // Different paperless_document_id is allowed
+    expect(() => {
+      insertDocumentLink(sqlite, 'link-diff-doc', 'budget_source', 'bs-001', 43);
+    }).not.toThrow();
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -637,7 +637,7 @@ export const documentLinks = sqliteTable(
   {
     id: text('id').primaryKey(),
     entityType: text('entity_type', {
-      enum: ['work_item', 'household_item', 'invoice'],
+      enum: ['work_item', 'household_item', 'invoice', 'budget_source', 'subsidy_program'],
     }).notNull(),
     entityId: text('entity_id').notNull(),
     paperlessDocumentId: integer('paperless_document_id').notNull(),

--- a/server/src/routes/documentLinks.test.ts
+++ b/server/src/routes/documentLinks.test.ts
@@ -141,6 +141,48 @@ describe('Document Links Routes', () => {
   }
 
   /**
+   * Create a budget source via the API and return its ID.
+   */
+  async function createBudgetSource(cookie: string, name = 'Test Budget Source'): Promise<string> {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/budget-sources',
+      headers: { cookie, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name,
+        sourceType: 'bank_loan',
+        totalAmount: 100000,
+        status: 'active',
+      }),
+    });
+    expect(response.statusCode).toBe(201);
+    return response.json<{ budgetSource: { id: string } }>().budgetSource.id;
+  }
+
+  /**
+   * Create a subsidy program via the API and return its ID.
+   */
+  async function createSubsidyProgram(
+    cookie: string,
+    name = 'Test Subsidy Program',
+  ): Promise<string> {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/subsidy-programs',
+      headers: { cookie, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name,
+        reductionType: 'percentage',
+        reductionValue: 10,
+        applicationStatus: 'eligible',
+        categoryIds: [],
+      }),
+    });
+    expect(response.statusCode).toBe(201);
+    return response.json<{ subsidyProgram: { id: string } }>().subsidyProgram.id;
+  }
+
+  /**
    * Create a vendor + invoice and return the invoice ID.
    */
   async function createVendorAndInvoice(cookie: string): Promise<string> {
@@ -391,6 +433,86 @@ describe('Document Links Routes', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    it('POST with entityType=budget_source passes schema validation (not 400) and creates link', async () => {
+      const { cookie } = await createUserWithSession();
+      const sourceId = await createBudgetSource(cookie);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/document-links',
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          entityType: 'budget_source',
+          entityId: sourceId,
+          paperlessDocumentId: 42,
+        }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json<{ documentLink: { entityType: string; entityId: string } }>();
+      expect(body.documentLink.entityType).toBe('budget_source');
+      expect(body.documentLink.entityId).toBe(sourceId);
+    });
+
+    it('POST with entityType=subsidy_program passes schema validation (not 400) and creates link', async () => {
+      const { cookie } = await createUserWithSession();
+      const programId = await createSubsidyProgram(cookie);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/document-links',
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          entityType: 'subsidy_program',
+          entityId: programId,
+          paperlessDocumentId: 77,
+        }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json<{ documentLink: { entityType: string; entityId: string } }>();
+      expect(body.documentLink.entityType).toBe('subsidy_program');
+      expect(body.documentLink.entityId).toBe(programId);
+    });
+
+    it('POST with entityType=budget_source and non-existent entityId returns 404', async () => {
+      const { cookie } = await createUserWithSession();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/document-links',
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          entityType: 'budget_source',
+          entityId: 'non-existent-id',
+          paperlessDocumentId: 42,
+        }),
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json<ApiErrorResponse>();
+      expect(body.error.code).toBe('NOT_FOUND');
+    });
+
+    it('POST with entityType=subsidy_program and non-existent entityId returns 404', async () => {
+      const { cookie } = await createUserWithSession();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/document-links',
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          entityType: 'subsidy_program',
+          entityId: 'non-existent-id',
+          paperlessDocumentId: 42,
+        }),
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json<ApiErrorResponse>();
+      expect(body.error.code).toBe('NOT_FOUND');
+    });
   });
 
   // ─── GET /api/document-links ───────────────────────────────────────────────
@@ -583,6 +705,36 @@ describe('Document Links Routes', () => {
       const body = response.json<DocumentLinkListResponse>();
       expect(body.documentLinks).toHaveLength(1);
       expect(body.documentLinks[0]!.entityType).toBe('invoice');
+    });
+
+    it('GET ?entityType=budget_source passes schema validation (not 400) and returns 200', async () => {
+      const { cookie } = await createUserWithSession('bs-get@example.com');
+      const sourceId = await createBudgetSource(cookie);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/document-links?entityType=budget_source&entityId=${sourceId}`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<DocumentLinkListResponse>();
+      expect(body.documentLinks).toEqual([]);
+    });
+
+    it('GET ?entityType=subsidy_program passes schema validation (not 400) and returns 200', async () => {
+      const { cookie } = await createUserWithSession('sp-get@example.com');
+      const programId = await createSubsidyProgram(cookie);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/document-links?entityType=subsidy_program&entityId=${programId}`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<DocumentLinkListResponse>();
+      expect(body.documentLinks).toEqual([]);
     });
   });
 

--- a/server/src/routes/documentLinks.ts
+++ b/server/src/routes/documentLinks.ts
@@ -25,7 +25,10 @@ const createLinkSchema = {
     type: 'object',
     required: ['entityType', 'entityId', 'paperlessDocumentId'],
     properties: {
-      entityType: { type: 'string', enum: ['work_item', 'household_item', 'invoice'] },
+      entityType: {
+        type: 'string',
+        enum: ['work_item', 'household_item', 'invoice', 'budget_source', 'subsidy_program'],
+      },
       entityId: { type: 'string', minLength: 1, maxLength: 36 },
       paperlessDocumentId: { type: 'integer', minimum: 1 },
     },
@@ -38,7 +41,10 @@ const listLinksSchema = {
     type: 'object',
     required: ['entityType', 'entityId'],
     properties: {
-      entityType: { type: 'string', enum: ['work_item', 'household_item', 'invoice'] },
+      entityType: {
+        type: 'string',
+        enum: ['work_item', 'household_item', 'invoice', 'budget_source', 'subsidy_program'],
+      },
       entityId: { type: 'string', minLength: 1, maxLength: 36 },
     },
     additionalProperties: false,

--- a/server/src/services/budgetSourceService.test.ts
+++ b/server/src/services/budgetSourceService.test.ts
@@ -1334,6 +1334,51 @@ describe('Budget Source Service', () => {
       }).not.toThrow();
     });
 
+    it('cascade-deletes document_links for the budget_source when deleted', () => {
+      const raw = insertRawSource({
+        name: 'To Delete With Docs',
+        sourceType: 'other',
+        totalAmount: 1000,
+      });
+      const now = new Date().toISOString();
+
+      // Insert two document links for this budget source
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-bs-1', 'budget_source', raw.id, 10, now);
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-bs-2', 'budget_source', raw.id, 20, now);
+
+      // Insert an unrelated document link for a different entity — must NOT be deleted
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-other', 'invoice', 'inv-unrelated', 10, now);
+
+      budgetSourceService.deleteBudgetSource(db, raw.id);
+
+      // Budget source links must be gone
+      const budgetSourceLinks = sqlite
+        .prepare(`SELECT id FROM document_links WHERE entity_type='budget_source' AND entity_id=?`)
+        .all(raw.id) as { id: string }[];
+      expect(budgetSourceLinks).toHaveLength(0);
+
+      // Unrelated invoice link must still exist
+      const otherLinks = sqlite
+        .prepare(`SELECT id FROM document_links WHERE id='dl-other'`)
+        .all() as { id: string }[];
+      expect(otherLinks).toHaveLength(1);
+    });
+
     it('throws BudgetSourceInUseError when work items reference the source', () => {
       const raw = insertRawSource({
         name: 'In Use Source',

--- a/server/src/services/budgetSourceService.ts
+++ b/server/src/services/budgetSourceService.ts
@@ -13,6 +13,7 @@ import {
   budgetCategories,
   vendors,
 } from '../db/schema.js';
+import { deleteLinksForEntity } from './documentLinkService.js';
 import {
   computeStatusContribution,
   splitByDeposits,
@@ -679,6 +680,9 @@ export function deleteBudgetSource(db: DbType, id: string): void {
       budgetLineCount,
     });
   }
+
+  // Cascade-delete any document links for this budget source
+  deleteLinksForEntity(db, 'budget_source', id);
 
   // Delete source
   db.delete(budgetSources).where(eq(budgetSources.id, id)).run();

--- a/server/src/services/documentLinkService.test.ts
+++ b/server/src/services/documentLinkService.test.ts
@@ -160,6 +160,50 @@ describe('documentLinkService', () => {
     return id;
   }
 
+  function insertTestBudgetSource(name = 'Test Budget Source') {
+    const id = `src-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.budgetSources)
+      .values({
+        id,
+        name,
+        sourceType: 'bank_loan',
+        totalAmount: 100000,
+        isDiscretionary: false,
+        interestRate: null,
+        terms: null,
+        notes: null,
+        status: 'active',
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  function insertTestSubsidyProgram(name = 'Test Subsidy Program') {
+    const id = `prog-${++idCounter}`;
+    const now = new Date(Date.now() + idCounter).toISOString();
+    db.insert(schema.subsidyPrograms)
+      .values({
+        id,
+        name,
+        description: null,
+        eligibility: null,
+        reductionType: 'percentage',
+        reductionValue: 10,
+        applicationStatus: 'eligible',
+        applicationDeadline: null,
+        notes: null,
+        createdBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return id;
+  }
+
   /**
    * Insert a document link directly (bypassing service for test setup).
    */
@@ -312,6 +356,84 @@ describe('documentLinkService', () => {
       expect(link1.id).not.toBe(link2.id);
       expect(link1.paperlessDocumentId).toBe(42);
       expect(link2.paperlessDocumentId).toBe(99);
+    });
+
+    it('creates a document link for a budget_source and returns entityType=budget_source', () => {
+      const sourceId = insertTestBudgetSource();
+
+      const result = documentLinkService.createLink(db, 'budget_source', sourceId, 55, 'user-001');
+
+      expect(result.entityType).toBe('budget_source');
+      expect(result.entityId).toBe(sourceId);
+      expect(result.paperlessDocumentId).toBe(55);
+      expect(result.createdBy).toEqual({ id: 'user-001', displayName: 'Test User' });
+    });
+
+    it('creates a document link for a subsidy_program and returns entityType=subsidy_program', () => {
+      const programId = insertTestSubsidyProgram();
+
+      const result = documentLinkService.createLink(
+        db,
+        'subsidy_program',
+        programId,
+        77,
+        'user-001',
+      );
+
+      expect(result.entityType).toBe('subsidy_program');
+      expect(result.entityId).toBe(programId);
+      expect(result.paperlessDocumentId).toBe(77);
+      expect(result.createdBy).toEqual({ id: 'user-001', displayName: 'Test User' });
+    });
+
+    it('throws NotFoundError "Budget source not found" when budget_source does not exist', () => {
+      expect(() => {
+        documentLinkService.createLink(db, 'budget_source', 'non-existent-id', 42, 'user-001');
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        documentLinkService.createLink(db, 'budget_source', 'non-existent-id', 42, 'user-001');
+      }).toThrow('Budget source not found');
+    });
+
+    it('throws NotFoundError "Subsidy program not found" when subsidy_program does not exist', () => {
+      expect(() => {
+        documentLinkService.createLink(db, 'subsidy_program', 'non-existent-id', 42, 'user-001');
+      }).toThrow(NotFoundError);
+
+      expect(() => {
+        documentLinkService.createLink(db, 'subsidy_program', 'non-existent-id', 42, 'user-001');
+      }).toThrow('Subsidy program not found');
+    });
+
+    it('throws DUPLICATE_DOCUMENT_LINK (409) when same budget_source link already exists', () => {
+      const sourceId = insertTestBudgetSource();
+      documentLinkService.createLink(db, 'budget_source', sourceId, 42, 'user-001');
+
+      let error: { code?: string; statusCode?: number } | undefined;
+      try {
+        documentLinkService.createLink(db, 'budget_source', sourceId, 42, 'user-001');
+      } catch (err) {
+        error = err as { code?: string; statusCode?: number };
+      }
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('DUPLICATE_DOCUMENT_LINK');
+      expect(error?.statusCode).toBe(409);
+    });
+
+    it('throws DUPLICATE_DOCUMENT_LINK (409) when same subsidy_program link already exists', () => {
+      const programId = insertTestSubsidyProgram();
+      documentLinkService.createLink(db, 'subsidy_program', programId, 99, 'user-001');
+
+      let error: { code?: string; statusCode?: number } | undefined;
+      try {
+        documentLinkService.createLink(db, 'subsidy_program', programId, 99, 'user-001');
+      } catch (err) {
+        error = err as { code?: string; statusCode?: number };
+      }
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('DUPLICATE_DOCUMENT_LINK');
+      expect(error?.statusCode).toBe(409);
     });
 
     it('persists the link to the database', () => {
@@ -642,6 +764,36 @@ describe('documentLinkService', () => {
       expect(() => {
         documentLinkService.deleteLinksForEntity(db, 'work_item', 'no-links-here');
       }).not.toThrow();
+    });
+
+    it('deletes all links for a budget_source entity and leaves other entities untouched', () => {
+      const sourceId = insertTestBudgetSource();
+      const workItemId = insertTestWorkItem();
+
+      insertRawDocumentLink('budget_source', sourceId, 42);
+      insertRawDocumentLink('budget_source', sourceId, 99);
+      insertRawDocumentLink('work_item', workItemId, 42); // must survive
+
+      documentLinkService.deleteLinksForEntity(db, 'budget_source', sourceId);
+
+      const remaining = db.select().from(schema.documentLinks).all();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.entityType).toBe('work_item');
+      expect(remaining[0]!.entityId).toBe(workItemId);
+    });
+
+    it('deletes all links for a subsidy_program entity and leaves other entities untouched', () => {
+      const programId = insertTestSubsidyProgram();
+      const workItemId = insertTestWorkItem();
+
+      insertRawDocumentLink('subsidy_program', programId, 55);
+      insertRawDocumentLink('work_item', workItemId, 55); // must survive
+
+      documentLinkService.deleteLinksForEntity(db, 'subsidy_program', programId);
+
+      const remaining = db.select().from(schema.documentLinks).all();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.entityType).toBe('work_item');
     });
   });
 

--- a/server/src/services/documentLinkService.ts
+++ b/server/src/services/documentLinkService.ts
@@ -14,7 +14,15 @@ import { randomUUID } from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schemaTypes from '../db/schema.js';
-import { documentLinks, users, workItems, invoices, householdItems } from '../db/schema.js';
+import {
+  documentLinks,
+  users,
+  workItems,
+  invoices,
+  householdItems,
+  budgetSources,
+  subsidyPrograms,
+} from '../db/schema.js';
 import { AppError, NotFoundError } from '../errors/AppError.js';
 import type {
   DocumentLink,
@@ -91,6 +99,16 @@ export function createLink(
     const item = db.select().from(householdItems).where(eq(householdItems.id, entityId)).get();
     if (!item) {
       throw new NotFoundError('Household item not found');
+    }
+  } else if (entityType === 'budget_source') {
+    const source = db.select().from(budgetSources).where(eq(budgetSources.id, entityId)).get();
+    if (!source) {
+      throw new NotFoundError('Budget source not found');
+    }
+  } else if (entityType === 'subsidy_program') {
+    const program = db.select().from(subsidyPrograms).where(eq(subsidyPrograms.id, entityId)).get();
+    if (!program) {
+      throw new NotFoundError('Subsidy program not found');
     }
   }
 

--- a/server/src/services/subsidyProgramService.test.ts
+++ b/server/src/services/subsidyProgramService.test.ts
@@ -1185,5 +1185,48 @@ describe('Subsidy Program Service', () => {
       expect(err.details?.workItemCount).toBe(5);
       expect(err.message).toBe('In use');
     });
+
+    it('cascade-deletes document_links for the subsidy_program when deleted', () => {
+      const id = insertRawProgram({ name: 'To Delete With Docs' });
+      const now = new Date().toISOString();
+
+      // Insert two document links for this subsidy program
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-sp-1', 'subsidy_program', id, 10, now);
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-sp-2', 'subsidy_program', id, 20, now);
+
+      // Insert an unrelated document link for a different entity — must NOT be deleted
+      sqlite
+        .prepare(
+          `INSERT INTO document_links (id, entity_type, entity_id, paperless_document_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('dl-other-sp', 'invoice', 'inv-unrelated', 10, now);
+
+      subsidyProgramService.deleteSubsidyProgram(db, id);
+
+      // Subsidy program links must be gone
+      const subsidyLinks = sqlite
+        .prepare(
+          `SELECT id FROM document_links WHERE entity_type='subsidy_program' AND entity_id=?`,
+        )
+        .all(id) as { id: string }[];
+      expect(subsidyLinks).toHaveLength(0);
+
+      // Unrelated invoice link must still exist
+      const otherLinks = sqlite
+        .prepare(`SELECT id FROM document_links WHERE id='dl-other-sp'`)
+        .all() as { id: string }[];
+      expect(otherLinks).toHaveLength(1);
+    });
   });
 });

--- a/server/src/services/subsidyProgramService.ts
+++ b/server/src/services/subsidyProgramService.ts
@@ -9,6 +9,7 @@ import {
   workItemSubsidies,
   users,
 } from '../db/schema.js';
+import { deleteLinksForEntity } from './documentLinkService.js';
 import type {
   SubsidyProgram,
   SubsidyReductionType,
@@ -424,6 +425,9 @@ export function deleteSubsidyProgram(db: DbType, id: string): void {
       workItemCount: references.length,
     });
   }
+
+  // Cascade-delete any document links for this subsidy program
+  deleteLinksForEntity(db, 'subsidy_program', id);
 
   // Delete program (junction table rows cascade via FK)
   db.delete(subsidyPrograms).where(eq(subsidyPrograms.id, id)).run();

--- a/shared/src/types/document.ts
+++ b/shared/src/types/document.ts
@@ -17,7 +17,12 @@ import type { PaginationMeta } from './pagination.js';
 /**
  * Entity types that can be linked to Paperless-ngx documents.
  */
-export type DocumentLinkEntityType = 'work_item' | 'household_item' | 'invoice';
+export type DocumentLinkEntityType =
+  | 'work_item'
+  | 'household_item'
+  | 'invoice'
+  | 'budget_source'
+  | 'subsidy_program';
 
 // ─── Paperless-ngx Proxy Types ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `getDocsToggle()`, `getDocsPanelById()`, and `expandSourceDocs()` methods to `BudgetSourcesPage.ts` POM, mirroring the existing budget-lines expansion pattern
- Adds `getProgramRowByName()`, `getDocsToggle()`, `getDocsPanelById()`, and `expandProgramDocs()` to `SubsidyProgramsPage.ts` POM
- Extends `e2e/tests/budget/budget-sources.spec.ts` with 7 documents-toggle scenarios (1 tagged `@smoke`): toggle visibility, aria-expanded, panel region attributes, "Documents" heading, disabled add button, not-configured banner, collapse, and edit-mode disable
- Extends `e2e/tests/budget/subsidy-programs.spec.ts` with identical 7 scenarios for subsidy programs
- Extends `e2e/tests/documents/documents-linked-sections.spec.ts` with 6 new scenarios (Scenarios 11–16) covering `LinkedDocumentsSection` on budget sources and subsidy programs via the toggle panel

All tests are tagged `@responsive` (run across desktop, tablet, mobile viewports). Two tests are additionally tagged `@smoke`. All tests create entities via API and clean up in `finally` blocks for parallel safety.

## Test plan

- [ ] Smoke tests pass (CI `e2e-smoke` job)
- [ ] Documents toggle button visible in budget source row header with `aria-expanded=false`
- [ ] Clicking toggle reveals `role="region"` panel with id `source-docs-<id>` and `aria-label="Documents for <name>"`
- [ ] Panel contains `h2 "Documents"` heading from LinkedDocumentsSection
- [ ] `"+ Add Document"` button visible and disabled (Paperless not configured in E2E)
- [ ] `"Paperless-ngx is not configured"` banner text visible inside panel
- [ ] Clicking toggle again removes panel from DOM; `aria-expanded` returns to `false`
- [ ] Toggle disabled when source is in edit mode
- [ ] Same 7 scenarios verified for subsidy programs (`program-docs-<id>`)
- [ ] `documents-linked-sections.spec.ts` Scenarios 11–16 pass

Closes #1744

🤖 Generated with [Claude Code](https://claude.com/claude-code)