### PR TITLE
feat(auto-itemize): forward Paperless-ngx human-authored metadata to LLM extraction prompt

### DIFF
--- a/server/src/services/budgetExtraction/prompts.test.ts
+++ b/server/src/services/budgetExtraction/prompts.test.ts
@@ -202,6 +202,115 @@ describe('buildUserPrompt()', () => {
     });
   });
 
+  // ─── Story #1767 — paperlessMetadata in buildUserPrompt ──────────────────────
+
+  describe('paperlessMetadata in buildUserPrompt', () => {
+    it('section present when all metadata fields provided', () => {
+      const result = buildUserPrompt('ocr text', {
+        paperlessMetadata: {
+          title: 'Invoice Jan',
+          correspondent: 'Bauhaus GmbH',
+          documentType: 'Invoice',
+          tags: ['construction'],
+          created: '2026-01-15',
+          originalFileName: 'bauhaus.pdf',
+        },
+      });
+      expect(result).toContain('Document metadata (human-authored');
+      expect(result).toContain('Bauhaus GmbH');
+      expect(result).toContain('Invoice Jan');
+      expect(result).toContain('Invoice');
+      expect(result).toContain('construction');
+      expect(result).toContain('2026-01-15');
+      expect(result).toContain('bauhaus.pdf');
+    });
+
+    it('section omitted when paperlessMetadata is absent', () => {
+      const result = buildUserPrompt('ocr', {});
+      expect(result).not.toContain('Document metadata');
+    });
+
+    it('section omitted when all sub-fields are null or empty', () => {
+      const result = buildUserPrompt('ocr', {
+        paperlessMetadata: {
+          title: null,
+          correspondent: null,
+          documentType: null,
+          tags: [],
+          created: null,
+          originalFileName: null,
+        },
+      });
+      expect(result).not.toContain('Document metadata');
+    });
+
+    it('null sub-fields skipped silently — no empty label lines for null fields', () => {
+      const result = buildUserPrompt('ocr', {
+        paperlessMetadata: {
+          title: 'My Doc',
+          correspondent: null,
+        },
+      });
+      expect(result).toContain('My Doc');
+      // Null correspondent must not produce a "Correspondent:" line at all
+      expect(result).not.toContain('Correspondent:');
+      // The metadata section body must not render the literal word "null" as a value
+      // (the JSON schema notation "| null" at the bottom is acceptable)
+      const metaStart = result.indexOf('Document metadata');
+      const metaEnd = result.indexOf('---');
+      if (metaStart !== -1 && metaEnd > metaStart) {
+        const metaSection = result.slice(metaStart, metaEnd);
+        expect(metaSection).not.toContain('null');
+      }
+    });
+
+    it('empty tags produce no Tags line', () => {
+      const result = buildUserPrompt('ocr', {
+        paperlessMetadata: { tags: [] },
+      });
+      expect(result).not.toContain('Tags:');
+    });
+
+    it('non-empty tags rendered as comma-separated list', () => {
+      const result = buildUserPrompt('ocr', {
+        paperlessMetadata: { tags: ['Reparatur', 'Keller'] },
+      });
+      expect(result).toContain('Reparatur, Keller');
+      expect(result).toContain('Tags:');
+    });
+
+    it('metadata section appears after Vendor line', () => {
+      const result = buildUserPrompt('ocr', {
+        paperlessMetadata: {
+          correspondent: 'Acme GmbH',
+        },
+      });
+      const metaIndex = result.indexOf('Document metadata');
+      const vendorIndex = result.indexOf('Vendor:');
+      expect(metaIndex).toBeGreaterThan(vendorIndex);
+    });
+
+    it('does not throw with partially populated metadata', () => {
+      expect(() => buildUserPrompt('ocr', { paperlessMetadata: { title: 'X' } })).not.toThrow();
+    });
+  });
+
+  // ─── Story #1767 — SYSTEM_PROMPT rule 13 ─────────────────────────────────────
+
+  describe('SYSTEM_PROMPT — rule 13', () => {
+    it('contains "Document metadata (human-authored)" (rule 13 present)', () => {
+      expect(SYSTEM_PROMPT).toContain('Document metadata (human-authored)');
+    });
+
+    it('contains the word "authoritative" (override semantics stated)', () => {
+      expect(SYSTEM_PROMPT.toLowerCase()).toContain('authoritative');
+    });
+
+    it('contains "correspondent" (LLM told to use it as vendor name)', () => {
+      expect(SYSTEM_PROMPT).toContain('correspondent');
+    });
+  });
+
   describe('fixture text embedding', () => {
     it('can embed obi-baumarkt fixture without throwing', () => {
       const fixture = readFileSync(resolve(FIXTURES_DIR, 'obi-baumarkt.txt'), 'utf8');

--- a/server/src/services/budgetExtraction/prompts.ts
+++ b/server/src/services/budgetExtraction/prompts.ts
@@ -52,7 +52,8 @@ IMPORTANT RULES:
 9. category: extract ONE short noun phrase for the line's trade or material type (e.g., "Materials", "Labor", "Tile work", "Electrical", "Plumbing", "Roofing", "Painting", "Flooring"). Use English even on German invoices. Keep ≤ 30 characters. Output null if unclear.
 10. chosenVendorName: If a list of available vendors is provided, extract the vendor name from the invoice and return the exact matching name from the list (case-sensitive match). Return null if no match found or no vendor list provided.
 11. If no line items can be reliably extracted, return { "invoiceDate": null, "dueDate": null, "invoiceNumber": null, "notes": null, "chosenVendorName": null, "lines": [] }.
-12. Output ONLY valid JSON, no markdown, no comments.`;
+12. Output ONLY valid JSON, no markdown, no comments.
+13. When "Document metadata (human-authored)" is provided, treat those fields as authoritative — they override anything inferred from OCR text alone. In particular: use the correspondent as the vendor name, the document type for context, tags as category hints, and the document date as a cross-check for invoiceDate.`;
 
 export function buildUserPrompt(ocrText: string, hints: ExtractionHints): string {
   const vendorName = hints.vendorName ?? 'unknown';
@@ -71,6 +72,21 @@ Locale: ${locale}`;
   if (hints.availableVendors && hints.availableVendors.length > 0) {
     const vendorList = hints.availableVendors.map((v) => `- ${v.name}`).join('\n');
     prompt += `\n\nAvailable vendors (return one of these names verbatim as "chosenVendorName", or null if none match):\n${vendorList}`;
+  }
+
+  // Add human-authored Paperless metadata if provided
+  if (hints.paperlessMetadata) {
+    const meta = hints.paperlessMetadata;
+    const metaParts: string[] = [];
+    if (meta.title) metaParts.push(`Title: ${meta.title}`);
+    if (meta.correspondent) metaParts.push(`Correspondent: ${meta.correspondent}`);
+    if (meta.documentType) metaParts.push(`Document Type: ${meta.documentType}`);
+    if (meta.tags && meta.tags.length > 0) metaParts.push(`Tags: ${meta.tags.join(', ')}`);
+    if (meta.created) metaParts.push(`Document Date: ${meta.created}`);
+    if (meta.originalFileName) metaParts.push(`Original Filename: ${meta.originalFileName}`);
+    if (metaParts.length > 0) {
+      prompt += `\n\nDocument metadata (human-authored — prioritize these over OCR-inferred values):\n${metaParts.map((p) => `- ${p}`).join('\n')}`;
+    }
   }
 
   prompt += `\n\n---

--- a/server/src/services/invoiceAutoItemizeService.test.ts
+++ b/server/src/services/invoiceAutoItemizeService.test.ts
@@ -3061,4 +3061,204 @@ describe('invoiceAutoItemizeService', () => {
       ).rejects.toThrow(ItemizedSumExceedsInvoiceError);
     });
   });
+
+  // ─── Story #1767 — paperlessMetadata enrichment ───────────────────────────────
+  //
+  // When the Paperless raw doc has a non-null correspondent/document_type, getDocument()
+  // makes additional HTTP calls to resolve their names. Fetch call order:
+  //   [0] Paperless document detail (/api/documents/42/)
+  //   [1] Paperless tags list (/api/tags/…)
+  //   [2] Correspondent name resolution (/api/correspondents/1/)
+  //   [3] Document type name resolution (/api/document_types/1/)
+  //   [4] LLM chat/completions
+  //
+  // When correspondent/document_type are null (plain makePaperlessRawDoc), no calls
+  // [2]/[3] happen, so LLM is at call[2].
+
+  /**
+   * Raw Paperless document with non-null correspondent, document_type, tags, and
+   * original_file_name — used to test metadata enrichment in the LLM prompt.
+   *
+   * Uses numeric IDs for correspondent (1) and document_type (1). The test must
+   * queue mocks for /api/correspondents/1/ and /api/document_types/1/ responses
+   * before the LLM mock.
+   */
+  function makePaperlessRawDocWithMeta(content = 'OCR invoice text'): object {
+    return {
+      id: 42,
+      title: 'Rechnung 2026-01',
+      content,
+      tags: [101], // tag ID 101 → resolved via tags list mock to name 'Bau'
+      created: '2026-01-15T00:00:00Z',
+      added: '2026-01-15T00:00:00Z',
+      modified: '2026-01-15T00:00:00Z',
+      correspondent: 1, // non-null → triggers /api/correspondents/1/ fetch
+      document_type: 1, // non-null → triggers /api/document_types/1/ fetch
+      archive_serial_number: null,
+      original_file_name: 'rechnung.pdf',
+      page_count: 2,
+    };
+  }
+
+  /** Tags list response that resolves tag ID 101 to name 'Bau'. */
+  const PAPERLESS_TAGS_WITH_BAU = {
+    count: 1,
+    results: [{ id: 101, name: 'Bau', colour: 3, document_count: 5 }],
+  };
+
+  describe('paperlessMetadata enrichment (Story #1767)', () => {
+    it('autoItemize dry-run enriches prompt with correspondent', async () => {
+      const vendorId = insertVendor(db, 'Some Vendor');
+      const invoiceId = insertInvoice(db, vendorId, 500);
+      linkDocument(db, invoiceId, 42);
+      const config = makeConfig();
+
+      // Doc, tags, correspondent name, document type name, LLM
+      mockFetch
+        .mockResolvedValueOnce(makeOkFetch(makePaperlessRawDocWithMeta()))
+        .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
+        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+
+      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+
+      const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
+      expect(llmCall![0]).toContain('chat/completions');
+      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const userMsg = llmBody.messages.find((m) => m.role === 'user');
+      expect(userMsg?.content).toContain('Bauhaus GmbH');
+    });
+
+    it('autoItemize dry-run enriches prompt with title', async () => {
+      const vendorId = insertVendor(db, 'Some Vendor');
+      const invoiceId = insertInvoice(db, vendorId, 500);
+      linkDocument(db, invoiceId, 42);
+      const config = makeConfig();
+
+      mockFetch
+        .mockResolvedValueOnce(makeOkFetch(makePaperlessRawDocWithMeta()))
+        .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
+        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+
+      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+
+      const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
+      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const userMsg = llmBody.messages.find((m) => m.role === 'user');
+      expect(userMsg?.content).toContain('Rechnung 2026-01');
+    });
+
+    it('autoItemize dry-run enriches prompt with tags', async () => {
+      const vendorId = insertVendor(db, 'Some Vendor');
+      const invoiceId = insertInvoice(db, vendorId, 500);
+      linkDocument(db, invoiceId, 42);
+      const config = makeConfig();
+
+      mockFetch
+        .mockResolvedValueOnce(makeOkFetch(makePaperlessRawDocWithMeta()))
+        .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
+        .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
+        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+
+      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+
+      const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
+      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const userMsg = llmBody.messages.find((m) => m.role === 'user');
+      // Tag ID 101 resolved to 'Bau' via PAPERLESS_TAGS_WITH_BAU
+      expect(userMsg?.content).toContain('Bau');
+    });
+
+    it('autoItemize dry-run omits metadata section when all Paperless fields are null/empty', async () => {
+      const vendorId = insertVendor(db, 'Some Vendor');
+      const invoiceId = insertInvoice(db, vendorId, 500);
+      linkDocument(db, invoiceId, 42);
+      // Use plain makePaperlessRawDoc: correspondent=null, document_type=null, tags=[], original_file_name='invoice.pdf'
+      // The title is 'Invoice PDF' and original_file_name is 'invoice.pdf' — these are non-null.
+      // To get NO metadata section, we need a doc where buildPaperlessMetadata produces all-empty/null.
+      // The plain doc has title='Invoice PDF' and originalFileName='invoice.pdf', so a section WOULD appear.
+      // We need a doc with title=null and originalFileName=null for the section to be suppressed.
+      const nullMetaDoc = {
+        id: 42,
+        title: null,
+        content: 'OCR text',
+        tags: [],
+        created: null,
+        added: null,
+        modified: null,
+        correspondent: null,
+        document_type: null,
+        archive_serial_number: null,
+        original_file_name: null,
+        page_count: 1,
+      };
+      const config = makeConfig();
+
+      // Doc (0), tags (1) — no correspondent/document_type fetches since both are null; LLM (2)
+      mockFetch
+        .mockResolvedValueOnce(makeOkFetch(nullMetaDoc))
+        .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_RESPONSE))
+        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+
+      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+
+      const llmCall = mockFetch.mock.calls[2] as [string, RequestInit];
+      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const userMsg = llmBody.messages.find((m) => m.role === 'user');
+      expect(userMsg?.content).not.toContain('Document metadata');
+    });
+
+    it('previewAutoItemize enriches prompt via runExtractionCore (correspondent present)', async () => {
+      insertVendor(db, 'Holz AG');
+      const config = makeConfig();
+
+      // For previewAutoItemize the fetch order is the same as autoItemize dry-run:
+      // [0] doc, [1] tags, [2] correspondent, [3] document_type, [4] LLM
+      const docWithHolzCorrespondent = {
+        id: 42,
+        title: 'Holz Rechnung',
+        content: 'OCR text',
+        tags: [],
+        created: '2026-02-01T00:00:00Z',
+        added: '2026-02-01T00:00:00Z',
+        modified: '2026-02-01T00:00:00Z',
+        correspondent: 2, // non-null → will fetch /api/correspondents/2/
+        document_type: null,
+        archive_serial_number: null,
+        original_file_name: 'holz.pdf',
+        page_count: 1,
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(makeOkFetch(docWithHolzCorrespondent))
+        .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_RESPONSE))
+        .mockResolvedValueOnce(makeOkFetch({ id: 2, name: 'Holz AG' }))
+        // No document_type fetch (document_type is null) — resolveDocumentTypeName returns null immediately
+        .mockResolvedValueOnce(makeOkFetch({
+          choices: [{ message: { content: JSON.stringify({ lines: [{ description: 'Holz item', totalAmount: 300, confidence: 0.9 }], chosenVendorName: 'Holz AG' }) } }],
+        }));
+
+      const result = (await previewAutoItemize(
+        db,
+        config,
+        { paperlessDocumentId: 42 },
+        PAPERLESS_AUTH,
+      )) as { lines: unknown[]; suggestedVendorId: string | null };
+
+      // Verify the LLM was called — it's the last fetch call (index 3 since document_type is null)
+      const llmCallIndex = mockFetch.mock.calls.length - 1;
+      const llmCall = mockFetch.mock.calls[llmCallIndex] as [string, RequestInit];
+      expect(llmCall![0]).toContain('chat/completions');
+      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const userMsg = llmBody.messages.find((m) => m.role === 'user');
+      expect(userMsg?.content).toContain('Holz AG');
+
+      // Also verify the suggestedVendorId is resolved
+      expect(result.suggestedVendorId).not.toBeNull();
+    });
+  });
 });

