### PR TITLE
ci(e2e): wait for apt/dpkg lock in remaining install-deps steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,15 +438,39 @@ jobs:
           key: apt-v3-playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Install Playwright system dependencies
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
-          for i in 1 2; do
+          # ubuntu-latest runners run a background apt-get (unattended-upgrades / boot-time
+          # package work) that holds the dpkg/apt lock early in the job. install-deps fails
+          # instantly with "Could not get lock" if it races that holder, so wait for the
+          # lock to free before each attempt and back off between attempts.
+          wait_for_apt() {
+            local max=180 waited=0
+            while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock >/dev/null 2>&1; do
+              if [ "$waited" -ge "$max" ]; then
+                echo "Timed out waiting for apt lock after ${max}s"
+                return 1
+              fi
+              echo "apt/dpkg lock held, waiting... (${waited}s)"
+              sleep 5
+              waited=$((waited + 5))
+            done
+          }
+          backoff=10
+          for i in 1 2 3; do
+            echo "Attempt $i: waiting for apt/dpkg lock to be free..."
+            wait_for_apt || echo "Proceeding despite lock-wait timeout on attempt $i"
             echo "Attempt $i: installing Playwright system dependencies..."
             if timeout 240 sudo npx playwright install-deps chromium webkit; then
               echo "Success on attempt $i"
               exit 0
             fi
-            echo "Attempt $i failed or timed out, retrying..."
+            echo "Attempt $i failed or timed out"
+            if [ "$i" -lt 3 ]; then
+              echo "Backing off ${backoff}s before retrying..."
+              sleep "$backoff"
+              backoff=$((backoff * 3))
+            fi
           done
           echo "All attempts failed"
           exit 1
@@ -525,15 +549,39 @@ jobs:
           key: apt-v3-playwright-${{ needs.e2e-warmup.outputs.playwright-version }}-${{ runner.os }}
 
       - name: Install Playwright system dependencies
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
-          for i in 1 2; do
+          # ubuntu-latest runners run a background apt-get (unattended-upgrades / boot-time
+          # package work) that holds the dpkg/apt lock early in the job. install-deps fails
+          # instantly with "Could not get lock" if it races that holder, so wait for the
+          # lock to free before each attempt and back off between attempts.
+          wait_for_apt() {
+            local max=180 waited=0
+            while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock >/dev/null 2>&1; do
+              if [ "$waited" -ge "$max" ]; then
+                echo "Timed out waiting for apt lock after ${max}s"
+                return 1
+              fi
+              echo "apt/dpkg lock held, waiting... (${waited}s)"
+              sleep 5
+              waited=$((waited + 5))
+            done
+          }
+          backoff=10
+          for i in 1 2 3; do
+            echo "Attempt $i: waiting for apt/dpkg lock to be free..."
+            wait_for_apt || echo "Proceeding despite lock-wait timeout on attempt $i"
             echo "Attempt $i: installing Playwright system dependencies..."
             if timeout 240 sudo npx playwright install-deps chromium webkit; then
               echo "Success on attempt $i"
               exit 0
             fi
-            echo "Attempt $i failed or timed out, retrying..."
+            echo "Attempt $i failed or timed out"
+            if [ "$i" -lt 3 ]; then
+              echo "Backing off ${backoff}s before retrying..."
+              sleep "$backoff"
+              backoff=$((backoff * 3))
+            fi
           done
           echo "All attempts failed"
           exit 1


### PR DESCRIPTION
## Summary

Promotion PR #1759's E2E Gates failed when **shard 11** errored at the `Install Playwright system dependencies` step with dpkg-lock contention ("Could not get lock") — no tests ran. This is the **same race** the warmup fix (#1760) addressed, but #1760 hardened **only** the `e2e-warmup` job's install-deps step.

Two more identical, unhardened `Install Playwright system dependencies` steps remained:
- one in the `e2e-smoke` job
- one in the sharded `e2e` job (the one that just failed)

## Change

Applies the proven #1760 hardening to **both** remaining steps:
- `wait_for_apt` helper that waits (up to 180s) for the dpkg/apt lock to free **before each attempt**
- 3 attempts with exponential backoff between them (10s → 30s → 90s)
- per-step `timeout-minutes` bumped 10 → 15

The block is byte-identical to the warmup job's. No other steps touched; surrounding `Restore apt cache` / `Install Playwright browsers (cache miss fallback)` steps are preserved.

## Validation
- `js-yaml` parses the workflow cleanly
- `grep -c 'wait_for_apt() {'` = **3** (warmup + e2e-smoke + e2e shard)
- `grep -c 'for i in 1 2; do'` = **0** (no old 2-attempt loops remain)

Unblocks the beta→main promotion (PR #1759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)