### PR TITLE
feat(dashboard): add New Diary Entry and New Invoice quick-create items to Add menu (#1735)

### DIFF
--- a/client/src/i18n/de/dashboard.json
+++ b/client/src/i18n/de/dashboard.json
@@ -8,7 +8,9 @@
       "addButton": "Hinzufügen",
       "addWorkItem": "Neues Arbeitspaket",
       "addHouseholdItem": "Neuer Haushaltsartikel",
-      "addMilestone": "Neuer Meilenstein"
+      "addMilestone": "Neuer Meilenstein",
+      "addDiaryEntry": "Neuer Tagebucheintrag",
+      "addInvoice": "Neue Rechnung"
     }
   },
   "sections": {

--- a/client/src/i18n/en/dashboard.json
+++ b/client/src/i18n/en/dashboard.json
@@ -8,7 +8,9 @@
       "addButton": "Add",
       "addWorkItem": "New Work Item",
       "addHouseholdItem": "New Household Item",
-      "addMilestone": "New Milestone"
+      "addMilestone": "New Milestone",
+      "addDiaryEntry": "New Diary Entry",
+      "addInvoice": "New Invoice"
     }
   },
   "sections": {

--- a/client/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/client/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -781,17 +781,19 @@ describe('DashboardPage', () => {
       expect(addBtn).toHaveTextContent('Add');
     });
 
-    it('dropdown is closed by default — no add menu in document', () => {
+    it('dropdown is closed by default — new diary-entry and invoice testids are absent', () => {
       renderPage();
 
       // The customize dropdown may also render a role="menu" when Customize is clicked,
-      // but by default neither is open. We verify the add dropdown is absent specifically.
+      // but by default neither is open. We verify all 5 add menu items are absent.
       expect(screen.queryByTestId('dashboard-add-work-item')).not.toBeInTheDocument();
       expect(screen.queryByTestId('dashboard-add-household-item')).not.toBeInTheDocument();
       expect(screen.queryByTestId('dashboard-add-milestone')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('dashboard-add-diary-entry')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('dashboard-add-invoice')).not.toBeInTheDocument();
     });
 
-    it('clicking "Add" opens the dropdown with 3 menu items', async () => {
+    it('clicking "Add" opens the dropdown with all 5 menu items', async () => {
       renderPage();
 
       await userEvent.click(screen.getByTestId('dashboard-add-button'));
@@ -800,6 +802,25 @@ describe('DashboardPage', () => {
       expect(screen.getByTestId('dashboard-add-work-item')).toBeInTheDocument();
       expect(screen.getByTestId('dashboard-add-household-item')).toBeInTheDocument();
       expect(screen.getByTestId('dashboard-add-milestone')).toBeInTheDocument();
+      expect(screen.getByTestId('dashboard-add-diary-entry')).toBeInTheDocument();
+      expect(screen.getByTestId('dashboard-add-invoice')).toBeInTheDocument();
+    });
+
+    it('menu items appear in correct document order', async () => {
+      renderPage();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-button'));
+
+      const menu = screen.getByRole('menu');
+      const items = menu.querySelectorAll('[role="menuitem"]');
+      const testIds = Array.from(items).map((el) => (el as HTMLElement).dataset['testid'] ?? '');
+      expect(testIds).toEqual([
+        'dashboard-add-work-item',
+        'dashboard-add-household-item',
+        'dashboard-add-milestone',
+        'dashboard-add-diary-entry',
+        'dashboard-add-invoice',
+      ]);
     });
 
     it('clicking outside the dropdown closes it', async () => {
@@ -849,6 +870,48 @@ describe('DashboardPage', () => {
       await userEvent.click(screen.getByTestId('dashboard-add-milestone'));
 
       expect(screen.getByTestId('location')).toHaveTextContent('/project/milestones/new');
+    });
+
+    it('"New Diary Entry" menu item navigates to /diary/new', async () => {
+      renderWithLocation();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-button'));
+      await userEvent.click(screen.getByTestId('dashboard-add-diary-entry'));
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/diary/new');
+    });
+
+    it('"New Invoice" menu item navigates to /budget/invoices (pathname)', async () => {
+      // The navigate call uses /budget/invoices?create=1; MemoryRouter tracks pathname separately.
+      // LocationDisplay only exposes pathname — assert the pathname portion.
+      renderWithLocation();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-button'));
+      await userEvent.click(screen.getByTestId('dashboard-add-invoice'));
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/budget/invoices');
+    });
+
+    it('"New Diary Entry" closes the menu when clicked', async () => {
+      renderPage();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-button'));
+      expect(screen.getByTestId('dashboard-add-diary-entry')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-diary-entry'));
+
+      expect(screen.queryByTestId('dashboard-add-diary-entry')).not.toBeInTheDocument();
+    });
+
+    it('"New Invoice" closes the menu when clicked', async () => {
+      renderPage();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-button'));
+      expect(screen.getByTestId('dashboard-add-invoice')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('dashboard-add-invoice'));
+
+      expect(screen.queryByTestId('dashboard-add-invoice')).not.toBeInTheDocument();
     });
 
     it('"Add" button has aria-haspopup="menu"', () => {

--- a/client/src/pages/DashboardPage/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage/DashboardPage.tsx
@@ -531,6 +531,30 @@ export function DashboardPage() {
                 >
                   {t('page.actions.addMilestone')}
                 </button>
+                <button
+                  type="button"
+                  className={styles.addMenuItem}
+                  role="menuitem"
+                  onClick={() => {
+                    setAddOpen(false);
+                    void navigate('/diary/new');
+                  }}
+                  data-testid="dashboard-add-diary-entry"
+                >
+                  {t('page.actions.addDiaryEntry')}
+                </button>
+                <button
+                  type="button"
+                  className={styles.addMenuItem}
+                  role="menuitem"
+                  onClick={() => {
+                    setAddOpen(false);
+                    void navigate('/budget/invoices?create=1');
+                  }}
+                  data-testid="dashboard-add-invoice"
+                >
+                  {t('page.actions.addInvoice')}
+                </button>
               </div>
             )}
           </div>

--- a/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
@@ -1188,8 +1188,10 @@ describe('InvoicesPage', () => {
       });
 
       // The URL should no longer carry ?create=1
-      const locationEl = screen.getByTestId('location-search');
-      expect(locationEl.textContent).not.toContain('create=1');
+      await waitFor(() => {
+        const locationEl = screen.getByTestId('location-search');
+        expect(locationEl.textContent).not.toContain('create=1');
+      });
     });
   });
 });

--- a/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.test.tsx
@@ -1024,4 +1024,172 @@ describe('InvoicesPage', () => {
       });
     });
   });
+
+  // ─── Story #1735: ?create=1 auto-open effect ────────────────────────────────
+
+  describe('?create=1 auto-open effect (Story #1735)', () => {
+    /** Renders the page with ?create=1 in the URL and a location helper
+     *  that exposes pathname+search so tests can assert the param is removed. */
+    function LocationSearchDisplay() {
+      const location = useLocation();
+      return <div data-testid="location-search">{location.pathname + location.search}</div>;
+    }
+
+    function renderPageWithCreate() {
+      return render(
+        <MemoryRouter initialEntries={['/budget/invoices?create=1']}>
+          <Routes>
+            <Route path="/budget/invoices" element={<InvoicesPageModule.InvoicesPage />} />
+            <Route path="/budget/invoices/:id" element={<div>Invoice Detail</div>} />
+            <Route path="/settings/vendors/:id" element={<div>Vendor Detail</div>} />
+          </Routes>
+          <LocationSearchDisplay />
+        </MemoryRouter>,
+      );
+    }
+
+    // (A) integrationStatus unresolved (both APIs pending) → no modal opens
+    it('(A) does not auto-open any modal while integration status is still loading', async () => {
+      mockGetPaperlessStatus.mockReturnValue(new Promise(() => {}));
+      mockFetchConfig.mockReturnValue(new Promise(() => {}));
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+
+      renderPageWithCreate();
+
+      // Give the effect a chance to fire if it wrongly ignores the loading gate
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(
+        document.querySelector('[data-testid="paperless-picker-modal"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    // (B) ?create=1 absent + status resolved → no modal opens
+    it('(B) does not auto-open any modal when ?create=1 is absent from the URL', async () => {
+      mockGetPaperlessStatus.mockResolvedValue({
+        configured: true,
+        reachable: true,
+        error: null,
+        paperlessUrl: 'https://paperless.example.com',
+        filterTag: null,
+      });
+      mockFetchConfig.mockResolvedValue({ autoItemizeEnabled: true });
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+
+      // Use renderPage() which starts at /budget/invoices (no ?create param)
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('new-invoice-button')).not.toHaveAttribute(
+          'aria-disabled',
+          'true',
+        );
+      });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(
+        document.querySelector('[data-testid="paperless-picker-modal"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    // (C) ?create=1 + Paperless NOT configured + autoItemizeEnabled=false → manual modal
+    it('(C) auto-opens manual modal when Paperless not configured and ?create=1', async () => {
+      mockGetPaperlessStatus.mockResolvedValue({
+        configured: false,
+        reachable: false,
+        error: null,
+        paperlessUrl: null,
+        filterTag: null,
+      });
+      mockFetchConfig.mockResolvedValue({ autoItemizeEnabled: false });
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+      mockFetchVendors.mockResolvedValue(emptyVendorsResponse);
+
+      renderPageWithCreate();
+
+      // Manual modal should auto-open
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Paperless picker must NOT be present
+      expect(
+        document.querySelector('[data-testid="paperless-picker-modal"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    // (D) ?create=1 + Paperless configured + reachable + autoItemizeEnabled=true → Paperless picker
+    it('(D) auto-opens Paperless picker when Paperless configured and autoItemizeEnabled=true', async () => {
+      mockGetPaperlessStatus.mockResolvedValue({
+        configured: true,
+        reachable: true,
+        error: null,
+        paperlessUrl: 'https://paperless.example.com',
+        filterTag: null,
+      });
+      mockFetchConfig.mockResolvedValue({ autoItemizeEnabled: true });
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+
+      renderPageWithCreate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('paperless-picker-modal')).toBeInTheDocument();
+      });
+
+      // Manual create modal must NOT be present
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    // (E) ?create=1 + Paperless configured + autoItemizeEnabled DISABLED → manual modal
+    it('(E) auto-opens manual modal when Paperless configured but autoItemizeEnabled=false', async () => {
+      mockGetPaperlessStatus.mockResolvedValue({
+        configured: true,
+        reachable: true,
+        error: null,
+        paperlessUrl: 'https://paperless.example.com',
+        filterTag: null,
+      });
+      mockFetchConfig.mockResolvedValue({ autoItemizeEnabled: false });
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+      mockFetchVendors.mockResolvedValue(emptyVendorsResponse);
+
+      renderPageWithCreate();
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      expect(
+        document.querySelector('[data-testid="paperless-picker-modal"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    // (F) after auto-open, the URL no longer contains create=1
+    it('(F) removes ?create=1 from the URL after auto-opening the modal', async () => {
+      mockGetPaperlessStatus.mockResolvedValue({
+        configured: false,
+        reachable: false,
+        error: null,
+        paperlessUrl: null,
+        filterTag: null,
+      });
+      mockFetchConfig.mockResolvedValue({ autoItemizeEnabled: false });
+      mockFetchAllInvoices.mockResolvedValue(emptyResponse);
+      mockFetchVendors.mockResolvedValue(emptyVendorsResponse);
+
+      renderPageWithCreate();
+
+      // Wait for the modal to open (confirms the effect ran)
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // The URL should no longer carry ?create=1
+      const locationEl = screen.getByTestId('location-search');
+      expect(locationEl.textContent).not.toContain('create=1');
+    });
+  });
 });

--- a/client/src/pages/InvoicesPage/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage/InvoicesPage.tsx
@@ -9,7 +9,6 @@ import type {
   InvoiceStatusBreakdown,
   PaperlessDocumentSearchResult,
   PaperlessStatusResponse,
-  AppConfigResponse,
 } from '@cornerstone/shared';
 import type { ColumnDef, TableState } from '../../components/DataTable/DataTable.js';
 import { DataTable } from '../../components/DataTable/DataTable.js';
@@ -275,6 +274,27 @@ export function InvoicesPage() {
     setCreateError('');
     setShowCreateModal(true);
   };
+
+  // Consume ?create=1 from the Dashboard "Add Invoice" shortcut.
+  // Only fires once integrationStatus has fully resolved (both fields non-null)
+  // to match the readiness gate used by the page's own "Add Invoice" button.
+  useEffect(() => {
+    if (integrationStatus.paperless === null || integrationStatus.autoItemizeEnabled === null) {
+      return;
+    }
+    if (searchParams.get('create') === '1') {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('create');
+          return next;
+        },
+        { replace: true },
+      );
+      openCreateModal();
+    }
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- openCreateModal is a stable plain function; intentionally omitted
+  }, [integrationStatus, searchParams, setSearchParams]);
 
   const closeCreateModal = () => {
     if (!isCreating) {

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -49,6 +49,12 @@ export class DashboardPage {
   /** The consolidated "Add" dropdown trigger button (data-testid="dashboard-add-button"). */
   readonly addButton: Locator;
 
+  /** "New Diary Entry" menu item in the Add dropdown (data-testid="dashboard-add-diary-entry"). */
+  readonly addDiaryEntryButton: Locator;
+
+  /** "New Invoice" menu item in the Add dropdown (data-testid="dashboard-add-invoice"). */
+  readonly addInvoiceButton: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
@@ -75,6 +81,10 @@ export class DashboardPage {
 
     // Consolidated "Add" dropdown button (replaces the 3 individual add buttons)
     this.addButton = page.getByTestId('dashboard-add-button');
+
+    // New menu items added in issue #1735
+    this.addDiaryEntryButton = page.getByTestId('dashboard-add-diary-entry');
+    this.addInvoiceButton = page.getByTestId('dashboard-add-invoice');
   }
 
   async goto(): Promise<void> {
@@ -137,11 +147,12 @@ export class DashboardPage {
 
   /**
    * Opens the "Add" dropdown and waits for the menu items to appear.
-   * The dropdown contains "Add Work Item", "Add Household Item", and "Add Milestone" options.
+   * The dropdown contains five items: Work Item, Household Item, Milestone, Diary Entry, Invoice.
    */
   async openAddDropdown(): Promise<void> {
     await this.addButton.click();
     await this.page.getByTestId('dashboard-add-work-item').waitFor({ state: 'visible' });
+    await this.page.getByTestId('dashboard-add-diary-entry').waitFor({ state: 'visible' });
   }
 
   /**

--- a/e2e/tests/navigation/dashboard.spec.ts
+++ b/e2e/tests/navigation/dashboard.spec.ts
@@ -955,6 +955,329 @@ test.describe('"Add" dropdown (Scenario 12)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Scenario 13: Add dropdown — Diary Entry and Invoice shortcuts (#1735)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Full summary shape expected by InvoicesPage — the existing mockInvoices() helper omits
+ * the quotation and overdue buckets that the page accesses (summary.overdue.count etc.).
+ * We define a richer mock inline here to avoid modifying the shared helper.
+ */
+function mockInvoicesFullSummary() {
+  return {
+    invoices: [],
+    pagination: { total: 0, page: 1, pageSize: 10, totalPages: 0 },
+    summary: {
+      pending: { count: 0, totalAmount: 0 },
+      paid: { count: 0, totalAmount: 0 },
+      claimed: { count: 0, totalAmount: 0 },
+      quotation: { count: 0, totalAmount: 0 },
+      overdue: { count: 0, totalAmount: 0 },
+    },
+  };
+}
+
+/**
+ * Intercepts the three APIs that InvoicesPage fetches on mount so the page renders
+ * cleanly in scenarios 13c–13f without interference from live test data.
+ * NOTE: @smoke omitted — requires Story #1735 implementation to be in beta. Re-add after merge.
+ */
+async function interceptInvoicesPageApis(page: InstanceType<typeof DashboardPage>['page']) {
+  await page.route('**/api/paperless/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        configured: false,
+        reachable: false,
+        error: null,
+        paperlessUrl: null,
+        filterTag: null,
+      }),
+    });
+  });
+  await page.route('**/api/config', async (route) => {
+    try {
+      const realResp = await route.fetch();
+      const realBody = (await realResp.json()) as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...realBody, autoItemizeEnabled: false }),
+      });
+    } catch {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ currency: 'EUR', autoItemizeEnabled: false }),
+      });
+    }
+  });
+  await page.route('**/api/invoices*', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockInvoicesFullSummary()),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+async function uninterceptInvoicesPageApis(page: InstanceType<typeof DashboardPage>['page']) {
+  await page.unroute('**/api/paperless/status');
+  await page.unroute('**/api/config');
+  await page.unroute('**/api/invoices*');
+}
+
+test.describe('Add dropdown — Diary Entry and Invoice shortcuts (Scenario 13, #1735)', () => {
+  // Scenario 13a: Add dropdown contains all five items in correct document order
+  test('Add dropdown contains all five items in correct document order', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+
+      // Collect all menu items from the Add dropdown menu in DOM order
+      const menuItems = page.getByRole('menu').getByRole('menuitem');
+      await expect(menuItems).toHaveCount(5);
+
+      // Verify each item by data-testid in document order
+      const expectedTestIds = [
+        'dashboard-add-work-item',
+        'dashboard-add-household-item',
+        'dashboard-add-milestone',
+        'dashboard-add-diary-entry',
+        'dashboard-add-invoice',
+      ];
+      for (let i = 0; i < expectedTestIds.length; i++) {
+        await expect(menuItems.nth(i)).toHaveAttribute('data-testid', expectedTestIds[i]);
+      }
+    } finally {
+      await uninterceptDashboardApis(page);
+    }
+  });
+
+  // Scenario 13b: "New Diary Entry" closes the menu and navigates to /diary/new
+  test('"New Diary Entry" closes the menu and navigates to /diary/new', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+      await dashboardPage.addDiaryEntryButton.click();
+
+      // Menu should close and navigate to /diary/new
+      await page.waitForURL(/\/diary\/new/);
+      expect(page.url()).toContain('/diary/new');
+
+      // The diary create page h1 should confirm we actually landed there
+      await expect(page.getByRole('heading', { level: 1, name: 'New Diary Entry' })).toBeVisible();
+    } finally {
+      await uninterceptDashboardApis(page);
+    }
+  });
+
+  // Scenario 13c: "New Invoice" navigates to /budget/invoices
+  test('"New Invoice" navigates to /budget/invoices', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+    await interceptInvoicesPageApis(page);
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+      await dashboardPage.addInvoiceButton.click();
+
+      await page.waitForURL(/\/budget\/invoices/);
+      expect(page.url()).toContain('/budget/invoices');
+    } finally {
+      await uninterceptDashboardApis(page);
+      await uninterceptInvoicesPageApis(page);
+    }
+  });
+
+  // Scenario 13d: "New Invoice" auto-opens the manual create modal when Paperless is not configured
+  test('"New Invoice" auto-opens manual create modal when Paperless is not configured', async ({
+    page,
+  }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+    await interceptInvoicesPageApis(page);
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+      await dashboardPage.addInvoiceButton.click();
+
+      // Wait for navigation to invoices page
+      await page.waitForURL(/\/budget\/invoices/);
+
+      // The manual create modal should open automatically (triggered by ?create=1)
+      // Modal title is t('invoices.modal.title') = "Add Invoice"
+      const createDialog = page.getByRole('dialog', { name: /Add Invoice/i });
+      await expect(createDialog).toBeVisible();
+
+      // Confirm the Paperless picker modal is NOT present
+      await expect(
+        page.getByRole('dialog', { name: /Select Invoice Document/i }),
+      ).not.toBeVisible();
+    } finally {
+      await uninterceptDashboardApis(page);
+      await uninterceptInvoicesPageApis(page);
+    }
+  });
+
+  // Scenario 13e: after manual create modal opens, URL no longer contains create=1
+  test('After manual create modal opens, URL no longer contains create=1', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+    await interceptInvoicesPageApis(page);
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+      await dashboardPage.addInvoiceButton.click();
+
+      await page.waitForURL(/\/budget\/invoices/);
+
+      // Wait for the modal to open — confirms the useEffect fired and called setSearchParams
+      const createDialog = page.getByRole('dialog', { name: /Add Invoice/i });
+      await expect(createDialog).toBeVisible();
+
+      // The URL must no longer contain create=1 (replaced via setSearchParams { replace: true })
+      expect(page.url()).not.toContain('create=1');
+    } finally {
+      await uninterceptDashboardApis(page);
+      await uninterceptInvoicesPageApis(page);
+    }
+  });
+
+  // Scenario 13f: "New Invoice" auto-opens Paperless picker when Paperless configured + auto-itemize enabled
+  test('"New Invoice" auto-opens Paperless picker when Paperless configured and auto-itemize enabled', async ({
+    page,
+  }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await interceptDashboardApis(page);
+
+    // Override the status/config intercepts for this scenario: Paperless configured + auto-itemize
+    await page.route('**/api/paperless/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          configured: true,
+          reachable: true,
+          error: null,
+          paperlessUrl: 'http://paperless.example.com',
+          filterTag: null,
+        }),
+      });
+    });
+    await page.route('**/api/config', async (route) => {
+      try {
+        const realResp = await route.fetch();
+        const realBody = (await realResp.json()) as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ...realBody, autoItemizeEnabled: true }),
+        });
+      } catch {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ currency: 'EUR', autoItemizeEnabled: true }),
+        });
+      }
+    });
+    await page.route('**/api/invoices*', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockInvoicesFullSummary()),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+    // Paperless picker also fetches correspondents on mount
+    await page.route('**/api/paperless/correspondents*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ correspondents: [] }),
+      });
+    });
+    // Paperless picker fetches documents via DocumentBrowser
+    await page.route('**/api/paperless/documents*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ documents: [], count: 0, next: null, previous: null }),
+      });
+    });
+    // DocumentBrowser also fetches tags in its Phase 2 call
+    await page.route('**/api/paperless/tags*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tags: [] }),
+      });
+    });
+
+    try {
+      await dashboardPage.goto();
+      await dashboardPage.waitForCardsLoaded();
+
+      await dashboardPage.openAddDropdown();
+      await dashboardPage.addInvoiceButton.click();
+
+      await page.waitForURL(/\/budget\/invoices/);
+
+      // The Paperless picker modal should open automatically
+      // InvoicePaperlessPickerModal renders inside Modal with title = t('budget:invoices.pickerModal.title')
+      // Check InvoicePaperlessPickerModal title via the modal dialog role
+      const pickerDialog = page.getByRole('dialog', { name: /Select Invoice Document/i });
+      await expect(pickerDialog).toBeVisible();
+
+      // Manual create dialog must NOT be present
+      await expect(page.getByRole('dialog', { name: /Add Invoice/i })).not.toBeVisible();
+    } finally {
+      await uninterceptDashboardApis(page);
+      await page.unroute('**/api/paperless/status');
+      await page.unroute('**/api/config');
+      await page.unroute('**/api/invoices*');
+      await page.unroute('**/api/paperless/correspondents*');
+      await page.unroute('**/api/paperless/documents*');
+      await page.unroute('**/api/paperless/tags*');
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // ARIA / Accessibility
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds **New Diary Entry** to the DashboardPage global Add menu → navigates to `/diary/new`
- Adds **New Invoice** to the DashboardPage global Add menu → navigates to `/budget/invoices?create=1`
- InvoicesPage consumes the `create` query param: auto-opens the existing Paperless-vs-manual create flow once integration status resolves, then clears the param from the URL so it doesn't re-trigger on navigation
- English and German i18n keys added to the `dashboard` namespace

Fixes #1735

## Test plan

- [x] Unit tests added for DashboardPage (new menu items render, click handlers navigate correctly)
- [x] Unit tests added for InvoicesPage (`?create=1` param auto-opens create flow and clears param)
- [x] E2E tests updated: DashboardPage POM extended with new menu items; dashboard navigation spec covers both new items
- [x] German translations provided by translator agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)