--- a/server/src/services/invoiceAutoItemizeService.ts
+++ b/server/src/services/invoiceAutoItemizeService.ts
@@ -39,6 +39,7 @@ import type { AppConfig } from '../plugins/config.js';
 import type {
   ExtractedLine,
   ExtractionHints,
+  PaperlessDocument,
   InvoiceBudgetLineListDetailResponse,
   InvoicePatchForAutoItemize,
   AutoItemizeDryRunResponse,
@@ -61,6 +62,20 @@ export interface AutoItemizeRequestBody {
   dryRun: boolean;
   lines?: ExtractedLine[];
   invoicePatch?: InvoicePatchForAutoItemize;
+}
+
+/**
+ * Extract human-authored Paperless-ngx metadata for inclusion in LLM extraction hints.
+ */
+function buildPaperlessMetadata(doc: PaperlessDocument): ExtractionHints['paperlessMetadata'] {
+  return {
+    title: doc.title,
+    correspondent: doc.correspondent,
+    documentType: doc.documentType,
+    tags: doc.tags.map((t) => t.name),
+    created: doc.created,
+    originalFileName: doc.originalFileName,
+  };
 }
 
 /**
@@ -146,7 +161,10 @@ export async function autoItemize(
     );
 
     const provider = getProvider(config);
-    const hints = buildHints(invoice, vendorName);
+    const hints: ExtractionHints = {
+      ...buildHints(invoice, vendorName),
+      paperlessMetadata: buildPaperlessMetadata(doc),
+    };
     // Truncate OCR text to MAX_OCR_CHARS to prevent LLM overload
     const ocrText =
       (doc.content ?? '').length > MAX_OCR_CHARS
@@ -558,7 +576,11 @@ async function runExtractionCore(
     (doc.content ?? '').length > MAX_OCR_CHARS
       ? (doc.content ?? '').slice(0, MAX_OCR_CHARS)
       : (doc.content ?? '');
-  const result = await provider.extract(ocrText, hints);
+  const enrichedHints: ExtractionHints = {
+    ...hints,
+    paperlessMetadata: buildPaperlessMetadata(doc),
+  };
+  const result = await provider.extract(ocrText, enrichedHints);
   computeDueDateFallback(result);
 
   // Map LLM-extracted category names to budget category IDs

--- a/shared/src/types/budgetExtraction.ts
+++ b/shared/src/types/budgetExtraction.ts
@@ -48,6 +48,25 @@ export interface ExtractionHints {
    * EPIC-18 Story #1679: Added for Paperless-first invoice creation preview.
    */
   availableVendors?: Array<{ id: string; name: string }>;
+  /**
+   * Human-authored metadata from Paperless-ngx.
+   * These fields are set by the user in Paperless-ngx and should be prioritized
+   * over values the LLM infers from OCR text alone.
+   */
+  paperlessMetadata?: {
+    /** User-set document title in Paperless-ngx. */
+    title?: string | null;
+    /** Correspondent (person/org) assigned in Paperless-ngx. */
+    correspondent?: string | null;
+    /** Document type assigned in Paperless-ngx. */
+    documentType?: string | null;
+    /** Tag names applied to this document. */
+    tags?: string[];
+    /** ISO 8601 date (YYYY-MM-DD) set by user as the document's creation date. */
+    created?: string | null;
+    /** Original filename of the uploaded file. */
+    originalFileName?: string | null;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extends `AutoItemizeHints` type in `shared/src/types/budgetExtraction.ts` to carry all human-authored Paperless-ngx metadata fields (title, correspondent, document type, tags, creation date, original filename)
- Updates the LLM system prompt in `server/src/services/budgetExtraction/prompts.ts` to include a new rule instructing the model to treat these metadata fields as authoritative over OCR-inferred values, and to inject them into the extraction context block when present
- Updates both `autoItemize` and `previewAutoItemize` paths in `server/src/services/invoiceAutoItemizeService.ts` to forward the metadata from the Paperless document response into the hints object

Fixes #1767

## Test plan

- [x] Unit tests added for prompt generation with and without each metadata field (prompts.test.ts)
- [x] Unit tests added for both service paths verifying hints are forwarded correctly (invoiceAutoItemizeService.test.ts)
- [x] Pre-commit hook quality gates pass

Co-Authored-By: Claude dev-team-lead (Sonnet 4.6) <noreply@anthropic.com>