### PR TITLE
chore(deps): fix security vulnerabilities in dev dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,6 @@
     "style-loader": "4.0.0",
     "webpack": "5.107.2",
     "webpack-cli": "7.0.3",
-    "webpack-dev-server": "5.2.4"
+    "webpack-dev-server": "5.2.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "style-loader": "4.0.0",
         "webpack": "5.107.2",
         "webpack-cli": "7.0.3",
-        "webpack-dev-server": "5.2.4"
+        "webpack-dev-server": "5.2.5"
       }
     },
     "client/node_modules/@types/react": {
@@ -150,16 +150,6 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^6.23.0"
-      }
-    },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -18507,41 +18497,20 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http2-wrapper": {
@@ -19266,6 +19235,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -33717,11 +33695,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
@@ -34241,14 +34218,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -34656,11 +34635,10 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "serialize-javascript": "7.0.5",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.2.0",
+    "webpack-dev-server": "5.2.5",
+    "undici": "7.28.0",
+    "http-proxy-middleware": "3.0.7",
+    "uuid": "11.1.1"
   }
 }

--- a/server/src/services/invoiceAutoItemizeService.test.ts
+++ b/server/src/services/invoiceAutoItemizeService.test.ts
@@ -3119,13 +3119,26 @@ describe('invoiceAutoItemizeService', () => {
         .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
-        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+        .mockResolvedValueOnce(
+          makeOkFetch(
+            makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }]),
+          ),
+        );
 
-      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+      await autoItemize(
+        db,
+        config,
+        invoiceId,
+        'user-1',
+        { paperlessDocumentId: 42, mode: 'append', dryRun: true },
+        PAPERLESS_AUTH,
+      );
 
       const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
       expect(llmCall![0]).toContain('chat/completions');
-      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const llmBody = JSON.parse(llmCall![1].body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
       const userMsg = llmBody.messages.find((m) => m.role === 'user');
       expect(userMsg?.content).toContain('Bauhaus GmbH');
     });
@@ -3141,12 +3154,25 @@ describe('invoiceAutoItemizeService', () => {
         .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
-        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+        .mockResolvedValueOnce(
+          makeOkFetch(
+            makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }]),
+          ),
+        );
 
-      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+      await autoItemize(
+        db,
+        config,
+        invoiceId,
+        'user-1',
+        { paperlessDocumentId: 42, mode: 'append', dryRun: true },
+        PAPERLESS_AUTH,
+      );
 
       const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
-      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const llmBody = JSON.parse(llmCall![1].body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
       const userMsg = llmBody.messages.find((m) => m.role === 'user');
       expect(userMsg?.content).toContain('Rechnung 2026-01');
     });
@@ -3162,12 +3188,25 @@ describe('invoiceAutoItemizeService', () => {
         .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_WITH_BAU))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Bauhaus GmbH' }))
         .mockResolvedValueOnce(makeOkFetch({ id: 1, name: 'Invoice' }))
-        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+        .mockResolvedValueOnce(
+          makeOkFetch(
+            makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }]),
+          ),
+        );
 
-      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+      await autoItemize(
+        db,
+        config,
+        invoiceId,
+        'user-1',
+        { paperlessDocumentId: 42, mode: 'append', dryRun: true },
+        PAPERLESS_AUTH,
+      );
 
       const llmCall = mockFetch.mock.calls[4] as [string, RequestInit];
-      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const llmBody = JSON.parse(llmCall![1].body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
       const userMsg = llmBody.messages.find((m) => m.role === 'user');
       // Tag ID 101 resolved to 'Bau' via PAPERLESS_TAGS_WITH_BAU
       expect(userMsg?.content).toContain('Bau');
@@ -3202,12 +3241,25 @@ describe('invoiceAutoItemizeService', () => {
       mockFetch
         .mockResolvedValueOnce(makeOkFetch(nullMetaDoc))
         .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_RESPONSE))
-        .mockResolvedValueOnce(makeOkFetch(makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }])));
+        .mockResolvedValueOnce(
+          makeOkFetch(
+            makeLlmResponse([{ description: 'Item', totalAmount: 200, confidence: 0.9 }]),
+          ),
+        );
 
-      await autoItemize(db, config, invoiceId, 'user-1', { paperlessDocumentId: 42, mode: 'append', dryRun: true }, PAPERLESS_AUTH);
+      await autoItemize(
+        db,
+        config,
+        invoiceId,
+        'user-1',
+        { paperlessDocumentId: 42, mode: 'append', dryRun: true },
+        PAPERLESS_AUTH,
+      );
 
       const llmCall = mockFetch.mock.calls[2] as [string, RequestInit];
