### PR TITLE
fix(e2e): replace waitForResponse with waitForLoaded for diary mode-switch step

### DIFF
--- a/e2e/tests/diary/diary-automatic-events.spec.ts
+++ b/e2e/tests/diary/diary-automatic-events.spec.ts
@@ -122,14 +122,14 @@ test.describe('Type chip filter for automatic entries (Scenario 2)', () => {
       await diaryPage.goto();
       await diaryPage.waitForLoaded();
 
-      // Default mode is now "Manual" — switch to "All" so the automatic type chips are visible
+      // Default mode is now "Manual" — switch to "All" so the automatic type chips are visible.
+      // Use waitForLoaded() after the click instead of waitForResponse: it waits for
+      // the full load cycle (isLoading→false, empty-state visible), guaranteeing the
+      // All-click API response was received and captured in requests[].
       const allChip = page.getByTestId('mode-filter-all');
       await allChip.waitFor({ state: 'visible' });
-      const switchResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/api/diary-entries') && resp.status() === 200,
-      );
       await allChip.click();
-      await switchResponse;
+      await diaryPage.waitForLoaded();
 
       // Reset captured requests from initial load + mode switch
       requests.length = 0;

--- a/e2e/tests/diary/diary-r2-uat.spec.ts
+++ b/e2e/tests/diary/diary-r2-uat.spec.ts
@@ -176,14 +176,14 @@ test.describe('Manual mode hides automatic type chips (Scenario 2)', () => {
       await diaryPage.waitForLoaded();
       await diaryPage.openFiltersIfCollapsed();
 
-      // Default is now "Manual" — switch to "All" first so we can test clicking Manual
+      // Default is now "Manual" — switch to "All" first so we can test clicking Manual.
+      // Use waitForLoaded() after the click instead of waitForResponse: it waits for
+      // the full load cycle (isLoading→false, empty-state visible), guaranteeing the
+      // All-click API response was received before we register the next listener.
       const allChip = page.getByTestId('mode-filter-all');
       await allChip.waitFor({ state: 'visible' });
-      const switchResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/api/diary-entries') && resp.status() === 200,
-      );
       await allChip.click();
-      await switchResponse;
+      await diaryPage.waitForLoaded();
 
       // Register the response promise BEFORE clicking the Manual chip
       const responsePromise = page.waitForResponse(
@@ -614,14 +614,14 @@ test.describe('Manual mode API parameter (Scenario 10)', () => {
       await diaryPage.waitForLoaded();
       await diaryPage.openFiltersIfCollapsed();
 
-      // Default is now "Manual" — switch to "All" first so we can test clicking Manual
+      // Default is now "Manual" — switch to "All" first so we can test clicking Manual.
+      // Use waitForLoaded() after the click instead of waitForResponse: it waits for
+      // the full load cycle (isLoading→false, empty-state visible), guaranteeing the
+      // All-click API response was received and captured in requests[].
       const allChip = page.getByTestId('mode-filter-all');
       await allChip.waitFor({ state: 'visible' });
-      let switchResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/api/diary-entries') && resp.status() === 200,
-      );
       await allChip.click();
-      await switchResponse;
+      await diaryPage.waitForLoaded();
 
       // Reset captured requests from the "All" switch
       requests.length = 0;


### PR DESCRIPTION
## Summary

- Replaces the `waitForResponse()` pattern with `diaryPage.waitForLoaded()` for the "switch to All first" step in diary E2E tests
- Fixes a race condition that caused flaky failures under `maxFailures:1` on promotion PRs targeting `main`
- Affects: `diary-r2-uat.spec.ts` Scenarios 2 and 10, `diary-automatic-events.spec.ts` Scenario 2

## Root Cause

The `waitForResponse()` listener was registered *after* clicking the All chip and waiting for the first response. In `E2E_FAIL_FAST=1` mode (promotion PRs only), high CI contention could cause:

1. Click All chip → `aria-pressed` updates (sync) → useEffect fires (async) → API response arrives
2. `await switchResponse` is satisfied
3. Register `responsePromise` for Manual chip click
4. BUT: sometimes the All-click's API response is delayed and arrives AFTER step 3, fulfilling `responsePromise` prematurely

`waitForLoaded()` waits for `isLoading` to become `false` (empty state or timeline visible), which is directly tied to the `finally` block of `loadEntries()`. This guarantees the full API cycle completes before the next listener is registered.

## Test plan
- [ ] All E2E shards pass in CI (beta PR, no fail-fast)
- [ ] Quality Gates pass
- [ ] Promotion PR #1791 CI passes after this merges to beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)