### PR TITLE
refactor(auto-itemize): harmonize existing-invoice and new-invoice flows

### DIFF
--- a/client/src/components/autoItemize/AutoItemizePdfPreview.module.css
+++ b/client/src/components/autoItemize/AutoItemizePdfPreview.module.css
@@ -1,0 +1,76 @@
+.pdfPreviewWrapper {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pdfIframe {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-tertiary);
+  display: block;
+}
+
+.pdfLoadingOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-lg);
+  z-index: var(--z-dropdown);
+}
+
+.pdfFallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+  min-height: 200px;
+  flex: 1;
+  padding: var(--spacing-6);
+}
+
+.pdfFallbackLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.pdfFallbackLink {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: var(--transition-button);
+}
+
+.pdfFallbackLink:hover {
+  color: var(--color-primary-hover);
+  text-decoration: underline;
+}
+
+.pdfFallbackLink:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
+@media (max-width: 860px) {
+  .pdfIframe {
+    min-height: 60vh;
+    height: 60vh;
+    position: static;
+  }
+}

--- a/client/src/components/autoItemize/AutoItemizePdfPreview.tsx
+++ b/client/src/components/autoItemize/AutoItemizePdfPreview.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { TFunction } from 'i18next';
+import { getDocumentPreviewUrl } from '../../lib/paperlessApi.js';
+import { Spinner } from '../Spinner/Spinner.js';
+import styles from './AutoItemizePdfPreview.module.css';
+
+interface AutoItemizePdfPreviewProps {
+  documentId: number;
+  paperlessUrl?: string | null;
+  t: TFunction;
+}
+
+export function AutoItemizePdfPreview({ documentId, paperlessUrl, t }: AutoItemizePdfPreviewProps) {
+  const [pdfLoaded, setPdfLoaded] = useState(false);
+  const [pdfFailed, setPdfFailed] = useState(false);
+
+  if (pdfFailed) {
+    return (
+      <div
+        className={styles.pdfFallback}
+        role="region"
+        aria-label={t('autoItemize.previewUnavailable')}
+      >
+        <svg
+          aria-hidden="true"
+          width="32"
+          height="32"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--color-text-muted)"
+          strokeWidth="1.5"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+        <span className={styles.pdfFallbackLabel}>{t('autoItemize.previewUnavailable')}</span>
+        {paperlessUrl && (
+          <a
+            href={`${paperlessUrl}/documents/${documentId}/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.pdfFallbackLink}
+          >
+            {t('autoItemize.openInPaperless')}
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.pdfPreviewWrapper}>
+      {!pdfLoaded && (
+        <div className={styles.pdfLoadingOverlay} aria-hidden="true">
+          <Spinner size="md" color="muted" label={t('autoItemize.pdfPreviewTitle')} />
+        </div>
+      )}
+      <iframe
+        className={styles.pdfIframe}
+        src={getDocumentPreviewUrl(documentId)}
+        title={t('autoItemize.pdfPreviewTitle')}
+        onLoad={() => setPdfLoaded(true)}
+        onErrorCapture={() => setPdfFailed(true)}
+      />
+    </div>
+  );
+}

--- a/client/src/components/autoItemize/index.ts
+++ b/client/src/components/autoItemize/index.ts
@@ -1,4 +1,5 @@
 export { AutoItemizeLineCard } from './AutoItemizeLineCard.js';
 export { AutoItemizeLineList } from './AutoItemizeLineList.js';
+export { AutoItemizePdfPreview } from './AutoItemizePdfPreview.js';
 export { BudgetLinePickerModal } from './BudgetLinePickerModal.js';
 export type { LineWithInclude } from './types.js';

--- a/client/src/hooks/useAutoItemizeLines.test.ts
+++ b/client/src/hooks/useAutoItemizeLines.test.ts
@@ -1,0 +1,411 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for useAutoItemizeLines hook.
+ *
+ * Tests handler behaviour, confidence derivation, and onFieldsEdited callback.
+ * useBudgetLinePicker is mocked so no real API calls are made.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react';
+
+// ─── Mocks (before static imports) ──────────────────────────────────────────
+
+const mockOpenPicker = jest.fn();
+const mockClosePicker = jest.fn();
+const mockInitializeStaticData = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+let mockPickerStateOverride: Record<string, unknown> = {};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OnLineCreatedFn = (...args: any[]) => void;
+let capturedOnLineCreated: OnLineCreatedFn | null = null;
+
+jest.unstable_mockModule('./useBudgetLinePicker.js', () => ({
+  useBudgetLinePicker: ({ onLineCreated }: { onLineCreated: OnLineCreatedFn }) => {
+    capturedOnLineCreated = onLineCreated;
+    return {
+      pickerState: {
+        isOpen: false,
+        step: 1,
+        type: 'work_item',
+        itemId: 'wi-1',
+        itemTitle: 'Kitchen',
+        isLoading: false,
+        error: null,
+        budgetLines: [],
+        budgetSources: [{ id: 'src-1', name: 'Main', isDiscretionary: true }],
+        vendors: [{ id: 'v-1', name: 'Builder Co', trade: null }],
+        categories: [{ id: 'cat-1', name: 'Cat 1' }],
+        showCreateForm: false,
+        createError: null,
+        createForm: undefined,
+        ...mockPickerStateOverride,
+      },
+      openPicker: mockOpenPicker,
+      closePicker: mockClosePicker,
+      handleSelectItem: jest.fn(),
+      showCreateBudgetLineForm: jest.fn(),
+      handleCreateBudgetLine: jest.fn(),
+      setPickerState: jest.fn(),
+      initializeStaticData: mockInitializeStaticData,
+      createBudgetLineButtonRef: { current: null },
+    };
+  },
+}));
+
+jest.unstable_mockModule('../contexts/LocaleContext.js', () => ({
+  LocaleProvider: ({ children }: { children: unknown }) => children,
+  useLocale: () => ({ locale: 'en', setLocale: jest.fn() }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeLine(overrides: Record<string, any> = {}): any {
+  return {
+    rowId: 'r1',
+    description: 'Tile work',
+    totalAmount: 300,
+    includesVat: true,
+    confidence: 0.9,
+    quantity: null,
+    unit: null,
+    unitPrice: null,
+    vatRate: null,
+    vendorName: null,
+    included: true,
+    budgetCategoryId: 'cat-1',
+    budgetSourceId: 'src-1',
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeOptions(overrides: Record<string, any> = {}) {
+  return {
+    invoiceId: 'inv-1',
+    invoiceAmount: 1000,
+    document: null,
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useAutoItemizeLines', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let useAutoItemizeLines: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPickerStateOverride = {};
+    capturedOnLineCreated = null;
+    ({ useAutoItemizeLines } = await import('./useAutoItemizeLines.js'));
+  });
+
+  it('calls initializeStaticData on mount', () => {
+    renderHook(() => useAutoItemizeLines(makeOptions()));
+    expect(mockInitializeStaticData).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts with empty lines', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+    expect(result.current.lines).toEqual([]);
+  });
+
+  it('onToggleInclude flips the included flag', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ included: true })]);
+    });
+    act(() => {
+      result.current.handlers.onToggleInclude('r1');
+    });
+
+    expect(result.current.lines[0].included).toBe(false);
+  });
+
+  it('onFieldChange updates a string field and calls onFieldsEdited', () => {
+    const onFieldsEdited = jest.fn();
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions({ onFieldsEdited })));
+
+    act(() => {
+      result.current.setLines([makeLine({ description: 'old' })]);
+    });
+    act(() => {
+      result.current.handlers.onFieldChange('r1', 'description', 'new');
+    });
+
+    expect(result.current.lines[0].description).toBe('new');
+    expect(onFieldsEdited).toHaveBeenCalledTimes(1);
+  });
+
+  it('onFieldChange coerces quantity string → null for empty string', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ quantity: 5 })]);
+    });
+    act(() => {
+      result.current.handlers.onFieldChange('r1', 'quantity', '');
+    });
+
+    expect(result.current.lines[0].quantity).toBeNull();
+  });
+
+  it('onFieldChange coerces quantity string → number', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine()]);
+    });
+    act(() => {
+      result.current.handlers.onFieldChange('r1', 'quantity', '3.5');
+    });
+
+    expect(result.current.lines[0].quantity).toBe(3.5);
+  });
+
+  it('onAssign opens the picker', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+    act(() => {
+      result.current.handlers.onAssign('r1');
+    });
+    expect(mockOpenPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('onSelectBudgetLine assigns the line and closes the picker', () => {
+    const onFieldsEdited = jest.fn();
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions({ onFieldsEdited })));
+
+    act(() => {
+      result.current.setLines([makeLine()]);
+      result.current.handlers.onAssign('r1'); // set activeRowId
+    });
+
+    act(() => {
+      result.current.handlers.onSelectBudgetLine({
+        id: 'wib-1',
+        workItemId: 'wi-1',
+        description: 'My line',
+      });
+    });
+
+    expect(result.current.lines[0]).toMatchObject({
+      assignedBudgetLineId: 'wib-1',
+      assignedBudgetLineType: 'work_item',
+    });
+    expect(mockClosePicker).toHaveBeenCalledTimes(1);
+    expect(onFieldsEdited).toHaveBeenCalled();
+  });
+
+  it('onClearAssign resets assignment and calls onFieldsEdited', () => {
+    const onFieldsEdited = jest.fn();
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions({ onFieldsEdited })));
+
+    act(() => {
+      result.current.setLines([
+        makeLine({ assignedBudgetLineId: 'old', assignedBudgetLineType: 'work_item' }),
+      ]);
+    });
+    act(() => {
+      result.current.handlers.onClearAssign('r1');
+    });
+
+    expect(result.current.lines[0].assignedBudgetLineId).toBeUndefined();
+    expect(onFieldsEdited).toHaveBeenCalled();
+  });
+
+  it('onInlineDraftChange merges updates and calls onFieldsEdited', () => {
+    const onFieldsEdited = jest.fn();
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions({ onFieldsEdited })));
+
+    act(() => {
+      result.current.setLines([
+        makeLine({
+          inlineCreatedBudgetLineDraft: {
+            description: 'old',
+            confidence: 'invoice',
+            plannedAmount: '100',
+            budgetCategoryId: '',
+            budgetSourceId: '',
+            vendorId: '',
+            pricingMode: 'direct',
+            quantity: '',
+            unit: '',
+            unitPrice: '',
+            includesVat: true,
+          },
+        }),
+      ]);
+    });
+    act(() => {
+      result.current.handlers.onInlineDraftChange('r1', { description: 'updated' });
+    });
+
+    expect(result.current.lines[0].inlineCreatedBudgetLineDraft?.description).toBe('updated');
+    expect(onFieldsEdited).toHaveBeenCalled();
+  });
+
+  // ─── Confidence derivation ──────────────────────────────────────────────────
+
+  it('derives invoice confidence + hides field when documentType=Invoice', () => {
+    const { result } = renderHook(() =>
+      useAutoItemizeLines(
+        makeOptions({
+          document: {
+            documentType: 'Invoice',
+            id: 1,
+            title: 'Doc',
+            content: null,
+            tags: [],
+            created: null,
+            added: null,
+            modified: null,
+            correspondent: null,
+            archiveSerialNumber: null,
+            originalFileName: null,
+            pageCount: null,
+            searchHit: null,
+          },
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.setLines([makeLine()]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe('invoice');
+    expect(result.current.lines[0]?.inlineHideConfidence).toBe(true);
+  });
+
+  it('derives quote confidence + hides field when documentType=Quotation', () => {
+    const { result } = renderHook(() =>
+      useAutoItemizeLines(
+        makeOptions({
+          document: {
+            documentType: 'Quotation',
+            id: 1,
+            title: 'Doc',
+            content: null,
+            tags: [],
+            created: null,
+            added: null,
+            modified: null,
+            correspondent: null,
+            archiveSerialNumber: null,
+            originalFileName: null,
+            pageCount: null,
+            searchHit: null,
+          },
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.setLines([makeLine()]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe('quote');
+    expect(result.current.lines[0]?.inlineHideConfidence).toBe(true);
+  });
+
+  it('falls back to score-based confidence (≥0.85 → invoice) when no doc type', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ confidence: 0.95 })]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe('invoice');
+    expect(result.current.lines[0]?.inlineHideConfidence).toBe(false);
+  });
+
+  it('score 0.7 → quote', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ confidence: 0.7 })]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe('quote');
+  });
+
+  it('score 0.4 → professional_estimate', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ confidence: 0.4 })]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe(
+      'professional_estimate',
+    );
+  });
+
+  it('score 0.1 → own_estimate', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([makeLine({ confidence: 0.1 })]);
+      result.current.handlers.onAssign('r1');
+    });
+    act(() => {
+      result.current.handlers.onQueueNewBudgetLine();
+    });
+
+    expect(result.current.lines[0]?.inlineCreatedBudgetLineDraft?.confidence).toBe('own_estimate');
+  });
+
+  // ─── onLineCreated (picker callback) ────────────────────────────────────────
+
+  it('onLineCreated (from picker) assigns the created line to the active row', () => {
+    const { result } = renderHook(() => useAutoItemizeLines(makeOptions()));
+
+    act(() => {
+      result.current.setLines([
+        makeLine({
+          assignedItemId: 'wi-1',
+          assignedItemType: 'work_item',
+          inlineCreatedBudgetLineDraft: {},
+        }),
+      ]);
+      result.current.handlers.onAssign('r1'); // sets activeRowId
+    });
+
+    expect(capturedOnLineCreated).not.toBeNull();
+
+    act(() => {
+      capturedOnLineCreated!({ id: 'created-id', workItemId: 'wi-1', description: 'Created' });
+    });
+
+    expect(result.current.lines[0]).toMatchObject({
+      assignedBudgetLineId: 'created-id',
+      assignedBudgetLineType: 'work_item',
+      inlineCreatedBudgetLineDraft: undefined,
+    });
+  });
+});

--- a/client/src/hooks/useAutoItemizeLines.ts
+++ b/client/src/hooks/useAutoItemizeLines.ts
@@ -1,0 +1,338 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type {
+  WorkItemBudgetLine,
+  HouseholdItemBudgetLine,
+  PaperlessDocumentSearchResult,
+  ConfidenceLevel,
+} from '@cornerstone/shared';
+import { useBudgetLinePicker } from './useBudgetLinePicker.js';
+import type { UseBudgetLinePickerReturn } from './useBudgetLinePicker.js';
+import type { LineWithInclude } from '../components/autoItemize/types.js';
+import type { BudgetLineFormState } from './useBudgetSection.js';
+
+export interface UseAutoItemizeLinesOptions {
+  invoiceId: string;
+  invoiceAmount: number;
+  document?: PaperlessDocumentSearchResult | null;
+  /**
+   * Called after any mutating line handler (field change, assign, clear, etc.).
+   * AutoItemizePage passes `() => setLineFieldsEdited(true)` for dirty tracking.
+   */
+  onFieldsEdited?: () => void;
+}
+
+export interface UseAutoItemizeLinesReturn {
+  lines: LineWithInclude[];
+  setLines: Dispatch<SetStateAction<LineWithInclude[]>>;
+  picker: UseBudgetLinePickerReturn;
+  handlers: {
+    onToggleInclude: (rowId: string) => void;
+    onFieldChange: (rowId: string, field: keyof LineWithInclude, value: unknown) => void;
+    onAssign: (rowId: string) => void;
+    onSelectBudgetLine: (line: WorkItemBudgetLine | HouseholdItemBudgetLine) => void;
+    onQueueNewBudgetLine: () => void;
+    onInlineDraftChange: (rowId: string, updates: Partial<BudgetLineFormState>) => void;
+    onClearAssign: (rowId: string) => void;
+  };
+}
+
+/**
+ * Manages all line-state and picker integration for both auto-itemize flows.
+ *
+ * Internally calls useBudgetLinePicker so the consuming page no longer needs to.
+ * All handlers are stable (useCallback with empty deps) — they read from refs
+ * that are kept current on every render to avoid stale closures.
+ */
+export function useAutoItemizeLines({
+  invoiceId,
+  invoiceAmount,
+  document,
+  onFieldsEdited,
+}: UseAutoItemizeLinesOptions): UseAutoItemizeLinesReturn {
+  const [lines, setLines] = useState<LineWithInclude[]>([]);
+
+  // Mutable refs — updated every render so stable callbacks always see fresh values.
+  const activeRowIdRef = useRef<string | null>(null);
+  const wasCreatedFromExtractionRef = useRef(false);
+  const linesRef = useRef(lines);
+  linesRef.current = lines;
+  const onFieldsEditedRef = useRef(onFieldsEdited);
+  onFieldsEditedRef.current = onFieldsEdited;
+  const documentRef = useRef(document);
+  documentRef.current = document;
+
+  // Filled in after picker is created (breaks the circular dep on picker.closePicker /
+  // picker.openPicker without needing closePicker in useCallback deps).
+  const openPickerRef = useRef<() => void>(() => {});
+  const closePickerRef = useRef<() => void>(() => {});
+
+  // Stable callback: picker calls this after a budget line is created via its form.
+  // Note: useBudgetLinePicker also calls closePicker() after invoking onLineCreated,
+  // so we do not need to do so here.
+  const onLineCreated = useCallback(
+    (line: WorkItemBudgetLine | HouseholdItemBudgetLine) => {
+      const rowId = activeRowIdRef.current;
+      if (!rowId) return;
+      const lineType: 'work_item' | 'household_item' =
+        'workItemId' in line ? 'work_item' : 'household_item';
+      const fromExtraction = wasCreatedFromExtractionRef.current;
+      wasCreatedFromExtractionRef.current = false;
+      setLines((prev) =>
+        prev.map((l) =>
+          l.rowId === rowId
+            ? {
+                ...l,
+                assignedBudgetLineId: line.id,
+                assignedBudgetLineType: lineType,
+                assignedBudgetLineDescription: line.description,
+                createdFromExtraction: fromExtraction,
+                inlineCreatedBudgetLineDraft: undefined,
+                inlineHideConfidence: undefined,
+              }
+            : l,
+        ),
+      );
+      onFieldsEditedRef.current?.();
+      activeRowIdRef.current = null;
+    },
+    [], // empty: all reads from stable refs or state setters
+  );
+
+  const picker = useBudgetLinePicker({
+    invoiceId,
+    invoiceAmount,
+    eagerLinkInvoice: false,
+    onLineCreated,
+  });
+
+  // Keep picker function refs current every render.
+  openPickerRef.current = picker.openPicker;
+  closePickerRef.current = picker.closePicker;
+
+  // Initialize categories, sources, and vendors once on mount.
+  useEffect(() => {
+    void picker.initializeStaticData();
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- initialize once on mount
+  }, []);
+
+  // Re-default budgetSourceId for lines that lack one once sources become available.
+  useEffect(() => {
+    const sources = picker.pickerState.budgetSources;
+    if (!sources || sources.length === 0) return;
+    const firstSourceId = sources[0]?.id;
+    if (!firstSourceId) return;
+    if (!linesRef.current.some((l) => !l.budgetSourceId)) return;
+    /* eslint-disable @eslint-react/set-state-in-effect */
+    setLines((prev) =>
+      prev.map((l) => (l.budgetSourceId ? l : { ...l, budgetSourceId: firstSourceId })),
+    );
+    /* eslint-enable @eslint-react/set-state-in-effect */
+  }, [picker.pickerState.budgetSources]);
+
+  // ─── Handlers ──────────────────────────────────────────────────────────────
+
+  const onToggleInclude = useCallback((rowId: string) => {
+    setLines((prev) => prev.map((l) => (l.rowId === rowId ? { ...l, included: !l.included } : l)));
+  }, []);
+
+  const onFieldChange = useCallback(
+    (rowId: string, field: keyof LineWithInclude, value: unknown) => {
+      setLines((prev) =>
+        prev.map((line) => {
+          if (line.rowId !== rowId) return line;
+          let coercedValue: unknown = value;
+          if (['quantity', 'unitPrice'].includes(field as string)) {
+            if (value === '' || value === null) {
+              coercedValue = null;
+            } else if (typeof value === 'string') {
+              const parsed = parseFloat(value);
+              coercedValue = isNaN(parsed) ? null : parsed;
+            }
+          } else if (field === 'totalAmount') {
+            if (typeof value === 'string') {
+              const parsed = parseFloat(value);
+              coercedValue = isNaN(parsed) ? 0 : parsed;
+            }
+          }
+          return {
+            ...line,
+            [field]: coercedValue,
+            // When the user toggles includesVat on the line card, mirror it into
+            // the inline draft form so the two never drift out of sync.
+            ...(field === 'includesVat' && line.inlineCreatedBudgetLineDraft
+              ? {
+                  inlineCreatedBudgetLineDraft: {
+                    ...line.inlineCreatedBudgetLineDraft,
+                    includesVat: coercedValue as boolean,
+                  },
+                }
+              : {}),
+          };
+        }),
+      );
+      onFieldsEditedRef.current?.();
+    },
+    [],
+  );
+
+  const onAssign = useCallback((rowId: string) => {
+    activeRowIdRef.current = rowId;
+    openPickerRef.current();
+  }, []);
+
+  const onSelectBudgetLine = useCallback(
+    (budgetLine: WorkItemBudgetLine | HouseholdItemBudgetLine) => {
+      const rowId = activeRowIdRef.current;
+      if (!rowId) return;
+      const lineType: 'work_item' | 'household_item' =
+        'workItemId' in budgetLine ? 'work_item' : 'household_item';
+      setLines((prev) =>
+        prev.map((l) =>
+          l.rowId === rowId
+            ? {
+                ...l,
+                assignedBudgetLineId: budgetLine.id,
+                assignedBudgetLineType: lineType,
+                assignedBudgetLineDescription: budgetLine.description ?? null,
+              }
+            : l,
+        ),
+      );
+      onFieldsEditedRef.current?.();
+      closePickerRef.current();
+      activeRowIdRef.current = null;
+    },
+    [],
+  );
+
+  const onQueueNewBudgetLine = useCallback(() => {
+    const rowId = activeRowIdRef.current;
+    if (!rowId) return;
+    const row = linesRef.current.find((l) => l.rowId === rowId);
+    if (!row) return;
+
+    const ps = picker.pickerState;
+    const vendors = ps.vendors ?? [];
+    const sources = ps.budgetSources ?? [];
+    const discretionaryId = sources.find((s) => s.isDiscretionary)?.id;
+    const budgetSourceId = row.budgetSourceId ?? discretionaryId ?? '';
+
+    const vendorId = row.vendorName
+      ? (vendors.find((v) => v.name.toLowerCase() === row.vendorName!.toLowerCase())?.id ?? null)
+      : null;
+
+    // Derive confidence from Paperless document type when available (both flows),
+    // falling back to the ML extraction score.
+    let confidence: ConfidenceLevel;
+    let isConfidenceAutoApplied = false;
+    const docType = documentRef.current?.documentType;
+    if (docType === 'Invoice') {
+      confidence = 'invoice';
+      isConfidenceAutoApplied = true;
+    } else if (docType === 'Quotation') {
+      confidence = 'quote';
+      isConfidenceAutoApplied = true;
+    } else {
+      confidence =
+        row.confidence >= 0.85
+          ? 'invoice'
+          : row.confidence >= 0.6
+            ? 'quote'
+            : row.confidence >= 0.3
+              ? 'professional_estimate'
+              : 'own_estimate';
+    }
+
+    const draft: BudgetLineFormState = {
+      description: row.description ?? '',
+      plannedAmount: String(row.totalAmount ?? ''),
+      confidence,
+      budgetCategoryId: ps.type === 'household_item' ? '' : (row.budgetCategoryId ?? ''),
+      budgetSourceId,
+      vendorId: vendorId ?? '',
+      pricingMode: row.quantity != null && row.unitPrice != null ? 'unit' : 'direct',
+      quantity: row.quantity != null ? String(row.quantity) : '',
+      unit: row.unit ?? '',
+      unitPrice: row.unitPrice != null ? String(row.unitPrice) : '',
+      includesVat: row.includesVat !== false,
+    };
+
+    setLines((prev) =>
+      prev.map((l) =>
+        l.rowId === rowId
+          ? {
+              ...l,
+              assignedItemId: ps.itemId ?? undefined,
+              assignedItemType: ps.type ?? undefined,
+              inlineCreatedBudgetLineDraft: draft,
+              inlineHideConfidence: isConfidenceAutoApplied,
+            }
+          : l,
+      ),
+    );
+    onFieldsEditedRef.current?.();
+    closePickerRef.current();
+    activeRowIdRef.current = null;
+  }, [picker.pickerState]);
+
+  const onInlineDraftChange = useCallback(
+    (rowId: string, updates: Partial<BudgetLineFormState>) => {
+      setLines((prev) =>
+        prev.map((l) =>
+          l.rowId === rowId
+            ? {
+                ...l,
+                // Mirror includesVat changes from the inline form back to the
+                // parent line so the two never drift out of sync.
+                ...(updates.includesVat !== undefined
+                  ? { includesVat: updates.includesVat }
+                  : {}),
+                inlineCreatedBudgetLineDraft: l.inlineCreatedBudgetLineDraft
+                  ? { ...l.inlineCreatedBudgetLineDraft, ...updates }
+                  : l.inlineCreatedBudgetLineDraft,
+              }
+            : l,
+        ),
+      );
+      onFieldsEditedRef.current?.();
+    },
+    [],
+  );
+
+  const onClearAssign = useCallback((rowId: string) => {
+    setLines((prev) =>
+      prev.map((l) =>
+        l.rowId === rowId
+          ? {
+              ...l,
+              assignedBudgetLineId: undefined,
+              assignedBudgetLineType: undefined,
+              assignedBudgetLineDescription: undefined,
+              createdFromExtraction: undefined,
+              assignedItemId: undefined,
+              assignedItemType: undefined,
+              inlineCreatedBudgetLineDraft: undefined,
+              inlineHideConfidence: undefined,
+            }
+          : l,
+      ),
+    );
+    onFieldsEditedRef.current?.();
+  }, []);
+
+  return {
+    lines,
+    setLines,
+    picker,
+    handlers: {
+      onToggleInclude,
+      onFieldChange,
+      onAssign,
+      onSelectBudgetLine,
+      onQueueNewBudgetLine,
+      onInlineDraftChange,
+      onClearAssign,
+    },
+  };
+}

--- a/client/src/lib/autoItemizeDraftUtils.test.ts
+++ b/client/src/lib/autoItemizeDraftUtils.test.ts
@@ -11,8 +11,10 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockCreateWorkItem = jest.fn();
-const mockCreateHouseholdItem = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateWorkItem = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateHouseholdItem = jest.fn<any>();
 
 jest.unstable_mockModule('./errorTranslation.js', () => ({
   translateApiError: (_code: string) => 'Translated error',

--- a/client/src/lib/autoItemizeDraftUtils.test.ts
+++ b/client/src/lib/autoItemizeDraftUtils.test.ts
@@ -1,0 +1,296 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for materializeInlineDrafts.
+ *
+ * Key invariant: financial fields (includesVat, quantity, unit, unitPrice,
+ * plannedAmount) are taken from the LIVE line state, not the draft snapshot.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockCreateWorkItem = jest.fn();
+const mockCreateHouseholdItem = jest.fn();
+
+jest.unstable_mockModule('./errorTranslation.js', () => ({
+  translateApiError: (_code: string) => 'Translated error',
+}));
+
+// ApiClientError mock — has .error.code
+class MockApiClientError extends Error {
+  statusCode = 500;
+  error = { code: 'SERVER_ERROR', message: 'Server error' };
+}
+
+jest.unstable_mockModule('./apiClient.js', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+  put: jest.fn(),
+  setBaseUrl: jest.fn(),
+  getBaseUrl: jest.fn().mockReturnValue('/api'),
+  ApiClientError: MockApiClientError,
+  NetworkError: class MockNetworkError extends Error {},
+}));
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+const i18n = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: (key: string) => key as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tErrors: (key: string) => key as any,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeLine(overrides: Record<string, any> = {}): any {
+  return {
+    rowId: 'row-1',
+    description: 'Tile work',
+    totalAmount: 300,
+    includesVat: true,
+    confidence: 0.9,
+    quantity: null,
+    unit: null,
+    unitPrice: null,
+    vatRate: null,
+    vendorName: null,
+    included: true,
+    budgetCategoryId: 'cat-1',
+    budgetSourceId: 'src-1',
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeDraftLine(overrides: Record<string, any> = {}): any {
+  return makeLine({
+    assignedItemId: 'wi-1',
+    assignedItemType: 'work_item',
+    inlineCreatedBudgetLineDraft: {
+      description: 'Draft desc',
+      plannedAmount: '300',
+      confidence: 'invoice',
+      budgetCategoryId: 'cat-1',
+      budgetSourceId: 'src-1',
+      vendorId: 'v-1',
+      pricingMode: 'direct',
+      quantity: '',
+      unit: '',
+      unitPrice: '',
+      includesVat: true,
+    },
+    ...overrides,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeCreatedBudgetLine(id: string): any {
+  return {
+    id,
+    workItemId: 'wi-1',
+    description: 'Created',
+    plannedAmount: 300,
+    confidence: 'invoice',
+    includesVat: true,
+    quantity: null,
+    unit: null,
+    unitPrice: null,
+    budgetCategory: null,
+    budgetSource: null,
+    vendor: null,
+    actualCost: 0,
+    actualCostPaid: 0,
+    confidenceMargin: 0,
+    invoiceLink: null,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('materializeInlineDrafts', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let materializeInlineDrafts: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockCreateWorkItem.mockResolvedValue(makeCreatedBudgetLine('new-wib-1'));
+    mockCreateHouseholdItem.mockResolvedValue(makeCreatedBudgetLine('new-hib-1'));
+    ({ materializeInlineDrafts } = await import('./autoItemizeDraftUtils.js'));
+  });
+
+  it('passes through lines without a draft unchanged', async () => {
+    const line = makeLine();
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result).toEqual({ ok: true, lines: [line] });
+    expect(mockCreateWorkItem).not.toHaveBeenCalled();
+  });
+
+  it('materialises a draft: calls createWorkItemBudget and converts to assign-existing', async () => {
+    const line = makeDraftLine();
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockCreateWorkItem).toHaveBeenCalledWith(
+      'wi-1',
+      expect.objectContaining({ plannedAmount: 300 }),
+    );
+    expect(result.lines[0]).toMatchObject({
+      assignedBudgetLineId: 'new-wib-1',
+      assignedBudgetLineType: 'work_item',
+      inlineCreatedBudgetLineDraft: undefined,
+    });
+  });
+
+  it('routes household_item to createHouseholdItemBudget', async () => {
+    const line = makeDraftLine({ assignedItemId: 'hi-1', assignedItemType: 'household_item' });
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(true);
+    expect(mockCreateHouseholdItem).toHaveBeenCalled();
+    expect(mockCreateWorkItem).not.toHaveBeenCalled();
+  });
+
+  // ─── VAT / amount sync fix ──────────────────────────────────────────────────
+
+  it('uses live line.includesVat (not stale draft.includesVat) — VAT sync fix', async () => {
+    const line = makeDraftLine({
+      includesVat: false, // live value changed after "New budget line" clicked
+      inlineCreatedBudgetLineDraft: {
+        description: 'desc',
+        plannedAmount: '300',
+        confidence: 'invoice',
+        budgetCategoryId: 'cat-1',
+        budgetSourceId: 'src-1',
+        vendorId: '',
+        pricingMode: 'direct',
+        quantity: '',
+        unit: '',
+        unitPrice: '',
+        includesVat: true, // stale snapshot
+      },
+    });
+
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(true);
+
+    // API payload uses live value
+    expect(mockCreateWorkItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ includesVat: false }),
+    );
+    // Converted line uses live value
+    expect(result.lines[0].includesVat).toBe(false);
+  });
+
+  it('uses live line.totalAmount as plannedAmount in direct mode', async () => {
+    const line = makeDraftLine({
+      totalAmount: 450, // user edited line amount after queuing draft
+      inlineCreatedBudgetLineDraft: {
+        description: 'desc',
+        plannedAmount: '300', // stale
+        confidence: 'invoice',
+        budgetCategoryId: 'cat-1',
+        budgetSourceId: 'src-1',
+        vendorId: '',
+        pricingMode: 'direct',
+        quantity: '',
+        unit: '',
+        unitPrice: '',
+        includesVat: true,
+      },
+    });
+
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(true);
+    expect(mockCreateWorkItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ plannedAmount: 450 }),
+    );
+    expect(result.lines[0].totalAmount).toBe(450);
+  });
+
+  it('computes plannedAmount from live quantity × unitPrice when both are set', async () => {
+    const line = makeDraftLine({
+      quantity: 5,
+      unitPrice: 80,
+      inlineCreatedBudgetLineDraft: {
+        description: 'desc',
+        plannedAmount: '300', // stale
+        confidence: 'invoice',
+        budgetCategoryId: 'cat-1',
+        budgetSourceId: 'src-1',
+        vendorId: '',
+        pricingMode: 'unit',
+        quantity: '3', // stale
+        unit: 'm²',
+        unitPrice: '100', // stale
+        includesVat: true,
+      },
+    });
+
+    const result = await materializeInlineDrafts(
+      [line],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(true);
+    // 5 × 80 = 400, not 3 × 100 = 300
+    expect(mockCreateWorkItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ plannedAmount: 400, quantity: 5, unitPrice: 80 }),
+    );
+  });
+
+  // ─── Error paths ───────────────────────────────────────────────────────────
+
+  it('returns { ok: false } when createWorkItemBudget rejects', async () => {
+    mockCreateWorkItem.mockRejectedValue(new Error('Network failure'));
+    const result = await materializeInlineDrafts(
+      [makeDraftLine()],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(false);
+    expect(typeof (result as { ok: false; error: string }).error).toBe('string');
+  });
+
+  it('processes mixed lines: only materialises the draft line', async () => {
+    const assignedLine = makeLine({ rowId: 'a', assignedBudgetLineId: 'existing' });
+    const draftLine = makeDraftLine({ rowId: 'b' });
+    const plainLine = makeLine({ rowId: 'c' });
+
+    const result = await materializeInlineDrafts(
+      [assignedLine, draftLine, plainLine],
+      { workItem: mockCreateWorkItem, householdItem: mockCreateHouseholdItem },
+      i18n,
+    );
+    expect(result.ok).toBe(true);
+    expect(mockCreateWorkItem).toHaveBeenCalledTimes(1);
+    expect(result.lines[0].rowId).toBe('a');
+    expect(result.lines[1].assignedBudgetLineId).toBe('new-wib-1');
+    expect(result.lines[2].rowId).toBe('c');
+  });
+});

--- a/client/src/lib/autoItemizeDraftUtils.ts
+++ b/client/src/lib/autoItemizeDraftUtils.ts
@@ -1,0 +1,112 @@
+import type { TFunction } from 'i18next';
+import type {
+  WorkItemBudgetLine,
+  HouseholdItemBudgetLine,
+  CreateBudgetLineRequest,
+} from '@cornerstone/shared';
+import type { LineWithInclude } from '../components/autoItemize/types.js';
+import { ApiClientError } from './apiClient.js';
+import { translateApiError } from './errorTranslation.js';
+
+type CreateFn = (
+  itemId: string,
+  data: CreateBudgetLineRequest,
+) => Promise<WorkItemBudgetLine | HouseholdItemBudgetLine>;
+
+interface MaterializeOk {
+  ok: true;
+  lines: LineWithInclude[];
+}
+
+interface MaterializeErr {
+  ok: false;
+  error: string;
+}
+
+/**
+ * Resolve all queued inline-draft budget lines into real IDs before the final
+ * autoItemize commit call.
+ *
+ * Financial fields (amount, includesVat, quantity, unit, unitPrice) are taken
+ * from the LIVE line state so that the created budget line always matches the
+ * invoice line item as the user sees it at save time — not the snapshot taken
+ * when "New budget line" was clicked.
+ *
+ * Metadata (description, confidence, category, source, vendor) comes from the
+ * inline draft form the user filled in.
+ */
+export async function materializeInlineDrafts(
+  workingLines: LineWithInclude[],
+  create: { workItem: CreateFn; householdItem: CreateFn },
+  i18n: { t: TFunction; tErrors: TFunction },
+): Promise<MaterializeOk | MaterializeErr> {
+  const { t, tErrors } = i18n;
+  const result = [...workingLines];
+
+  for (let i = 0; i < result.length; i++) {
+    const line = result[i]!;
+    if (!line.inlineCreatedBudgetLineDraft || !line.assignedItemId || !line.assignedItemType) {
+      continue;
+    }
+
+    const draft = line.inlineCreatedBudgetLineDraft;
+
+    // Derive net base from the LIVE line state.
+    // Unit pricing: quantity × unitPrice (if both set on the live line).
+    // Direct pricing: totalAmount from the live line.
+    const hasUnitPricing = line.quantity != null && line.unitPrice != null;
+    let netBase: number;
+    if (hasUnitPricing) {
+      netBase = Math.round(line.quantity! * line.unitPrice! * 100) / 100;
+    } else {
+      netBase = line.totalAmount ?? 0;
+    }
+
+    if (!isFinite(netBase) || netBase < 0) {
+      return { ok: false, error: t('autoItemize.inlineDraftInvalid') };
+    }
+
+    // Financial fields from live line; metadata-only fields from draft form.
+    const payload: CreateBudgetLineRequest = {
+      description: draft.description.trim() || null,
+      plannedAmount: netBase,
+      confidence: draft.confidence,
+      budgetCategoryId:
+        line.assignedItemType === 'work_item' ? draft.budgetCategoryId || null : null,
+      budgetSourceId: draft.budgetSourceId || null,
+      vendorId: draft.vendorId || null,
+      quantity: hasUnitPricing ? (line.quantity ?? null) : null,
+      unit: hasUnitPricing ? (line.unit ?? null) : null,
+      unitPrice: hasUnitPricing ? (line.unitPrice ?? null) : null,
+      includesVat: line.includesVat, // live line state — NOT draft.includesVat
+    };
+
+    try {
+      const createFn =
+        line.assignedItemType === 'work_item' ? create.workItem : create.householdItem;
+      const created = await createFn(line.assignedItemId, payload);
+
+      // Convert to assign-existing. The downstream autoItemize/commit call
+      // creates the invoice↔budget-line junction; do NOT link here too.
+      result[i] = {
+        ...line,
+        assignedBudgetLineId: created.id,
+        assignedBudgetLineType: line.assignedItemType,
+        totalAmount: netBase, // live amount
+        includesVat: line.includesVat, // live VAT flag
+        inlineCreatedBudgetLineDraft: undefined,
+        inlineHideConfidence: undefined,
+        assignedItemId: undefined,
+        assignedItemType: undefined,
+      };
+    } catch (err) {
+      const errorMsg =
+        err instanceof ApiClientError
+          ? translateApiError(err.error.code, tErrors)
+          : t('autoItemize.inlineDraftCreateFailed');
+      return { ok: false, error: errorMsg };
+    }
+  }
+
+  return { ok: true, lines: result };
+}

--- a/client/src/pages/AutoItemizePage/AutoItemizePage.tsx
+++ b/client/src/pages/AutoItemizePage/AutoItemizePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type {
@@ -8,25 +8,18 @@ import type {
   PaperlessDocumentSearchResult,
   InvoicePatchForAutoItemize,
   InvoiceStatus,
-  WorkItemBudgetLine,
-  HouseholdItemBudgetLine,
-  ConfidenceLevel,
 } from '@cornerstone/shared';
 import type { BadgeVariantMap } from '../../components/Badge/Badge.js';
 import { fetchInvoiceById } from '../../lib/invoicesApi.js';
 import { autoItemize } from '../../lib/invoiceAutoItemizeApi.js';
-import {
-  getPaperlessDocument,
-  getDocumentPreviewUrl,
-  getPaperlessStatus,
-} from '../../lib/paperlessApi.js';
+import { getPaperlessDocument, getPaperlessStatus } from '../../lib/paperlessApi.js';
 import { createWorkItemBudget } from '../../lib/workItemBudgetsApi.js';
 import { createHouseholdItemBudget } from '../../lib/householdItemBudgetsApi.js';
+import { materializeInlineDrafts } from '../../lib/autoItemizeDraftUtils.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import { translateApiError } from '../../lib/errorTranslation.js';
 import { useFormatters } from '../../lib/formatters.js';
-import { useBudgetLinePicker } from '../../hooks/useBudgetLinePicker.js';
-import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+import { useAutoItemizeLines } from '../../hooks/useAutoItemizeLines.js';
 import { Modal } from '../../components/Modal/Modal.js';
 import { Spinner } from '../../components/Spinner/Spinner.js';
 import { FormError } from '../../components/FormError/FormError.js';
@@ -34,6 +27,7 @@ import { SuggestionBadge } from '../../components/SuggestionBadge/SuggestionBadg
 import badgeStyles from '../../components/Badge/Badge.module.css';
 import {
   AutoItemizeLineList,
+  AutoItemizePdfPreview,
   BudgetLinePickerModal,
   type LineWithInclude,
 } from '../../components/autoItemize/index.js';
@@ -57,9 +51,9 @@ export function AutoItemizePage() {
   const navigate = useNavigate();
   const { t } = useTranslation('budget');
   const { t: tErrors } = useTranslation('errors');
+  const { t: tSettings } = useTranslation('settings');
   const { formatCurrency } = useFormatters();
 
-  // Badge variants for "Created from auto-itemization"
   const createdFromExtractionVariants = useMemo(
     (): BadgeVariantMap => ({
       true: {
@@ -70,17 +64,14 @@ export function AutoItemizePage() {
     [t],
   );
 
-  // Page state - ALL hooks must be called unconditionally before any early return
+  // Page state — ALL hooks must be called unconditionally before any early return
   const [pageStatus, setPageStatus] = useState<PageStatus>('loading');
   const [invoice, setInvoice] = useState<Invoice | null>(null);
   const [document, setDocument] = useState<PaperlessDocumentSearchResult | null>(null);
-  const [lines, setLines] = useState<LineWithInclude[]>([]);
   const [warnings, setWarnings] = useState<AutoItemizeWarning[]>([]);
   const [mode, setMode] = useState<'append' | 'replace'>('append');
   const [pageError, setPageError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
-  const [pdfLoaded, setPdfLoaded] = useState(false);
-  const [pdfFailed, setPdfFailed] = useState(false);
   const [paperlessStatus, setPaperlessStatus] = useState<Awaited<
     ReturnType<typeof getPaperlessStatus>
   > | null>(null);
@@ -91,7 +82,6 @@ export function AutoItemizePage() {
   );
   const [extractedNotes, setExtractedNotes] = useState<string | undefined>(undefined);
 
-  // Metadata edits
   const [metadataEdits, setMetadataEdits] = useState<MetadataEdits>({
     invoiceNumber: null,
     amount: '',
@@ -101,66 +91,22 @@ export function AutoItemizePage() {
     status: 'pending',
   });
 
-  // Dirty state tracking and cancel confirmation
   const [isDirty, setIsDirty] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [announceMessage, setAnnounceMessage] = useState('');
-
-  // Budget line picker state
-  const [activeRowId, setActiveRowId] = useState<string | null>(null);
   const [lineFieldsEdited, setLineFieldsEdited] = useState(false);
-  const wasCreatedFromExtractionRef = useRef(false);
-  const { t: tSettings } = useTranslation('settings');
 
-  const picker = useBudgetLinePicker({
-    invoiceId: invoiceId || '',
+  const { lines, setLines, picker, handlers } = useAutoItemizeLines({
+    invoiceId: invoiceId ?? '',
     invoiceAmount: invoice?.amount ?? 0,
-    eagerLinkInvoice: false,
-    onLineCreated: (line, _invoiceBudgetLineId) => {
-      if (!activeRowId) return;
-      // Determine the type from the returned budget line object
-      // WorkItemBudgetLine has workItemId, HouseholdItemBudgetLine has householdItemId
-      const lineType = 'workItemId' in line ? 'work_item' : 'household_item';
-      // Snapshot the ref value NOW (before setLines) so the updater closure captures
-      // the correct value regardless of when React executes the deferred updater.
-      // Reading wasCreatedFromExtractionRef.current INSIDE the setLines updater causes a
-      // race on WebKit: the ref is reset to false before the updater executes (React 18
-      // automatic batching defers updater execution after the synchronous reset).
-      const fromExtraction = wasCreatedFromExtractionRef.current;
-      wasCreatedFromExtractionRef.current = false;
-      // Store the assigned budget line ID, type, and description on the row
-      // Note: when eagerLinkInvoice is false, invoiceBudgetLineId will be null
-      // Use line.id (the work_item_budget or household_item_budget ID) instead
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === activeRowId
-            ? {
-                ...l,
-                assignedBudgetLineId: line.id,
-                assignedBudgetLineType: lineType,
-                assignedBudgetLineDescription: line.description,
-                createdFromExtraction: fromExtraction,
-                inlineCreatedBudgetLineDraft: undefined,
-              }
-            : l,
-        ),
-      );
-      setLineFieldsEdited(true);
-      picker.closePicker();
-      setActiveRowId(null);
-    },
+    document,
+    onFieldsEdited: () => setLineFieldsEdited(true),
   });
-
-  // Eagerly load categories, sources, and vendors on mount
-  useEffect(() => {
-    picker.initializeStaticData();
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- picker is stable, only initialize once on mount
-  }, []);
 
   // Timer effect for elapsed seconds counter
   useEffect(() => {
     if (pageStatus !== 'loading') {
-      // eslint-disable-next-line @eslint-react/set-state-in-effect -- reset counter when loading stops (not synchronous)
+      // eslint-disable-next-line @eslint-react/set-state-in-effect
       setElapsed(0);
       return;
     }
@@ -172,20 +118,17 @@ export function AutoItemizePage() {
 
   // Load invoice and fetch dry-run on mount
   useEffect(() => {
-    if (!invoiceId || !documentId) return; // Guard inside effect
+    if (!invoiceId || !documentId) return;
 
     const loadData = async () => {
       setPageStatus('loading');
       setPageError(null);
       setLineFieldsEdited(false);
       setElapsed(0);
-      setPdfLoaded(false);
-      setPdfFailed(false);
       setExtractedInvoiceNumber(undefined);
       setExtractedNotes(undefined);
 
       try {
-        // Load Paperless status for the fallback link
         try {
           const status = await getPaperlessStatus();
           setPaperlessStatus(status);
@@ -199,11 +142,9 @@ export function AutoItemizePage() {
           });
         }
 
-        // Fetch invoice
         const inv = await fetchInvoiceById(invoiceId);
         setInvoice(inv);
 
-        // Fetch document
         const docId = parseInt(documentId, 10);
         if (isNaN(docId)) {
           setPageError(t('autoItemize.invalidDocumentId'));
@@ -217,7 +158,6 @@ export function AutoItemizePage() {
           searchHit: null,
         });
 
-        // Initialize metadata edits with current invoice data
         setMetadataEdits({
           invoiceNumber: inv.invoiceNumber ?? null,
           amount: inv.amount.toString(),
@@ -227,7 +167,6 @@ export function AutoItemizePage() {
           status: inv.status,
         });
 
-        // Run dry-run auto-itemize
         const _autoItemizeResult = await autoItemize(invoiceId, {
           paperlessDocumentId: docId,
           mode: 'append',
@@ -256,9 +195,7 @@ export function AutoItemizePage() {
         }
       } catch (err) {
         if (err instanceof ApiClientError) {
-          const errorCode = err.error.code;
-          const errorMsg = translateApiError(errorCode, tErrors);
-          setPageError(errorMsg);
+          setPageError(translateApiError(err.error.code, tErrors));
         } else {
           setPageError(t('autoItemize.loadError'));
         }
@@ -283,33 +220,12 @@ export function AutoItemizePage() {
     [invoice],
   );
 
-  // Re-default budgetSourceId when sources become available
-  useEffect(() => {
-    if (
-      picker.pickerState.budgetSources &&
-      picker.pickerState.budgetSources.length > 0 &&
-      lines.some((l) => !l.budgetSourceId)
-    ) {
-      const firstSourceId = picker.pickerState.budgetSources[0]?.id;
-      if (firstSourceId) {
-        /* eslint-disable @eslint-react/set-state-in-effect -- initializes editable lines from extraction result */
-        setLines((prev) =>
-          prev.map((l) => (l.budgetSourceId ? l : { ...l, budgetSourceId: firstSourceId })),
-        );
-        /* eslint-enable @eslint-react/set-state-in-effect */
-      }
-    }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- picker.pickerState identity changes each render; data is stable
-  }, [picker.pickerState.budgetSources]);
-
-  // Track dirty state without synchronous setState in effect
   useEffect(() => {
     const metadataChanged = Object.entries(metadataEdits).some(
       ([key, value]) => value !== originalMetadata[key as keyof MetadataEdits],
     );
     const linesChanged = lines.some((line) => !line.included);
-
-    // eslint-disable-next-line @eslint-react/set-state-in-effect -- Intentional: dirty state must be recalculated when inputs change
+    // eslint-disable-next-line @eslint-react/set-state-in-effect
     setIsDirty(metadataChanged || linesChanged || lineFieldsEdited);
   }, [metadataEdits, lines, originalMetadata, lineFieldsEdited]);
 
@@ -336,87 +252,20 @@ export function AutoItemizePage() {
     try {
       const docId = parseInt(documentId, 10);
       const includedLines = lines.filter((l) => l.included);
-      const workingLines = [...includedLines];
 
-      // Materialize queued create-new lines BEFORE autoItemize call
-      for (let i = 0; i < workingLines.length; i++) {
-        const line = workingLines[i]!;
-        if (!line.inlineCreatedBudgetLineDraft || !line.assignedItemId || !line.assignedItemType) {
-          continue;
-        }
+      const materialized = await materializeInlineDrafts(
+        includedLines,
+        { workItem: createWorkItemBudget, householdItem: createHouseholdItemBudget },
+        { t, tErrors },
+      );
 
-        const draft = line.inlineCreatedBudgetLineDraft!;
-
-        // Parse and validate netBase
-        let netBase: number;
-        if (draft.pricingMode === 'unit') {
-          const q = parseFloat(draft.quantity);
-          const p = parseFloat(draft.unitPrice);
-          if (!isFinite(q) || !isFinite(p)) {
-            setPageError(t('autoItemize.inlineDraftInvalid'));
-            setPageStatus('ready');
-            return;
-          }
-          netBase = Math.round(q * p * 100) / 100;
-        } else {
-          netBase = parseFloat(draft.plannedAmount);
-          if (!isFinite(netBase) || netBase < 0) {
-            setPageError(t('autoItemize.inlineDraftInvalid'));
-            setPageStatus('ready');
-            return;
-          }
-        }
-
-        // Build payload for budget line creation
-        const payload = {
-          description: draft.description.trim() || null,
-          plannedAmount: netBase,
-          confidence: draft.confidence,
-          budgetCategoryId:
-            line.assignedItemType === 'work_item' ? draft.budgetCategoryId || null : null,
-          budgetSourceId: draft.budgetSourceId || null,
-          vendorId: draft.vendorId || null,
-          quantity: draft.pricingMode === 'unit' ? parseFloat(draft.quantity) || null : null,
-          unit: draft.pricingMode === 'unit' ? draft.unit || null : null,
-          unitPrice: draft.pricingMode === 'unit' ? parseFloat(draft.unitPrice) || null : null,
-          includesVat: draft.includesVat,
-        };
-
-        // Create the budget line
-        let newBudgetLineId: string;
-        try {
-          const createFn =
-            line.assignedItemType === 'work_item'
-              ? createWorkItemBudget
-              : createHouseholdItemBudget;
-          const createdBudgetLine = await createFn(line.assignedItemId, payload);
-          newBudgetLineId = createdBudgetLine.id;
-        } catch (err) {
-          const errorMsg =
-            err instanceof ApiClientError
-              ? translateApiError(err.error.code, tErrors)
-              : t('autoItemize.inlineDraftCreateFailed');
-          setPageError(errorMsg);
-          setPageStatus('ready');
-          return;
-        }
-
-        // Convert the queued line to an assign-existing entry. The single
-        // autoItemize call below creates the invoice<->budget-line junction and
-        // stores the GROSS itemized amount server-side (effectiveLineAmount on
-        // totalAmount + includesVat). We must NOT link here as well, or the
-        // junction would be created twice (BUDGET_LINE_ALREADY_LINKED).
-        workingLines[i] = {
-          ...line,
-          assignedBudgetLineId: newBudgetLineId,
-          assignedBudgetLineType: line.assignedItemType,
-          totalAmount: netBase,
-          includesVat: draft.includesVat,
-          inlineCreatedBudgetLineDraft: undefined,
-          assignedItemId: undefined,
-          assignedItemType: undefined,
-        };
+      if (!materialized.ok) {
+        setPageError(materialized.error);
+        setPageStatus('ready');
+        return;
       }
+
+      const workingLines = materialized.lines;
 
       // Build invoicePatch only if metadata changed
       const patch: Partial<InvoicePatchForAutoItemize> = {};
@@ -439,7 +288,6 @@ export function AutoItemizePage() {
         patch.status = metadataEdits.status;
       }
 
-      // Validate that all included lines have a category (including materialized ones)
       const missingCategories = workingLines.filter(
         (l) => !l.assignedBudgetLineId && !l.budgetCategoryId,
       );
@@ -449,8 +297,6 @@ export function AutoItemizePage() {
         return;
       }
 
-      // Map lines to payload using workingLines (which includes materialized results)
-      // Note: vatRate is omitted from the payload (dropped from UI)
       const linesPayload: ExtractedLine[] = workingLines.map((l) => ({
         description: l.description,
         quantity: l.quantity,
@@ -481,13 +327,10 @@ export function AutoItemizePage() {
         ...(Object.keys(patch).length > 0 ? { invoicePatch: patch } : {}),
       });
 
-      // Navigate back on success
       navigate(`/budget/invoices/${invoiceId}`);
     } catch (err) {
       if (err instanceof ApiClientError) {
-        const errorCode = err.error.code;
-        const errorMsg = translateApiError(errorCode, tErrors);
-        setPageError(errorMsg);
+        setPageError(translateApiError(err.error.code, tErrors));
       } else {
         setPageError(t('autoItemize.saveError'));
       }
@@ -513,173 +356,6 @@ export function AutoItemizePage() {
       setAnnounceMessage(t('autoItemize.suggestionApplied', { field }));
     },
     [t],
-  );
-
-  const handleLineToggle = useCallback((rowId: string) => {
-    setLines((prev) =>
-      prev.map((line) => (line.rowId === rowId ? { ...line, included: !line.included } : line)),
-    );
-  }, []);
-
-  const handleLineFieldChange = useCallback(
-    (rowId: string, field: keyof LineWithInclude, value: unknown) => {
-      setLines((prev) =>
-        prev.map((line) => {
-          if (line.rowId !== rowId) return line;
-
-          // Type coercion for different field types
-          let coercedValue: unknown = value;
-
-          // For number fields, convert empty string to null, else parse
-          if (['quantity', 'unitPrice'].includes(field as string)) {
-            if (value === '' || value === null) {
-              coercedValue = null;
-            } else if (typeof value === 'string') {
-              const parsed = parseFloat(value);
-              coercedValue = isNaN(parsed) ? null : parsed;
-            }
-          }
-          // For totalAmount, always parse as number
-          else if (field === 'totalAmount') {
-            if (typeof value === 'string') {
-              const parsed = parseFloat(value);
-              coercedValue = isNaN(parsed) ? 0 : parsed;
-            }
-          }
-
-          return {
-            ...line,
-            [field]: coercedValue,
-            ...(field === 'includesVat' && line.inlineCreatedBudgetLineDraft
-              ? {
-                  inlineCreatedBudgetLineDraft: {
-                    ...line.inlineCreatedBudgetLineDraft,
-                    includesVat: coercedValue as boolean,
-                  },
-                }
-              : {}),
-          };
-        }),
-      );
-      setLineFieldsEdited(true);
-    },
-    [],
-  );
-
-  const handleAssignButtonClick = useCallback(
-    (rowId: string) => {
-      setActiveRowId(rowId);
-      picker.openPicker();
-    },
-    [picker],
-  );
-
-  /**
-   * Step 2: User selects a budget line from the filtered list.
-   * Do NOT call any API — just store the budget line ID and details on the row.
-   */
-  const handleSelectBudgetLine = useCallback(
-    (budgetLine: WorkItemBudgetLine | HouseholdItemBudgetLine) => {
-      if (!activeRowId) return;
-
-      const lineType: 'work_item' | 'household_item' =
-        'workItemId' in budgetLine ? 'work_item' : 'household_item';
-
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === activeRowId
-            ? {
-                ...l,
-                assignedBudgetLineId: budgetLine.id,
-                assignedBudgetLineType: lineType,
-                assignedBudgetLineDescription: budgetLine.description ?? null,
-              }
-            : l,
-        ),
-      );
-      setLineFieldsEdited(true);
-      picker.closePicker();
-      setActiveRowId(null);
-    },
-    [activeRowId, picker],
-  );
-
-  const handleQueueNewBudgetLine = useCallback(() => {
-    if (!activeRowId) return;
-    const row = lines.find((l) => l.rowId === activeRowId);
-    if (!row) return;
-
-    // Resolve vendorId from row's vendorName against already-loaded vendors
-    const vendors = picker.pickerState.vendors ?? [];
-    const vendorId = row.vendorName
-      ? (vendors.find((v) => v.name.toLowerCase() === row.vendorName!.toLowerCase())?.id ?? null)
-      : null;
-
-    // Resolve budgetSourceId: use row's value or fall back to discretionary
-    const sources = picker.pickerState.budgetSources ?? [];
-    const discretionaryId = sources.find((s) => s.isDiscretionary)?.id;
-    const budgetSourceId = row.budgetSourceId ?? discretionaryId ?? '';
-
-    // Map numeric confidence (0..1) to ConfidenceLevel enum
-    const confidence: ConfidenceLevel =
-      row.confidence >= 0.85
-        ? 'invoice'
-        : row.confidence >= 0.6
-          ? 'quote'
-          : row.confidence >= 0.3
-            ? 'professional_estimate'
-            : 'own_estimate';
-
-    const draft: BudgetLineFormState = {
-      description: row.description ?? '',
-      plannedAmount: String(row.totalAmount ?? ''),
-      confidence,
-      budgetCategoryId:
-        picker.pickerState.type === 'household_item' ? '' : (row.budgetCategoryId ?? ''),
-      budgetSourceId,
-      vendorId: vendorId ?? '',
-      pricingMode: row.quantity != null && row.unitPrice != null ? 'unit' : 'direct',
-      quantity: row.quantity != null ? String(row.quantity) : '',
-      unit: row.unit ?? '',
-      unitPrice: row.unitPrice != null ? String(row.unitPrice) : '',
-      includesVat: row.includesVat !== false,
-    };
-
-    setLines((prev) =>
-      prev.map((l) =>
-        l.rowId === activeRowId
-          ? {
-              ...l,
-              assignedItemId: picker.pickerState.itemId ?? undefined,
-              assignedItemType: picker.pickerState.type ?? undefined,
-              inlineCreatedBudgetLineDraft: draft,
-            }
-          : l,
-      ),
-    );
-    setLineFieldsEdited(true);
-    picker.closePicker();
-    setActiveRowId(null);
-  }, [activeRowId, lines, picker]);
-
-  const handleInlineDraftChange = useCallback(
-    (rowId: string, updates: Partial<BudgetLineFormState>) => {
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === rowId
-            ? {
-                ...l,
-                ...(updates.includesVat !== undefined ? { includesVat: updates.includesVat } : {}),
-                inlineCreatedBudgetLineDraft: l.inlineCreatedBudgetLineDraft
-                  ? { ...l.inlineCreatedBudgetLineDraft, ...updates }
-                  : l.inlineCreatedBudgetLineDraft,
-              }
-            : l,
-        ),
-      );
-      setLineFieldsEdited(true);
-    },
-    [],
   );
 
   const handleRetry = useCallback(() => {
@@ -716,9 +392,7 @@ export function AutoItemizePage() {
         }
       } catch (err) {
         if (err instanceof ApiClientError) {
-          const errorCode = err.error.code;
-          const errorMsg = translateApiError(errorCode, tErrors);
-          setPageError(errorMsg);
+          setPageError(translateApiError(err.error.code, tErrors));
         } else {
           setPageError(t('autoItemize.loadError'));
         }
@@ -727,10 +401,9 @@ export function AutoItemizePage() {
     };
 
     void loadData();
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- picker.pickerState identity changes each render; its data is stable so the effect re-runs on the listed deps only
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- picker.pickerState identity changes each render; its data is stable
   }, [invoiceId, documentId, t, tErrors]);
 
-  // Suggest amount from warnings
   const amountSuggestion = useMemo(
     () => warnings.find((w) => w.code === 'TOTAL_MISMATCH')?.extractedTotal,
     [warnings],
@@ -783,12 +456,10 @@ export function AutoItemizePage() {
     };
   }, [lines, metadataEdits.amount, invoice?.amount]);
 
-  // Guard for missing params (after all hooks are called)
   if (!invoiceId || !documentId) {
     return <div>{t('autoItemize.error')}</div>;
   }
 
-  // Render content based on page status
   if (pageStatus === 'loading') {
     return (
       <div className={styles.pageContainer}>
@@ -849,12 +520,10 @@ export function AutoItemizePage() {
               {t('autoItemize.skipToForm')}
             </a>
 
-            {/* Live region for announcements */}
             <div role="status" aria-atomic="true" className={sharedStyles.srOnly}>
               {announceMessage}
             </div>
 
-            {/* Error banner */}
             {pageError && <FormError variant="banner" message={pageError} />}
 
             {/* Metadata section */}
@@ -900,10 +569,7 @@ export function AutoItemizePage() {
                       step="0.01"
                       value={metadataEdits.amount}
                       onChange={(e) =>
-                        setMetadataEdits((prev) => ({
-                          ...prev,
-                          amount: e.target.value,
-                        }))
+                        setMetadataEdits((prev) => ({ ...prev, amount: e.target.value }))
                       }
                     />
                   </div>
@@ -927,10 +593,7 @@ export function AutoItemizePage() {
                       type="date"
                       value={metadataEdits.date}
                       onChange={(e) =>
-                        setMetadataEdits((prev) => ({
-                          ...prev,
-                          date: e.target.value,
-                        }))
+                        setMetadataEdits((prev) => ({ ...prev, date: e.target.value }))
                       }
                     />
                   </div>
@@ -1059,28 +722,10 @@ export function AutoItemizePage() {
               <h3 className={styles.sectionTitle}>{t('autoItemize.extractedLines')}</h3>
               <AutoItemizeLineList
                 lines={lines}
-                onToggleInclude={handleLineToggle}
-                onFieldChange={handleLineFieldChange}
-                onAssign={handleAssignButtonClick}
-                onClearAssign={(rowId) => {
-                  setLines((prev) =>
-                    prev.map((l) =>
-                      l.rowId === rowId
-                        ? {
-                            ...l,
-                            assignedBudgetLineId: undefined,
-                            assignedBudgetLineType: undefined,
-                            assignedBudgetLineDescription: undefined,
-                            createdFromExtraction: undefined,
-                            assignedItemId: undefined,
-                            assignedItemType: undefined,
-                            inlineCreatedBudgetLineDraft: undefined,
-                          }
-                        : l,
-                    ),
-                  );
-                  setLineFieldsEdited(true);
-                }}
+                onToggleInclude={handlers.onToggleInclude}
+                onFieldChange={handlers.onFieldChange}
+                onAssign={handlers.onAssign}
+                onClearAssign={handlers.onClearAssign}
                 categories={picker.pickerState.categories ?? []}
                 budgetSources={picker.pickerState.budgetSources ?? []}
                 discretionarySourceId={
@@ -1093,7 +738,7 @@ export function AutoItemizePage() {
                 formatCurrency={formatCurrency}
                 t={t}
                 tSettings={tSettings}
-                onInlineDraftChange={handleInlineDraftChange}
+                onInlineDraftChange={handlers.onInlineDraftChange}
                 confidenceLabels={CONFIDENCE_LABELS}
                 vendors={picker.pickerState.vendors ?? []}
                 budgetCategories={picker.pickerState.categories ?? []}
@@ -1121,56 +766,13 @@ export function AutoItemizePage() {
             </div>
           </div>
 
-          {/* Preview column — PDF iframe */}
+          {/* Preview column */}
           <div className={styles.previewColumn}>
-            {!pdfFailed ? (
-              <div className={styles.pdfPreviewWrapper}>
-                {!pdfLoaded && (
-                  <div className={styles.pdfLoadingOverlay} aria-hidden="true">
-                    <Spinner size="md" color="muted" label={t('autoItemize.pdfPreviewTitle')} />
-                  </div>
-                )}
-                <iframe
-                  className={styles.pdfIframe}
-                  src={getDocumentPreviewUrl(parseInt(documentId, 10))}
-                  title={t('autoItemize.pdfPreviewTitle')}
-                  onLoad={() => setPdfLoaded(true)}
-                  onErrorCapture={() => setPdfFailed(true)}
-                />
-              </div>
-            ) : (
-              <div
-                className={styles.pdfFallback}
-                role="region"
-                aria-label={t('autoItemize.previewUnavailable')}
-              >
-                <svg
-                  aria-hidden="true"
-                  width="32"
-                  height="32"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="var(--color-text-muted)"
-                  strokeWidth="1.5"
-                >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span className={styles.pdfFallbackLabel}>
-                  {t('autoItemize.previewUnavailable')}
-                </span>
-                {paperlessStatus?.paperlessUrl && (
-                  <a
-                    href={`${paperlessStatus.paperlessUrl}/documents/${documentId}/`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.pdfFallbackLink}
-                  >
-                    {t('autoItemize.openInPaperless')}
-                  </a>
-                )}
-              </div>
-            )}
+            <AutoItemizePdfPreview
+              documentId={parseInt(documentId, 10)}
+              paperlessUrl={paperlessStatus?.paperlessUrl}
+              t={t}
+            />
           </div>
         </div>
       </div>
@@ -1192,8 +794,8 @@ export function AutoItemizePage() {
             setPickerState={picker.setPickerState}
             handleSelectItem={picker.handleSelectItem}
             createBudgetLineButtonRef={picker.createBudgetLineButtonRef}
-            onSelectBudgetLine={handleSelectBudgetLine}
-            onCreateNewBudgetLine={handleQueueNewBudgetLine}
+            onSelectBudgetLine={handlers.onSelectBudgetLine}
+            onCreateNewBudgetLine={handlers.onQueueNewBudgetLine}
             onBackToStep1={() =>
               picker.setPickerState((prev) => ({
                 ...prev,

--- a/client/src/pages/PaperlessInvoiceReviewPage/PaperlessInvoiceReviewPage.test.tsx
+++ b/client/src/pages/PaperlessInvoiceReviewPage/PaperlessInvoiceReviewPage.test.tsx
@@ -31,7 +31,6 @@ import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type * as PaperlessApiModule from '../../lib/paperlessApi.js';
 import type * as InvoiceAutoItemizeApiModule from '../../lib/invoiceAutoItemizeApi.js';
-import type * as VendorsApiModule from '../../lib/vendorsApi.js';
 import type {
   PaperlessDocumentDetailResponse,
   AutoItemizePreviewResponse,

--- a/client/src/pages/PaperlessInvoiceReviewPage/PaperlessInvoiceReviewPage.tsx
+++ b/client/src/pages/PaperlessInvoiceReviewPage/PaperlessInvoiceReviewPage.tsx
@@ -1,29 +1,22 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useLocation, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type {
   ExtractedLine,
   PaperlessDocumentSearchResult,
   CreateInvoiceRequest,
-  ConfidenceLevel,
-  WorkItemBudgetLine,
-  HouseholdItemBudgetLine,
 } from '@cornerstone/shared';
 import { createWorkItemBudget } from '../../lib/workItemBudgetsApi.js';
 import { createHouseholdItemBudget } from '../../lib/householdItemBudgetsApi.js';
+import { materializeInlineDrafts } from '../../lib/autoItemizeDraftUtils.js';
 import type { BadgeVariantMap } from '../../components/Badge/Badge.js';
-import {
-  getPaperlessDocument,
-  getDocumentPreviewUrl,
-  getPaperlessStatus,
-} from '../../lib/paperlessApi.js';
+import { getPaperlessDocument, getPaperlessStatus } from '../../lib/paperlessApi.js';
 import { previewAutoItemize, commitAutoItemizeCreate } from '../../lib/invoiceAutoItemizeApi.js';
 import { fetchVendors } from '../../lib/vendorsApi.js';
 import { ApiClientError } from '../../lib/apiClient.js';
 import { translateApiError } from '../../lib/errorTranslation.js';
 import { useFormatters } from '../../lib/formatters.js';
-import { useBudgetLinePicker } from '../../hooks/useBudgetLinePicker.js';
-import type { BudgetLineFormState } from '../../hooks/useBudgetSection.js';
+import { useAutoItemizeLines } from '../../hooks/useAutoItemizeLines.js';
 import { Modal } from '../../components/Modal/Modal.js';
 import { Spinner } from '../../components/Spinner/Spinner.js';
 import { FormError } from '../../components/FormError/FormError.js';
@@ -32,6 +25,7 @@ import { SearchPicker } from '../../components/SearchPicker/SearchPicker.js';
 import badgeStyles from '../../components/Badge/Badge.module.css';
 import {
   AutoItemizeLineList,
+  AutoItemizePdfPreview,
   BudgetLinePickerModal,
   type LineWithInclude,
 } from '../../components/autoItemize/index.js';
@@ -65,7 +59,6 @@ export function PaperlessInvoiceReviewPage() {
   const state = (location.state || {}) as LocationState;
   const documentId = state.documentId;
 
-  // Badge variants
   const createdFromExtractionVariants = useMemo(
     (): BadgeVariantMap => ({
       true: {
@@ -76,13 +69,13 @@ export function PaperlessInvoiceReviewPage() {
     [t],
   );
 
-  // Page state
   const [pageStatus, setPageStatus] = useState<PageStatus>('loading');
   const [document, setDocument] = useState<PaperlessDocumentSearchResult | null>(null);
-  const [lines, setLines] = useState<LineWithInclude[]>([]);
   const [pageError, setPageError] = useState<string | null>(null);
+  const [paperlessStatus, setPaperlessStatus] = useState<Awaited<
+    ReturnType<typeof getPaperlessStatus>
+  > | null>(null);
 
-  // Metadata edits (date initialized in effect)
   const [metadataEdits, setMetadataEdits] = useState<MetadataEdits>({
     invoiceNumber: null,
     amount: '',
@@ -98,60 +91,27 @@ export function PaperlessInvoiceReviewPage() {
   const [vendorError, setVendorError] = useState<string | null>(null);
   const [vendors, setVendors] = useState<Array<{ id: string; name: string }>>([]);
 
-  // PDF preview state
-  const [pdfLoaded, setPdfLoaded] = useState(false);
-  const [pdfFailed, setPdfFailed] = useState(false);
-  const [paperlessStatus, setPaperlessStatus] = useState<Awaited<
-    ReturnType<typeof getPaperlessStatus>
-  > | null>(null);
-
-  // Dirty state tracking
-  const wasCreatedFromExtractionRef = useRef(false);
-
-  // Budget line picker state
-  const [activeRowId, setActiveRowId] = useState<string | null>(null);
-
-  const picker = useBudgetLinePicker({
+  const { lines, setLines, picker, handlers } = useAutoItemizeLines({
     invoiceId: '',
     invoiceAmount: parseFloat(metadataEdits.amount) || 0,
-    eagerLinkInvoice: false,
-    onLineCreated: (line, _invoiceBudgetLineId) => {
-      if (!activeRowId) return;
-      const lineType = 'workItemId' in line ? 'work_item' : 'household_item';
-      const fromExtraction = wasCreatedFromExtractionRef.current;
-      wasCreatedFromExtractionRef.current = false;
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === activeRowId
-            ? {
-                ...l,
-                assignedBudgetLineId: line.id,
-                assignedBudgetLineType: lineType,
-                assignedBudgetLineDescription: line.description,
-                createdFromExtraction: fromExtraction,
-                inlineCreatedBudgetLineDraft: undefined,
-                inlineHideConfidence: undefined,
-              }
-            : l,
-        ),
-      );
-      picker.closePicker();
-      setActiveRowId(null);
-    },
+    document,
   });
 
-  // Initialize static data on mount
-  useEffect(() => {
-    picker.initializeStaticData();
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, []);
-
-  // Load vendors on mount
+  // Load vendors for the SearchPicker on mount.
   useEffect(() => {
     void fetchVendors({ pageSize: 100 }).then((res) =>
       setVendors(res.vendors.map((v) => ({ id: v.id, name: v.name }))),
     );
   }, []);
+
+  // Back-fill suggested vendor name from loaded vendors.
+  useEffect(() => {
+    if (suggestedVendorId && vendors.length > 0 && !suggestedVendorName) {
+      const match = vendors.find((v) => v.id === suggestedVendorId);
+      // eslint-disable-next-line @eslint-react/set-state-in-effect
+      if (match) setSuggestedVendorName(match.name);
+    }
+  }, [vendors, suggestedVendorId, suggestedVendorName]);
 
   // Load document and run preview on mount
   useEffect(() => {
@@ -160,11 +120,8 @@ export function PaperlessInvoiceReviewPage() {
     const loadData = async () => {
       setPageStatus('loading');
       setPageError(null);
-      setPdfLoaded(false);
-      setPdfFailed(false);
 
       try {
-        // Load Paperless status for the fallback link
         try {
           const status = await getPaperlessStatus();
           setPaperlessStatus(status);
@@ -178,20 +135,10 @@ export function PaperlessInvoiceReviewPage() {
           });
         }
 
-        // Fetch document
         const docResponse = await getPaperlessDocument(documentId);
         setDocument({
           ...docResponse.document,
           searchHit: null,
-        });
-
-        // Initialize metadata edits with default values
-        setMetadataEdits({
-          invoiceNumber: null,
-          amount: '',
-          date: new Date().toISOString().split('T')[0] ?? '',
-          dueDate: null,
-          notes: null,
         });
 
         // Run preview auto-itemize
@@ -209,21 +156,19 @@ export function PaperlessInvoiceReviewPage() {
 
         setLines(linesWithInclude);
 
-        // Set suggested vendor ID if available (name resolution deferred to separate effect)
         if (previewResult.suggestedVendorId) {
           setSuggestedVendorId(previewResult.suggestedVendorId);
           setVendorId(previewResult.suggestedVendorId);
         }
 
-        // Compute total from extracted line amounts (accounting for VAT-gross-up on net lines)
-        const computedTotal = linesWithInclude.reduce((sum, line) => {
-          return (
+        // Compute total from extracted line amounts (accounting for VAT gross-up on net lines)
+        const computedTotal = linesWithInclude.reduce(
+          (sum, line) =>
             sum +
-            effectiveLineAmount({ amount: line.totalAmount ?? 0, includesVat: line.includesVat })
-          );
-        }, 0);
+            effectiveLineAmount({ amount: line.totalAmount ?? 0, includesVat: line.includesVat }),
+          0,
+        );
 
-        // Initialize metadata from extraction
         setMetadataEdits({
           invoiceNumber: previewResult.extractedInvoiceNumber ?? null,
           amount: computedTotal > 0 ? String(computedTotal) : '',
@@ -235,9 +180,7 @@ export function PaperlessInvoiceReviewPage() {
         setPageStatus('ready');
       } catch (err) {
         if (err instanceof ApiClientError) {
-          const errorCode = err.error.code;
-          const errorMsg = translateApiError(errorCode, tErrors);
-          setPageError(errorMsg);
+          setPageError(translateApiError(err.error.code, tErrors));
         } else {
           setPageError(t('autoItemize.loadError'));
         }
@@ -246,16 +189,8 @@ export function PaperlessInvoiceReviewPage() {
     };
 
     void loadData();
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- picker.pickerState identity changes each render
   }, [documentId, t, tErrors]);
-
-  // Back-fill suggested vendor name from loaded vendors
-  useEffect(() => {
-    if (suggestedVendorId && vendors.length > 0 && !suggestedVendorName) {
-      const match = vendors.find((v) => v.id === suggestedVendorId);
-      if (match) setSuggestedVendorName(match.name);
-    }
-  }, [vendors, suggestedVendorId, suggestedVendorName]);
 
   const handleCancel = useCallback(() => {
     navigate('/budget/invoices');
@@ -264,7 +199,6 @@ export function PaperlessInvoiceReviewPage() {
   const handleSave = useCallback(async () => {
     if (!documentId || !document) return;
 
-    // Vendor validation — inline field error (not silent)
     if (!vendorId) {
       setVendorError(t('autoItemize.vendorRequired'));
       return;
@@ -276,11 +210,9 @@ export function PaperlessInvoiceReviewPage() {
 
     try {
       const includedLines = lines.filter((l) => l.included);
-      const workingLines = [...includedLines];
 
-      // Validate that all included lines with create-new mode have a category
-      // Lines with inlineCreatedBudgetLineDraft are exempt (category is in the draft)
-      const missingCategories = workingLines.filter(
+      // Validate categories before materialization (lines with inline draft are exempt)
+      const missingCategories = includedLines.filter(
         (l) => !l.assignedBudgetLineId && !l.inlineCreatedBudgetLineDraft && !l.budgetCategoryId,
       );
       if (missingCategories.length > 0) {
@@ -289,84 +221,20 @@ export function PaperlessInvoiceReviewPage() {
         return;
       }
 
-      // Materialize queued create-new lines BEFORE commitAutoItemizeCreate call
-      for (let i = 0; i < workingLines.length; i++) {
-        const line = workingLines[i]!;
-        if (!line.inlineCreatedBudgetLineDraft || !line.assignedItemId || !line.assignedItemType) {
-          continue;
-        }
+      const materialized = await materializeInlineDrafts(
+        includedLines,
+        { workItem: createWorkItemBudget, householdItem: createHouseholdItemBudget },
+        { t, tErrors },
+      );
 
-        const draft = line.inlineCreatedBudgetLineDraft!;
-
-        // Parse and validate netBase
-        let netBase: number;
-        if (draft.pricingMode === 'unit') {
-          const q = parseFloat(draft.quantity);
-          const p = parseFloat(draft.unitPrice);
-          if (!isFinite(q) || !isFinite(p)) {
-            setPageError(t('autoItemize.inlineDraftInvalid'));
-            setPageStatus('ready');
-            return;
-          }
-          netBase = Math.round(q * p * 100) / 100;
-        } else {
-          netBase = parseFloat(draft.plannedAmount);
-          if (!isFinite(netBase) || netBase < 0) {
-            setPageError(t('autoItemize.inlineDraftInvalid'));
-            setPageStatus('ready');
-            return;
-          }
-        }
-
-        // Build payload for budget line creation
-        const payload = {
-          description: draft.description.trim() || null,
-          plannedAmount: netBase,
-          confidence: draft.confidence,
-          budgetCategoryId:
-            line.assignedItemType === 'work_item' ? draft.budgetCategoryId || null : null,
-          budgetSourceId: draft.budgetSourceId || null,
-          vendorId: draft.vendorId || null,
-          quantity: draft.pricingMode === 'unit' ? parseFloat(draft.quantity) || null : null,
-          unit: draft.pricingMode === 'unit' ? draft.unit || null : null,
-          unitPrice: draft.pricingMode === 'unit' ? parseFloat(draft.unitPrice) || null : null,
-          includesVat: draft.includesVat,
-        };
-
-        // Create the budget line
-        let newBudgetLineId: string;
-        try {
-          const createFn =
-            line.assignedItemType === 'work_item'
-              ? createWorkItemBudget
-              : createHouseholdItemBudget;
-          const createdBudgetLine = await createFn(line.assignedItemId, payload);
-          newBudgetLineId = createdBudgetLine.id;
-        } catch (err) {
-          const errorMsg =
-            err instanceof ApiClientError
-              ? translateApiError(err.error.code, tErrors)
-              : t('autoItemize.inlineDraftCreateFailed');
-          setPageError(errorMsg);
-          setPageStatus('ready');
-          return;
-        }
-
-        // Convert the queued line to an assign-existing entry.
-        workingLines[i] = {
-          ...line,
-          assignedBudgetLineId: newBudgetLineId,
-          assignedBudgetLineType: line.assignedItemType,
-          totalAmount: netBase,
-          includesVat: draft.includesVat,
-          inlineCreatedBudgetLineDraft: undefined,
-          inlineHideConfidence: undefined,
-          assignedItemId: undefined,
-          assignedItemType: undefined,
-        };
+      if (!materialized.ok) {
+        setPageError(materialized.error);
+        setPageStatus('ready');
+        return;
       }
 
-      // Build invoice creation request
+      const workingLines = materialized.lines;
+
       const invoice: CreateInvoiceRequest = {
         invoiceNumber: metadataEdits.invoiceNumber ?? null,
         amount: parseFloat(metadataEdits.amount) || 0,
@@ -376,7 +244,6 @@ export function PaperlessInvoiceReviewPage() {
         notes: metadataEdits.notes ?? null,
       };
 
-      // Map lines to payload using workingLines (which includes materialized results)
       const linesPayload: ExtractedLine[] = workingLines.map((l) => ({
         description: l.description,
         quantity: l.quantity,
@@ -399,7 +266,6 @@ export function PaperlessInvoiceReviewPage() {
             }),
       }));
 
-      // Commit the invoice creation
       const result = await commitAutoItemizeCreate({
         paperlessDocumentId: documentId,
         vendorId,
@@ -407,185 +273,16 @@ export function PaperlessInvoiceReviewPage() {
         lines: linesPayload,
       });
 
-      // Navigate to the created invoice
       navigate(`/budget/invoices/${result.invoice.id}`);
     } catch (err) {
       if (err instanceof ApiClientError) {
-        const errorCode = err.error.code;
-        const errorMsg = translateApiError(errorCode, tErrors);
-        setPageError(errorMsg);
+        setPageError(translateApiError(err.error.code, tErrors));
       } else {
         setPageError(t('autoItemize.saveError'));
       }
       setPageStatus('ready');
     }
   }, [documentId, document, vendorId, lines, metadataEdits, navigate, t, tErrors]);
-
-  const handleLineToggle = useCallback((rowId: string) => {
-    setLines((prev) =>
-      prev.map((line) => (line.rowId === rowId ? { ...line, included: !line.included } : line)),
-    );
-  }, []);
-
-  const handleLineFieldChange = useCallback(
-    (rowId: string, field: keyof LineWithInclude, value: unknown) => {
-      setLines((prev) =>
-        prev.map((line) => {
-          if (line.rowId !== rowId) return line;
-
-          let coercedValue: unknown = value;
-
-          if (['quantity', 'unitPrice'].includes(field as string)) {
-            if (value === '' || value === null) {
-              coercedValue = null;
-            } else if (typeof value === 'string') {
-              const parsed = parseFloat(value);
-              coercedValue = isNaN(parsed) ? null : parsed;
-            }
-          } else if (field === 'totalAmount') {
-            if (typeof value === 'string') {
-              const parsed = parseFloat(value);
-              coercedValue = isNaN(parsed) ? 0 : parsed;
-            }
-          }
-
-          return {
-            ...line,
-            [field]: coercedValue,
-          };
-        }),
-      );
-    },
-    [],
-  );
-
-  const handleAssignButtonClick = useCallback(
-    (rowId: string) => {
-      setActiveRowId(rowId);
-      picker.openPicker();
-    },
-    [picker],
-  );
-
-  /**
-   * Step 2: User selects a budget line from the filtered list.
-   * Do NOT call any API — just store the budget line ID and details on the row.
-   */
-  const handleSelectBudgetLine = useCallback(
-    (budgetLine: WorkItemBudgetLine | HouseholdItemBudgetLine) => {
-      if (!activeRowId) return;
-
-      const lineType: 'work_item' | 'household_item' =
-        'workItemId' in budgetLine ? 'work_item' : 'household_item';
-
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === activeRowId
-            ? {
-                ...l,
-                assignedBudgetLineId: budgetLine.id,
-                assignedBudgetLineType: lineType,
-                assignedBudgetLineDescription: budgetLine.description ?? null,
-              }
-            : l,
-        ),
-      );
-      picker.closePicker();
-      setActiveRowId(null);
-    },
-    [activeRowId, picker],
-  );
-
-  const handleQueueNewBudgetLine = useCallback(() => {
-    if (!activeRowId) return;
-    const row = lines.find((l) => l.rowId === activeRowId);
-    if (!row) return;
-
-    // Resolve vendorId from row's vendorName against already-loaded vendors
-    const vendors = picker.pickerState.vendors ?? [];
-    const vendorId = row.vendorName
-      ? (vendors.find((v) => v.name.toLowerCase() === row.vendorName!.toLowerCase())?.id ?? null)
-      : null;
-
-    // Resolve budgetSourceId: use row's value or fall back to discretionary
-    const sources = picker.pickerState.budgetSources ?? [];
-    const discretionaryId = sources.find((s) => s.isDiscretionary)?.id;
-    const budgetSourceId = row.budgetSourceId ?? discretionaryId ?? '';
-
-    // Auto-apply confidence based on document type (Paperless-ngx document type metadata)
-    // If doc type is "Invoice" → confidence = 'invoice', hide field
-    // If doc type is "Quotation" → confidence = 'quote', hide field
-    // Otherwise → derive from ML score, show field normally
-    let confidence: ConfidenceLevel;
-    let isConfidenceAutoApplied = false;
-
-    if (document?.documentType === 'Invoice') {
-      confidence = 'invoice';
-      isConfidenceAutoApplied = true;
-    } else if (document?.documentType === 'Quotation') {
-      confidence = 'quote';
-      isConfidenceAutoApplied = true;
-    } else {
-      // Fallback to score-based derivation
-      confidence =
-        row.confidence >= 0.85
-          ? 'invoice'
-          : row.confidence >= 0.6
-            ? 'quote'
-            : row.confidence >= 0.3
-              ? 'professional_estimate'
-              : 'own_estimate';
-    }
-
-    const draft: BudgetLineFormState = {
-      description: row.description ?? '',
-      plannedAmount: String(row.totalAmount ?? ''),
-      confidence,
-      budgetCategoryId:
-        picker.pickerState.type === 'household_item' ? '' : (row.budgetCategoryId ?? ''),
-      budgetSourceId,
-      vendorId: vendorId ?? '',
-      pricingMode: row.quantity != null && row.unitPrice != null ? 'unit' : 'direct',
-      quantity: row.quantity != null ? String(row.quantity) : '',
-      unit: row.unit ?? '',
-      unitPrice: row.unitPrice != null ? String(row.unitPrice) : '',
-      includesVat: row.includesVat !== false,
-    };
-
-    setLines((prev) =>
-      prev.map((l) =>
-        l.rowId === activeRowId
-          ? {
-              ...l,
-              assignedItemId: picker.pickerState.itemId ?? undefined,
-              assignedItemType: picker.pickerState.type ?? undefined,
-              inlineCreatedBudgetLineDraft: draft,
-              inlineHideConfidence: isConfidenceAutoApplied,
-            }
-          : l,
-      ),
-    );
-    picker.closePicker();
-    setActiveRowId(null);
-  }, [activeRowId, lines, picker, document]);
-
-  const handleInlineDraftChange = useCallback(
-    (rowId: string, updates: Partial<BudgetLineFormState>) => {
-      setLines((prev) =>
-        prev.map((l) =>
-          l.rowId === rowId
-            ? {
-                ...l,
-                inlineCreatedBudgetLineDraft: l.inlineCreatedBudgetLineDraft
-                  ? { ...l.inlineCreatedBudgetLineDraft, ...updates }
-                  : l.inlineCreatedBudgetLineDraft,
-              }
-            : l,
-        ),
-      );
-    },
-    [],
-  );
 
   // Compute totals and variance (must be before any early returns for React rules)
   const computedTotal = useMemo(
@@ -609,12 +306,10 @@ export function PaperlessInvoiceReviewPage() {
     };
   }, [computedTotal, metadataEdits.amount]);
 
-  // Guard for missing documentId
   if (!documentId) {
     return <div>{t('autoItemize.error')}</div>;
   }
 
-  // Render loading state
   if (pageStatus === 'loading') {
     return (
       <div className={styles.pageContainer}>
@@ -639,7 +334,6 @@ export function PaperlessInvoiceReviewPage() {
     );
   }
 
-  // Render error state
   if (pageStatus === 'error' || !document) {
     return (
       <div className={styles.pageContainer}>
@@ -661,7 +355,6 @@ export function PaperlessInvoiceReviewPage() {
     );
   }
 
-  // Ready state - render review form
   return (
     <>
       <div className={styles.pageContainer}>
@@ -681,7 +374,6 @@ export function PaperlessInvoiceReviewPage() {
               {t('autoItemize.skipToForm')}
             </a>
 
-            {/* Page-level error banner */}
             {pageError && <FormError variant="banner" message={pageError} />}
 
             {/* Vendor card */}
@@ -731,10 +423,9 @@ export function PaperlessInvoiceReviewPage() {
               </div>
             </div>
 
-            {/* Metadata card — invoice number, amount, date, due-date, notes */}
+            {/* Metadata card */}
             <div className={styles.metadataCard}>
               <h2 className={styles.sectionTitle}>{t('autoItemize.invoiceMetadata')}</h2>
-              {/* Invoice Number */}
               <div className={styles.fieldRow}>
                 <label htmlFor="invoice-number" className={styles.label}>
                   {t('autoItemize.invoiceNumber')}
@@ -754,7 +445,6 @@ export function PaperlessInvoiceReviewPage() {
                   />
                 </div>
               </div>
-              {/* Amount */}
               <div className={styles.fieldRow}>
                 <label htmlFor="amount" className={styles.label}>
                   {t('autoItemize.amount')}
@@ -773,7 +463,6 @@ export function PaperlessInvoiceReviewPage() {
                   />
                 </div>
               </div>
-              {/* Date */}
               <div className={styles.fieldRow}>
                 <label htmlFor="date" className={styles.label}>
                   {t('autoItemize.date')}
@@ -789,7 +478,6 @@ export function PaperlessInvoiceReviewPage() {
                   />
                 </div>
               </div>
-              {/* Due Date */}
               <div className={styles.fieldRow}>
                 <label htmlFor="due-date" className={styles.label}>
                   {t('autoItemize.dueDate')}
@@ -805,7 +493,6 @@ export function PaperlessInvoiceReviewPage() {
                   />
                 </div>
               </div>
-              {/* Notes */}
               <div className={styles.fieldRow}>
                 <label htmlFor="notes" className={styles.label}>
                   {t('autoItemize.notes')}
@@ -824,32 +511,14 @@ export function PaperlessInvoiceReviewPage() {
               </div>
             </div>
 
-            {/* Line items — shared component */}
+            {/* Line items */}
             <AutoItemizeLineList
               lines={lines}
-              onToggleInclude={handleLineToggle}
-              onFieldChange={handleLineFieldChange}
-              onAssign={handleAssignButtonClick}
-              onClearAssign={(rowId) => {
-                setLines((prev) =>
-                  prev.map((l) =>
-                    l.rowId === rowId
-                      ? {
-                          ...l,
-                          assignedBudgetLineId: undefined,
-                          assignedBudgetLineType: undefined,
-                          assignedBudgetLineDescription: undefined,
-                          createdFromExtraction: undefined,
-                          assignedItemId: undefined,
-                          assignedItemType: undefined,
-                          inlineCreatedBudgetLineDraft: undefined,
-                          inlineHideConfidence: undefined,
-                        }
-                      : l,
-                  ),
-                );
-              }}
-              onInlineDraftChange={handleInlineDraftChange}
+              onToggleInclude={handlers.onToggleInclude}
+              onFieldChange={handlers.onFieldChange}
+              onAssign={handlers.onAssign}
+              onClearAssign={handlers.onClearAssign}
+              onInlineDraftChange={handlers.onInlineDraftChange}
               categories={picker.pickerState.categories ?? []}
               budgetSources={picker.pickerState.budgetSources ?? []}
               discretionarySourceId={
@@ -867,7 +536,7 @@ export function PaperlessInvoiceReviewPage() {
               tSettings={tSettings}
             />
 
-            {/* Actions — inline in form column, no sticky bar */}
+            {/* Actions */}
             <div className={styles.actions}>
               <button
                 type="button"
@@ -892,54 +561,11 @@ export function PaperlessInvoiceReviewPage() {
 
           {/* Preview column */}
           <div className={styles.previewColumn}>
-            {!pdfFailed ? (
-              <div className={styles.pdfPreviewWrapper}>
-                {!pdfLoaded && (
-                  <div className={styles.pdfLoadingOverlay} aria-hidden="true">
-                    <Spinner size="md" color="muted" label={t('autoItemize.pdfPreviewTitle')} />
-                  </div>
-                )}
-                <iframe
-                  className={styles.pdfIframe}
-                  src={getDocumentPreviewUrl(documentId)}
-                  title={t('autoItemize.pdfPreviewTitle')}
-                  onLoad={() => setPdfLoaded(true)}
-                  onErrorCapture={() => setPdfFailed(true)}
-                />
-              </div>
-            ) : (
-              <div
-                className={styles.pdfFallback}
-                role="region"
-                aria-label={t('autoItemize.previewUnavailable')}
-              >
-                <svg
-                  aria-hidden="true"
-                  width="32"
-                  height="32"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="var(--color-text-muted)"
-                  strokeWidth="1.5"
-                >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span className={styles.pdfFallbackLabel}>
-                  {t('autoItemize.previewUnavailable')}
-                </span>
-                {paperlessStatus?.paperlessUrl && (
-                  <a
-                    href={`${paperlessStatus.paperlessUrl}/documents/${documentId}/`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.pdfFallbackLink}
-                  >
-                    {t('autoItemize.openInPaperless')}
-                  </a>
-                )}
-              </div>
-            )}
+            <AutoItemizePdfPreview
+              documentId={documentId}
+              paperlessUrl={paperlessStatus?.paperlessUrl}
+              t={t}
+            />
           </div>
         </div>
       </div>
@@ -961,8 +587,8 @@ export function PaperlessInvoiceReviewPage() {
             setPickerState={picker.setPickerState}
             handleSelectItem={picker.handleSelectItem}
             createBudgetLineButtonRef={picker.createBudgetLineButtonRef}
-            onSelectBudgetLine={handleSelectBudgetLine}
-            onCreateNewBudgetLine={handleQueueNewBudgetLine}
+            onSelectBudgetLine={handlers.onSelectBudgetLine}
+            onCreateNewBudgetLine={handlers.onQueueNewBudgetLine}
             onBackToStep1={() =>
               picker.setPickerState((prev) => ({
                 ...prev,


### PR DESCRIPTION
## Summary

- Extracts three shared units from the two auto-itemize page flows (`AutoItemizePage` / `PaperlessInvoiceReviewPage`), eliminating ~865 lines of duplication:
  - **`materializeInlineDrafts`** (`autoItemizeDraftUtils.ts`) — pure async helper for resolving inline budget-line drafts at save time
  - **`AutoItemizePdfPreview`** component — shared PDF preview column (iframe + loading overlay + fallback) that was copy-pasted verbatim
  - **`useAutoItemizeLines`** hook — encapsulates all line-state management and `useBudgetLinePicker` integration; both pages now call one hook instead of ~150 lines each

- **Fixes VAT/amount sync bug**: financial fields (`includesVat`, `quantity`, `unitPrice`, `totalAmount`) on the created budget line now come from the **live line state**, not the draft snapshot taken when "New budget line" was clicked. If the user changes `includesVat` on the line card after queuing a draft, the created budget line now correctly mirrors it.

- **Aligns confidence derivation** between the two flows: both now read the Paperless `documentType` (`Invoice` → `invoice`, `Quotation` → `quote`) before falling back to the ML score. Previously only `PaperlessInvoiceReviewPage` did this.

## Test plan

- [ ] New `autoItemizeDraftUtils.test.ts` — verifies VAT sync fix, amount sync, unit pricing, error paths, mixed-line arrays
- [ ] New `useAutoItemizeLines.test.ts` — verifies all handlers, confidence derivation (all four score tiers + both doc types), `onFieldsEdited` callback
- [ ] Existing `AutoItemizePage` test suites must pass unchanged
- [ ] Existing `PaperlessInvoiceReviewPage` test suites must pass unchanged
- [ ] CI Quality Gates (typecheck + unit tests + Docker build) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)