-      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const llmBody = JSON.parse(llmCall![1].body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
       const userMsg = llmBody.messages.find((m) => m.role === 'user');
       expect(userMsg?.content).not.toContain('Document metadata');
     });
@@ -3238,9 +3290,20 @@ describe('invoiceAutoItemizeService', () => {
         .mockResolvedValueOnce(makeOkFetch(PAPERLESS_TAGS_RESPONSE))
         .mockResolvedValueOnce(makeOkFetch({ id: 2, name: 'Holz AG' }))
         // No document_type fetch (document_type is null) — resolveDocumentTypeName returns null immediately
-        .mockResolvedValueOnce(makeOkFetch({
-          choices: [{ message: { content: JSON.stringify({ lines: [{ description: 'Holz item', totalAmount: 300, confidence: 0.9 }], chosenVendorName: 'Holz AG' }) } }],
-        }));
+        .mockResolvedValueOnce(
+          makeOkFetch({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    lines: [{ description: 'Holz item', totalAmount: 300, confidence: 0.9 }],
+                    chosenVendorName: 'Holz AG',
+                  }),
+                },
+              },
+            ],
+          }),
+        );
 
       const result = (await previewAutoItemize(
         db,
@@ -3253,7 +3316,9 @@ describe('invoiceAutoItemizeService', () => {
       const llmCallIndex = mockFetch.mock.calls.length - 1;
       const llmCall = mockFetch.mock.calls[llmCallIndex] as [string, RequestInit];
       expect(llmCall![0]).toContain('chat/completions');
-      const llmBody = JSON.parse(llmCall![1].body as string) as { messages: Array<{ role: string; content: string }> };
+      const llmBody = JSON.parse(llmCall![1].body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
       const userMsg = llmBody.messages.find((m) => m.role === 'user');
       expect(userMsg?.content).toContain('Holz AG');
 

--- a/server/src/services/paperlessService.test.ts
+++ b/server/src/services/paperlessService.test.ts
@@ -983,7 +983,13 @@ describe('getDocuments()', () => {
   });
 
   it('returns multiple documents in the map', async () => {
-    const doc2 = { ...RAW_DOCUMENT_1, id: 43, title: 'Second Doc', correspondent: null, document_type: null };
+    const doc2 = {
+      ...RAW_DOCUMENT_1,
+      id: 43,
+      title: 'Second Doc',
+      correspondent: null,
+      document_type: null,
+    };
     mockFetch.mockResolvedValueOnce(mockJsonResponse(RAW_TAGS_RESPONSE));
     mockFetch.mockResolvedValueOnce(
       mockJsonResponse({ count: 2, results: [RAW_DOCUMENT_1, doc2] }),

--- a/server/src/services/paperlessService.ts
+++ b/server/src/services/paperlessService.ts
@@ -513,7 +513,11 @@ export async function getDocuments(
   // Fetch tags and all documents in parallel — just 2 API calls regardless of N
   const [tagsMap, raw] = await Promise.all([
     fetchTagsMap(baseUrl, token),
-    fetchPaperless<RawPaperlessListResponse>(baseUrl, token, `/api/documents/?${params.toString()}`),
+    fetchPaperless<RawPaperlessListResponse>(
+      baseUrl,
+      token,
+      `/api/documents/?${params.toString()}`,
+    ),
   ]);
 
   const presentDocs = raw.results;


### PR DESCRIPTION
## Summary

- Upgrades `webpack-dev-server` 5.2.4 → 5.2.5 (fixes HMR WebSocket interception)
- Adds root `overrides` to force patched transitive dependency versions:
  - `undici` → 7.28.0 (TLS cert bypass + shared-cache disclosure)
  - `http-proxy-middleware` → 3.0.7 (Host-header bypass + CRLF injection)
  - `uuid` → 11.1.1 (buffer bounds overwrite via sockjs)
- All overrides are dev-dependency scope only — not present in the production Docker image
- Also includes Prettier formatting of two server test files that exceeded line width

Closes Dependabot alerts #57, #58, #59, #60, #61.
`npm audit` now reports **0 vulnerabilities**.

Supersedes Dependabot PR #1762 (which targeted `main` instead of `beta`).

## Test plan
- [ ] `npm audit` passes with 0 vulnerabilities
- [ ] Unit tests pass
- [ ] Docker build succeeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>