### PR TITLE
chore: update implementation checklist with lessons learned

### DIFF
--- a/.claude/checklists/implementation-checklist.md
+++ b/.claude/checklists/implementation-checklist.md
@@ -28,6 +28,7 @@ This checklist is updated after each epic's lessons-learned sync (see `/epic-clo
 ## Frontend — Shared Components
 
 - [ ] **Badge usage**: Status indicators must use the shared `Badge` component with appropriate variant maps. Never create inline status pills or colored spans.
+- [ ] **Badge variant map completeness**: Every `BadgeVariantMap` entry must include BOTH `label` (translated via `t()`) AND `className` (the CSS module class). A missing `className` leaves the CSS variant rule with no effect (style is dead on arrival); a missing/hardcoded `label` ships untranslated English to users. This is a recurring bug (e.g. PR #1548 shipped `UNASSIGNED_BADGE_VARIANTS` without `className`, so the `.iblUnassigned` rule never applied).
 - [ ] **SearchPicker usage**: Entity selection dropdowns must use the shared `SearchPicker` component. Never create custom search dropdowns.
 - [ ] **Modal usage**: Dialog overlays must use the shared `Modal` component. Never create custom overlay/backdrop implementations.
 - [ ] **Skeleton usage**: Loading placeholders must use the shared `Skeleton` component.


### PR DESCRIPTION
Lessons-learned sync from the v2.11.0 release.

Adds a **Badge variant-map completeness** check to `implementation-checklist.md`: every `BadgeVariantMap` entry must carry both `label` (translated via `t()`) and `className` (the CSS module class). Captured from a recurring review finding — PR #1548 shipped `UNASSIGNED_BADGE_VARIANTS` without a `className`, leaving the `.iblUnassigned` style rule dead on arrival.

Checklist-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)