### PR TITLE
ci(e2e-warmup): wait for apt/dpkg lock before installing Playwright deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,15 +315,39 @@ jobs:
 
       - name: Download Playwright system dependencies
         if: steps.apt-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
-          for i in 1 2; do
+          # ubuntu-latest runners run a background apt-get (unattended-upgrades / boot-time
+          # package work) that holds the dpkg/apt lock early in the job. install-deps fails
+          # instantly with "Could not get lock" if it races that holder, so wait for the
+          # lock to free before each attempt and back off between attempts.
+          wait_for_apt() {
+            local max=180 waited=0
+            while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock >/dev/null 2>&1; do
+              if [ "$waited" -ge "$max" ]; then
+                echo "Timed out waiting for apt lock after ${max}s"
+                return 1
+              fi
+              echo "apt/dpkg lock held, waiting... (${waited}s)"
+              sleep 5
+              waited=$((waited + 5))
+            done
+          }
+          backoff=10
+          for i in 1 2 3; do
+            echo "Attempt $i: waiting for apt/dpkg lock to be free..."
+            wait_for_apt || echo "Proceeding despite lock-wait timeout on attempt $i"
             echo "Attempt $i: installing Playwright system dependencies..."
             if timeout 240 sudo npx playwright install-deps chromium webkit; then
               echo "Success on attempt $i"
               exit 0
             fi
-            echo "Attempt $i failed or timed out, retrying..."
+            echo "Attempt $i failed or timed out"
+            if [ "$i" -lt 3 ]; then
+              echo "Backing off ${backoff}s before retrying..."
+              sleep "$backoff"
+              backoff=$((backoff * 3))
+            fi
           done
           echo "All attempts failed"
           exit 1


### PR DESCRIPTION
## Summary

Hardens the `e2e-warmup` job's **Download Playwright system dependencies** step in `.github/workflows/ci.yml` to deterministically wait for the apt/dpkg lock to free before each `install-deps` attempt, with real backoff between attempts.

## Root cause

Two consecutive beta CI runs failed here with:

```
E: Could not get lock /var/cache/apt/archives/lock. It is held by process NNNN (apt-get)
E: Unable to lock directory /var/cache/apt/archives/
Failed to install browser dependencies
Error: Installation process exited with code: 100
```

GitHub `ubuntu-latest` runners run a background `apt-get` (unattended-upgrades / boot-time package work) that holds the dpkg/apt lock early in the job. The previous retry loop did **not** wait for that lock to release and had **no backoff**: attempt 1 burned its `timeout 240` waiting, and attempt 2 failed instantly on the still-held lock.

Because the step failed, the downstream **Save apt cache** step never ran, leaving the apt cache for this key empty — so every subsequent run re-hit the same race (not self-healing). This **blocked the beta→main promotion (PR #1759)**.

## Fix

- Add a `wait_for_apt` helper that polls `fuser` on the apt/dpkg lock files (`/var/lib/dpkg/lock-frontend`, `/var/lib/dpkg/lock`, `/var/cache/apt/archives/lock`, `/var/lib/apt/lists/lock`) in a bounded ~180s loop before each attempt.
- Increase to **3 attempts** and call `wait_for_apt` before each `install-deps`.
- Add exponential-ish backoff (**10s, 30s**) between failed attempts so a transient lock holder has time to finish.
- Keep the existing `timeout 240` guard on `install-deps`; bump per-step `timeout-minutes` 10 → 15 to accommodate lock waits.
- Cache restore/save step logic is **unchanged**; `if:`, `working-directory: e2e`, and the overall success/exit-1 semantics are preserved.

## Validation

- YAML parses (`js-yaml`).
- No production files touched (CI workflow only), so no Haiku co-author trailer required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)